### PR TITLE
Phase 3 (slice 1) — app shell, student records, admissions

### DIFF
--- a/omnischools/app/(app)/admissions/page.tsx
+++ b/omnischools/app/(app)/admissions/page.tsx
@@ -1,0 +1,93 @@
+import Link from "next/link";
+import { desc, eq } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import { admissionApplications } from "@/db/schema";
+import { AdmissionActions } from "@/components/admissions/admission-actions";
+
+export const dynamic = "force-dynamic";
+
+const STATUS_STYLES: Record<string, string> = {
+  SUBMITTED: "bg-warn-bg text-warn",
+  UNDER_REVIEW: "bg-gold-bg text-navy",
+  ACCEPTED: "bg-green-bg text-green",
+  REJECTED: "bg-terra-bg text-terra",
+  WAITLISTED: "bg-bg text-navy-3",
+};
+
+export default async function AdmissionsPage() {
+  const { school } = await requireSchool();
+  const apps = await withSchool(school.id, (tx) =>
+    tx
+      .select()
+      .from(admissionApplications)
+      .where(eq(admissionApplications.schoolId, school.id))
+      .orderBy(desc(admissionApplications.submittedAt))
+      .limit(200),
+  );
+
+  const pending = apps.filter(
+    (a) => a.status === "SUBMITTED" || a.status === "UNDER_REVIEW",
+  );
+
+  return (
+    <div className="mx-auto max-w-page">
+      <div className="mb-6">
+        <h1 className="font-display text-3xl font-semibold text-navy">Admissions</h1>
+        <p className="text-sm text-navy-3">
+          {pending.length} awaiting review · {apps.length} total · public link:{" "}
+          <Link
+            href={`/apply/${encodeURIComponent(school.gesCode)}`}
+            className="font-mono text-gold hover:underline"
+          >
+            /apply/{school.gesCode}
+          </Link>
+        </p>
+      </div>
+
+      {apps.length === 0 ? (
+        <div className="border-border-2 bg-surface rounded-xl border border-dashed p-12 text-center">
+          <p className="font-display text-lg text-navy">No applications yet.</p>
+          <p className="mt-1 text-sm text-navy-3">
+            Share your school&apos;s public application link with prospective parents.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {apps.map((a) => {
+            const decided = !(a.status === "SUBMITTED" || a.status === "UNDER_REVIEW");
+            return (
+              <div
+                key={a.id}
+                className="bg-surface flex flex-wrap items-center justify-between gap-3 rounded-xl border border-border px-4 py-3"
+              >
+                <div className="min-w-0">
+                  <div className="font-medium text-navy">
+                    {a.applicantLastName}, {a.applicantFirstName}{" "}
+                    {a.applicantOtherNames ?? ""}
+                    <span className="ml-2 text-xs text-navy-3">
+                      {a.desiredClassLabel ? `→ ${a.desiredClassLabel}` : ""}
+                    </span>
+                  </div>
+                  <div className="text-xs text-navy-3">
+                    Guardian {a.guardianName} ·{" "}
+                    <span className="font-mono">{a.guardianPhone}</span>
+                  </div>
+                </div>
+                <div className="flex items-center gap-3">
+                  <span
+                    className={`rounded-pill px-2 py-0.5 text-xs font-medium ${STATUS_STYLES[a.status]}`}
+                  >
+                    {a.status.charAt(0) +
+                      a.status.slice(1).toLowerCase().replace("_", " ")}
+                  </span>
+                  <AdmissionActions applicationId={a.id} decided={decided} />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/omnischools/app/(app)/dashboard/page.tsx
+++ b/omnischools/app/(app)/dashboard/page.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link";
+import { eq, and, sql } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import { students, admissionApplications } from "@/db/schema";
+
+export const dynamic = "force-dynamic";
+
+export default async function DashboardPage() {
+  const { school } = await requireSchool();
+  const stats = await withSchool(school.id, async (tx) => {
+    const [{ activeStudents }] = await tx
+      .select({ activeStudents: sql<number>`count(*)::int` })
+      .from(students)
+      .where(and(eq(students.schoolId, school.id), eq(students.status, "ACTIVE")));
+    const [{ pending }] = await tx
+      .select({ pending: sql<number>`count(*)::int` })
+      .from(admissionApplications)
+      .where(
+        and(
+          eq(admissionApplications.schoolId, school.id),
+          eq(admissionApplications.status, "SUBMITTED"),
+        ),
+      );
+    return { activeStudents, pending };
+  });
+
+  const cards = [
+    { label: "Active students", value: stats.activeStudents, href: "/students" },
+    { label: "Pending applications", value: stats.pending, href: "/admissions" },
+  ];
+
+  return (
+    <div className="mx-auto max-w-page">
+      <h1 className="mb-1 font-display text-3xl font-semibold text-navy">
+        Good day, {school.shortName ?? "team"}.
+      </h1>
+      <p className="mb-8 text-sm text-navy-2">
+        Here&apos;s the shape of your school today.
+      </p>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {cards.map((c) => (
+          <Link
+            key={c.label}
+            href={c.href}
+            className="bg-surface rounded-xl border border-border p-5 transition-colors hover:border-gold-soft"
+          >
+            <div className="font-display text-4xl font-semibold text-navy">{c.value}</div>
+            <div className="mt-1 text-sm text-navy-3">{c.label}</div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/omnischools/app/(app)/fees/[studentId]/page.tsx
+++ b/omnischools/app/(app)/fees/[studentId]/page.tsx
@@ -1,0 +1,185 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { and, desc, eq } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import { students, invoices, payments, receipts } from "@/db/schema";
+import { num } from "@/lib/fees-helpers";
+import { IssueInvoiceForm } from "@/components/fees/issue-invoice-form";
+import { RecordPaymentForm } from "@/components/fees/record-payment-form";
+import { VoidPaymentButton } from "@/components/fees/void-payment-button";
+
+export const dynamic = "force-dynamic";
+
+const ghs = (v: number) => `GHS ${v.toFixed(2)}`;
+
+const INV_STATUS: Record<string, string> = {
+  ISSUED: "bg-warn-bg text-warn",
+  PARTIAL: "bg-gold-bg text-navy",
+  PAID: "bg-green-bg text-green",
+  OVERDUE: "bg-terra-bg text-terra",
+  VOIDED: "bg-bg text-navy-3",
+  DRAFT: "bg-bg text-navy-3",
+  EXEMPT: "bg-bg text-navy-3",
+};
+
+export default async function StudentFeesPage({
+  params,
+}: {
+  params: { studentId: string };
+}) {
+  const { school } = await requireSchool();
+  const data = await withSchool(school.id, async (tx) => {
+    const [student] = await tx
+      .select()
+      .from(students)
+      .where(and(eq(students.id, params.studentId), eq(students.schoolId, school.id)));
+    if (!student) return null;
+    const invs = await tx
+      .select()
+      .from(invoices)
+      .where(eq(invoices.studentId, student.id))
+      .orderBy(desc(invoices.issuedAt));
+    const pays = await tx
+      .select({
+        id: payments.id,
+        grossAmount: payments.grossAmount,
+        method: payments.method,
+        settlementStatus: payments.settlementStatus,
+        recordedAt: payments.recordedAt,
+        voidedAt: payments.voidedAt,
+        receiptNumber: receipts.receiptNumber,
+      })
+      .from(payments)
+      .leftJoin(receipts, eq(receipts.paymentId, payments.id))
+      .where(eq(payments.studentId, student.id))
+      .orderBy(desc(payments.recordedAt));
+    return { student, invs, pays };
+  });
+
+  if (!data) notFound();
+  const { student, invs, pays } = data;
+  const balance = invs
+    .filter((i) => i.status !== "VOIDED")
+    .reduce((s, i) => s + num(i.balanceAmount), 0);
+
+  return (
+    <div className="mx-auto max-w-page">
+      <Link href="/fees" className="text-sm text-navy-3 hover:text-gold">
+        ← Fees
+      </Link>
+      <div className="mb-6 mt-2 flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h1 className="font-display text-3xl font-semibold text-navy">
+            {student.firstName} {student.lastName}
+          </h1>
+          <p className="font-mono text-xs text-navy-3">{student.studentCode}</p>
+        </div>
+        <div className="text-right">
+          <div className="text-xs uppercase tracking-wide text-navy-3">Balance</div>
+          <div
+            className={`font-display text-3xl font-semibold ${balance > 0 ? "text-terra" : "text-green"}`}
+          >
+            {ghs(balance)}
+          </div>
+        </div>
+      </div>
+
+      <div className="mb-8 flex flex-wrap items-start gap-3">
+        <RecordPaymentForm studentId={student.id} />
+        <IssueInvoiceForm studentId={student.id} />
+      </div>
+
+      <h2 className="mb-3 font-display text-xl font-semibold text-navy">Invoices</h2>
+      {invs.length === 0 ? (
+        <p className="mb-8 text-sm text-navy-3">No invoices yet.</p>
+      ) : (
+        <div className="bg-surface mb-8 overflow-hidden rounded-xl border border-border">
+          <table className="w-full text-sm">
+            <thead className="bg-bg border-b border-border text-left text-xs uppercase tracking-wide text-navy-3">
+              <tr>
+                <th className="px-4 py-3 font-semibold">Invoice</th>
+                <th className="px-4 py-3 text-right font-semibold">Billed</th>
+                <th className="px-4 py-3 text-right font-semibold">Paid</th>
+                <th className="px-4 py-3 text-right font-semibold">Balance</th>
+                <th className="px-4 py-3 font-semibold">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {invs.map((i) => (
+                <tr key={i.id}>
+                  <td className="px-4 py-3 font-mono text-xs text-navy-2">
+                    {i.invoiceNumber}
+                  </td>
+                  <td className="px-4 py-3 text-right text-navy">
+                    {ghs(num(i.billedAmount))}
+                  </td>
+                  <td className="px-4 py-3 text-right text-navy-2">
+                    {ghs(num(i.paidAmount))}
+                  </td>
+                  <td className="px-4 py-3 text-right font-medium text-navy">
+                    {ghs(num(i.balanceAmount))}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={`rounded-pill px-2 py-0.5 text-xs font-medium ${INV_STATUS[i.status]}`}
+                    >
+                      {i.status.charAt(0) + i.status.slice(1).toLowerCase()}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <h2 className="mb-3 font-display text-xl font-semibold text-navy">Payments</h2>
+      {pays.length === 0 ? (
+        <p className="text-sm text-navy-3">No payments yet.</p>
+      ) : (
+        <div className="bg-surface overflow-hidden rounded-xl border border-border">
+          <table className="w-full text-sm">
+            <thead className="bg-bg border-b border-border text-left text-xs uppercase tracking-wide text-navy-3">
+              <tr>
+                <th className="px-4 py-3 font-semibold">Receipt</th>
+                <th className="px-4 py-3 font-semibold">Method</th>
+                <th className="px-4 py-3 text-right font-semibold">Amount</th>
+                <th className="px-4 py-3 font-semibold">Settlement</th>
+                <th className="px-4 py-3 font-semibold"></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {pays.map((p) => (
+                <tr key={p.id} className={p.voidedAt ? "opacity-50" : ""}>
+                  <td className="px-4 py-3 font-mono text-xs text-navy-2">
+                    {p.receiptNumber ?? "—"}
+                  </td>
+                  <td className="px-4 py-3 text-navy-2">
+                    {p.method.replaceAll("_", " ").toLowerCase()}
+                  </td>
+                  <td className="px-4 py-3 text-right font-medium text-navy">
+                    {ghs(num(p.grossAmount))}
+                  </td>
+                  <td className="px-4 py-3 text-navy-2">
+                    {p.voidedAt ? (
+                      <span className="rounded-pill bg-terra-bg px-2 py-0.5 text-xs text-terra">
+                        Voided
+                      </span>
+                    ) : (
+                      p.settlementStatus.charAt(0) +
+                      p.settlementStatus.slice(1).toLowerCase()
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    {!p.voidedAt && <VoidPaymentButton paymentId={p.id} />}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/omnischools/app/(app)/fees/page.tsx
+++ b/omnischools/app/(app)/fees/page.tsx
@@ -1,0 +1,115 @@
+import Link from "next/link";
+import { and, eq, sql, desc } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import { invoices, students } from "@/db/schema";
+
+export const dynamic = "force-dynamic";
+
+const ghs = (v: number) => `GHS ${v.toFixed(2)}`;
+
+export default async function FeesPage() {
+  const { school } = await requireSchool();
+  const data = await withSchool(school.id, async (tx) => {
+    const [totals] = await tx
+      .select({
+        billed: sql<number>`coalesce(sum(${invoices.billedAmount}), 0)::float`,
+        paid: sql<number>`coalesce(sum(${invoices.paidAmount}), 0)::float`,
+        balance: sql<number>`coalesce(sum(${invoices.balanceAmount}), 0)::float`,
+      })
+      .from(invoices)
+      .where(and(eq(invoices.schoolId, school.id), sql`${invoices.status} <> 'VOIDED'`));
+
+    const debtors = await tx
+      .select({
+        studentId: invoices.studentId,
+        firstName: students.firstName,
+        lastName: students.lastName,
+        code: students.studentCode,
+        balance: sql<number>`sum(${invoices.balanceAmount})::float`,
+      })
+      .from(invoices)
+      .innerJoin(students, eq(invoices.studentId, students.id))
+      .where(and(eq(invoices.schoolId, school.id), sql`${invoices.balanceAmount} > 0`))
+      .groupBy(
+        invoices.studentId,
+        students.firstName,
+        students.lastName,
+        students.studentCode,
+      )
+      .orderBy(desc(sql`sum(${invoices.balanceAmount})`))
+      .limit(100);
+
+    return { totals, debtors };
+  });
+
+  const cards = [
+    { label: "Billed", value: data.totals.billed },
+    { label: "Collected", value: data.totals.paid },
+    { label: "Outstanding", value: data.totals.balance },
+  ];
+
+  return (
+    <div className="mx-auto max-w-page">
+      <h1 className="mb-1 font-display text-3xl font-semibold text-navy">Fees</h1>
+      <p className="mb-6 text-sm text-navy-3">
+        Collections for {school.name}. Open a student to issue an invoice or record a
+        payment.
+      </p>
+
+      <div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {cards.map((c) => (
+          <div key={c.label} className="bg-surface rounded-xl border border-border p-5">
+            <div className="font-display text-3xl font-semibold text-navy">
+              {ghs(c.value)}
+            </div>
+            <div className="mt-1 text-sm text-navy-3">{c.label}</div>
+          </div>
+        ))}
+      </div>
+
+      <h2 className="mb-3 font-display text-xl font-semibold text-navy">
+        Students with a balance
+      </h2>
+      {data.debtors.length === 0 ? (
+        <div className="border-border-2 bg-surface rounded-xl border border-dashed p-12 text-center">
+          <p className="font-display text-lg text-navy">Nothing outstanding.</p>
+          <p className="mt-1 text-sm text-navy-3">
+            Open a student from{" "}
+            <Link href="/students" className="text-gold underline">
+              Students
+            </Link>{" "}
+            to issue an invoice.
+          </p>
+        </div>
+      ) : (
+        <div className="bg-surface overflow-hidden rounded-xl border border-border">
+          <table className="w-full text-sm">
+            <thead className="bg-bg border-b border-border text-left text-xs uppercase tracking-wide text-navy-3">
+              <tr>
+                <th className="px-4 py-3 font-semibold">Code</th>
+                <th className="px-4 py-3 font-semibold">Student</th>
+                <th className="px-4 py-3 text-right font-semibold">Balance</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {data.debtors.map((d) => (
+                <tr key={d.studentId} className="hover:bg-bg transition-colors">
+                  <td className="px-4 py-3 font-mono text-xs text-navy-2">{d.code}</td>
+                  <td className="px-4 py-3 font-medium text-navy">
+                    <Link href={`/fees/${d.studentId}`} className="hover:text-gold">
+                      {d.lastName}, {d.firstName}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-right font-semibold text-terra">
+                    {ghs(d.balance)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/omnischools/app/(app)/layout.tsx
+++ b/omnischools/app/(app)/layout.tsx
@@ -1,0 +1,28 @@
+import { requireSchool } from "@/lib/auth/server";
+import { AppSidebar } from "@/components/app/sidebar";
+
+export default async function AppLayout({ children }: { children: React.ReactNode }) {
+  const { school, user } = await requireSchool();
+  return (
+    <div className="bg-bg flex min-h-screen">
+      <AppSidebar />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <header className="bg-surface flex items-center justify-between gap-4 border-b border-border px-6 py-3">
+          <div className="min-w-0">
+            <div className="truncate font-display text-base font-semibold text-navy">
+              {school.name}
+            </div>
+            <div className="text-xs text-navy-3">
+              {school.schoolType.charAt(0) + school.schoolType.slice(1).toLowerCase()} ·{" "}
+              {user.roles[0]?.replaceAll("_", " ").toLowerCase()}
+            </div>
+          </div>
+          <span className="flex shrink-0 items-center gap-1.5 rounded-pill bg-green-bg px-2.5 py-1 text-xs font-medium text-green">
+            ● Connected
+          </span>
+        </header>
+        <main className="flex-1 p-6">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/omnischools/app/(app)/students/[id]/page.tsx
+++ b/omnischools/app/(app)/students/[id]/page.tsx
@@ -1,0 +1,93 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { and, eq } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import { students, studentGuardians } from "@/db/schema";
+
+export const dynamic = "force-dynamic";
+
+export default async function StudentDetailPage({ params }: { params: { id: string } }) {
+  const { school } = await requireSchool();
+  const data = await withSchool(school.id, async (tx) => {
+    const [student] = await tx
+      .select()
+      .from(students)
+      .where(and(eq(students.id, params.id), eq(students.schoolId, school.id)));
+    if (!student) return null;
+    const guardians = await tx
+      .select()
+      .from(studentGuardians)
+      .where(eq(studentGuardians.studentId, student.id));
+    return { student, guardians };
+  });
+
+  if (!data) notFound();
+  const { student, guardians } = data;
+
+  const facts: [string, string][] = [
+    ["Student code", student.studentCode],
+    ["Sex", student.sex.charAt(0) + student.sex.slice(1).toLowerCase()],
+    ["Date of birth", student.dateOfBirth ?? "—"],
+    ["Class", student.currentClassLabel ?? "—"],
+    ["Status", student.status.charAt(0) + student.status.slice(1).toLowerCase()],
+    ["Enrolled", student.enrolledOn ?? "—"],
+  ];
+
+  return (
+    <div className="mx-auto max-w-3xl">
+      <Link href="/students" className="text-sm text-navy-3 hover:text-gold">
+        ← Students
+      </Link>
+      <h1 className="mb-1 mt-2 font-display text-3xl font-semibold text-navy">
+        {student.firstName} {student.otherNames ?? ""} {student.lastName}
+      </h1>
+      <p className="mb-6 font-mono text-xs text-navy-3">{student.studentCode}</p>
+
+      <div className="bg-surface rounded-xl border border-border p-6">
+        <dl className="grid grid-cols-1 gap-x-8 gap-y-3 sm:grid-cols-2">
+          {facts.map(([k, v]) => (
+            <div
+              key={k}
+              className="flex justify-between border-b border-border py-2 text-sm"
+            >
+              <dt className="font-semibold text-navy-3">{k}</dt>
+              <dd className="text-navy">{v}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+
+      <h2 className="mb-3 mt-8 font-display text-xl font-semibold text-navy">
+        Guardians
+      </h2>
+      {guardians.length === 0 ? (
+        <p className="text-sm text-navy-3">No guardian recorded.</p>
+      ) : (
+        <div className="space-y-2">
+          {guardians.map((g) => (
+            <div
+              key={g.id}
+              className="bg-surface flex items-center justify-between rounded-lg border border-border px-4 py-3"
+            >
+              <div>
+                <div className="text-sm font-medium text-navy">
+                  {g.name}{" "}
+                  <span className="text-navy-3">
+                    · {g.relationship.charAt(0) + g.relationship.slice(1).toLowerCase()}
+                  </span>
+                </div>
+                <div className="font-mono text-xs text-navy-3">{g.phone}</div>
+              </div>
+              {g.isPrimary && (
+                <span className="rounded-pill bg-gold-bg px-2 py-0.5 text-xs font-medium text-navy">
+                  Primary
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/omnischools/app/(app)/students/new/page.tsx
+++ b/omnischools/app/(app)/students/new/page.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+import { NewStudentForm } from "@/components/students/new-student-form";
+
+export const metadata = { title: "Add student" };
+
+export default function NewStudentPage() {
+  return (
+    <div className="mx-auto max-w-3xl">
+      <Link href="/students" className="text-sm text-navy-3 hover:text-gold">
+        ← Students
+      </Link>
+      <h1 className="mb-6 mt-2 font-display text-3xl font-semibold text-navy">
+        Add a student
+      </h1>
+      <NewStudentForm />
+    </div>
+  );
+}

--- a/omnischools/app/(app)/students/page.tsx
+++ b/omnischools/app/(app)/students/page.tsx
@@ -1,0 +1,98 @@
+import Link from "next/link";
+import { desc, eq } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import { students } from "@/db/schema";
+
+export const dynamic = "force-dynamic";
+
+const STATUS_STYLES: Record<string, string> = {
+  ACTIVE: "bg-green-bg text-green",
+  INACTIVE: "bg-bg text-navy-3",
+  GRADUATED: "bg-gold-bg text-navy",
+  WITHDRAWN: "bg-terra-bg text-terra",
+  TRANSFERRED: "bg-warn-bg text-warn",
+};
+
+export default async function StudentsPage() {
+  const { school } = await requireSchool();
+  const rows = await withSchool(school.id, (tx) =>
+    tx
+      .select()
+      .from(students)
+      .where(eq(students.schoolId, school.id))
+      .orderBy(desc(students.createdAt))
+      .limit(200),
+  );
+
+  return (
+    <div className="mx-auto max-w-page">
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="font-display text-3xl font-semibold text-navy">Students</h1>
+          <p className="text-sm text-navy-3">{rows.length} on roll</p>
+        </div>
+        <Link
+          href="/students/new"
+          className="text-bg rounded-md bg-navy px-4 py-2.5 text-sm font-semibold transition-colors hover:bg-navy-deep"
+        >
+          + Add student
+        </Link>
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="border-border-2 bg-surface rounded-xl border border-dashed p-12 text-center">
+          <p className="font-display text-lg text-navy">No students yet.</p>
+          <p className="mt-1 text-sm text-navy-3">
+            Add one directly, or accept an application from{" "}
+            <Link href="/admissions" className="text-gold underline">
+              Admissions
+            </Link>
+            .
+          </p>
+        </div>
+      ) : (
+        <div className="bg-surface overflow-hidden rounded-xl border border-border">
+          <table className="w-full text-sm">
+            <thead className="bg-bg border-b border-border text-left text-xs uppercase tracking-wide text-navy-3">
+              <tr>
+                <th className="px-4 py-3 font-semibold">Code</th>
+                <th className="px-4 py-3 font-semibold">Name</th>
+                <th className="px-4 py-3 font-semibold">Sex</th>
+                <th className="px-4 py-3 font-semibold">Class</th>
+                <th className="px-4 py-3 font-semibold">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {rows.map((s) => (
+                <tr key={s.id} className="hover:bg-bg transition-colors">
+                  <td className="px-4 py-3 font-mono text-xs text-navy-2">
+                    <Link href={`/students/${s.id}`} className="hover:text-gold">
+                      {s.studentCode}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 font-medium text-navy">
+                    <Link href={`/students/${s.id}`} className="hover:text-gold">
+                      {s.lastName}, {s.firstName} {s.otherNames ?? ""}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-navy-2">
+                    {s.sex.charAt(0) + s.sex.slice(1).toLowerCase()}
+                  </td>
+                  <td className="px-4 py-3 text-navy-2">{s.currentClassLabel ?? "—"}</td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={`rounded-pill px-2 py-0.5 text-xs font-medium ${STATUS_STYLES[s.status]}`}
+                    >
+                      {s.status.charAt(0) + s.status.slice(1).toLowerCase()}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/omnischools/app/(marketing)/apply/[code]/page.tsx
+++ b/omnischools/app/(marketing)/apply/[code]/page.tsx
@@ -1,0 +1,46 @@
+import { eq } from "drizzle-orm";
+import { withoutTenantScope } from "@/lib/db/rls";
+import { schools } from "@/db/schema";
+import { ApplyForm } from "@/components/admissions/apply-form";
+
+export const dynamic = "force-dynamic";
+
+export default async function ApplyPage({ params }: { params: { code: string } }) {
+  const code = decodeURIComponent(params.code);
+  const found = await withoutTenantScope((tx) =>
+    tx.select({ name: schools.name }).from(schools).where(eq(schools.gesCode, code)),
+  );
+  const school = found[0];
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-16">
+      {!school ? (
+        <div className="border-border-2 bg-surface rounded-2xl border border-dashed p-12 text-center">
+          <h1 className="font-display text-2xl font-semibold text-navy">
+            School not found
+          </h1>
+          <p className="mt-2 text-sm text-navy-3">
+            The application link <span className="font-mono">{code}</span> doesn&apos;t
+            match a school. Please check the link from the school.
+          </p>
+        </div>
+      ) : (
+        <>
+          <div className="mb-8 text-center">
+            <div className="mb-3 inline-block text-[11px] font-bold uppercase tracking-[0.18em] text-gold">
+              Admission application
+            </div>
+            <h1 className="font-display text-4xl font-semibold text-navy">
+              {school.name}
+            </h1>
+            <p className="mt-2 text-sm text-navy-2">
+              Complete the form below. The school reviews each application and contacts
+              the guardian by SMS.
+            </p>
+          </div>
+          <ApplyForm schoolCode={code} />
+        </>
+      )}
+    </main>
+  );
+}

--- a/omnischools/components/admissions/admission-actions.tsx
+++ b/omnischools/components/admissions/admission-actions.tsx
@@ -1,0 +1,54 @@
+"use client";
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { decideApplication } from "@/lib/actions/admissions";
+
+export function AdmissionActions({
+  applicationId,
+  decided,
+}: {
+  applicationId: string;
+  decided: boolean;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function decide(decision: "ACCEPTED" | "REJECTED" | "WAITLISTED") {
+    setError(null);
+    startTransition(async () => {
+      const res = await decideApplication({ applicationId, decision });
+      if (res.ok) router.refresh();
+      else setError(res.error);
+    });
+  }
+
+  if (decided) return null;
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        onClick={() => decide("ACCEPTED")}
+        disabled={pending}
+        className="rounded-md bg-green px-3 py-1.5 text-xs font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+      >
+        Accept
+      </button>
+      <button
+        onClick={() => decide("WAITLISTED")}
+        disabled={pending}
+        className="rounded-md bg-warn-bg px-3 py-1.5 text-xs font-semibold text-warn transition-opacity hover:opacity-90 disabled:opacity-50"
+      >
+        Waitlist
+      </button>
+      <button
+        onClick={() => decide("REJECTED")}
+        disabled={pending}
+        className="border-border-2 rounded-md border px-3 py-1.5 text-xs font-semibold text-terra transition-colors hover:bg-terra-bg disabled:opacity-50"
+      >
+        Reject
+      </button>
+      {error && <span className="text-xs text-terra">{error}</span>}
+    </div>
+  );
+}

--- a/omnischools/components/admissions/apply-form.tsx
+++ b/omnischools/components/admissions/apply-form.tsx
@@ -1,0 +1,133 @@
+"use client";
+import { useState } from "react";
+import { submitApplication } from "@/lib/actions/admissions";
+
+const fieldClass =
+  "w-full rounded-md border border-border-2 bg-bg px-3.5 py-2.5 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
+const labelClass = "mb-1.5 block text-xs font-semibold text-navy-2";
+
+export function ApplyForm({ schoolCode }: { schoolCode: string }) {
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  async function action(formData: FormData) {
+    setSaving(true);
+    setError(null);
+    const res = await submitApplication({
+      schoolCode,
+      applicantFirstName: formData.get("applicantFirstName"),
+      applicantLastName: formData.get("applicantLastName"),
+      applicantOtherNames: formData.get("applicantOtherNames"),
+      sex: formData.get("sex"),
+      dateOfBirth: formData.get("dateOfBirth"),
+      desiredClassLabel: formData.get("desiredClassLabel"),
+      guardianName: formData.get("guardianName"),
+      guardianPhone: formData.get("guardianPhone"),
+      guardianEmail: formData.get("guardianEmail"),
+    });
+    setSaving(false);
+    if (res.ok) setDone(true);
+    else setError(res.error);
+  }
+
+  if (done) {
+    return (
+      <div className="bg-surface rounded-2xl border border-border p-9 text-center shadow-md">
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-green-bg font-display text-xl text-green">
+          ✓
+        </div>
+        <h2 className="mb-2 font-display text-2xl font-semibold text-navy">
+          Application received.
+        </h2>
+        <p className="mx-auto max-w-[360px] text-sm text-navy-2">
+          The school will review and contact the guardian by SMS. Thank you.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      action={action}
+      className="bg-surface space-y-5 rounded-2xl border border-border p-6 shadow-md"
+    >
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div>
+          <label className={labelClass}>Applicant first name</label>
+          <input name="applicantFirstName" required className={fieldClass} />
+        </div>
+        <div>
+          <label className={labelClass}>Last name</label>
+          <input name="applicantLastName" required className={fieldClass} />
+        </div>
+        <div>
+          <label className={labelClass}>
+            Other names <span className="font-medium text-navy-3">— optional</span>
+          </label>
+          <input name="applicantOtherNames" className={fieldClass} />
+        </div>
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div>
+          <label className={labelClass}>Sex</label>
+          <select name="sex" required defaultValue="" className={fieldClass}>
+            <option value="" disabled>
+              Choose
+            </option>
+            <option value="MALE">Male</option>
+            <option value="FEMALE">Female</option>
+          </select>
+        </div>
+        <div>
+          <label className={labelClass}>
+            Date of birth <span className="font-medium text-navy-3">— optional</span>
+          </label>
+          <input name="dateOfBirth" type="date" className={fieldClass} />
+        </div>
+        <div>
+          <label className={labelClass}>
+            Class applying for <span className="font-medium text-navy-3">— optional</span>
+          </label>
+          <input
+            name="desiredClassLabel"
+            placeholder="e.g. JHS 1"
+            className={fieldClass}
+          />
+        </div>
+      </div>
+      <div className="border-t border-border pt-5">
+        <h3 className="mb-3 font-display text-base font-semibold text-navy">Guardian</h3>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div>
+            <label className={labelClass}>Name</label>
+            <input name="guardianName" required className={fieldClass} />
+          </div>
+          <div>
+            <label className={labelClass}>Phone</label>
+            <input
+              name="guardianPhone"
+              required
+              placeholder="024 000 0000"
+              className={fieldClass}
+            />
+          </div>
+          <div>
+            <label className={labelClass}>
+              Email <span className="font-medium text-navy-3">— optional</span>
+            </label>
+            <input name="guardianEmail" type="email" className={fieldClass} />
+          </div>
+        </div>
+      </div>
+      {error && <p className="text-sm text-terra">{error}</p>}
+      <button
+        type="submit"
+        disabled={saving}
+        className="text-bg rounded-md bg-navy px-6 py-3 text-sm font-semibold transition-colors hover:bg-navy-deep disabled:opacity-60"
+      >
+        {saving ? "Submitting…" : "Submit application"}
+      </button>
+    </form>
+  );
+}

--- a/omnischools/components/app/sidebar.tsx
+++ b/omnischools/components/app/sidebar.tsx
@@ -7,11 +7,11 @@ const NAV = [
   { href: "/dashboard", label: "Dashboard", icon: "D" },
   { href: "/students", label: "Students", icon: "S" },
   { href: "/admissions", label: "Admissions", icon: "A" },
+  { href: "/fees", label: "Fees", icon: "F" },
 ];
 
 // Roadmap items (later Phase 3 slices) — shown disabled to convey the shape.
 const SOON = [
-  { label: "Fees", icon: "F" },
   { label: "Attendance", icon: "T" },
   { label: "Gradebook", icon: "G" },
   { label: "Communication", icon: "C" },

--- a/omnischools/components/app/sidebar.tsx
+++ b/omnischools/components/app/sidebar.tsx
@@ -1,0 +1,71 @@
+"use client";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+
+const NAV = [
+  { href: "/dashboard", label: "Dashboard", icon: "D" },
+  { href: "/students", label: "Students", icon: "S" },
+  { href: "/admissions", label: "Admissions", icon: "A" },
+];
+
+// Roadmap items (later Phase 3 slices) — shown disabled to convey the shape.
+const SOON = [
+  { label: "Fees", icon: "F" },
+  { label: "Attendance", icon: "T" },
+  { label: "Gradebook", icon: "G" },
+  { label: "Communication", icon: "C" },
+];
+
+export function AppSidebar() {
+  const pathname = usePathname();
+  return (
+    <aside className="bg-surface hidden w-60 shrink-0 flex-col border-r border-border md:flex">
+      <div className="flex items-center gap-2.5 px-5 py-[18px]">
+        <span className="flex h-8 w-8 items-center justify-center rounded-md bg-navy font-display text-[15px] font-semibold italic text-gold-soft">
+          O
+        </span>
+        <span className="font-display text-lg font-semibold text-navy">Omnischools</span>
+      </div>
+      <nav className="flex-1 space-y-0.5 px-3 py-2">
+        {NAV.map((item) => {
+          const active = pathname === item.href || pathname.startsWith(item.href + "/");
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                active ? "bg-gold-bg text-navy" : "hover:bg-bg text-navy-2",
+              )}
+            >
+              <span
+                className={cn(
+                  "flex h-6 w-6 items-center justify-center rounded font-display text-xs italic",
+                  active ? "bg-navy text-gold-soft" : "bg-bg text-navy-3",
+                )}
+              >
+                {item.icon}
+              </span>
+              {item.label}
+            </Link>
+          );
+        })}
+        <div className="px-3 pb-1 pt-5 text-[10px] font-semibold uppercase tracking-[0.12em] text-navy-3">
+          Coming soon
+        </div>
+        {SOON.map((item) => (
+          <span
+            key={item.label}
+            className="text-navy-3/60 flex cursor-not-allowed items-center gap-3 rounded-md px-3 py-2 text-sm font-medium"
+          >
+            <span className="bg-bg text-navy-3/60 flex h-6 w-6 items-center justify-center rounded font-display text-xs italic">
+              {item.icon}
+            </span>
+            {item.label}
+          </span>
+        ))}
+      </nav>
+    </aside>
+  );
+}

--- a/omnischools/components/fees/issue-invoice-form.tsx
+++ b/omnischools/components/fees/issue-invoice-form.tsx
@@ -1,0 +1,157 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { issueInvoice } from "@/lib/actions/fees";
+
+const fieldClass =
+  "w-full rounded-md border border-border-2 bg-bg px-3 py-2 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
+const labelClass = "mb-1.5 block text-xs font-semibold text-navy-2";
+
+type Line = { description: string; amount: string };
+
+export function IssueInvoiceForm({ studentId }: { studentId: string }) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [lines, setLines] = useState<Line[]>([{ description: "Tuition", amount: "" }]);
+  const [discount, setDiscount] = useState("0");
+  const [dueAt, setDueAt] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const total =
+    lines.reduce((s, l) => s + (Number(l.amount) || 0), 0) - (Number(discount) || 0);
+
+  function setLine(i: number, key: keyof Line, v: string) {
+    setLines((ls) => ls.map((l, idx) => (idx === i ? { ...l, [key]: v } : l)));
+  }
+
+  async function submit() {
+    setSaving(true);
+    setError(null);
+    const res = await issueInvoice({
+      studentId,
+      discountAmount: discount,
+      dueAt,
+      lineItems: lines
+        .filter((l) => l.description && l.amount)
+        .map((l) => ({ description: l.description, amount: l.amount })),
+    });
+    setSaving(false);
+    if (res.ok) {
+      setOpen(false);
+      setLines([{ description: "Tuition", amount: "" }]);
+      setDiscount("0");
+      setDueAt("");
+      router.refresh();
+    } else {
+      setError(res.error);
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="border-border-2 bg-surface rounded-md border px-4 py-2.5 text-sm font-semibold text-navy transition-colors hover:bg-gold-bg"
+      >
+        Issue invoice
+      </button>
+    );
+  }
+
+  return (
+    <div className="bg-surface rounded-xl border border-border p-5">
+      <h3 className="mb-3 font-display text-base font-semibold text-navy">New invoice</h3>
+      <div className="space-y-2">
+        {lines.map((l, i) => (
+          <div key={i} className="flex gap-2">
+            <input
+              className={fieldClass}
+              placeholder="Description (e.g. Tuition)"
+              value={l.description}
+              onChange={(e) => setLine(i, "description", e.target.value)}
+            />
+            <input
+              className="border-border-2 bg-bg w-32 rounded-md border px-3 py-2 text-sm text-navy outline-none focus:border-gold"
+              type="number"
+              step="0.01"
+              min="0"
+              placeholder="0.00"
+              value={l.amount}
+              onChange={(e) => setLine(i, "amount", e.target.value)}
+            />
+            {lines.length > 1 && (
+              <button
+                type="button"
+                onClick={() => setLines((ls) => ls.filter((_, idx) => idx !== i))}
+                className="rounded-md px-2 text-navy-3 hover:text-terra"
+                aria-label="Remove line"
+              >
+                ×
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+      <button
+        type="button"
+        onClick={() => setLines((ls) => [...ls, { description: "", amount: "" }])}
+        className="mt-2 text-sm font-semibold text-gold hover:underline"
+      >
+        + Add line
+      </button>
+
+      <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div>
+          <label className={labelClass}>Discount (GHS)</label>
+          <input
+            className={fieldClass}
+            type="number"
+            step="0.01"
+            min="0"
+            value={discount}
+            onChange={(e) => setDiscount(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className={labelClass}>
+            Due date <span className="font-medium text-navy-3">— optional</span>
+          </label>
+          <input
+            className={fieldClass}
+            type="date"
+            value={dueAt}
+            onChange={(e) => setDueAt(e.target.value)}
+          />
+        </div>
+      </div>
+
+      <div className="mt-4 flex items-center justify-between border-t border-border pt-4">
+        <span className="text-sm text-navy-3">
+          Billed total:{" "}
+          <span className="font-display text-lg font-semibold text-navy">
+            GHS {Math.max(0, total).toFixed(2)}
+          </span>
+        </span>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            className="hover:bg-bg rounded-md px-3 py-2 text-sm font-semibold text-navy-2"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={saving}
+            className="text-bg rounded-md bg-navy px-5 py-2 text-sm font-semibold transition-colors hover:bg-navy-deep disabled:opacity-60"
+          >
+            {saving ? "Issuing…" : "Issue invoice"}
+          </button>
+        </div>
+      </div>
+      {error && <p className="mt-3 text-sm text-terra">{error}</p>}
+    </div>
+  );
+}

--- a/omnischools/components/fees/record-payment-form.tsx
+++ b/omnischools/components/fees/record-payment-form.tsx
@@ -1,0 +1,136 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { recordPayment } from "@/lib/actions/fees";
+
+const fieldClass =
+  "w-full rounded-md border border-border-2 bg-bg px-3.5 py-2.5 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
+const labelClass = "mb-1.5 block text-xs font-semibold text-navy-2";
+
+const METHODS = [
+  ["MTN_MOMO", "MTN MoMo"],
+  ["TELECEL_CASH", "Telecel Cash"],
+  ["AIRTELTIGO_MONEY", "AirtelTigo Money"],
+  ["CASH", "Cash"],
+  ["BANK_TRANSFER", "Bank transfer"],
+  ["CHEQUE", "Cheque"],
+  ["OTHER", "Other"],
+] as const;
+
+export function RecordPaymentForm({ studentId }: { studentId: string }) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [done, setDone] = useState<string | null>(null);
+
+  async function action(formData: FormData) {
+    setSaving(true);
+    setError(null);
+    const res = await recordPayment({
+      studentId,
+      method: formData.get("method"),
+      grossAmount: formData.get("grossAmount"),
+      methodReference: formData.get("methodReference"),
+    });
+    setSaving(false);
+    if (res.ok) {
+      setDone(res.receiptNumber);
+      router.refresh();
+    } else {
+      setError(res.error);
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => {
+          setOpen(true);
+          setDone(null);
+        }}
+        className="rounded-md bg-green px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+      >
+        Record payment
+      </button>
+    );
+  }
+
+  return (
+    <div className="bg-surface rounded-xl border border-border p-5">
+      {done ? (
+        <div className="flex items-center justify-between gap-4">
+          <p className="text-sm text-navy">
+            ✓ Payment recorded · receipt <span className="font-mono">{done}</span> ·
+            guardian notified by SMS.
+          </p>
+          <button
+            onClick={() => setOpen(false)}
+            className="hover:bg-bg rounded-md px-3 py-1.5 text-sm font-semibold text-navy-2"
+          >
+            Close
+          </button>
+        </div>
+      ) : (
+        <form action={action} className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div>
+              <label className={labelClass}>Amount (GHS)</label>
+              <input
+                name="grossAmount"
+                type="number"
+                step="0.01"
+                min="0"
+                required
+                className={fieldClass}
+              />
+            </div>
+            <div>
+              <label className={labelClass}>Method</label>
+              <select name="method" required defaultValue="" className={fieldClass}>
+                <option value="" disabled>
+                  Choose
+                </option>
+                {METHODS.map(([v, l]) => (
+                  <option key={v} value={v}>
+                    {l}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className={labelClass}>
+                Reference <span className="font-medium text-navy-3">— optional</span>
+              </label>
+              <input
+                name="methodReference"
+                placeholder="MoMo txn id"
+                className={fieldClass}
+              />
+            </div>
+          </div>
+          <p className="text-xs text-navy-3">
+            Auto-allocated oldest invoice first; any excess is held as credit.
+          </p>
+          {error && <p className="text-sm text-terra">{error}</p>}
+          <div className="flex items-center gap-3">
+            <button
+              type="submit"
+              disabled={saving}
+              className="text-bg rounded-md bg-navy px-5 py-2.5 text-sm font-semibold transition-colors hover:bg-navy-deep disabled:opacity-60"
+            >
+              {saving ? "Recording…" : "Record & receipt"}
+            </button>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              className="hover:bg-bg rounded-md px-3 py-2.5 text-sm font-semibold text-navy-2"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/omnischools/components/fees/void-payment-button.tsx
+++ b/omnischools/components/fees/void-payment-button.tsx
@@ -1,0 +1,45 @@
+"use client";
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { voidPayment } from "@/lib/actions/fees";
+
+export function VoidPaymentButton({ paymentId }: { paymentId: string }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [confirming, setConfirming] = useState(false);
+
+  function doVoid() {
+    startTransition(async () => {
+      await voidPayment({ paymentId });
+      router.refresh();
+    });
+  }
+
+  if (!confirming) {
+    return (
+      <button
+        onClick={() => setConfirming(true)}
+        className="text-xs font-semibold text-navy-3 hover:text-terra"
+      >
+        Void
+      </button>
+    );
+  }
+  return (
+    <span className="flex items-center gap-1.5 text-xs">
+      <button
+        onClick={doVoid}
+        disabled={pending}
+        className="font-semibold text-terra hover:underline disabled:opacity-50"
+      >
+        {pending ? "Voiding…" : "Confirm void"}
+      </button>
+      <button
+        onClick={() => setConfirming(false)}
+        className="text-navy-3 hover:text-navy"
+      >
+        cancel
+      </button>
+    </span>
+  );
+}

--- a/omnischools/components/students/new-student-form.tsx
+++ b/omnischools/components/students/new-student-form.tsx
@@ -1,0 +1,133 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { createStudent } from "@/lib/actions/students";
+
+const fieldClass =
+  "w-full rounded-md border border-border-2 bg-bg px-3.5 py-2.5 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
+const labelClass = "mb-1.5 block text-xs font-semibold text-navy-2";
+
+export function NewStudentForm() {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  async function action(formData: FormData) {
+    setSaving(true);
+    setError(null);
+    const res = await createStudent({
+      firstName: formData.get("firstName"),
+      lastName: formData.get("lastName"),
+      otherNames: formData.get("otherNames"),
+      sex: formData.get("sex"),
+      dateOfBirth: formData.get("dateOfBirth"),
+      classLabel: formData.get("classLabel"),
+      guardianName: formData.get("guardianName"),
+      guardianPhone: formData.get("guardianPhone"),
+      guardianRelation: formData.get("guardianRelation"),
+    });
+    setSaving(false);
+    if (res.ok) router.push(`/students/${res.studentId}`);
+    else setError(res.error);
+  }
+
+  return (
+    <form
+      action={action}
+      className="bg-surface space-y-5 rounded-xl border border-border p-6"
+    >
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div>
+          <label className={labelClass}>First name</label>
+          <input name="firstName" required className={fieldClass} />
+        </div>
+        <div>
+          <label className={labelClass}>Last name</label>
+          <input name="lastName" required className={fieldClass} />
+        </div>
+        <div>
+          <label className={labelClass}>
+            Other names <span className="font-medium text-navy-3">— optional</span>
+          </label>
+          <input name="otherNames" className={fieldClass} />
+        </div>
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div>
+          <label className={labelClass}>Sex</label>
+          <select name="sex" required defaultValue="" className={fieldClass}>
+            <option value="" disabled>
+              Choose
+            </option>
+            <option value="MALE">Male</option>
+            <option value="FEMALE">Female</option>
+          </select>
+        </div>
+        <div>
+          <label className={labelClass}>
+            Date of birth <span className="font-medium text-navy-3">— optional</span>
+          </label>
+          <input name="dateOfBirth" type="date" className={fieldClass} />
+        </div>
+        <div>
+          <label className={labelClass}>
+            Class <span className="font-medium text-navy-3">— optional</span>
+          </label>
+          <input name="classLabel" placeholder="e.g. JHS 1A" className={fieldClass} />
+        </div>
+      </div>
+
+      <div className="border-t border-border pt-5">
+        <h3 className="mb-3 font-display text-base font-semibold text-navy">
+          Primary guardian{" "}
+          <span className="text-sm font-normal text-navy-3">— optional</span>
+        </h3>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div>
+            <label className={labelClass}>Name</label>
+            <input name="guardianName" className={fieldClass} />
+          </div>
+          <div>
+            <label className={labelClass}>Phone</label>
+            <input
+              name="guardianPhone"
+              placeholder="024 000 0000"
+              className={fieldClass}
+            />
+          </div>
+          <div>
+            <label className={labelClass}>Relationship</label>
+            <select
+              name="guardianRelation"
+              defaultValue="GUARDIAN"
+              className={fieldClass}
+            >
+              <option value="MOTHER">Mother</option>
+              <option value="FATHER">Father</option>
+              <option value="GUARDIAN">Guardian</option>
+              <option value="OTHER">Other</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      {error && <p className="text-sm text-terra">{error}</p>}
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={saving}
+          className="text-bg rounded-md bg-navy px-5 py-2.5 text-sm font-semibold transition-colors hover:bg-navy-deep disabled:opacity-60"
+        >
+          {saving ? "Saving…" : "Create student"}
+        </button>
+        <button
+          type="button"
+          onClick={() => router.push("/students")}
+          className="hover:bg-bg rounded-md px-4 py-2.5 text-sm font-semibold text-navy-2"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/omnischools/db/migrations/0002_gorgeous_phantom_reporter.sql
+++ b/omnischools/db/migrations/0002_gorgeous_phantom_reporter.sql
@@ -1,0 +1,73 @@
+CREATE TYPE "public"."admission_status" AS ENUM('SUBMITTED', 'UNDER_REVIEW', 'ACCEPTED', 'REJECTED', 'WAITLISTED');--> statement-breakpoint
+CREATE TYPE "public"."guardian_relation" AS ENUM('MOTHER', 'FATHER', 'GUARDIAN', 'OTHER');--> statement-breakpoint
+CREATE TYPE "public"."sex" AS ENUM('MALE', 'FEMALE');--> statement-breakpoint
+CREATE TYPE "public"."student_status" AS ENUM('ACTIVE', 'INACTIVE', 'GRADUATED', 'WITHDRAWN', 'TRANSFERRED');--> statement-breakpoint
+CREATE TABLE "student_guardian" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"school_id" uuid NOT NULL,
+	"student_id" uuid NOT NULL,
+	"name" text NOT NULL,
+	"relationship" "guardian_relation" DEFAULT 'GUARDIAN' NOT NULL,
+	"phone" text NOT NULL,
+	"email" text,
+	"is_primary" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "students" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"school_id" uuid NOT NULL,
+	"student_code" text NOT NULL,
+	"first_name" text NOT NULL,
+	"last_name" text NOT NULL,
+	"other_names" text,
+	"sex" "sex" NOT NULL,
+	"date_of_birth" date,
+	"status" "student_status" DEFAULT 'ACTIVE' NOT NULL,
+	"current_class_label" text,
+	"enrolled_on" date,
+	"admission_application_id" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "uniq_student_code_per_school" UNIQUE("school_id","student_code")
+);
+--> statement-breakpoint
+CREATE TABLE "admission_application" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"school_id" uuid NOT NULL,
+	"applicant_first_name" text NOT NULL,
+	"applicant_last_name" text NOT NULL,
+	"applicant_other_names" text,
+	"sex" "sex" NOT NULL,
+	"date_of_birth" date,
+	"desired_class_label" text,
+	"guardian_name" text NOT NULL,
+	"guardian_phone" text NOT NULL,
+	"guardian_email" text,
+	"status" "admission_status" DEFAULT 'SUBMITTED' NOT NULL,
+	"notes" text,
+	"student_id" uuid,
+	"decided_by_user_id" uuid,
+	"submitted_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"decided_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "admission_document" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"school_id" uuid NOT NULL,
+	"application_id" uuid NOT NULL,
+	"label" text NOT NULL,
+	"file_key" text NOT NULL,
+	"uploaded_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "student_guardian" ADD CONSTRAINT "student_guardian_school_id_ref_school_id_fk" FOREIGN KEY ("school_id") REFERENCES "public"."ref_school"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "student_guardian" ADD CONSTRAINT "student_guardian_student_id_students_id_fk" FOREIGN KEY ("student_id") REFERENCES "public"."students"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "students" ADD CONSTRAINT "students_school_id_ref_school_id_fk" FOREIGN KEY ("school_id") REFERENCES "public"."ref_school"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "admission_application" ADD CONSTRAINT "admission_application_school_id_ref_school_id_fk" FOREIGN KEY ("school_id") REFERENCES "public"."ref_school"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "admission_application" ADD CONSTRAINT "admission_application_student_id_students_id_fk" FOREIGN KEY ("student_id") REFERENCES "public"."students"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "admission_application" ADD CONSTRAINT "admission_application_decided_by_user_id_ref_user_id_fk" FOREIGN KEY ("decided_by_user_id") REFERENCES "public"."ref_user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "admission_document" ADD CONSTRAINT "admission_document_school_id_ref_school_id_fk" FOREIGN KEY ("school_id") REFERENCES "public"."ref_school"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "admission_document" ADD CONSTRAINT "admission_document_application_id_admission_application_id_fk" FOREIGN KEY ("application_id") REFERENCES "public"."admission_application"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "guardian_student_idx" ON "student_guardian" USING btree ("student_id");--> statement-breakpoint
+CREATE INDEX "students_school_idx" ON "students" USING btree ("school_id");--> statement-breakpoint
+CREATE INDEX "admission_school_status_idx" ON "admission_application" USING btree ("school_id","status");

--- a/omnischools/db/migrations/0003_smart_wilson_fisk.sql
+++ b/omnischools/db/migrations/0003_smart_wilson_fisk.sql
@@ -1,0 +1,129 @@
+CREATE TYPE "public"."allocation_method" AS ENUM('MANUAL', 'AUTO_OLDEST_FIRST', 'AUTO_NEWEST_FIRST');--> statement-breakpoint
+CREATE TYPE "public"."allocation_type" AS ENUM('INVOICE', 'CREDIT', 'REFUND');--> statement-breakpoint
+CREATE TYPE "public"."invoice_status" AS ENUM('DRAFT', 'ISSUED', 'PARTIAL', 'PAID', 'OVERDUE', 'EXEMPT', 'VOIDED');--> statement-breakpoint
+CREATE TYPE "public"."payment_actor_type" AS ENUM('ADMIN', 'SYSTEM', 'WEBHOOK', 'RECONCILIATION_JOB');--> statement-breakpoint
+CREATE TYPE "public"."payment_event_type" AS ENUM('CREATED', 'ALLOCATION_ADDED', 'ALLOCATION_VOIDED', 'SETTLED', 'VOIDED', 'SMS_SENT', 'SMS_FAILED', 'REFUNDED', 'DISCOUNT_OVERRIDDEN');--> statement-breakpoint
+CREATE TYPE "public"."payment_method" AS ENUM('MTN_MOMO', 'TELECEL_CASH', 'AIRTELTIGO_MONEY', 'BANK_TRANSFER', 'CASH', 'CHEQUE', 'OTHER');--> statement-breakpoint
+CREATE TYPE "public"."settlement_status" AS ENUM('PENDING', 'CONFIRMED', 'SETTLED', 'RECONCILED', 'DISPUTED');--> statement-breakpoint
+CREATE TABLE "fee_category" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"school_id" uuid NOT NULL,
+	"name" text NOT NULL,
+	"active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "uniq_fee_category_per_school" UNIQUE("school_id","name")
+);
+--> statement-breakpoint
+CREATE TABLE "invoice_line_item" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"school_id" uuid NOT NULL,
+	"invoice_id" uuid NOT NULL,
+	"fee_category_id" uuid,
+	"description" text NOT NULL,
+	"amount" numeric(12, 2) NOT NULL,
+	"is_optional" boolean DEFAULT false NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "invoice" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"school_id" uuid NOT NULL,
+	"student_id" uuid NOT NULL,
+	"invoice_number" text NOT NULL,
+	"academic_year" text NOT NULL,
+	"period_id" uuid,
+	"subtotal_amount" numeric(12, 2) NOT NULL,
+	"discount_amount" numeric(12, 2) DEFAULT '0' NOT NULL,
+	"billed_amount" numeric(12, 2) NOT NULL,
+	"paid_amount" numeric(12, 2) DEFAULT '0' NOT NULL,
+	"balance_amount" numeric(12, 2) NOT NULL,
+	"status" "invoice_status" DEFAULT 'ISSUED' NOT NULL,
+	"issued_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"due_at" timestamp with time zone,
+	"paid_at" timestamp with time zone,
+	"voided_at" timestamp with time zone,
+	CONSTRAINT "uniq_invoice_number_per_school" UNIQUE("school_id","invoice_number")
+);
+--> statement-breakpoint
+CREATE TABLE "payment_allocation" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"school_id" uuid NOT NULL,
+	"payment_id" uuid NOT NULL,
+	"invoice_id" uuid,
+	"allocation_type" "allocation_type" DEFAULT 'INVOICE' NOT NULL,
+	"amount" numeric(12, 2) NOT NULL,
+	"allocation_method" "allocation_method" DEFAULT 'MANUAL' NOT NULL,
+	"allocated_by_user_id" uuid,
+	"allocated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"voided_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "payment_audit_log" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"school_id" uuid NOT NULL,
+	"payment_id" uuid,
+	"invoice_id" uuid,
+	"event_type" "payment_event_type" NOT NULL,
+	"actor_user_id" uuid,
+	"actor_type" "payment_actor_type" DEFAULT 'ADMIN' NOT NULL,
+	"before_state" jsonb,
+	"after_state" jsonb,
+	"notes" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "payment" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"school_id" uuid NOT NULL,
+	"student_id" uuid NOT NULL,
+	"recorded_by_user_id" uuid,
+	"gross_amount" numeric(12, 2) NOT NULL,
+	"fee_amount" numeric(12, 2) DEFAULT '0' NOT NULL,
+	"net_amount" numeric(12, 2) NOT NULL,
+	"currency" text DEFAULT 'GHS' NOT NULL,
+	"method" "payment_method" NOT NULL,
+	"method_reference" text,
+	"aggregator" text,
+	"settlement_status" "settlement_status" DEFAULT 'PENDING' NOT NULL,
+	"paid_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"recorded_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"voided_at" timestamp with time zone,
+	"voided_by_user_id" uuid
+);
+--> statement-breakpoint
+CREATE TABLE "receipt" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"school_id" uuid NOT NULL,
+	"payment_id" uuid NOT NULL,
+	"receipt_number" text NOT NULL,
+	"student_id" uuid NOT NULL,
+	"pdf_url" text,
+	"generated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"voided_at" timestamp with time zone,
+	"void_replacement_id" uuid,
+	CONSTRAINT "receipt_payment_id_unique" UNIQUE("payment_id"),
+	CONSTRAINT "uniq_receipt_number_per_school" UNIQUE("school_id","receipt_number")
+);
+--> statement-breakpoint
+ALTER TABLE "fee_category" ADD CONSTRAINT "fee_category_school_id_ref_school_id_fk" FOREIGN KEY ("school_id") REFERENCES "public"."ref_school"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "invoice_line_item" ADD CONSTRAINT "invoice_line_item_school_id_ref_school_id_fk" FOREIGN KEY ("school_id") REFERENCES "public"."ref_school"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "invoice_line_item" ADD CONSTRAINT "invoice_line_item_invoice_id_invoice_id_fk" FOREIGN KEY ("invoice_id") REFERENCES "public"."invoice"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "invoice_line_item" ADD CONSTRAINT "invoice_line_item_fee_category_id_fee_category_id_fk" FOREIGN KEY ("fee_category_id") REFERENCES "public"."fee_category"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "invoice" ADD CONSTRAINT "invoice_school_id_ref_school_id_fk" FOREIGN KEY ("school_id") REFERENCES "public"."ref_school"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "invoice" ADD CONSTRAINT "invoice_student_id_students_id_fk" FOREIGN KEY ("student_id") REFERENCES "public"."students"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "invoice" ADD CONSTRAINT "invoice_period_id_academic_period_period_id_fk" FOREIGN KEY ("period_id") REFERENCES "public"."academic_period"("period_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "payment_allocation" ADD CONSTRAINT "payment_allocation_school_id_ref_school_id_fk" FOREIGN KEY ("school_id") REFERENCES "public"."ref_school"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "payment_allocation" ADD CONSTRAINT "payment_allocation_payment_id_payment_id_fk" FOREIGN KEY ("payment_id") REFERENCES "public"."payment"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "payment_allocation" ADD CONSTRAINT "payment_allocation_invoice_id_invoice_id_fk" FOREIGN KEY ("invoice_id") REFERENCES "public"."invoice"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "payment_allocation" ADD CONSTRAINT "payment_allocation_allocated_by_user_id_ref_user_id_fk" FOREIGN KEY ("allocated_by_user_id") REFERENCES "public"."ref_user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "payment_audit_log" ADD CONSTRAINT "payment_audit_log_school_id_ref_school_id_fk" FOREIGN KEY ("school_id") REFERENCES "public"."ref_school"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "payment_audit_log" ADD CONSTRAINT "payment_audit_log_actor_user_id_ref_user_id_fk" FOREIGN KEY ("actor_user_id") REFERENCES "public"."ref_user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "payment" ADD CONSTRAINT "payment_school_id_ref_school_id_fk" FOREIGN KEY ("school_id") REFERENCES "public"."ref_school"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "payment" ADD CONSTRAINT "payment_student_id_students_id_fk" FOREIGN KEY ("student_id") REFERENCES "public"."students"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "payment" ADD CONSTRAINT "payment_recorded_by_user_id_ref_user_id_fk" FOREIGN KEY ("recorded_by_user_id") REFERENCES "public"."ref_user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "payment" ADD CONSTRAINT "payment_voided_by_user_id_ref_user_id_fk" FOREIGN KEY ("voided_by_user_id") REFERENCES "public"."ref_user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "receipt" ADD CONSTRAINT "receipt_school_id_ref_school_id_fk" FOREIGN KEY ("school_id") REFERENCES "public"."ref_school"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "receipt" ADD CONSTRAINT "receipt_payment_id_payment_id_fk" FOREIGN KEY ("payment_id") REFERENCES "public"."payment"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "receipt" ADD CONSTRAINT "receipt_student_id_students_id_fk" FOREIGN KEY ("student_id") REFERENCES "public"."students"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "invoice_student_idx" ON "invoice" USING btree ("student_id");--> statement-breakpoint
+CREATE INDEX "payment_audit_school_time_idx" ON "payment_audit_log" USING btree ("school_id","created_at");--> statement-breakpoint
+CREATE INDEX "payment_student_idx" ON "payment" USING btree ("student_id");

--- a/omnischools/db/migrations/meta/0002_snapshot.json
+++ b/omnischools/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,1701 @@
+{
+  "id": "a570e033-e042-419c-a7d2-a665bfcb7a2c",
+  "prevId": "aa9beb59-2b0e-4bd6-8730-31485858ce86",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ref_district": {
+      "name": "ref_district",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_district_region_id_ref_region_id_fk": {
+          "name": "ref_district_region_id_ref_region_id_fk",
+          "tableFrom": "ref_district",
+          "tableTo": "ref_region",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_district_code_unique": {
+          "name": "ref_district_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_region": {
+      "name": "ref_region",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_region_code_unique": {
+          "name": "ref_region_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_school_product": {
+      "name": "ref_school_product",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product": {
+          "name": "product",
+          "type": "product",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_school_product_school_id_ref_school_id_fk": {
+          "name": "ref_school_product_school_id_ref_school_id_fk",
+          "tableFrom": "ref_school_product",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_school_product": {
+          "name": "uniq_school_product",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "product"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_school": {
+      "name": "ref_school",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ges_code": {
+          "name": "ges_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_type": {
+          "name": "school_type",
+          "type": "school_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'BASIC'"
+        },
+        "shs_category": {
+          "name": "shs_category",
+          "type": "shs_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownership_type": {
+          "name": "ownership_type",
+          "type": "ownership_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRIVATE'"
+        },
+        "district_id": {
+          "name": "district_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_school_district_id_ref_district_id_fk": {
+          "name": "ref_school_district_id_ref_district_id_fk",
+          "tableFrom": "ref_school",
+          "tableTo": "ref_district",
+          "columnsFrom": [
+            "district_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ref_school_region_id_ref_region_id_fk": {
+          "name": "ref_school_region_id_ref_region_id_fk",
+          "tableFrom": "ref_school",
+          "tableTo": "ref_region",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_school_ges_code_unique": {
+          "name": "ref_school_ges_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "ges_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_assignment": {
+      "name": "role_assignment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_ref": {
+          "name": "scope_ref",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_assignment_user_id_ref_user_id_fk": {
+          "name": "role_assignment_user_id_ref_user_id_fk",
+          "tableFrom": "role_assignment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_assignment_school_id_ref_school_id_fk": {
+          "name": "role_assignment_school_id_ref_school_id_fk",
+          "tableFrom": "role_assignment",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_assignment_role_id_ref_role_id_fk": {
+          "name": "role_assignment_role_id_ref_role_id_fk",
+          "tableFrom": "role_assignment",
+          "tableTo": "ref_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_role": {
+      "name": "ref_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "app_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_role_code_unique": {
+          "name": "ref_role_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_user": {
+      "name": "ref_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_user_phone_unique": {
+          "name": "ref_user_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.academic_period": {
+      "name": "academic_period",
+      "schema": "",
+      "columns": {
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_number": {
+          "name": "period_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_label": {
+          "name": "period_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_on": {
+          "name": "ends_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "academic_period_school_id_academic_year_ref_academic_period_config_school_id_academic_year_fk": {
+          "name": "academic_period_school_id_academic_year_ref_academic_period_config_school_id_academic_year_fk",
+          "tableFrom": "academic_period",
+          "tableTo": "ref_academic_period_config",
+          "columnsFrom": [
+            "school_id",
+            "academic_year"
+          ],
+          "columnsTo": [
+            "school_id",
+            "academic_year"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_academic_period_config": {
+      "name": "ref_academic_period_config",
+      "schema": "",
+      "columns": {
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_type": {
+          "name": "period_type",
+          "type": "period_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_count": {
+          "name": "period_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "period_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured_at": {
+          "name": "configured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "configured_by": {
+          "name": "configured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_academic_period_config_school_id_ref_school_id_fk": {
+          "name": "ref_academic_period_config_school_id_ref_school_id_fk",
+          "tableFrom": "ref_academic_period_config",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ref_academic_period_config_configured_by_ref_user_id_fk": {
+          "name": "ref_academic_period_config_configured_by_ref_user_id_fk",
+          "tableFrom": "ref_academic_period_config",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "configured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ref_academic_period_config_school_id_academic_year_pk": {
+          "name": "ref_academic_period_config_school_id_academic_year_pk",
+          "columns": [
+            "school_id",
+            "academic_year"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gen_period_defaults": {
+      "name": "gen_period_defaults",
+      "schema": "",
+      "columns": {
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_line": {
+          "name": "product_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_number": {
+          "name": "period_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_label": {
+          "name": "period_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_on": {
+          "name": "ends_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_at": {
+          "name": "extracted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gen_period_defaults_reviewed_by_ref_user_id_fk": {
+          "name": "gen_period_defaults_reviewed_by_ref_user_id_fk",
+          "tableFrom": "gen_period_defaults",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gen_period_defaults_academic_year_product_line_period_number_pk": {
+          "name": "gen_period_defaults_academic_year_product_line_period_number_pk",
+          "columns": [
+            "academic_year",
+            "product_line",
+            "period_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "audit_id": {
+          "name": "audit_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_role": {
+          "name": "actor_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before_jsonb": {
+          "name": "before_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_jsonb": {
+          "name": "after_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_school_time_idx": {
+          "name": "audit_school_time_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_entity_idx": {
+          "name": "audit_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_school_id_ref_school_id_fk": {
+          "name": "audit_log_school_id_ref_school_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_log_actor_user_id_ref_user_id_fk": {
+          "name": "audit_log_actor_user_id_ref_user_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_anomaly_rule": {
+      "name": "ref_anomaly_rule",
+      "schema": "",
+      "columns": {
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_code": {
+          "name": "rule_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "anomaly_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applies_to": {
+          "name": "applies_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold_jsonb": {
+          "name": "threshold_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_anomaly_rule_rule_code_unique": {
+          "name": "ref_anomaly_rule_rule_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rule_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.marketing_lead": {
+      "name": "marketing_lead",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organisation": {
+          "name": "organisation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'demo_form'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_guardian": {
+      "name": "student_guardian",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "guardian_relation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GUARDIAN'"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "guardian_student_idx": {
+          "name": "guardian_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_guardian_school_id_ref_school_id_fk": {
+          "name": "student_guardian_school_id_ref_school_id_fk",
+          "tableFrom": "student_guardian",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_guardian_student_id_students_id_fk": {
+          "name": "student_guardian_student_id_students_id_fk",
+          "tableFrom": "student_guardian",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.students": {
+      "name": "students",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_code": {
+          "name": "student_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "other_names": {
+          "name": "other_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "student_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "current_class_label": {
+          "name": "current_class_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrolled_on": {
+          "name": "enrolled_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admission_application_id": {
+          "name": "admission_application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "students_school_idx": {
+          "name": "students_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "students_school_id_ref_school_id_fk": {
+          "name": "students_school_id_ref_school_id_fk",
+          "tableFrom": "students",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_student_code_per_school": {
+          "name": "uniq_student_code_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admission_application": {
+      "name": "admission_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_first_name": {
+          "name": "applicant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_last_name": {
+          "name": "applicant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_other_names": {
+          "name": "applicant_other_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desired_class_label": {
+          "name": "desired_class_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guardian_name": {
+          "name": "guardian_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guardian_phone": {
+          "name": "guardian_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guardian_email": {
+          "name": "guardian_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "admission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SUBMITTED'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admission_school_status_idx": {
+          "name": "admission_school_status_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admission_application_school_id_ref_school_id_fk": {
+          "name": "admission_application_school_id_ref_school_id_fk",
+          "tableFrom": "admission_application",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admission_application_student_id_students_id_fk": {
+          "name": "admission_application_student_id_students_id_fk",
+          "tableFrom": "admission_application",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "admission_application_decided_by_user_id_ref_user_id_fk": {
+          "name": "admission_application_decided_by_user_id_ref_user_id_fk",
+          "tableFrom": "admission_application",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admission_document": {
+      "name": "admission_document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admission_document_school_id_ref_school_id_fk": {
+          "name": "admission_document_school_id_ref_school_id_fk",
+          "tableFrom": "admission_document",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admission_document_application_id_admission_application_id_fk": {
+          "name": "admission_document_application_id_admission_application_id_fk",
+          "tableFrom": "admission_document",
+          "tableTo": "admission_application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.admission_status": {
+      "name": "admission_status",
+      "schema": "public",
+      "values": [
+        "SUBMITTED",
+        "UNDER_REVIEW",
+        "ACCEPTED",
+        "REJECTED",
+        "WAITLISTED"
+      ]
+    },
+    "public.anomaly_severity": {
+      "name": "anomaly_severity",
+      "schema": "public",
+      "values": [
+        "LOW",
+        "MEDIUM",
+        "HIGH"
+      ]
+    },
+    "public.app_role": {
+      "name": "app_role",
+      "schema": "public",
+      "values": [
+        "ADMIN",
+        "HEADMASTER",
+        "VICE_HEADMASTER_ACADEMIC",
+        "TEACHER",
+        "FORM_MASTER",
+        "HOUSEMASTER",
+        "STUDENT",
+        "PARENT",
+        "BURSAR",
+        "DEAN_OF_BOARDING",
+        "MATRON"
+      ]
+    },
+    "public.guardian_relation": {
+      "name": "guardian_relation",
+      "schema": "public",
+      "values": [
+        "MOTHER",
+        "FATHER",
+        "GUARDIAN",
+        "OTHER"
+      ]
+    },
+    "public.ownership_type": {
+      "name": "ownership_type",
+      "schema": "public",
+      "values": [
+        "PUBLIC",
+        "PRIVATE",
+        "MISSION",
+        "INTERNATIONAL"
+      ]
+    },
+    "public.period_source": {
+      "name": "period_source",
+      "schema": "public",
+      "values": [
+        "GES_DEFAULT",
+        "SCHOOL_OVERRIDE"
+      ]
+    },
+    "public.period_type": {
+      "name": "period_type",
+      "schema": "public",
+      "values": [
+        "TERM",
+        "SEMESTER"
+      ]
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "public",
+      "values": [
+        "BASIC",
+        "SENIOR",
+        "OVERSIGHT"
+      ]
+    },
+    "public.school_type": {
+      "name": "school_type",
+      "schema": "public",
+      "values": [
+        "BASIC",
+        "SENIOR",
+        "COMBINED"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "MALE",
+        "FEMALE"
+      ]
+    },
+    "public.shs_category": {
+      "name": "shs_category",
+      "schema": "public",
+      "values": [
+        "A",
+        "B",
+        "C",
+        "D",
+        "E",
+        "F"
+      ]
+    },
+    "public.student_status": {
+      "name": "student_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "INACTIVE",
+        "GRADUATED",
+        "WITHDRAWN",
+        "TRANSFERRED"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/omnischools/db/migrations/meta/0003_snapshot.json
+++ b/omnischools/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,2703 @@
+{
+  "id": "4b2d2f0d-83c5-47d8-9b59-d03914ad3407",
+  "prevId": "a570e033-e042-419c-a7d2-a665bfcb7a2c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ref_district": {
+      "name": "ref_district",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_district_region_id_ref_region_id_fk": {
+          "name": "ref_district_region_id_ref_region_id_fk",
+          "tableFrom": "ref_district",
+          "tableTo": "ref_region",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_district_code_unique": {
+          "name": "ref_district_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_region": {
+      "name": "ref_region",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_region_code_unique": {
+          "name": "ref_region_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_school_product": {
+      "name": "ref_school_product",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product": {
+          "name": "product",
+          "type": "product",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_school_product_school_id_ref_school_id_fk": {
+          "name": "ref_school_product_school_id_ref_school_id_fk",
+          "tableFrom": "ref_school_product",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_school_product": {
+          "name": "uniq_school_product",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "product"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_school": {
+      "name": "ref_school",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ges_code": {
+          "name": "ges_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_type": {
+          "name": "school_type",
+          "type": "school_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'BASIC'"
+        },
+        "shs_category": {
+          "name": "shs_category",
+          "type": "shs_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownership_type": {
+          "name": "ownership_type",
+          "type": "ownership_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRIVATE'"
+        },
+        "district_id": {
+          "name": "district_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_school_district_id_ref_district_id_fk": {
+          "name": "ref_school_district_id_ref_district_id_fk",
+          "tableFrom": "ref_school",
+          "tableTo": "ref_district",
+          "columnsFrom": [
+            "district_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ref_school_region_id_ref_region_id_fk": {
+          "name": "ref_school_region_id_ref_region_id_fk",
+          "tableFrom": "ref_school",
+          "tableTo": "ref_region",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_school_ges_code_unique": {
+          "name": "ref_school_ges_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "ges_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_assignment": {
+      "name": "role_assignment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_ref": {
+          "name": "scope_ref",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_assignment_user_id_ref_user_id_fk": {
+          "name": "role_assignment_user_id_ref_user_id_fk",
+          "tableFrom": "role_assignment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_assignment_school_id_ref_school_id_fk": {
+          "name": "role_assignment_school_id_ref_school_id_fk",
+          "tableFrom": "role_assignment",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_assignment_role_id_ref_role_id_fk": {
+          "name": "role_assignment_role_id_ref_role_id_fk",
+          "tableFrom": "role_assignment",
+          "tableTo": "ref_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_role": {
+      "name": "ref_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "app_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_role_code_unique": {
+          "name": "ref_role_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_user": {
+      "name": "ref_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_user_phone_unique": {
+          "name": "ref_user_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.academic_period": {
+      "name": "academic_period",
+      "schema": "",
+      "columns": {
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_number": {
+          "name": "period_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_label": {
+          "name": "period_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_on": {
+          "name": "ends_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "academic_period_school_id_academic_year_ref_academic_period_config_school_id_academic_year_fk": {
+          "name": "academic_period_school_id_academic_year_ref_academic_period_config_school_id_academic_year_fk",
+          "tableFrom": "academic_period",
+          "tableTo": "ref_academic_period_config",
+          "columnsFrom": [
+            "school_id",
+            "academic_year"
+          ],
+          "columnsTo": [
+            "school_id",
+            "academic_year"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_academic_period_config": {
+      "name": "ref_academic_period_config",
+      "schema": "",
+      "columns": {
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_type": {
+          "name": "period_type",
+          "type": "period_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_count": {
+          "name": "period_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "period_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured_at": {
+          "name": "configured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "configured_by": {
+          "name": "configured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_academic_period_config_school_id_ref_school_id_fk": {
+          "name": "ref_academic_period_config_school_id_ref_school_id_fk",
+          "tableFrom": "ref_academic_period_config",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ref_academic_period_config_configured_by_ref_user_id_fk": {
+          "name": "ref_academic_period_config_configured_by_ref_user_id_fk",
+          "tableFrom": "ref_academic_period_config",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "configured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ref_academic_period_config_school_id_academic_year_pk": {
+          "name": "ref_academic_period_config_school_id_academic_year_pk",
+          "columns": [
+            "school_id",
+            "academic_year"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gen_period_defaults": {
+      "name": "gen_period_defaults",
+      "schema": "",
+      "columns": {
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_line": {
+          "name": "product_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_number": {
+          "name": "period_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_label": {
+          "name": "period_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_on": {
+          "name": "ends_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_at": {
+          "name": "extracted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gen_period_defaults_reviewed_by_ref_user_id_fk": {
+          "name": "gen_period_defaults_reviewed_by_ref_user_id_fk",
+          "tableFrom": "gen_period_defaults",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gen_period_defaults_academic_year_product_line_period_number_pk": {
+          "name": "gen_period_defaults_academic_year_product_line_period_number_pk",
+          "columns": [
+            "academic_year",
+            "product_line",
+            "period_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "audit_id": {
+          "name": "audit_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_role": {
+          "name": "actor_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before_jsonb": {
+          "name": "before_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_jsonb": {
+          "name": "after_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_school_time_idx": {
+          "name": "audit_school_time_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_entity_idx": {
+          "name": "audit_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_school_id_ref_school_id_fk": {
+          "name": "audit_log_school_id_ref_school_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_log_actor_user_id_ref_user_id_fk": {
+          "name": "audit_log_actor_user_id_ref_user_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_anomaly_rule": {
+      "name": "ref_anomaly_rule",
+      "schema": "",
+      "columns": {
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_code": {
+          "name": "rule_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "anomaly_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applies_to": {
+          "name": "applies_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold_jsonb": {
+          "name": "threshold_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_anomaly_rule_rule_code_unique": {
+          "name": "ref_anomaly_rule_rule_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rule_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.marketing_lead": {
+      "name": "marketing_lead",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organisation": {
+          "name": "organisation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'demo_form'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_guardian": {
+      "name": "student_guardian",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "guardian_relation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GUARDIAN'"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "guardian_student_idx": {
+          "name": "guardian_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_guardian_school_id_ref_school_id_fk": {
+          "name": "student_guardian_school_id_ref_school_id_fk",
+          "tableFrom": "student_guardian",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_guardian_student_id_students_id_fk": {
+          "name": "student_guardian_student_id_students_id_fk",
+          "tableFrom": "student_guardian",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.students": {
+      "name": "students",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_code": {
+          "name": "student_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "other_names": {
+          "name": "other_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "student_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "current_class_label": {
+          "name": "current_class_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrolled_on": {
+          "name": "enrolled_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admission_application_id": {
+          "name": "admission_application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "students_school_idx": {
+          "name": "students_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "students_school_id_ref_school_id_fk": {
+          "name": "students_school_id_ref_school_id_fk",
+          "tableFrom": "students",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_student_code_per_school": {
+          "name": "uniq_student_code_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admission_application": {
+      "name": "admission_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_first_name": {
+          "name": "applicant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_last_name": {
+          "name": "applicant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_other_names": {
+          "name": "applicant_other_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desired_class_label": {
+          "name": "desired_class_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guardian_name": {
+          "name": "guardian_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guardian_phone": {
+          "name": "guardian_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guardian_email": {
+          "name": "guardian_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "admission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SUBMITTED'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admission_school_status_idx": {
+          "name": "admission_school_status_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admission_application_school_id_ref_school_id_fk": {
+          "name": "admission_application_school_id_ref_school_id_fk",
+          "tableFrom": "admission_application",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admission_application_student_id_students_id_fk": {
+          "name": "admission_application_student_id_students_id_fk",
+          "tableFrom": "admission_application",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "admission_application_decided_by_user_id_ref_user_id_fk": {
+          "name": "admission_application_decided_by_user_id_ref_user_id_fk",
+          "tableFrom": "admission_application",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admission_document": {
+      "name": "admission_document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admission_document_school_id_ref_school_id_fk": {
+          "name": "admission_document_school_id_ref_school_id_fk",
+          "tableFrom": "admission_document",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admission_document_application_id_admission_application_id_fk": {
+          "name": "admission_document_application_id_admission_application_id_fk",
+          "tableFrom": "admission_document",
+          "tableTo": "admission_application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_category": {
+      "name": "fee_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_category_school_id_ref_school_id_fk": {
+          "name": "fee_category_school_id_ref_school_id_fk",
+          "tableFrom": "fee_category",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_fee_category_per_school": {
+          "name": "uniq_fee_category_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_line_item": {
+      "name": "invoice_line_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_category_id": {
+          "name": "fee_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_optional": {
+          "name": "is_optional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_line_item_school_id_ref_school_id_fk": {
+          "name": "invoice_line_item_school_id_ref_school_id_fk",
+          "tableFrom": "invoice_line_item",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_line_item_invoice_id_invoice_id_fk": {
+          "name": "invoice_line_item_invoice_id_invoice_id_fk",
+          "tableFrom": "invoice_line_item",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_line_item_fee_category_id_fee_category_id_fk": {
+          "name": "invoice_line_item_fee_category_id_fee_category_id_fk",
+          "tableFrom": "invoice_line_item",
+          "tableTo": "fee_category",
+          "columnsFrom": [
+            "fee_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice": {
+      "name": "invoice",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal_amount": {
+          "name": "subtotal_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "billed_amount": {
+          "name": "billed_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "balance_amount": {
+          "name": "balance_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ISSUED'"
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_student_idx": {
+          "name": "invoice_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_school_id_ref_school_id_fk": {
+          "name": "invoice_school_id_ref_school_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_student_id_students_id_fk": {
+          "name": "invoice_student_id_students_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_period_id_academic_period_period_id_fk": {
+          "name": "invoice_period_id_academic_period_period_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "period_id"
+          ],
+          "columnsTo": [
+            "period_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_invoice_number_per_school": {
+          "name": "uniq_invoice_number_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "invoice_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_allocation": {
+      "name": "payment_allocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allocation_type": {
+          "name": "allocation_type",
+          "type": "allocation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INVOICE'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allocation_method": {
+          "name": "allocation_method",
+          "type": "allocation_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MANUAL'"
+        },
+        "allocated_by_user_id": {
+          "name": "allocated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allocated_at": {
+          "name": "allocated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payment_allocation_school_id_ref_school_id_fk": {
+          "name": "payment_allocation_school_id_ref_school_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_allocation_payment_id_payment_id_fk": {
+          "name": "payment_allocation_payment_id_payment_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "payment",
+          "columnsFrom": [
+            "payment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_allocation_invoice_id_invoice_id_fk": {
+          "name": "payment_allocation_invoice_id_invoice_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_allocation_allocated_by_user_id_ref_user_id_fk": {
+          "name": "payment_allocation_allocated_by_user_id_ref_user_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "allocated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_audit_log": {
+      "name": "payment_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "payment_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "payment_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ADMIN'"
+        },
+        "before_state": {
+          "name": "before_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_state": {
+          "name": "after_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_audit_school_time_idx": {
+          "name": "payment_audit_school_time_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_audit_log_school_id_ref_school_id_fk": {
+          "name": "payment_audit_log_school_id_ref_school_id_fk",
+          "tableFrom": "payment_audit_log",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_audit_log_actor_user_id_ref_user_id_fk": {
+          "name": "payment_audit_log_actor_user_id_ref_user_id_fk",
+          "tableFrom": "payment_audit_log",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment": {
+      "name": "payment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gross_amount": {
+          "name": "gross_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_amount": {
+          "name": "fee_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "net_amount": {
+          "name": "net_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GHS'"
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method_reference": {
+          "name": "method_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregator": {
+          "name": "aggregator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settlement_status": {
+          "name": "settlement_status",
+          "type": "settlement_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_by_user_id": {
+          "name": "voided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payment_student_idx": {
+          "name": "payment_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_school_id_ref_school_id_fk": {
+          "name": "payment_school_id_ref_school_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_student_id_students_id_fk": {
+          "name": "payment_student_id_students_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_recorded_by_user_id_ref_user_id_fk": {
+          "name": "payment_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_voided_by_user_id_ref_user_id_fk": {
+          "name": "payment_voided_by_user_id_ref_user_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "voided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.receipt": {
+      "name": "receipt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receipt_number": {
+          "name": "receipt_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_replacement_id": {
+          "name": "void_replacement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "receipt_school_id_ref_school_id_fk": {
+          "name": "receipt_school_id_ref_school_id_fk",
+          "tableFrom": "receipt",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "receipt_payment_id_payment_id_fk": {
+          "name": "receipt_payment_id_payment_id_fk",
+          "tableFrom": "receipt",
+          "tableTo": "payment",
+          "columnsFrom": [
+            "payment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "receipt_student_id_students_id_fk": {
+          "name": "receipt_student_id_students_id_fk",
+          "tableFrom": "receipt",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "receipt_payment_id_unique": {
+          "name": "receipt_payment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "payment_id"
+          ]
+        },
+        "uniq_receipt_number_per_school": {
+          "name": "uniq_receipt_number_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "receipt_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.admission_status": {
+      "name": "admission_status",
+      "schema": "public",
+      "values": [
+        "SUBMITTED",
+        "UNDER_REVIEW",
+        "ACCEPTED",
+        "REJECTED",
+        "WAITLISTED"
+      ]
+    },
+    "public.allocation_method": {
+      "name": "allocation_method",
+      "schema": "public",
+      "values": [
+        "MANUAL",
+        "AUTO_OLDEST_FIRST",
+        "AUTO_NEWEST_FIRST"
+      ]
+    },
+    "public.allocation_type": {
+      "name": "allocation_type",
+      "schema": "public",
+      "values": [
+        "INVOICE",
+        "CREDIT",
+        "REFUND"
+      ]
+    },
+    "public.anomaly_severity": {
+      "name": "anomaly_severity",
+      "schema": "public",
+      "values": [
+        "LOW",
+        "MEDIUM",
+        "HIGH"
+      ]
+    },
+    "public.app_role": {
+      "name": "app_role",
+      "schema": "public",
+      "values": [
+        "ADMIN",
+        "HEADMASTER",
+        "VICE_HEADMASTER_ACADEMIC",
+        "TEACHER",
+        "FORM_MASTER",
+        "HOUSEMASTER",
+        "STUDENT",
+        "PARENT",
+        "BURSAR",
+        "DEAN_OF_BOARDING",
+        "MATRON"
+      ]
+    },
+    "public.guardian_relation": {
+      "name": "guardian_relation",
+      "schema": "public",
+      "values": [
+        "MOTHER",
+        "FATHER",
+        "GUARDIAN",
+        "OTHER"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "ISSUED",
+        "PARTIAL",
+        "PAID",
+        "OVERDUE",
+        "EXEMPT",
+        "VOIDED"
+      ]
+    },
+    "public.ownership_type": {
+      "name": "ownership_type",
+      "schema": "public",
+      "values": [
+        "PUBLIC",
+        "PRIVATE",
+        "MISSION",
+        "INTERNATIONAL"
+      ]
+    },
+    "public.payment_actor_type": {
+      "name": "payment_actor_type",
+      "schema": "public",
+      "values": [
+        "ADMIN",
+        "SYSTEM",
+        "WEBHOOK",
+        "RECONCILIATION_JOB"
+      ]
+    },
+    "public.payment_event_type": {
+      "name": "payment_event_type",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "ALLOCATION_ADDED",
+        "ALLOCATION_VOIDED",
+        "SETTLED",
+        "VOIDED",
+        "SMS_SENT",
+        "SMS_FAILED",
+        "REFUNDED",
+        "DISCOUNT_OVERRIDDEN"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "MTN_MOMO",
+        "TELECEL_CASH",
+        "AIRTELTIGO_MONEY",
+        "BANK_TRANSFER",
+        "CASH",
+        "CHEQUE",
+        "OTHER"
+      ]
+    },
+    "public.period_source": {
+      "name": "period_source",
+      "schema": "public",
+      "values": [
+        "GES_DEFAULT",
+        "SCHOOL_OVERRIDE"
+      ]
+    },
+    "public.period_type": {
+      "name": "period_type",
+      "schema": "public",
+      "values": [
+        "TERM",
+        "SEMESTER"
+      ]
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "public",
+      "values": [
+        "BASIC",
+        "SENIOR",
+        "OVERSIGHT"
+      ]
+    },
+    "public.school_type": {
+      "name": "school_type",
+      "schema": "public",
+      "values": [
+        "BASIC",
+        "SENIOR",
+        "COMBINED"
+      ]
+    },
+    "public.settlement_status": {
+      "name": "settlement_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "CONFIRMED",
+        "SETTLED",
+        "RECONCILED",
+        "DISPUTED"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "MALE",
+        "FEMALE"
+      ]
+    },
+    "public.shs_category": {
+      "name": "shs_category",
+      "schema": "public",
+      "values": [
+        "A",
+        "B",
+        "C",
+        "D",
+        "E",
+        "F"
+      ]
+    },
+    "public.student_status": {
+      "name": "student_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "INACTIVE",
+        "GRADUATED",
+        "WITHDRAWN",
+        "TRANSFERRED"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/omnischools/db/migrations/meta/_journal.json
+++ b/omnischools/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1780471647143,
       "tag": "0001_spotty_loa",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1780472599954,
+      "tag": "0002_gorgeous_phantom_reporter",
+      "breakpoints": true
     }
   ]
 }

--- a/omnischools/db/migrations/meta/_journal.json
+++ b/omnischools/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1780472599954,
       "tag": "0002_gorgeous_phantom_reporter",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1780510365209,
+      "tag": "0003_smart_wilson_fisk",
+      "breakpoints": true
     }
   ]
 }

--- a/omnischools/db/schema/_enums.ts
+++ b/omnischools/db/schema/_enums.ts
@@ -37,3 +37,26 @@ export const periodSourceEnum = pgEnum("period_source", [
 
 // Anomaly engine
 export const anomalySeverityEnum = pgEnum("anomaly_severity", ["LOW", "MEDIUM", "HIGH"]);
+
+// Students & admissions
+export const sexEnum = pgEnum("sex", ["MALE", "FEMALE"]);
+export const studentStatusEnum = pgEnum("student_status", [
+  "ACTIVE",
+  "INACTIVE",
+  "GRADUATED",
+  "WITHDRAWN",
+  "TRANSFERRED",
+]);
+export const guardianRelationEnum = pgEnum("guardian_relation", [
+  "MOTHER",
+  "FATHER",
+  "GUARDIAN",
+  "OTHER",
+]);
+export const admissionStatusEnum = pgEnum("admission_status", [
+  "SUBMITTED",
+  "UNDER_REVIEW",
+  "ACCEPTED",
+  "REJECTED",
+  "WAITLISTED",
+]);

--- a/omnischools/db/schema/_enums.ts
+++ b/omnischools/db/schema/_enums.ts
@@ -60,3 +60,57 @@ export const admissionStatusEnum = pgEnum("admission_status", [
   "REJECTED",
   "WAITLISTED",
 ]);
+
+// Fees & payments (schoolup-payment-data-model)
+export const invoiceStatusEnum = pgEnum("invoice_status", [
+  "DRAFT",
+  "ISSUED",
+  "PARTIAL",
+  "PAID",
+  "OVERDUE",
+  "EXEMPT",
+  "VOIDED",
+]);
+export const paymentMethodEnum = pgEnum("payment_method", [
+  "MTN_MOMO",
+  "TELECEL_CASH",
+  "AIRTELTIGO_MONEY",
+  "BANK_TRANSFER",
+  "CASH",
+  "CHEQUE",
+  "OTHER",
+]);
+export const settlementStatusEnum = pgEnum("settlement_status", [
+  "PENDING",
+  "CONFIRMED",
+  "SETTLED",
+  "RECONCILED",
+  "DISPUTED",
+]);
+export const allocationTypeEnum = pgEnum("allocation_type", [
+  "INVOICE",
+  "CREDIT",
+  "REFUND",
+]);
+export const allocationMethodEnum = pgEnum("allocation_method", [
+  "MANUAL",
+  "AUTO_OLDEST_FIRST",
+  "AUTO_NEWEST_FIRST",
+]);
+export const paymentEventTypeEnum = pgEnum("payment_event_type", [
+  "CREATED",
+  "ALLOCATION_ADDED",
+  "ALLOCATION_VOIDED",
+  "SETTLED",
+  "VOIDED",
+  "SMS_SENT",
+  "SMS_FAILED",
+  "REFUNDED",
+  "DISCOUNT_OVERRIDDEN",
+]);
+export const paymentActorTypeEnum = pgEnum("payment_actor_type", [
+  "ADMIN",
+  "SYSTEM",
+  "WEBHOOK",
+  "RECONCILIATION_JOB",
+]);

--- a/omnischools/db/schema/admissions.ts
+++ b/omnischools/db/schema/admissions.ts
@@ -1,0 +1,48 @@
+import { pgTable, uuid, text, date, timestamp, index } from "drizzle-orm/pg-core";
+import { sexEnum, admissionStatusEnum } from "./_enums";
+import { schools } from "./tenancy";
+import { users } from "./identity";
+import { students } from "./students";
+
+/** A prospective student's application. On ACCEPT it produces a `students` row. */
+export const admissionApplications = pgTable(
+  "admission_application",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    schoolId: uuid("school_id")
+      .notNull()
+      .references(() => schools.id, { onDelete: "cascade" }),
+    applicantFirstName: text("applicant_first_name").notNull(),
+    applicantLastName: text("applicant_last_name").notNull(),
+    applicantOtherNames: text("applicant_other_names"),
+    sex: sexEnum("sex").notNull(),
+    dateOfBirth: date("date_of_birth"),
+    desiredClassLabel: text("desired_class_label"),
+    guardianName: text("guardian_name").notNull(),
+    guardianPhone: text("guardian_phone").notNull(),
+    guardianEmail: text("guardian_email"),
+    status: admissionStatusEnum("status").notNull().default("SUBMITTED"),
+    notes: text("notes"),
+    studentId: uuid("student_id").references(() => students.id), // set on ACCEPT
+    decidedByUserId: uuid("decided_by_user_id").references(() => users.id),
+    submittedAt: timestamp("submitted_at", { withTimezone: true }).notNull().defaultNow(),
+    decidedAt: timestamp("decided_at", { withTimezone: true }),
+  },
+  (t) => ({
+    bySchoolStatus: index("admission_school_status_idx").on(t.schoolId, t.status),
+  }),
+);
+
+/** Uploaded supporting documents (metadata; files live in Supabase Storage). */
+export const admissionDocuments = pgTable("admission_document", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  schoolId: uuid("school_id")
+    .notNull()
+    .references(() => schools.id, { onDelete: "cascade" }),
+  applicationId: uuid("application_id")
+    .notNull()
+    .references(() => admissionApplications.id, { onDelete: "cascade" }),
+  label: text("label").notNull(),
+  fileKey: text("file_key").notNull(), // storage object key
+  uploadedAt: timestamp("uploaded_at", { withTimezone: true }).notNull().defaultNow(),
+});

--- a/omnischools/db/schema/fees.ts
+++ b/omnischools/db/schema/fees.ts
@@ -1,0 +1,183 @@
+import {
+  pgTable,
+  uuid,
+  text,
+  numeric,
+  boolean,
+  jsonb,
+  timestamp,
+  unique,
+  index,
+} from "drizzle-orm/pg-core";
+import {
+  invoiceStatusEnum,
+  paymentMethodEnum,
+  settlementStatusEnum,
+  allocationTypeEnum,
+  allocationMethodEnum,
+  paymentEventTypeEnum,
+  paymentActorTypeEnum,
+} from "./_enums";
+import { schools } from "./tenancy";
+import { students } from "./students";
+import { users } from "./identity";
+import { academicPeriod } from "./periods";
+
+const money = (name: string) => numeric(name, { precision: 12, scale: 2 });
+
+/** Fee categories (Tuition, Books, Transport, ...) — per school. */
+export const feeCategories = pgTable(
+  "fee_category",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    schoolId: uuid("school_id")
+      .notNull()
+      .references(() => schools.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    active: boolean("active").notNull().default(true),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({ uniqName: unique("uniq_fee_category_per_school").on(t.schoolId, t.name) }),
+);
+
+/** A bill issued to a student for a term. paid/balance denormalised for fast reads. */
+export const invoices = pgTable(
+  "invoice",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    schoolId: uuid("school_id")
+      .notNull()
+      .references(() => schools.id, { onDelete: "cascade" }),
+    studentId: uuid("student_id")
+      .notNull()
+      .references(() => students.id, { onDelete: "cascade" }),
+    invoiceNumber: text("invoice_number").notNull(),
+    academicYear: text("academic_year").notNull(),
+    periodId: uuid("period_id").references(() => academicPeriod.periodId),
+    subtotalAmount: money("subtotal_amount").notNull(),
+    discountAmount: money("discount_amount").notNull().default("0"),
+    billedAmount: money("billed_amount").notNull(),
+    paidAmount: money("paid_amount").notNull().default("0"),
+    balanceAmount: money("balance_amount").notNull(),
+    status: invoiceStatusEnum("status").notNull().default("ISSUED"),
+    issuedAt: timestamp("issued_at", { withTimezone: true }).notNull().defaultNow(),
+    dueAt: timestamp("due_at", { withTimezone: true }),
+    paidAt: timestamp("paid_at", { withTimezone: true }),
+    voidedAt: timestamp("voided_at", { withTimezone: true }),
+  },
+  (t) => ({
+    uniqNumber: unique("uniq_invoice_number_per_school").on(t.schoolId, t.invoiceNumber),
+    byStudent: index("invoice_student_idx").on(t.studentId),
+  }),
+);
+
+export const invoiceLineItems = pgTable("invoice_line_item", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  schoolId: uuid("school_id")
+    .notNull()
+    .references(() => schools.id, { onDelete: "cascade" }),
+  invoiceId: uuid("invoice_id")
+    .notNull()
+    .references(() => invoices.id, { onDelete: "cascade" }),
+  feeCategoryId: uuid("fee_category_id").references(() => feeCategories.id),
+  description: text("description").notNull(),
+  amount: money("amount").notNull(),
+  isOptional: boolean("is_optional").notNull().default(false),
+});
+
+/** One row per flow of money in. aggregator stays null in MVP1 (manual entry). */
+export const payments = pgTable(
+  "payment",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    schoolId: uuid("school_id")
+      .notNull()
+      .references(() => schools.id, { onDelete: "cascade" }),
+    studentId: uuid("student_id")
+      .notNull()
+      .references(() => students.id, { onDelete: "cascade" }),
+    recordedByUserId: uuid("recorded_by_user_id").references(() => users.id),
+    grossAmount: money("gross_amount").notNull(),
+    feeAmount: money("fee_amount").notNull().default("0"),
+    netAmount: money("net_amount").notNull(),
+    currency: text("currency").notNull().default("GHS"),
+    method: paymentMethodEnum("method").notNull(),
+    methodReference: text("method_reference"),
+    aggregator: text("aggregator"), // null in MVP1
+    settlementStatus: settlementStatusEnum("settlement_status")
+      .notNull()
+      .default("PENDING"),
+    paidAt: timestamp("paid_at", { withTimezone: true }).notNull().defaultNow(),
+    recordedAt: timestamp("recorded_at", { withTimezone: true }).notNull().defaultNow(),
+    voidedAt: timestamp("voided_at", { withTimezone: true }),
+    voidedByUserId: uuid("voided_by_user_id").references(() => users.id),
+  },
+  (t) => ({ byStudent: index("payment_student_idx").on(t.studentId) }),
+);
+
+/** Distribution of a payment across invoices (or credit/refund). */
+export const paymentAllocations = pgTable("payment_allocation", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  schoolId: uuid("school_id")
+    .notNull()
+    .references(() => schools.id, { onDelete: "cascade" }),
+  paymentId: uuid("payment_id")
+    .notNull()
+    .references(() => payments.id, { onDelete: "cascade" }),
+  invoiceId: uuid("invoice_id").references(() => invoices.id),
+  allocationType: allocationTypeEnum("allocation_type").notNull().default("INVOICE"),
+  amount: money("amount").notNull(),
+  allocationMethod: allocationMethodEnum("allocation_method").notNull().default("MANUAL"),
+  allocatedByUserId: uuid("allocated_by_user_id").references(() => users.id),
+  allocatedAt: timestamp("allocated_at", { withTimezone: true }).notNull().defaultNow(),
+  voidedAt: timestamp("voided_at", { withTimezone: true }),
+});
+
+/** One receipt per payment (1:1), generated on successful recording. */
+export const receipts = pgTable(
+  "receipt",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    schoolId: uuid("school_id")
+      .notNull()
+      .references(() => schools.id, { onDelete: "cascade" }),
+    paymentId: uuid("payment_id")
+      .notNull()
+      .references(() => payments.id, { onDelete: "cascade" })
+      .unique(),
+    receiptNumber: text("receipt_number").notNull(),
+    studentId: uuid("student_id")
+      .notNull()
+      .references(() => students.id, { onDelete: "cascade" }),
+    pdfUrl: text("pdf_url"),
+    generatedAt: timestamp("generated_at", { withTimezone: true }).notNull().defaultNow(),
+    voidedAt: timestamp("voided_at", { withTimezone: true }),
+    voidReplacementId: uuid("void_replacement_id"),
+  },
+  (t) => ({
+    uniqNumber: unique("uniq_receipt_number_per_school").on(t.schoolId, t.receiptNumber),
+  }),
+);
+
+/** Append-only history of all payment events. Never updated or deleted. */
+export const paymentAuditLog = pgTable(
+  "payment_audit_log",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    schoolId: uuid("school_id")
+      .notNull()
+      .references(() => schools.id, { onDelete: "cascade" }),
+    paymentId: uuid("payment_id"),
+    invoiceId: uuid("invoice_id"),
+    eventType: paymentEventTypeEnum("event_type").notNull(),
+    actorUserId: uuid("actor_user_id").references(() => users.id),
+    actorType: paymentActorTypeEnum("actor_type").notNull().default("ADMIN"),
+    beforeState: jsonb("before_state"),
+    afterState: jsonb("after_state"),
+    notes: text("notes"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    bySchoolTime: index("payment_audit_school_time_idx").on(t.schoolId, t.createdAt),
+  }),
+);

--- a/omnischools/db/schema/index.ts
+++ b/omnischools/db/schema/index.ts
@@ -12,3 +12,4 @@ export * from "./anomaly";
 export * from "./marketing";
 export * from "./students";
 export * from "./admissions";
+export * from "./fees";

--- a/omnischools/db/schema/index.ts
+++ b/omnischools/db/schema/index.ts
@@ -10,3 +10,5 @@ export * from "./periods";
 export * from "./audit";
 export * from "./anomaly";
 export * from "./marketing";
+export * from "./students";
+export * from "./admissions";

--- a/omnischools/db/schema/students.ts
+++ b/omnischools/db/schema/students.ts
@@ -1,0 +1,65 @@
+import {
+  pgTable,
+  uuid,
+  text,
+  date,
+  boolean,
+  timestamp,
+  unique,
+  index,
+} from "drizzle-orm/pg-core";
+import { sexEnum, studentStatusEnum, guardianRelationEnum } from "./_enums";
+import { schools } from "./tenancy";
+
+/**
+ * The student is the central object — the single source of truth every module reads.
+ * SHS-specific columns (programme/house/residency) are added in Phase 4; Basic leaves
+ * `current_class_label` as free text until the classes table lands with attendance.
+ */
+export const students = pgTable(
+  "students",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    schoolId: uuid("school_id")
+      .notNull()
+      .references(() => schools.id, { onDelete: "cascade" }),
+    studentCode: text("student_code").notNull(), // school's admission / student number
+    firstName: text("first_name").notNull(),
+    lastName: text("last_name").notNull(),
+    otherNames: text("other_names"),
+    sex: sexEnum("sex").notNull(),
+    dateOfBirth: date("date_of_birth"),
+    status: studentStatusEnum("status").notNull().default("ACTIVE"),
+    currentClassLabel: text("current_class_label"), // placeholder until classes table
+    enrolledOn: date("enrolled_on"),
+    admissionApplicationId: uuid("admission_application_id"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    uniqCode: unique("uniq_student_code_per_school").on(t.schoolId, t.studentCode),
+    bySchool: index("students_school_idx").on(t.schoolId),
+  }),
+);
+
+/** Guardians/parents — SMS-first contacts attached to a student. */
+export const studentGuardians = pgTable(
+  "student_guardian",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    schoolId: uuid("school_id")
+      .notNull()
+      .references(() => schools.id, { onDelete: "cascade" }),
+    studentId: uuid("student_id")
+      .notNull()
+      .references(() => students.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    relationship: guardianRelationEnum("relationship").notNull().default("GUARDIAN"),
+    phone: text("phone").notNull(), // E.164
+    email: text("email"),
+    isPrimary: boolean("is_primary").notNull().default(true),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    byStudent: index("guardian_student_idx").on(t.studentId),
+  }),
+);

--- a/omnischools/db/sql/policies.sql
+++ b/omnischools/db/sql/policies.sql
@@ -50,7 +50,14 @@ BEGIN
     'students',
     'student_guardian',
     'admission_application',
-    'admission_document'
+    'admission_document',
+    'fee_category',
+    'invoice',
+    'invoice_line_item',
+    'payment',
+    'payment_allocation',
+    'receipt',
+    'payment_audit_log'
   ]
   LOOP
     EXECUTE format('ALTER TABLE %I ENABLE ROW LEVEL SECURITY;', tbl);

--- a/omnischools/db/sql/policies.sql
+++ b/omnischools/db/sql/policies.sql
@@ -46,7 +46,11 @@ BEGIN
     'role_assignment',
     'ref_academic_period_config',
     'academic_period',
-    'audit_log'
+    'audit_log',
+    'students',
+    'student_guardian',
+    'admission_application',
+    'admission_document'
   ]
   LOOP
     EXECUTE format('ALTER TABLE %I ENABLE ROW LEVEL SECURITY;', tbl);

--- a/omnischools/lib/actions/admissions.ts
+++ b/omnischools/lib/actions/admissions.ts
@@ -1,0 +1,206 @@
+"use server";
+import { eq, and } from "drizzle-orm";
+import { safeRevalidate } from "@/lib/revalidate";
+import { z } from "zod";
+import { withSchool, withoutTenantScope } from "@/lib/db/rls";
+import { recordAudit } from "@/lib/db/audit";
+import { requireSchool, resolveActor } from "@/lib/auth/server";
+import { normalizeGhanaPhone } from "@/lib/auth";
+import { sendSms } from "@/lib/sms";
+import { nextStudentCode } from "@/lib/students-helpers";
+import { schools, students, studentGuardians, admissionApplications } from "@/db/schema";
+
+const ApplicationSchema = z.object({
+  schoolCode: z.string().min(2, "School code is required").max(40),
+  applicantFirstName: z.string().min(1, "First name is required").max(120),
+  applicantLastName: z.string().min(1, "Last name is required").max(120),
+  applicantOtherNames: z.string().max(120).optional().or(z.literal("")),
+  sex: z.enum(["MALE", "FEMALE"]),
+  dateOfBirth: z.string().optional().or(z.literal("")),
+  desiredClassLabel: z.string().max(60).optional().or(z.literal("")),
+  guardianName: z.string().min(1, "Guardian name is required").max(160),
+  guardianPhone: z.string().min(7, "Guardian phone is required").max(40),
+  guardianEmail: z.string().email().optional().or(z.literal("")),
+});
+
+export type SubmitApplicationResult =
+  | { ok: true; applicationId: string }
+  | { ok: false; error: string };
+
+/** Public: a prospective student applies to a school identified by its GES code. */
+export async function submitApplication(
+  input: unknown,
+): Promise<SubmitApplicationResult> {
+  const parsed = ApplicationSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid application" };
+  }
+  const d = parsed.data;
+  try {
+    const out = await withoutTenantScope(async (tx) => {
+      const [school] = await tx
+        .select({ id: schools.id })
+        .from(schools)
+        .where(eq(schools.gesCode, d.schoolCode));
+      if (!school)
+        return { ok: false as const, error: "We couldn't find a school with that code." };
+
+      const [app] = await tx
+        .insert(admissionApplications)
+        .values({
+          schoolId: school.id,
+          applicantFirstName: d.applicantFirstName,
+          applicantLastName: d.applicantLastName,
+          applicantOtherNames: d.applicantOtherNames || null,
+          sex: d.sex,
+          dateOfBirth: d.dateOfBirth || null,
+          desiredClassLabel: d.desiredClassLabel || null,
+          guardianName: d.guardianName,
+          guardianPhone: normalizeGhanaPhone(d.guardianPhone),
+          guardianEmail: d.guardianEmail || null,
+          status: "SUBMITTED",
+        })
+        .returning();
+
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorRole: "APPLICANT",
+        actionType: "created",
+        entityType: "admission_application",
+        entityId: app.id,
+        after: { applicant: `${d.applicantFirstName} ${d.applicantLastName}` },
+        reason: "Public admission application",
+      });
+      return { ok: true as const, applicationId: app.id };
+    });
+
+    if (!out.ok) return { ok: false, error: out.error };
+    return { ok: true, applicationId: out.applicationId };
+  } catch {
+    return { ok: false, error: "Could not submit the application. Please try again." };
+  }
+}
+
+const DecisionSchema = z.object({
+  applicationId: z.string().uuid(),
+  decision: z.enum(["ACCEPTED", "REJECTED", "WAITLISTED"]),
+  notes: z.string().max(2000).optional().or(z.literal("")),
+});
+
+export type DecisionResult =
+  | { ok: true; studentId?: string }
+  | { ok: false; error: string };
+
+/** Admin: decide on an application. ACCEPT creates a student + primary guardian. */
+export async function decideApplication(input: unknown): Promise<DecisionResult> {
+  const { school } = await requireSchool();
+  const parsed = DecisionSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid decision" };
+  }
+  const d = parsed.data;
+  const actor = await resolveActor(school.id);
+
+  try {
+    const out = await withSchool(school.id, async (tx) => {
+      const [app] = await tx
+        .select()
+        .from(admissionApplications)
+        .where(
+          and(
+            eq(admissionApplications.id, d.applicationId),
+            eq(admissionApplications.schoolId, school.id),
+          ),
+        );
+      if (!app) return { ok: false as const, error: "Application not found." };
+      if (app.status === "ACCEPTED")
+        return { ok: false as const, error: "Already accepted." };
+
+      let studentId: string | undefined;
+      if (d.decision === "ACCEPTED") {
+        const studentCode = await nextStudentCode(tx, school.id);
+        const [student] = await tx
+          .insert(students)
+          .values({
+            schoolId: school.id,
+            studentCode,
+            firstName: app.applicantFirstName,
+            lastName: app.applicantLastName,
+            otherNames: app.applicantOtherNames,
+            sex: app.sex,
+            dateOfBirth: app.dateOfBirth,
+            currentClassLabel: app.desiredClassLabel,
+            enrolledOn: new Date().toISOString().slice(0, 10),
+            admissionApplicationId: app.id,
+          })
+          .returning();
+        studentId = student.id;
+
+        await tx.insert(studentGuardians).values({
+          schoolId: school.id,
+          studentId: student.id,
+          name: app.guardianName,
+          phone: app.guardianPhone,
+          email: app.guardianEmail,
+          isPrimary: true,
+        });
+
+        await recordAudit(tx, {
+          schoolId: school.id,
+          actorUserId: actor.id ?? undefined,
+          actorRole: actor.role,
+          actionType: "created",
+          entityType: "student",
+          entityId: student.id,
+          after: { studentCode, fromApplication: app.id },
+          reason: "Admission accepted",
+        });
+      }
+
+      await tx
+        .update(admissionApplications)
+        .set({
+          status: d.decision,
+          notes: d.notes || app.notes,
+          studentId: studentId ?? app.studentId,
+          decidedByUserId: actor.id ?? undefined,
+          decidedAt: new Date(),
+        })
+        .where(eq(admissionApplications.id, app.id));
+
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: d.decision.toLowerCase(),
+        entityType: "admission_application",
+        entityId: app.id,
+        before: { status: app.status },
+        after: { status: d.decision },
+        reason: "Admission decision",
+      });
+
+      return {
+        ok: true as const,
+        studentId,
+        guardianPhone: app.guardianPhone,
+        decision: d.decision,
+      };
+    });
+
+    if (!out.ok) return { ok: false, error: out.error };
+
+    // notify guardian (stubbed)
+    if (out.decision === "ACCEPTED") {
+      await sendSms(
+        out.guardianPhone,
+        `${school.shortName ?? "Omnischools"}: Admission accepted. Welcome! We'll be in touch with next steps.`,
+      );
+    }
+    safeRevalidate("/admissions");
+    safeRevalidate("/students");
+    return { ok: true, studentId: out.studentId };
+  } catch {
+    return { ok: false, error: "Could not record the decision. Please try again." };
+  }
+}

--- a/omnischools/lib/actions/fees.ts
+++ b/omnischools/lib/actions/fees.ts
@@ -1,0 +1,390 @@
+"use server";
+import { and, asc, eq, inArray, sql } from "drizzle-orm";
+import { z } from "zod";
+import { withSchool } from "@/lib/db/rls";
+import { recordAudit } from "@/lib/db/audit";
+import { requireSchool, resolveActor } from "@/lib/auth/server";
+import { sendSms } from "@/lib/sms";
+import { safeRevalidate } from "@/lib/revalidate";
+import {
+  num,
+  round2,
+  toMoney,
+  nextInvoiceNumber,
+  nextReceiptNumber,
+  settlementFor,
+} from "@/lib/fees-helpers";
+import {
+  students,
+  studentGuardians,
+  invoices,
+  invoiceLineItems,
+  payments,
+  paymentAllocations,
+  receipts,
+  paymentAuditLog,
+} from "@/db/schema";
+
+// ---------------------------------------------------------------- issue invoice
+const LineItemSchema = z.object({
+  description: z.string().min(1).max(200),
+  amount: z.coerce.number().positive("Amount must be > 0"),
+  feeCategoryId: z.string().uuid().optional().or(z.literal("")),
+});
+const IssueInvoiceSchema = z.object({
+  studentId: z.string().uuid(),
+  periodId: z.string().uuid().optional().or(z.literal("")),
+  dueAt: z.string().optional().or(z.literal("")),
+  discountAmount: z.coerce.number().min(0).default(0),
+  lineItems: z.array(LineItemSchema).min(1, "Add at least one line item"),
+});
+
+export type IssueInvoiceResult =
+  | { ok: true; invoiceId: string; invoiceNumber: string; billed: number }
+  | { ok: false; error: string };
+
+export async function issueInvoice(input: unknown): Promise<IssueInvoiceResult> {
+  const { school } = await requireSchool();
+  const parsed = IssueInvoiceSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid invoice" };
+  }
+  const d = parsed.data;
+  const actor = await resolveActor(school.id);
+
+  try {
+    const out = await withSchool(school.id, async (tx) => {
+      const [student] = await tx
+        .select({ id: students.id })
+        .from(students)
+        .where(and(eq(students.id, d.studentId), eq(students.schoolId, school.id)));
+      if (!student) return { ok: false as const, error: "Student not found." };
+
+      const subtotal = round2(d.lineItems.reduce((s, li) => s + li.amount, 0));
+      const discount = round2(d.discountAmount);
+      const billed = round2(subtotal - discount);
+      if (billed < 0) return { ok: false as const, error: "Discount exceeds subtotal." };
+
+      const invoiceNumber = await nextInvoiceNumber(tx, school.id);
+      const now = new Date();
+      const startYear = now.getMonth() >= 8 ? now.getFullYear() : now.getFullYear() - 1;
+      const academicYear = `${startYear}/${String((startYear + 1) % 100).padStart(2, "0")}`;
+      const [inv] = await tx
+        .insert(invoices)
+        .values({
+          schoolId: school.id,
+          studentId: d.studentId,
+          invoiceNumber,
+          academicYear,
+          periodId: d.periodId || null,
+          subtotalAmount: toMoney(subtotal),
+          discountAmount: toMoney(discount),
+          billedAmount: toMoney(billed),
+          paidAmount: "0.00",
+          balanceAmount: toMoney(billed),
+          status: "ISSUED",
+          dueAt: d.dueAt ? new Date(d.dueAt) : null,
+        })
+        .returning();
+
+      await tx.insert(invoiceLineItems).values(
+        d.lineItems.map((li) => ({
+          schoolId: school.id,
+          invoiceId: inv.id,
+          feeCategoryId: li.feeCategoryId || null,
+          description: li.description,
+          amount: toMoney(li.amount),
+        })),
+      );
+
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "created",
+        entityType: "invoice",
+        entityId: inv.id,
+        after: { invoiceNumber, billed: toMoney(billed) },
+        reason: "Invoice issued",
+      });
+
+      return { ok: true as const, invoiceId: inv.id, invoiceNumber, billed };
+    });
+
+    if (!out.ok) return out;
+    safeRevalidate("/fees");
+    safeRevalidate(`/fees/${d.studentId}`);
+    return out;
+  } catch {
+    return { ok: false, error: "Could not issue the invoice. Please try again." };
+  }
+}
+
+// --------------------------------------------------------------- record payment
+const RecordPaymentSchema = z.object({
+  studentId: z.string().uuid(),
+  method: z.enum([
+    "MTN_MOMO",
+    "TELECEL_CASH",
+    "AIRTELTIGO_MONEY",
+    "BANK_TRANSFER",
+    "CASH",
+    "CHEQUE",
+    "OTHER",
+  ]),
+  grossAmount: z.coerce.number().positive("Amount must be > 0"),
+  methodReference: z.string().max(120).optional().or(z.literal("")),
+});
+
+export type RecordPaymentResult =
+  | {
+      ok: true;
+      paymentId: string;
+      receiptNumber: string;
+      allocated: number;
+      credit: number;
+    }
+  | { ok: false; error: string };
+
+export async function recordPayment(input: unknown): Promise<RecordPaymentResult> {
+  const { school } = await requireSchool();
+  const parsed = RecordPaymentSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid payment" };
+  }
+  const d = parsed.data;
+  const actor = await resolveActor(school.id);
+
+  try {
+    const out = await withSchool(school.id, async (tx) => {
+      const [student] = await tx
+        .select({ id: students.id })
+        .from(students)
+        .where(and(eq(students.id, d.studentId), eq(students.schoolId, school.id)));
+      if (!student) return { ok: false as const, error: "Student not found." };
+
+      const gross = round2(d.grossAmount);
+      const [payment] = await tx
+        .insert(payments)
+        .values({
+          schoolId: school.id,
+          studentId: d.studentId,
+          recordedByUserId: actor.id ?? undefined,
+          grossAmount: toMoney(gross),
+          netAmount: toMoney(gross),
+          method: d.method,
+          methodReference: d.methodReference || null,
+          settlementStatus: settlementFor(d.method),
+        })
+        .returning();
+
+      await tx.insert(paymentAuditLog).values({
+        schoolId: school.id,
+        paymentId: payment.id,
+        eventType: "CREATED",
+        actorUserId: actor.id ?? undefined,
+        afterState: { gross: toMoney(gross), method: d.method },
+      });
+
+      // auto-allocate oldest-first across outstanding invoices
+      const outstanding = await tx
+        .select()
+        .from(invoices)
+        .where(
+          and(
+            eq(invoices.schoolId, school.id),
+            eq(invoices.studentId, d.studentId),
+            inArray(invoices.status, ["ISSUED", "PARTIAL", "OVERDUE"]),
+            sql`${invoices.balanceAmount} > 0`,
+          ),
+        )
+        .orderBy(asc(invoices.issuedAt));
+
+      let remaining = gross;
+      let allocated = 0;
+      for (const inv of outstanding) {
+        if (remaining <= 0) break;
+        const bal = num(inv.balanceAmount);
+        const applied = round2(Math.min(bal, remaining));
+        if (applied <= 0) continue;
+
+        await tx.insert(paymentAllocations).values({
+          schoolId: school.id,
+          paymentId: payment.id,
+          invoiceId: inv.id,
+          allocationType: "INVOICE",
+          amount: toMoney(applied),
+          allocationMethod: "AUTO_OLDEST_FIRST",
+          allocatedByUserId: actor.id ?? undefined,
+        });
+
+        const newPaid = round2(num(inv.paidAmount) + applied);
+        const newBal = round2(num(inv.billedAmount) - newPaid);
+        await tx
+          .update(invoices)
+          .set({
+            paidAmount: toMoney(newPaid),
+            balanceAmount: toMoney(newBal),
+            status: newBal <= 0 ? "PAID" : "PARTIAL",
+            paidAt: newBal <= 0 ? new Date() : null,
+          })
+          .where(eq(invoices.id, inv.id));
+
+        await tx.insert(paymentAuditLog).values({
+          schoolId: school.id,
+          paymentId: payment.id,
+          invoiceId: inv.id,
+          eventType: "ALLOCATION_ADDED",
+          actorUserId: actor.id ?? undefined,
+          afterState: { applied: toMoney(applied), invoice: inv.invoiceNumber },
+        });
+
+        remaining = round2(remaining - applied);
+        allocated = round2(allocated + applied);
+      }
+
+      // overpayment → unapplied credit
+      const credit = round2(remaining);
+      if (credit > 0) {
+        await tx.insert(paymentAllocations).values({
+          schoolId: school.id,
+          paymentId: payment.id,
+          invoiceId: null,
+          allocationType: "CREDIT",
+          amount: toMoney(credit),
+          allocationMethod: "MANUAL",
+          allocatedByUserId: actor.id ?? undefined,
+        });
+      }
+
+      const receiptNumber = await nextReceiptNumber(tx, school.id);
+      await tx.insert(receipts).values({
+        schoolId: school.id,
+        paymentId: payment.id,
+        receiptNumber,
+        studentId: d.studentId,
+      });
+
+      return {
+        ok: true as const,
+        paymentId: payment.id,
+        receiptNumber,
+        allocated,
+        credit,
+      };
+    });
+
+    if (!out.ok) return out;
+
+    // guardian receipt SMS (stub)
+    const [guardian] = await withSchool(school.id, (tx) =>
+      tx
+        .select({ phone: studentGuardians.phone })
+        .from(studentGuardians)
+        .where(
+          and(
+            eq(studentGuardians.studentId, d.studentId),
+            eq(studentGuardians.isPrimary, true),
+          ),
+        )
+        .limit(1),
+    );
+    if (guardian) {
+      await sendSms(
+        guardian.phone,
+        `${school.shortName ?? "Omnischools"}: Payment of GHS ${toMoney(d.grossAmount)} received. Receipt ${out.receiptNumber}. Thank you.`,
+      );
+    }
+
+    safeRevalidate("/fees");
+    safeRevalidate(`/fees/${d.studentId}`);
+    return out;
+  } catch {
+    return { ok: false, error: "Could not record the payment. Please try again." };
+  }
+}
+
+// ----------------------------------------------------------------- void payment
+export type VoidPaymentResult = { ok: true } | { ok: false; error: string };
+
+export async function voidPayment(input: {
+  paymentId: string;
+}): Promise<VoidPaymentResult> {
+  const { school } = await requireSchool();
+  const paymentId = z.string().uuid().safeParse(input?.paymentId);
+  if (!paymentId.success) return { ok: false, error: "Invalid payment." };
+  const actor = await resolveActor(school.id);
+
+  try {
+    const out = await withSchool(school.id, async (tx) => {
+      const [payment] = await tx
+        .select()
+        .from(payments)
+        .where(and(eq(payments.id, paymentId.data), eq(payments.schoolId, school.id)));
+      if (!payment) return { ok: false as const, error: "Payment not found." };
+      if (payment.voidedAt) return { ok: false as const, error: "Already voided." };
+
+      const allocs = await tx
+        .select()
+        .from(paymentAllocations)
+        .where(
+          and(
+            eq(paymentAllocations.paymentId, payment.id),
+            eq(paymentAllocations.allocationType, "INVOICE"),
+          ),
+        );
+
+      for (const a of allocs) {
+        if (a.voidedAt || !a.invoiceId) continue;
+        const [inv] = await tx
+          .select()
+          .from(invoices)
+          .where(eq(invoices.id, a.invoiceId));
+        if (inv) {
+          const newPaid = round2(num(inv.paidAmount) - num(a.amount));
+          const newBal = round2(num(inv.billedAmount) - newPaid);
+          await tx
+            .update(invoices)
+            .set({
+              paidAmount: toMoney(Math.max(0, newPaid)),
+              balanceAmount: toMoney(newBal),
+              status: newPaid <= 0 ? "ISSUED" : "PARTIAL",
+              paidAt: null,
+            })
+            .where(eq(invoices.id, inv.id));
+        }
+        await tx
+          .update(paymentAllocations)
+          .set({ voidedAt: new Date() })
+          .where(eq(paymentAllocations.id, a.id));
+      }
+
+      await tx
+        .update(payments)
+        .set({ voidedAt: new Date(), voidedByUserId: actor.id ?? undefined })
+        .where(eq(payments.id, payment.id));
+      await tx
+        .update(receipts)
+        .set({ voidedAt: new Date() })
+        .where(eq(receipts.paymentId, payment.id));
+
+      await tx.insert(paymentAuditLog).values({
+        schoolId: school.id,
+        paymentId: payment.id,
+        eventType: "VOIDED",
+        actorUserId: actor.id ?? undefined,
+        beforeState: { settlementStatus: payment.settlementStatus },
+        notes: "Payment voided",
+      });
+
+      return { ok: true as const, studentId: payment.studentId };
+    });
+
+    if (!out.ok) return out;
+    safeRevalidate("/fees");
+    safeRevalidate(`/fees/${out.studentId}`);
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Could not void the payment. Please try again." };
+  }
+}

--- a/omnischools/lib/actions/students.ts
+++ b/omnischools/lib/actions/students.ts
@@ -1,0 +1,84 @@
+"use server";
+import { z } from "zod";
+import { safeRevalidate } from "@/lib/revalidate";
+import { withSchool } from "@/lib/db/rls";
+import { recordAudit } from "@/lib/db/audit";
+import { requireSchool, resolveActor } from "@/lib/auth/server";
+import { normalizeGhanaPhone } from "@/lib/auth";
+import { nextStudentCode } from "@/lib/students-helpers";
+import { students, studentGuardians } from "@/db/schema";
+
+const CreateStudentSchema = z.object({
+  firstName: z.string().min(1, "First name is required").max(120),
+  lastName: z.string().min(1, "Last name is required").max(120),
+  otherNames: z.string().max(120).optional().or(z.literal("")),
+  sex: z.enum(["MALE", "FEMALE"]),
+  dateOfBirth: z.string().optional().or(z.literal("")),
+  classLabel: z.string().max(60).optional().or(z.literal("")),
+  guardianName: z.string().max(160).optional().or(z.literal("")),
+  guardianPhone: z.string().max(40).optional().or(z.literal("")),
+  guardianRelation: z.enum(["MOTHER", "FATHER", "GUARDIAN", "OTHER"]).default("GUARDIAN"),
+});
+
+export type CreateStudentResult =
+  | { ok: true; studentId: string; studentCode: string }
+  | { ok: false; error: string };
+
+export async function createStudent(input: unknown): Promise<CreateStudentResult> {
+  const { school } = await requireSchool();
+  const parsed = CreateStudentSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid student" };
+  }
+  const d = parsed.data;
+  const actor = await resolveActor(school.id);
+
+  try {
+    const out = await withSchool(school.id, async (tx) => {
+      const studentCode = await nextStudentCode(tx, school.id);
+      const [student] = await tx
+        .insert(students)
+        .values({
+          schoolId: school.id,
+          studentCode,
+          firstName: d.firstName,
+          lastName: d.lastName,
+          otherNames: d.otherNames || null,
+          sex: d.sex,
+          dateOfBirth: d.dateOfBirth || null,
+          currentClassLabel: d.classLabel || null,
+          enrolledOn: new Date().toISOString().slice(0, 10),
+        })
+        .returning();
+
+      if (d.guardianName && d.guardianPhone) {
+        await tx.insert(studentGuardians).values({
+          schoolId: school.id,
+          studentId: student.id,
+          name: d.guardianName,
+          relationship: d.guardianRelation,
+          phone: normalizeGhanaPhone(d.guardianPhone),
+          isPrimary: true,
+        });
+      }
+
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "created",
+        entityType: "student",
+        entityId: student.id,
+        after: { studentCode, name: `${d.firstName} ${d.lastName}` },
+        reason: "Manual student creation",
+      });
+
+      return { studentId: student.id, studentCode };
+    });
+
+    safeRevalidate("/students");
+    return { ok: true, ...out };
+  } catch {
+    return { ok: false, error: "Could not create the student. Please try again." };
+  }
+}

--- a/omnischools/lib/auth/server.ts
+++ b/omnischools/lib/auth/server.ts
@@ -1,0 +1,86 @@
+import { redirect } from "next/navigation";
+import { eq, and } from "drizzle-orm";
+import { env } from "@/lib/env";
+import { db } from "@/lib/db";
+import { schools, roleAssignments, roles, users } from "@/db/schema";
+import { getCurrentUser, type AppUser } from "@/lib/auth";
+
+export interface ActiveSchool {
+  id: string;
+  name: string;
+  shortName: string | null;
+  gesCode: string;
+  schoolType: "BASIC" | "SENIOR" | "COMBINED";
+}
+
+/**
+ * Resolve the school the current user is operating.
+ * Dev shim: the seeded demo school (Asankrangwa), else the first school.
+ * Prod: the user's first active role assignment's school.
+ */
+export async function getActiveSchool(): Promise<ActiveSchool | null> {
+  const user = await getCurrentUser();
+  if (!user) return null;
+
+  const cols = {
+    id: schools.id,
+    name: schools.name,
+    shortName: schools.shortName,
+    gesCode: schools.gesCode,
+    schoolType: schools.schoolType,
+  };
+
+  if (env.AUTH_DEV_BYPASS) {
+    const demo = await db
+      .select(cols)
+      .from(schools)
+      .where(eq(schools.gesCode, "WR-WAW-014"))
+      .limit(1);
+    if (demo[0]) return demo[0];
+    const first = await db.select(cols).from(schools).limit(1);
+    return first[0] ?? null;
+  }
+
+  const assigned = await db
+    .select(cols)
+    .from(roleAssignments)
+    .innerJoin(schools, eq(roleAssignments.schoolId, schools.id))
+    .where(eq(roleAssignments.userId, user.id))
+    .limit(1);
+  return assigned[0] ?? null;
+}
+
+/** For app pages: ensure a signed-in user, else send to login. */
+export async function requireUser(): Promise<AppUser> {
+  const user = await getCurrentUser();
+  if (!user) redirect("/login");
+  return user;
+}
+
+/** For app pages: ensure a user AND a resolvable school, else redirect. */
+export async function requireSchool(): Promise<{ user: AppUser; school: ActiveSchool }> {
+  const user = await requireUser();
+  const school = await getActiveSchool();
+  if (!school) redirect("/start");
+  return { user, school };
+}
+
+/**
+ * Resolve a real `ref_user` id to attribute audit rows to (FK-safe).
+ * Prod: the signed-in user. Dev shim: the school's ADMIN user (a seeded real row).
+ */
+export async function resolveActor(
+  schoolId: string,
+): Promise<{ id: string | null; role: string }> {
+  const user = await getCurrentUser();
+  if (!user) return { id: null, role: "APPLICANT" };
+  if (!env.AUTH_DEV_BYPASS) return { id: user.id, role: user.roles[0] ?? "ADMIN" };
+  const rows = await db
+    .select({ id: users.id })
+    .from(roleAssignments)
+    .innerJoin(roles, eq(roleAssignments.roleId, roles.id))
+    .innerJoin(users, eq(roleAssignments.userId, users.id))
+    .where(and(eq(roleAssignments.schoolId, schoolId), eq(roles.code, "ADMIN")))
+    .limit(1);
+  return { id: rows[0]?.id ?? null, role: "ADMIN" };
+}

--- a/omnischools/lib/fees-helpers.ts
+++ b/omnischools/lib/fees-helpers.ts
@@ -1,0 +1,51 @@
+import { eq, sql } from "drizzle-orm";
+import { invoices, receipts } from "@/db/schema";
+import type { Tx } from "@/lib/db";
+
+/** Round to 2 dp, avoiding binary float drift. */
+export function round2(n: number): number {
+  return Math.round((n + Number.EPSILON) * 100) / 100;
+}
+
+/** A money string ("340.00") for numeric columns. */
+export function toMoney(n: number): string {
+  return round2(n).toFixed(2);
+}
+
+/** Parse a numeric column (string) to a number. */
+export function num(v: string | number | null | undefined): number {
+  return v == null ? 0 : Number(v);
+}
+
+function yy(): string {
+  return String(new Date().getFullYear() % 100).padStart(2, "0");
+}
+
+export async function nextInvoiceNumber(tx: Tx, schoolId: string): Promise<string> {
+  const [{ count }] = await tx
+    .select({ count: sql<number>`count(*)::int` })
+    .from(invoices)
+    .where(eq(invoices.schoolId, schoolId));
+  return `INV${yy()}${String(count + 1).padStart(4, "0")}`;
+}
+
+export async function nextReceiptNumber(tx: Tx, schoolId: string): Promise<string> {
+  const [{ count }] = await tx
+    .select({ count: sql<number>`count(*)::int` })
+    .from(receipts)
+    .where(eq(receipts.schoolId, schoolId));
+  return `RCT${yy()}${String(count + 1).padStart(4, "0")}`;
+}
+
+/** MVP1 settlement status by method (cash settles immediately; momo/bank confirmed). */
+export function settlementFor(method: string): "SETTLED" | "CONFIRMED" | "PENDING" {
+  if (method === "CASH") return "SETTLED";
+  if (
+    method === "BANK_TRANSFER" ||
+    method.endsWith("_MOMO") ||
+    method.endsWith("_MONEY") ||
+    method === "TELECEL_CASH"
+  )
+    return "CONFIRMED";
+  return "PENDING";
+}

--- a/omnischools/lib/revalidate.ts
+++ b/omnischools/lib/revalidate.ts
@@ -1,0 +1,13 @@
+import { revalidatePath } from "next/cache";
+
+/**
+ * revalidatePath that no-ops outside a request scope (e.g. when a server action is
+ * invoked from a Node verification script). Harmless during real requests.
+ */
+export function safeRevalidate(path: string): void {
+  try {
+    revalidatePath(path);
+  } catch {
+    // not in a request scope — ignore
+  }
+}

--- a/omnischools/lib/students-helpers.ts
+++ b/omnischools/lib/students-helpers.ts
@@ -1,0 +1,17 @@
+import { eq, sql } from "drizzle-orm";
+import { students } from "@/db/schema";
+import type { Tx } from "@/lib/db";
+
+/**
+ * Generate the next student code for a school: OS{YY}{NNNN}, e.g. OS260001.
+ * Explicitly scoped by school_id (do not rely on RLS — the dev superuser bypasses it).
+ * The unique(school_id, student_code) constraint is the final guard against races.
+ */
+export async function nextStudentCode(tx: Tx, schoolId: string): Promise<string> {
+  const [{ count }] = await tx
+    .select({ count: sql<number>`count(*)::int` })
+    .from(students)
+    .where(eq(students.schoolId, schoolId));
+  const yy = String(new Date().getFullYear() % 100).padStart(2, "0");
+  return `OS${yy}${String(count + 1).padStart(4, "0")}`;
+}

--- a/omnischools/package.json
+++ b/omnischools/package.json
@@ -21,6 +21,7 @@
     "db:rls-test": "tsx scripts/rls-test.ts",
     "db:verify-onboarding": "tsx scripts/verify-onboarding.ts",
     "db:verify-admissions": "tsx scripts/verify-admissions.ts",
+    "db:verify-payments": "tsx scripts/verify-payments.ts",
     "db:setup": "drizzle-kit migrate && tsx scripts/apply-policies.ts && tsx db/seed/asankrangwa.ts"
   },
   "dependencies": {

--- a/omnischools/package.json
+++ b/omnischools/package.json
@@ -20,6 +20,7 @@
     "db:seed": "tsx db/seed/asankrangwa.ts",
     "db:rls-test": "tsx scripts/rls-test.ts",
     "db:verify-onboarding": "tsx scripts/verify-onboarding.ts",
+    "db:verify-admissions": "tsx scripts/verify-admissions.ts",
     "db:setup": "drizzle-kit migrate && tsx scripts/apply-policies.ts && tsx db/seed/asankrangwa.ts"
   },
   "dependencies": {

--- a/omnischools/scripts/verify-admissions.ts
+++ b/omnischools/scripts/verify-admissions.ts
@@ -1,0 +1,65 @@
+import "@/db/_loadenv";
+import { eq } from "drizzle-orm";
+import { submitApplication, decideApplication } from "@/lib/actions/admissions";
+import { db } from "@/lib/db";
+import { admissionApplications, students, studentGuardians } from "@/db/schema";
+
+// End-to-end: public application → admin accept → student + guardian created.
+// Uses the seeded Asankrangwa school (dev active school).
+const CODE = "WR-WAW-014";
+
+async function main() {
+  const sub = await submitApplication({
+    schoolCode: CODE,
+    applicantFirstName: "Test",
+    applicantLastName: "Applicant",
+    sex: "MALE",
+    desiredClassLabel: "JHS 1",
+    guardianName: "G. Test",
+    guardianPhone: "0240000099",
+  });
+  console.log("submit:", sub);
+  if (!sub.ok) process.exit(1);
+
+  const dec = await decideApplication({
+    applicationId: sub.applicationId,
+    decision: "ACCEPTED",
+  });
+  console.log("decide:", dec);
+  if (!dec.ok || !dec.studentId) process.exit(1);
+
+  const [stu] = await db.select().from(students).where(eq(students.id, dec.studentId));
+  const guardians = await db
+    .select()
+    .from(studentGuardians)
+    .where(eq(studentGuardians.studentId, dec.studentId));
+  const [app] = await db
+    .select()
+    .from(admissionApplications)
+    .where(eq(admissionApplications.id, sub.applicationId));
+
+  console.log(
+    `student=${stu?.studentCode} guardians=${guardians.length} appStatus=${app?.status} linked=${app?.studentId === dec.studentId}`,
+  );
+  const pass =
+    !!stu &&
+    guardians.length === 1 &&
+    app?.status === "ACCEPTED" &&
+    app?.studentId === dec.studentId;
+
+  // cleanup (delete application first to release its student_id FK, then the student)
+  await db
+    .delete(admissionApplications)
+    .where(eq(admissionApplications.id, sub.applicationId));
+  await db.delete(students).where(eq(students.id, dec.studentId));
+
+  console.log(
+    pass ? "\n✓ Admissions → student flow verified." : "\n✗ Assertions failed.",
+  );
+  process.exit(pass ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error("✗ verify-admissions error:", err);
+  process.exit(1);
+});

--- a/omnischools/scripts/verify-payments.ts
+++ b/omnischools/scripts/verify-payments.ts
@@ -1,0 +1,109 @@
+import "@/db/_loadenv";
+import { eq } from "drizzle-orm";
+import { createStudent } from "@/lib/actions/students";
+import { issueInvoice, recordPayment, voidPayment } from "@/lib/actions/fees";
+import { db } from "@/lib/db";
+import { students, invoices, payments, receipts } from "@/db/schema";
+import { num } from "@/lib/fees-helpers";
+
+// End-to-end fees flow against the dev active school (Asankrangwa).
+let failures = 0;
+function check(label: string, cond: boolean, detail = "") {
+  console.log(`${cond ? "✓" : "✗"} ${label}${detail ? ` (${detail})` : ""}`);
+  if (!cond) failures++;
+}
+
+async function invoiceState(studentId: string) {
+  const [inv] = await db.select().from(invoices).where(eq(invoices.studentId, studentId));
+  return inv;
+}
+
+async function main() {
+  // 1. create a throwaway student
+  const cs = await createStudent({
+    firstName: "Fee",
+    lastName: "Tester",
+    sex: "MALE",
+    guardianName: "G. Tester",
+    guardianPhone: "0240000088",
+  });
+  if (!cs.ok) {
+    console.error("createStudent failed", cs);
+    process.exit(1);
+  }
+  const sid = cs.studentId;
+
+  // 2. issue invoice: 600 subtotal - 100 discount = 500 billed
+  const inv = await issueInvoice({
+    studentId: sid,
+    discountAmount: 100,
+    lineItems: [{ description: "Tuition", amount: 600 }],
+  });
+  check(
+    "issue invoice ok",
+    inv.ok,
+    inv.ok
+      ? `${inv.invoiceNumber} billed ${inv.billed}`
+      : (inv as { error: string }).error,
+  );
+  if (inv.ok) check("billed = 500", inv.billed === 500);
+  let s = await invoiceState(sid);
+  check(
+    "invoice ISSUED, balance 500",
+    s.status === "ISSUED" && num(s.balanceAmount) === 500,
+  );
+
+  // 3. partial cash payment 200
+  const p1 = await recordPayment({ studentId: sid, method: "CASH", grossAmount: 200 });
+  check(
+    "payment 1 ok + receipt",
+    p1.ok,
+    p1.ok ? p1.receiptNumber : (p1 as { error: string }).error,
+  );
+  s = await invoiceState(sid);
+  check(
+    "invoice PARTIAL, paid 200 / balance 300",
+    s.status === "PARTIAL" && num(s.paidAmount) === 200 && num(s.balanceAmount) === 300,
+  );
+
+  // 4. full momo payment 300
+  const p2 = await recordPayment({
+    studentId: sid,
+    method: "MTN_MOMO",
+    grossAmount: 300,
+  });
+  check("payment 2 ok", p2.ok);
+  s = await invoiceState(sid);
+  check("invoice PAID, balance 0", s.status === "PAID" && num(s.balanceAmount) === 0);
+
+  const receiptCount = (
+    await db.select().from(receipts).where(eq(receipts.studentId, sid))
+  ).length;
+  check("two receipts generated", receiptCount === 2, `count=${receiptCount}`);
+
+  // 5. void the momo payment → back to PARTIAL
+  if (p2.ok) {
+    const v = await voidPayment({ paymentId: p2.paymentId });
+    check("void ok", v.ok);
+  }
+  s = await invoiceState(sid);
+  check(
+    "after void: PARTIAL, balance 300",
+    s.status === "PARTIAL" && num(s.balanceAmount) === 300,
+  );
+
+  // cleanup (payments first → cascades allocations + receipts, then invoices, then student)
+  await db.delete(payments).where(eq(payments.studentId, sid));
+  await db.delete(invoices).where(eq(invoices.studentId, sid));
+  await db.delete(students).where(eq(students.id, sid));
+
+  console.log(
+    failures === 0 ? "\n✓ Fees flow verified." : `\n✗ ${failures} assertion(s) failed.`,
+  );
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error("✗ verify-payments error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
@
## Summary
First slice of Phase 3 (Basic tier / MVP1): the authenticated app shell plus the two foundational modules — **student records** (the central object every other module reads) and **admissions**.

### App shell
- `(app)` layout: sidebar nav + topbar (school name, role, connection pill); mounted at `/dashboard`, `/students`, `/admissions`.
- Tenant context: `getActiveSchool` (dev → seeded Asankrangwa), `requireSchool`, and `resolveActor` (FK-safe audit attribution).

### Student records
- `students` + `student_guardian` tables (RLS). Central object; SHS columns deferred to Phase 4, `current_class_label` placeholder until the classes table.
- Students list, **Add student** (`createStudent`), detail view with guardians; dashboard counts.

### Admissions
- `admission_application` + `admission_document` tables (RLS).
- **Public** `/apply/[code]` form — school resolved by GES code via `withoutTenantScope` (RLS-safe public lookup).
- Internal **review queue** with Accept / Reject / Waitlist (`decideApplication`). **Accept** creates a student + primary guardian, links the application, and fires a guardian SMS (stub). All mutations audited.

### Data
- Migration `0002`; RLS policies extended to the 4 new tenant tables.
- `safeRevalidate` helper so server actions can also run from Node scripts.

## Verification
`pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm build` ✓ (17 routes) · `pnpm db:verify-admissions` ✓ (apply → accept → student `OS260001` + guardian, app linked).

## Next slices (Phase 3 → MVP1)
Fees & payments (invoices, manual MoMo/cash, receipts, append-only payment audit) → Attendance → Gradebook/report cards → Parent comms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@