### PR TITLE
Phase 3 (slice 4) — gradebook & report cards

### DIFF
--- a/omnischools/app/(app)/gradebook/page.tsx
+++ b/omnischools/app/(app)/gradebook/page.tsx
@@ -1,0 +1,171 @@
+import Link from "next/link";
+import { and, asc, eq, inArray } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import {
+  classes,
+  subjects,
+  students,
+  academicPeriod,
+  gradebookConfig,
+  gradebookScores,
+} from "@/db/schema";
+import { GradebookSelectors } from "@/components/gradebook/selectors";
+import { NewSubjectForm } from "@/components/gradebook/new-subject-form";
+import { ScoreGrid } from "@/components/gradebook/score-grid";
+
+export const dynamic = "force-dynamic";
+
+export default async function GradebookPage({
+  searchParams,
+}: {
+  searchParams: { classId?: string; subjectId?: string; periodId?: string };
+}) {
+  const { school } = await requireSchool();
+  const { classId, subjectId, periodId } = searchParams;
+
+  const base = await withSchool(school.id, async (tx) => {
+    const cls = await tx.select().from(classes).where(eq(classes.schoolId, school.id));
+    const subs = await tx.select().from(subjects).where(eq(subjects.schoolId, school.id));
+    const periods = await tx
+      .select()
+      .from(academicPeriod)
+      .where(eq(academicPeriod.schoolId, school.id));
+    const [cfg] = await tx
+      .select()
+      .from(gradebookConfig)
+      .where(eq(gradebookConfig.schoolId, school.id));
+    return {
+      cls,
+      subs,
+      periods,
+      weights: { cw: cfg?.classWeight ?? 50, ew: cfg?.examWeight ?? 50 },
+    };
+  });
+
+  let grid: React.ReactNode = (
+    <div className="border-border-2 bg-surface rounded-xl border border-dashed p-12 text-center text-sm text-navy-3">
+      Choose a class, subject and period to enter scores.
+    </div>
+  );
+
+  if (classId && subjectId && periodId) {
+    const data = await withSchool(school.id, async (tx) => {
+      const roster = await tx
+        .select({
+          id: students.id,
+          firstName: students.firstName,
+          lastName: students.lastName,
+          code: students.studentCode,
+        })
+        .from(students)
+        .where(
+          and(
+            eq(students.schoolId, school.id),
+            eq(students.classId, classId),
+            eq(students.status, "ACTIVE"),
+          ),
+        )
+        .orderBy(asc(students.lastName));
+      if (roster.length === 0)
+        return {
+          roster: [],
+          scores: [] as {
+            studentId: string;
+            classScore: string | null;
+            examScore: string | null;
+          }[],
+        };
+      const scores = await tx
+        .select({
+          studentId: gradebookScores.studentId,
+          classScore: gradebookScores.classScore,
+          examScore: gradebookScores.examScore,
+        })
+        .from(gradebookScores)
+        .where(
+          and(
+            eq(gradebookScores.schoolId, school.id),
+            eq(gradebookScores.subjectId, subjectId),
+            eq(gradebookScores.periodId, periodId),
+            inArray(
+              gradebookScores.studentId,
+              roster.map((r) => r.id),
+            ),
+          ),
+        );
+      return { roster, scores };
+    });
+
+    if (data.roster.length === 0) {
+      grid = (
+        <div className="border-border-2 bg-surface rounded-xl border border-dashed p-12 text-center text-sm text-navy-3">
+          No students in this class. Assign students from{" "}
+          <Link href="/attendance" className="text-gold underline">
+            Attendance
+          </Link>
+          .
+        </div>
+      );
+    } else {
+      const byStudent = new Map(data.scores.map((s) => [s.studentId, s]));
+      const roster = data.roster.map((r) => {
+        const s = byStudent.get(r.id);
+        return {
+          id: r.id,
+          name: `${r.lastName}, ${r.firstName}`,
+          code: r.code,
+          classScore: s?.classScore ?? "",
+          examScore: s?.examScore ?? "",
+        };
+      });
+      grid = (
+        <ScoreGrid
+          classId={classId}
+          subjectId={subjectId}
+          periodId={periodId}
+          weights={base.weights}
+          roster={roster}
+        />
+      );
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-page">
+      <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="font-display text-3xl font-semibold text-navy">Gradebook</h1>
+          <p className="text-sm text-navy-3">
+            Enter class &amp; exam scores; totals are weighted.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <Link
+            href="/gradebook/reports"
+            className="border-border-2 bg-surface rounded-md border px-4 py-2.5 text-sm font-semibold text-navy hover:bg-gold-bg"
+          >
+            Report cards
+          </Link>
+          <NewSubjectForm />
+        </div>
+      </div>
+
+      <div className="mb-5">
+        <GradebookSelectors
+          classes={base.cls.map((c) => ({ id: c.id, label: c.name }))}
+          subjects={base.subs.map((s) => ({ id: s.id, label: s.name }))}
+          periods={base.periods.map((p) => ({
+            id: p.periodId,
+            label: `${p.academicYear} · ${p.periodLabel}`,
+          }))}
+          classId={classId}
+          subjectId={subjectId}
+          periodId={periodId}
+        />
+      </div>
+
+      {grid}
+    </div>
+  );
+}

--- a/omnischools/app/(app)/gradebook/report/[studentId]/page.tsx
+++ b/omnischools/app/(app)/gradebook/report/[studentId]/page.tsx
@@ -1,0 +1,175 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { and, asc, eq } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import {
+  students,
+  academicPeriod,
+  subjects,
+  gradebookScores,
+  reportCards,
+} from "@/db/schema";
+import { PrintButton } from "@/components/gradebook/print-button";
+
+export const dynamic = "force-dynamic";
+
+export default async function ReportCardPage({
+  params,
+  searchParams,
+}: {
+  params: { studentId: string };
+  searchParams: { periodId?: string };
+}) {
+  const periodId = searchParams.periodId;
+  if (!periodId) notFound();
+  const { school } = await requireSchool();
+
+  const data = await withSchool(school.id, async (tx) => {
+    const [student] = await tx
+      .select()
+      .from(students)
+      .where(and(eq(students.id, params.studentId), eq(students.schoolId, school.id)));
+    if (!student) return null;
+    const [period] = await tx
+      .select()
+      .from(academicPeriod)
+      .where(eq(academicPeriod.periodId, periodId));
+    const lines = await tx
+      .select({
+        subject: subjects.name,
+        classScore: gradebookScores.classScore,
+        examScore: gradebookScores.examScore,
+        total: gradebookScores.total,
+        grade: gradebookScores.grade,
+      })
+      .from(gradebookScores)
+      .innerJoin(subjects, eq(gradebookScores.subjectId, subjects.id))
+      .where(
+        and(
+          eq(gradebookScores.schoolId, school.id),
+          eq(gradebookScores.studentId, student.id),
+          eq(gradebookScores.periodId, periodId),
+        ),
+      )
+      .orderBy(asc(subjects.name));
+    const [card] = await tx
+      .select()
+      .from(reportCards)
+      .where(
+        and(
+          eq(reportCards.studentId, student.id),
+          eq(reportCards.periodId, periodId),
+          eq(reportCards.schoolId, school.id),
+        ),
+      );
+    return { student, period, lines, card };
+  });
+
+  if (!data || !data.student) notFound();
+  const { student, period, lines, card } = data;
+
+  return (
+    <div className="mx-auto max-w-3xl">
+      <div className="mb-4 flex items-center justify-between print:hidden">
+        <Link href="/gradebook/reports" className="text-sm text-navy-3 hover:text-gold">
+          ← Report cards
+        </Link>
+        <PrintButton />
+      </div>
+
+      <div className="bg-surface rounded-xl border border-border p-8">
+        <div className="mb-6 border-b border-border pb-4 text-center">
+          <div className="font-display text-2xl font-semibold text-navy">
+            {school.name}
+          </div>
+          <div className="mt-1 text-sm text-navy-3">
+            Terminal Report ·{" "}
+            {period ? `${period.academicYear} · ${period.periodLabel}` : "—"}
+          </div>
+        </div>
+
+        <div className="mb-6 grid grid-cols-2 gap-2 text-sm">
+          <div>
+            <span className="text-navy-3">Student: </span>
+            <span className="font-medium text-navy">
+              {student.firstName} {student.otherNames ?? ""} {student.lastName}
+            </span>
+          </div>
+          <div className="text-right">
+            <span className="text-navy-3">Code: </span>
+            <span className="font-mono text-navy">{student.studentCode}</span>
+          </div>
+          <div>
+            <span className="text-navy-3">Class: </span>
+            <span className="text-navy">{student.currentClassLabel ?? "—"}</span>
+          </div>
+        </div>
+
+        <table className="w-full text-sm">
+          <thead className="border-y border-border text-left text-xs uppercase tracking-wide text-navy-3">
+            <tr>
+              <th className="py-2 font-semibold">Subject</th>
+              <th className="py-2 text-right font-semibold">Class</th>
+              <th className="py-2 text-right font-semibold">Exam</th>
+              <th className="py-2 text-right font-semibold">Total</th>
+              <th className="py-2 text-right font-semibold">Grade</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {lines.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="py-6 text-center text-navy-3">
+                  No scores entered for this period.
+                </td>
+              </tr>
+            ) : (
+              lines.map((l, i) => (
+                <tr key={i}>
+                  <td className="py-2 text-navy">{l.subject}</td>
+                  <td className="py-2 text-right text-navy-2">
+                    {l.classScore ? Number(l.classScore).toFixed(0) : "—"}
+                  </td>
+                  <td className="py-2 text-right text-navy-2">
+                    {l.examScore ? Number(l.examScore).toFixed(0) : "—"}
+                  </td>
+                  <td className="py-2 text-right font-medium text-navy">
+                    {l.total ? Number(l.total).toFixed(2) : "—"}
+                  </td>
+                  <td className="py-2 text-right font-semibold text-navy">
+                    {l.grade ?? "—"}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+
+        <div className="mt-6 flex items-end justify-between border-t border-border pt-4">
+          <div className="text-sm text-navy-2">
+            {card?.remark && (
+              <p>
+                <span className="text-navy-3">Remark: </span>
+                {card.remark}
+              </p>
+            )}
+            <p className="text-xs text-navy-3">
+              {card
+                ? `Generated ${new Date(card.generatedAt).toLocaleDateString()}`
+                : "Not yet generated"}
+            </p>
+          </div>
+          <div className="text-right">
+            <div className="text-xs uppercase tracking-wide text-navy-3">Overall</div>
+            <div className="font-display text-3xl font-semibold text-navy">
+              {card?.overallTotal ? Number(card.overallTotal).toFixed(2) : "—"}
+              {card?.overallGrade && (
+                <span className="ml-2 text-xl text-gold">{card.overallGrade}</span>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/omnischools/app/(app)/gradebook/reports/page.tsx
+++ b/omnischools/app/(app)/gradebook/reports/page.tsx
@@ -1,0 +1,136 @@
+import Link from "next/link";
+import { and, asc, eq } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import { classes, students, academicPeriod, reportCards } from "@/db/schema";
+import { GradebookSelectors } from "@/components/gradebook/selectors";
+import { GenerateReports } from "@/components/gradebook/generate-reports";
+
+export const dynamic = "force-dynamic";
+
+export default async function ReportsPage({
+  searchParams,
+}: {
+  searchParams: { classId?: string; periodId?: string };
+}) {
+  const { school } = await requireSchool();
+  const { classId, periodId } = searchParams;
+
+  const base = await withSchool(school.id, async (tx) => {
+    const cls = await tx.select().from(classes).where(eq(classes.schoolId, school.id));
+    const periods = await tx
+      .select()
+      .from(academicPeriod)
+      .where(eq(academicPeriod.schoolId, school.id));
+    return { cls, periods };
+  });
+
+  let body: React.ReactNode = (
+    <div className="border-border-2 bg-surface rounded-xl border border-dashed p-12 text-center text-sm text-navy-3">
+      Choose a class and period.
+    </div>
+  );
+
+  if (classId && periodId) {
+    const roster = await withSchool(school.id, (tx) =>
+      tx
+        .select({
+          id: students.id,
+          firstName: students.firstName,
+          lastName: students.lastName,
+          code: students.studentCode,
+          overall: reportCards.overallTotal,
+          grade: reportCards.overallGrade,
+        })
+        .from(students)
+        .leftJoin(
+          reportCards,
+          and(eq(reportCards.studentId, students.id), eq(reportCards.periodId, periodId)),
+        )
+        .where(
+          and(
+            eq(students.schoolId, school.id),
+            eq(students.classId, classId),
+            eq(students.status, "ACTIVE"),
+          ),
+        )
+        .orderBy(asc(students.lastName)),
+    );
+
+    body = (
+      <div>
+        <div className="bg-surface mb-5 rounded-xl border border-border p-5">
+          <GenerateReports classId={classId} periodId={periodId} />
+        </div>
+        {roster.length === 0 ? (
+          <p className="text-sm text-navy-3">No students in this class.</p>
+        ) : (
+          <div className="bg-surface overflow-hidden rounded-xl border border-border">
+            <table className="w-full text-sm">
+              <thead className="bg-bg border-b border-border text-left text-xs uppercase tracking-wide text-navy-3">
+                <tr>
+                  <th className="px-4 py-3 font-semibold">Student</th>
+                  <th className="px-4 py-3 text-right font-semibold">Overall</th>
+                  <th className="px-4 py-3 font-semibold">Grade</th>
+                  <th className="px-4 py-3"></th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {roster.map((r) => (
+                  <tr key={r.id} className="hover:bg-bg">
+                    <td className="px-4 py-3 font-medium text-navy">
+                      {r.lastName}, {r.firstName}
+                    </td>
+                    <td className="px-4 py-3 text-right text-navy">
+                      {r.overall ? Number(r.overall).toFixed(2) : "—"}
+                    </td>
+                    <td className="px-4 py-3 font-semibold text-navy-2">
+                      {r.grade ?? "—"}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <Link
+                        href={`/gradebook/report/${r.id}?periodId=${periodId}`}
+                        className="text-sm font-semibold text-gold hover:underline"
+                      >
+                        View report
+                      </Link>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-page">
+      <Link href="/gradebook" className="text-sm text-navy-3 hover:text-gold">
+        ← Gradebook
+      </Link>
+      <h1 className="mb-1 mt-2 font-display text-3xl font-semibold text-navy">
+        Report cards
+      </h1>
+      <p className="mb-5 text-sm text-navy-3">
+        Generate term report cards for a class, then open each student&apos;s card.
+      </p>
+      <div className="mb-5">
+        <GradebookSelectors
+          classes={base.cls.map((c) => ({ id: c.id, label: c.name }))}
+          subjects={[]}
+          periods={base.periods.map((p) => ({
+            id: p.periodId,
+            label: `${p.academicYear} · ${p.periodLabel}`,
+          }))}
+          classId={classId}
+          periodId={periodId}
+          basePath="/gradebook/reports"
+          showSubject={false}
+        />
+      </div>
+      {body}
+    </div>
+  );
+}

--- a/omnischools/components/app/sidebar.tsx
+++ b/omnischools/components/app/sidebar.tsx
@@ -9,13 +9,11 @@ const NAV = [
   { href: "/admissions", label: "Admissions", icon: "A" },
   { href: "/fees", label: "Fees", icon: "F" },
   { href: "/attendance", label: "Attendance", icon: "T" },
+  { href: "/gradebook", label: "Gradebook", icon: "G" },
 ];
 
 // Roadmap items (later Phase 3 slices) — shown disabled to convey the shape.
-const SOON = [
-  { label: "Gradebook", icon: "G" },
-  { label: "Communication", icon: "C" },
-];
+const SOON = [{ label: "Communication", icon: "C" }];
 
 export function AppSidebar() {
   const pathname = usePathname();

--- a/omnischools/components/gradebook/generate-reports.tsx
+++ b/omnischools/components/gradebook/generate-reports.tsx
@@ -1,0 +1,50 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { generateReportCards } from "@/lib/actions/gradebook";
+
+export function GenerateReports({
+  classId,
+  periodId,
+}: {
+  classId: string;
+  periodId: string;
+}) {
+  const router = useRouter();
+  const [remark, setRemark] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function run() {
+    setBusy(true);
+    setError(null);
+    setMsg(null);
+    const res = await generateReportCards({ classId, periodId, remark });
+    setBusy(false);
+    if (res.ok) {
+      setMsg(`Generated ${res.generated} report card${res.generated === 1 ? "" : "s"}.`);
+      router.refresh();
+    } else setError(res.error);
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <input
+        value={remark}
+        onChange={(e) => setRemark(e.target.value)}
+        placeholder="Optional class remark"
+        className="border-border-2 bg-bg grow rounded-md border px-3 py-2 text-sm text-navy outline-none focus:border-gold"
+      />
+      <button
+        onClick={run}
+        disabled={busy}
+        className="text-bg rounded-md bg-navy px-5 py-2 text-sm font-semibold hover:bg-navy-deep disabled:opacity-60"
+      >
+        {busy ? "Generating…" : "Generate term reports"}
+      </button>
+      {msg && <span className="w-full text-sm text-green">{msg}</span>}
+      {error && <span className="w-full text-sm text-terra">{error}</span>}
+    </div>
+  );
+}

--- a/omnischools/components/gradebook/new-subject-form.tsx
+++ b/omnischools/components/gradebook/new-subject-form.tsx
@@ -1,0 +1,65 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { createSubject } from "@/lib/actions/gradebook";
+
+export function NewSubjectForm() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="border-border-2 bg-surface rounded-md border px-4 py-2.5 text-sm font-semibold text-navy hover:bg-gold-bg"
+      >
+        + New subject
+      </button>
+    );
+  }
+  async function action(formData: FormData) {
+    setBusy(true);
+    setError(null);
+    const res = await createSubject({
+      name: formData.get("name"),
+      code: formData.get("code"),
+    });
+    setBusy(false);
+    if (res.ok) {
+      setOpen(false);
+      router.refresh();
+    } else setError(res.error ?? "Error");
+  }
+  return (
+    <form action={action} className="flex flex-wrap items-center gap-2">
+      <input
+        name="name"
+        required
+        placeholder="Subject (e.g. Mathematics)"
+        className="border-border-2 bg-bg rounded-md border px-3 py-2 text-sm text-navy outline-none focus:border-gold"
+      />
+      <input
+        name="code"
+        placeholder="Code"
+        className="border-border-2 bg-bg w-24 rounded-md border px-3 py-2 text-sm text-navy outline-none focus:border-gold"
+      />
+      <button
+        type="submit"
+        disabled={busy}
+        className="text-bg rounded-md bg-navy px-4 py-2 text-sm font-semibold hover:bg-navy-deep disabled:opacity-60"
+      >
+        {busy ? "Adding…" : "Add"}
+      </button>
+      <button
+        type="button"
+        onClick={() => setOpen(false)}
+        className="px-2 text-sm text-navy-3"
+      >
+        cancel
+      </button>
+      {error && <span className="w-full text-sm text-terra">{error}</span>}
+    </form>
+  );
+}

--- a/omnischools/components/gradebook/print-button.tsx
+++ b/omnischools/components/gradebook/print-button.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+export function PrintButton() {
+  return (
+    <button
+      onClick={() => window.print()}
+      className="border-border-2 bg-surface rounded-md border px-4 py-2 text-sm font-semibold text-navy hover:bg-gold-bg print:hidden"
+    >
+      Print
+    </button>
+  );
+}

--- a/omnischools/components/gradebook/score-grid.tsx
+++ b/omnischools/components/gradebook/score-grid.tsx
@@ -1,0 +1,145 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { saveScores } from "@/lib/actions/gradebook";
+import { weightedTotal, gradeFor } from "@/lib/gradebook-helpers";
+
+type Row = {
+  id: string;
+  name: string;
+  code: string;
+  classScore: string;
+  examScore: string;
+};
+
+const inputCls =
+  "w-20 rounded-md border border-border-2 bg-bg px-2 py-1.5 text-sm text-navy outline-none focus:border-gold";
+
+export function ScoreGrid({
+  classId,
+  subjectId,
+  periodId,
+  weights,
+  roster,
+}: {
+  classId: string;
+  subjectId: string;
+  periodId: string;
+  weights: { cw: number; ew: number };
+  roster: Row[];
+}) {
+  const router = useRouter();
+  const [rows, setRows] = useState<Record<string, { c: string; e: string }>>(
+    Object.fromEntries(roster.map((r) => [r.id, { c: r.classScore, e: r.examScore }])),
+  );
+  const [saving, setSaving] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  function set(id: string, key: "c" | "e", v: string) {
+    setRows((s) => ({ ...s, [id]: { ...s[id], [key]: v } }));
+  }
+  function preview(id: string) {
+    const c = rows[id].c === "" ? null : Number(rows[id].c);
+    const e = rows[id].e === "" ? null : Number(rows[id].e);
+    const t = weightedTotal(c, e, weights.cw, weights.ew);
+    return t == null ? null : { total: t, grade: gradeFor(t) };
+  }
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    setMsg(null);
+    const res = await saveScores({
+      classId,
+      subjectId,
+      periodId,
+      entries: roster.map((r) => ({
+        studentId: r.id,
+        classScore: rows[r.id].c === "" ? null : rows[r.id].c,
+        examScore: rows[r.id].e === "" ? null : rows[r.id].e,
+      })),
+    });
+    setSaving(false);
+    if (res.ok) {
+      setMsg(`Saved ${res.saved} score${res.saved === 1 ? "" : "s"}.`);
+      router.refresh();
+    } else setError(res.error);
+  }
+
+  return (
+    <div>
+      <div className="mb-3 flex items-center justify-between">
+        <p className="text-xs text-navy-3">
+          Class {weights.cw}% · Exam {weights.ew}% — total updates live.
+        </p>
+        <button
+          onClick={save}
+          disabled={saving}
+          className="text-bg rounded-md bg-navy px-5 py-2 text-sm font-semibold transition-colors hover:bg-navy-deep disabled:opacity-60"
+        >
+          {saving ? "Saving…" : "Save scores"}
+        </button>
+      </div>
+      {msg && (
+        <p className="mb-3 rounded-md bg-green-bg px-3 py-2 text-sm text-green">{msg}</p>
+      )}
+      {error && <p className="mb-3 text-sm text-terra">{error}</p>}
+
+      <div className="bg-surface overflow-hidden rounded-xl border border-border">
+        <table className="w-full text-sm">
+          <thead className="bg-bg border-b border-border text-left text-xs uppercase tracking-wide text-navy-3">
+            <tr>
+              <th className="px-4 py-3 font-semibold">Student</th>
+              <th className="px-4 py-3 font-semibold">Class ({weights.cw}%)</th>
+              <th className="px-4 py-3 font-semibold">Exam ({weights.ew}%)</th>
+              <th className="px-4 py-3 text-right font-semibold">Total</th>
+              <th className="px-4 py-3 font-semibold">Grade</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {roster.map((r) => {
+              const p = preview(r.id);
+              return (
+                <tr key={r.id}>
+                  <td className="px-4 py-2.5">
+                    <div className="font-medium text-navy">{r.name}</div>
+                    <div className="font-mono text-xs text-navy-3">{r.code}</div>
+                  </td>
+                  <td className="px-4 py-2.5">
+                    <input
+                      className={inputCls}
+                      type="number"
+                      min="0"
+                      max="100"
+                      step="0.01"
+                      value={rows[r.id].c}
+                      onChange={(e) => set(r.id, "c", e.target.value)}
+                    />
+                  </td>
+                  <td className="px-4 py-2.5">
+                    <input
+                      className={inputCls}
+                      type="number"
+                      min="0"
+                      max="100"
+                      step="0.01"
+                      value={rows[r.id].e}
+                      onChange={(e) => set(r.id, "e", e.target.value)}
+                    />
+                  </td>
+                  <td className="px-4 py-2.5 text-right font-medium text-navy">
+                    {p ? p.total.toFixed(2) : "—"}
+                  </td>
+                  <td className="px-4 py-2.5 font-semibold text-navy-2">
+                    {p ? p.grade : "—"}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/omnischools/components/gradebook/selectors.tsx
+++ b/omnischools/components/gradebook/selectors.tsx
@@ -1,0 +1,81 @@
+"use client";
+import { useRouter } from "next/navigation";
+
+type Opt = { id: string; label: string };
+
+/** Three linked selectors (class · subject · period) that drive /gradebook via query. */
+export function GradebookSelectors({
+  classes,
+  subjects,
+  periods,
+  classId,
+  subjectId,
+  periodId,
+  basePath = "/gradebook",
+  showSubject = true,
+}: {
+  classes: Opt[];
+  subjects: Opt[];
+  periods: Opt[];
+  classId?: string;
+  subjectId?: string;
+  periodId?: string;
+  basePath?: string;
+  showSubject?: boolean;
+}) {
+  const router = useRouter();
+  function go(next: { classId?: string; subjectId?: string; periodId?: string }) {
+    const p = new URLSearchParams();
+    const cId = next.classId ?? classId;
+    const sId = next.subjectId ?? subjectId;
+    const pId = next.periodId ?? periodId;
+    if (cId) p.set("classId", cId);
+    if (showSubject && sId) p.set("subjectId", sId);
+    if (pId) p.set("periodId", pId);
+    router.push(`${basePath}?${p.toString()}`);
+  }
+  const cls =
+    "rounded-md border border-border-2 bg-bg px-3 py-2 text-sm text-navy outline-none focus:border-gold";
+  return (
+    <div className="flex flex-wrap gap-2">
+      <select
+        value={classId ?? ""}
+        onChange={(e) => go({ classId: e.target.value })}
+        className={cls}
+      >
+        <option value="">Class…</option>
+        {classes.map((c) => (
+          <option key={c.id} value={c.id}>
+            {c.label}
+          </option>
+        ))}
+      </select>
+      {showSubject && (
+        <select
+          value={subjectId ?? ""}
+          onChange={(e) => go({ subjectId: e.target.value })}
+          className={cls}
+        >
+          <option value="">Subject…</option>
+          {subjects.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.label}
+            </option>
+          ))}
+        </select>
+      )}
+      <select
+        value={periodId ?? ""}
+        onChange={(e) => go({ periodId: e.target.value })}
+        className={cls}
+      >
+        <option value="">Period…</option>
+        {periods.map((p) => (
+          <option key={p.id} value={p.id}>
+            {p.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/omnischools/db/migrations/0005_bright_stone_men.sql
+++ b/omnischools/db/migrations/0005_bright_stone_men.sql
@@ -1,0 +1,57 @@
+CREATE TABLE "gradebook_config" (
+	"school_id" uuid PRIMARY KEY NOT NULL,
+	"class_weight" smallint DEFAULT 50 NOT NULL,
+	"exam_weight" smallint DEFAULT 50 NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "gradebook_score" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"school_id" uuid NOT NULL,
+	"student_id" uuid NOT NULL,
+	"subject_id" uuid NOT NULL,
+	"period_id" uuid NOT NULL,
+	"class_score" numeric(5, 2),
+	"exam_score" numeric(5, 2),
+	"total" numeric(5, 2),
+	"grade" text,
+	"updated_by_user_id" uuid,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "uniq_score_student_subject_period" UNIQUE("school_id","student_id","subject_id","period_id")
+);
+--> statement-breakpoint
+CREATE TABLE "report_card" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"school_id" uuid NOT NULL,
+	"student_id" uuid NOT NULL,
+	"period_id" uuid NOT NULL,
+	"overall_total" numeric(5, 2),
+	"overall_grade" text,
+	"subject_count" smallint,
+	"remark" text,
+	"generated_by_user_id" uuid,
+	"generated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "uniq_report_student_period" UNIQUE("school_id","student_id","period_id")
+);
+--> statement-breakpoint
+CREATE TABLE "subject" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"school_id" uuid NOT NULL,
+	"name" text NOT NULL,
+	"code" text,
+	"active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "uniq_subject_per_school" UNIQUE("school_id","name")
+);
+--> statement-breakpoint
+ALTER TABLE "gradebook_config" ADD CONSTRAINT "gradebook_config_school_id_ref_school_id_fk" FOREIGN KEY ("school_id") REFERENCES "public"."ref_school"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "gradebook_score" ADD CONSTRAINT "gradebook_score_school_id_ref_school_id_fk" FOREIGN KEY ("school_id") REFERENCES "public"."ref_school"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "gradebook_score" ADD CONSTRAINT "gradebook_score_student_id_students_id_fk" FOREIGN KEY ("student_id") REFERENCES "public"."students"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "gradebook_score" ADD CONSTRAINT "gradebook_score_subject_id_subject_id_fk" FOREIGN KEY ("subject_id") REFERENCES "public"."subject"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "gradebook_score" ADD CONSTRAINT "gradebook_score_period_id_academic_period_period_id_fk" FOREIGN KEY ("period_id") REFERENCES "public"."academic_period"("period_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "gradebook_score" ADD CONSTRAINT "gradebook_score_updated_by_user_id_ref_user_id_fk" FOREIGN KEY ("updated_by_user_id") REFERENCES "public"."ref_user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "report_card" ADD CONSTRAINT "report_card_school_id_ref_school_id_fk" FOREIGN KEY ("school_id") REFERENCES "public"."ref_school"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "report_card" ADD CONSTRAINT "report_card_student_id_students_id_fk" FOREIGN KEY ("student_id") REFERENCES "public"."students"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "report_card" ADD CONSTRAINT "report_card_period_id_academic_period_period_id_fk" FOREIGN KEY ("period_id") REFERENCES "public"."academic_period"("period_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "report_card" ADD CONSTRAINT "report_card_generated_by_user_id_ref_user_id_fk" FOREIGN KEY ("generated_by_user_id") REFERENCES "public"."ref_user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "subject" ADD CONSTRAINT "subject_school_id_ref_school_id_fk" FOREIGN KEY ("school_id") REFERENCES "public"."ref_school"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "score_period_subject_idx" ON "gradebook_score" USING btree ("period_id","subject_id");

--- a/omnischools/db/migrations/meta/0005_snapshot.json
+++ b/omnischools/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,3543 @@
+{
+  "id": "44120cf5-bf7f-41e2-bc28-2cbd610004ac",
+  "prevId": "a798df69-ed5b-48d4-aff8-34d49a1e93ff",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ref_district": {
+      "name": "ref_district",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_district_region_id_ref_region_id_fk": {
+          "name": "ref_district_region_id_ref_region_id_fk",
+          "tableFrom": "ref_district",
+          "tableTo": "ref_region",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_district_code_unique": {
+          "name": "ref_district_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_region": {
+      "name": "ref_region",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_region_code_unique": {
+          "name": "ref_region_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_school_product": {
+      "name": "ref_school_product",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product": {
+          "name": "product",
+          "type": "product",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_school_product_school_id_ref_school_id_fk": {
+          "name": "ref_school_product_school_id_ref_school_id_fk",
+          "tableFrom": "ref_school_product",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_school_product": {
+          "name": "uniq_school_product",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "product"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_school": {
+      "name": "ref_school",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ges_code": {
+          "name": "ges_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_type": {
+          "name": "school_type",
+          "type": "school_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'BASIC'"
+        },
+        "shs_category": {
+          "name": "shs_category",
+          "type": "shs_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownership_type": {
+          "name": "ownership_type",
+          "type": "ownership_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRIVATE'"
+        },
+        "district_id": {
+          "name": "district_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_school_district_id_ref_district_id_fk": {
+          "name": "ref_school_district_id_ref_district_id_fk",
+          "tableFrom": "ref_school",
+          "tableTo": "ref_district",
+          "columnsFrom": [
+            "district_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ref_school_region_id_ref_region_id_fk": {
+          "name": "ref_school_region_id_ref_region_id_fk",
+          "tableFrom": "ref_school",
+          "tableTo": "ref_region",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_school_ges_code_unique": {
+          "name": "ref_school_ges_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "ges_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_assignment": {
+      "name": "role_assignment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_ref": {
+          "name": "scope_ref",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_assignment_user_id_ref_user_id_fk": {
+          "name": "role_assignment_user_id_ref_user_id_fk",
+          "tableFrom": "role_assignment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_assignment_school_id_ref_school_id_fk": {
+          "name": "role_assignment_school_id_ref_school_id_fk",
+          "tableFrom": "role_assignment",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_assignment_role_id_ref_role_id_fk": {
+          "name": "role_assignment_role_id_ref_role_id_fk",
+          "tableFrom": "role_assignment",
+          "tableTo": "ref_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_role": {
+      "name": "ref_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "app_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_role_code_unique": {
+          "name": "ref_role_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_user": {
+      "name": "ref_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_user_phone_unique": {
+          "name": "ref_user_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.academic_period": {
+      "name": "academic_period",
+      "schema": "",
+      "columns": {
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_number": {
+          "name": "period_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_label": {
+          "name": "period_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_on": {
+          "name": "ends_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "academic_period_school_id_academic_year_ref_academic_period_config_school_id_academic_year_fk": {
+          "name": "academic_period_school_id_academic_year_ref_academic_period_config_school_id_academic_year_fk",
+          "tableFrom": "academic_period",
+          "tableTo": "ref_academic_period_config",
+          "columnsFrom": [
+            "school_id",
+            "academic_year"
+          ],
+          "columnsTo": [
+            "school_id",
+            "academic_year"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_academic_period_config": {
+      "name": "ref_academic_period_config",
+      "schema": "",
+      "columns": {
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_type": {
+          "name": "period_type",
+          "type": "period_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_count": {
+          "name": "period_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "period_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured_at": {
+          "name": "configured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "configured_by": {
+          "name": "configured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_academic_period_config_school_id_ref_school_id_fk": {
+          "name": "ref_academic_period_config_school_id_ref_school_id_fk",
+          "tableFrom": "ref_academic_period_config",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ref_academic_period_config_configured_by_ref_user_id_fk": {
+          "name": "ref_academic_period_config_configured_by_ref_user_id_fk",
+          "tableFrom": "ref_academic_period_config",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "configured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ref_academic_period_config_school_id_academic_year_pk": {
+          "name": "ref_academic_period_config_school_id_academic_year_pk",
+          "columns": [
+            "school_id",
+            "academic_year"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gen_period_defaults": {
+      "name": "gen_period_defaults",
+      "schema": "",
+      "columns": {
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_line": {
+          "name": "product_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_number": {
+          "name": "period_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_label": {
+          "name": "period_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_on": {
+          "name": "ends_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_at": {
+          "name": "extracted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gen_period_defaults_reviewed_by_ref_user_id_fk": {
+          "name": "gen_period_defaults_reviewed_by_ref_user_id_fk",
+          "tableFrom": "gen_period_defaults",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gen_period_defaults_academic_year_product_line_period_number_pk": {
+          "name": "gen_period_defaults_academic_year_product_line_period_number_pk",
+          "columns": [
+            "academic_year",
+            "product_line",
+            "period_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "audit_id": {
+          "name": "audit_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_role": {
+          "name": "actor_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before_jsonb": {
+          "name": "before_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_jsonb": {
+          "name": "after_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_school_time_idx": {
+          "name": "audit_school_time_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_entity_idx": {
+          "name": "audit_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_school_id_ref_school_id_fk": {
+          "name": "audit_log_school_id_ref_school_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_log_actor_user_id_ref_user_id_fk": {
+          "name": "audit_log_actor_user_id_ref_user_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_anomaly_rule": {
+      "name": "ref_anomaly_rule",
+      "schema": "",
+      "columns": {
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_code": {
+          "name": "rule_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "anomaly_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applies_to": {
+          "name": "applies_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold_jsonb": {
+          "name": "threshold_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_anomaly_rule_rule_code_unique": {
+          "name": "ref_anomaly_rule_rule_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rule_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.marketing_lead": {
+      "name": "marketing_lead",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organisation": {
+          "name": "organisation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'demo_form'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.class": {
+      "name": "class",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "class_school_id_ref_school_id_fk": {
+          "name": "class_school_id_ref_school_id_fk",
+          "tableFrom": "class",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_class_per_school": {
+          "name": "uniq_class_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_guardian": {
+      "name": "student_guardian",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "guardian_relation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GUARDIAN'"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "guardian_student_idx": {
+          "name": "guardian_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_guardian_school_id_ref_school_id_fk": {
+          "name": "student_guardian_school_id_ref_school_id_fk",
+          "tableFrom": "student_guardian",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_guardian_student_id_students_id_fk": {
+          "name": "student_guardian_student_id_students_id_fk",
+          "tableFrom": "student_guardian",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.students": {
+      "name": "students",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_code": {
+          "name": "student_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "other_names": {
+          "name": "other_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "student_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "current_class_label": {
+          "name": "current_class_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrolled_on": {
+          "name": "enrolled_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admission_application_id": {
+          "name": "admission_application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "students_school_idx": {
+          "name": "students_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "students_school_id_ref_school_id_fk": {
+          "name": "students_school_id_ref_school_id_fk",
+          "tableFrom": "students",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "students_class_id_class_id_fk": {
+          "name": "students_class_id_class_id_fk",
+          "tableFrom": "students",
+          "tableTo": "class",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_student_code_per_school": {
+          "name": "uniq_student_code_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admission_application": {
+      "name": "admission_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_first_name": {
+          "name": "applicant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_last_name": {
+          "name": "applicant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_other_names": {
+          "name": "applicant_other_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desired_class_label": {
+          "name": "desired_class_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guardian_name": {
+          "name": "guardian_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guardian_phone": {
+          "name": "guardian_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guardian_email": {
+          "name": "guardian_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "admission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SUBMITTED'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admission_school_status_idx": {
+          "name": "admission_school_status_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admission_application_school_id_ref_school_id_fk": {
+          "name": "admission_application_school_id_ref_school_id_fk",
+          "tableFrom": "admission_application",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admission_application_student_id_students_id_fk": {
+          "name": "admission_application_student_id_students_id_fk",
+          "tableFrom": "admission_application",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "admission_application_decided_by_user_id_ref_user_id_fk": {
+          "name": "admission_application_decided_by_user_id_ref_user_id_fk",
+          "tableFrom": "admission_application",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admission_document": {
+      "name": "admission_document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admission_document_school_id_ref_school_id_fk": {
+          "name": "admission_document_school_id_ref_school_id_fk",
+          "tableFrom": "admission_document",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admission_document_application_id_admission_application_id_fk": {
+          "name": "admission_document_application_id_admission_application_id_fk",
+          "tableFrom": "admission_document",
+          "tableTo": "admission_application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_category": {
+      "name": "fee_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_category_school_id_ref_school_id_fk": {
+          "name": "fee_category_school_id_ref_school_id_fk",
+          "tableFrom": "fee_category",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_fee_category_per_school": {
+          "name": "uniq_fee_category_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_line_item": {
+      "name": "invoice_line_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_category_id": {
+          "name": "fee_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_optional": {
+          "name": "is_optional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_line_item_school_id_ref_school_id_fk": {
+          "name": "invoice_line_item_school_id_ref_school_id_fk",
+          "tableFrom": "invoice_line_item",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_line_item_invoice_id_invoice_id_fk": {
+          "name": "invoice_line_item_invoice_id_invoice_id_fk",
+          "tableFrom": "invoice_line_item",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_line_item_fee_category_id_fee_category_id_fk": {
+          "name": "invoice_line_item_fee_category_id_fee_category_id_fk",
+          "tableFrom": "invoice_line_item",
+          "tableTo": "fee_category",
+          "columnsFrom": [
+            "fee_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice": {
+      "name": "invoice",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal_amount": {
+          "name": "subtotal_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "billed_amount": {
+          "name": "billed_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "balance_amount": {
+          "name": "balance_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ISSUED'"
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_student_idx": {
+          "name": "invoice_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_school_id_ref_school_id_fk": {
+          "name": "invoice_school_id_ref_school_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_student_id_students_id_fk": {
+          "name": "invoice_student_id_students_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_period_id_academic_period_period_id_fk": {
+          "name": "invoice_period_id_academic_period_period_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "period_id"
+          ],
+          "columnsTo": [
+            "period_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_invoice_number_per_school": {
+          "name": "uniq_invoice_number_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "invoice_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_allocation": {
+      "name": "payment_allocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allocation_type": {
+          "name": "allocation_type",
+          "type": "allocation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INVOICE'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allocation_method": {
+          "name": "allocation_method",
+          "type": "allocation_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MANUAL'"
+        },
+        "allocated_by_user_id": {
+          "name": "allocated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allocated_at": {
+          "name": "allocated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payment_allocation_school_id_ref_school_id_fk": {
+          "name": "payment_allocation_school_id_ref_school_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_allocation_payment_id_payment_id_fk": {
+          "name": "payment_allocation_payment_id_payment_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "payment",
+          "columnsFrom": [
+            "payment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_allocation_invoice_id_invoice_id_fk": {
+          "name": "payment_allocation_invoice_id_invoice_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_allocation_allocated_by_user_id_ref_user_id_fk": {
+          "name": "payment_allocation_allocated_by_user_id_ref_user_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "allocated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_audit_log": {
+      "name": "payment_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "payment_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "payment_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ADMIN'"
+        },
+        "before_state": {
+          "name": "before_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_state": {
+          "name": "after_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_audit_school_time_idx": {
+          "name": "payment_audit_school_time_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_audit_log_school_id_ref_school_id_fk": {
+          "name": "payment_audit_log_school_id_ref_school_id_fk",
+          "tableFrom": "payment_audit_log",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_audit_log_actor_user_id_ref_user_id_fk": {
+          "name": "payment_audit_log_actor_user_id_ref_user_id_fk",
+          "tableFrom": "payment_audit_log",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment": {
+      "name": "payment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gross_amount": {
+          "name": "gross_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_amount": {
+          "name": "fee_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "net_amount": {
+          "name": "net_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GHS'"
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method_reference": {
+          "name": "method_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregator": {
+          "name": "aggregator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settlement_status": {
+          "name": "settlement_status",
+          "type": "settlement_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_by_user_id": {
+          "name": "voided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payment_student_idx": {
+          "name": "payment_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_school_id_ref_school_id_fk": {
+          "name": "payment_school_id_ref_school_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_student_id_students_id_fk": {
+          "name": "payment_student_id_students_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_recorded_by_user_id_ref_user_id_fk": {
+          "name": "payment_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_voided_by_user_id_ref_user_id_fk": {
+          "name": "payment_voided_by_user_id_ref_user_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "voided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.receipt": {
+      "name": "receipt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receipt_number": {
+          "name": "receipt_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_replacement_id": {
+          "name": "void_replacement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "receipt_school_id_ref_school_id_fk": {
+          "name": "receipt_school_id_ref_school_id_fk",
+          "tableFrom": "receipt",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "receipt_payment_id_payment_id_fk": {
+          "name": "receipt_payment_id_payment_id_fk",
+          "tableFrom": "receipt",
+          "tableTo": "payment",
+          "columnsFrom": [
+            "payment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "receipt_student_id_students_id_fk": {
+          "name": "receipt_student_id_students_id_fk",
+          "tableFrom": "receipt",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "receipt_payment_id_unique": {
+          "name": "receipt_payment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "payment_id"
+          ]
+        },
+        "uniq_receipt_number_per_school": {
+          "name": "uniq_receipt_number_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "receipt_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attendance_correction": {
+      "name": "attendance_correction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_record_id": {
+          "name": "attendance_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_status": {
+          "name": "requested_status",
+          "type": "attendance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "correction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attendance_correction_school_id_ref_school_id_fk": {
+          "name": "attendance_correction_school_id_ref_school_id_fk",
+          "tableFrom": "attendance_correction",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_correction_attendance_record_id_attendance_record_id_fk": {
+          "name": "attendance_correction_attendance_record_id_attendance_record_id_fk",
+          "tableFrom": "attendance_correction",
+          "tableTo": "attendance_record",
+          "columnsFrom": [
+            "attendance_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_correction_requested_by_user_id_ref_user_id_fk": {
+          "name": "attendance_correction_requested_by_user_id_ref_user_id_fk",
+          "tableFrom": "attendance_correction",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attendance_correction_decided_by_user_id_ref_user_id_fk": {
+          "name": "attendance_correction_decided_by_user_id_ref_user_id_fk",
+          "tableFrom": "attendance_correction",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attendance_record": {
+      "name": "attendance_record",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "attendance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marked_by_user_id": {
+          "name": "marked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marked_at": {
+          "name": "marked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attendance_class_date_idx": {
+          "name": "attendance_class_date_idx",
+          "columns": [
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attendance_record_school_id_ref_school_id_fk": {
+          "name": "attendance_record_school_id_ref_school_id_fk",
+          "tableFrom": "attendance_record",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_record_student_id_students_id_fk": {
+          "name": "attendance_record_student_id_students_id_fk",
+          "tableFrom": "attendance_record",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_record_class_id_class_id_fk": {
+          "name": "attendance_record_class_id_class_id_fk",
+          "tableFrom": "attendance_record",
+          "tableTo": "class",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_record_marked_by_user_id_ref_user_id_fk": {
+          "name": "attendance_record_marked_by_user_id_ref_user_id_fk",
+          "tableFrom": "attendance_record",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "marked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_attendance_student_day": {
+          "name": "uniq_attendance_student_day",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gradebook_config": {
+      "name": "gradebook_config",
+      "schema": "",
+      "columns": {
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "class_weight": {
+          "name": "class_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "exam_weight": {
+          "name": "exam_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gradebook_config_school_id_ref_school_id_fk": {
+          "name": "gradebook_config_school_id_ref_school_id_fk",
+          "tableFrom": "gradebook_config",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gradebook_score": {
+      "name": "gradebook_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_score": {
+          "name": "class_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exam_score": {
+          "name": "exam_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "score_period_subject_idx": {
+          "name": "score_period_subject_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gradebook_score_school_id_ref_school_id_fk": {
+          "name": "gradebook_score_school_id_ref_school_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_score_student_id_students_id_fk": {
+          "name": "gradebook_score_student_id_students_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_score_subject_id_subject_id_fk": {
+          "name": "gradebook_score_subject_id_subject_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_score_period_id_academic_period_period_id_fk": {
+          "name": "gradebook_score_period_id_academic_period_period_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "period_id"
+          ],
+          "columnsTo": [
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_score_updated_by_user_id_ref_user_id_fk": {
+          "name": "gradebook_score_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_score_student_subject_period": {
+          "name": "uniq_score_student_subject_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "subject_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_card": {
+      "name": "report_card",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overall_total": {
+          "name": "overall_total",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overall_grade": {
+          "name": "overall_grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_count": {
+          "name": "subject_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "report_card_school_id_ref_school_id_fk": {
+          "name": "report_card_school_id_ref_school_id_fk",
+          "tableFrom": "report_card",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "report_card_student_id_students_id_fk": {
+          "name": "report_card_student_id_students_id_fk",
+          "tableFrom": "report_card",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "report_card_period_id_academic_period_period_id_fk": {
+          "name": "report_card_period_id_academic_period_period_id_fk",
+          "tableFrom": "report_card",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "period_id"
+          ],
+          "columnsTo": [
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "report_card_generated_by_user_id_ref_user_id_fk": {
+          "name": "report_card_generated_by_user_id_ref_user_id_fk",
+          "tableFrom": "report_card",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_report_student_period": {
+          "name": "uniq_report_student_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subject": {
+      "name": "subject",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subject_school_id_ref_school_id_fk": {
+          "name": "subject_school_id_ref_school_id_fk",
+          "tableFrom": "subject",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_subject_per_school": {
+          "name": "uniq_subject_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.admission_status": {
+      "name": "admission_status",
+      "schema": "public",
+      "values": [
+        "SUBMITTED",
+        "UNDER_REVIEW",
+        "ACCEPTED",
+        "REJECTED",
+        "WAITLISTED"
+      ]
+    },
+    "public.allocation_method": {
+      "name": "allocation_method",
+      "schema": "public",
+      "values": [
+        "MANUAL",
+        "AUTO_OLDEST_FIRST",
+        "AUTO_NEWEST_FIRST"
+      ]
+    },
+    "public.allocation_type": {
+      "name": "allocation_type",
+      "schema": "public",
+      "values": [
+        "INVOICE",
+        "CREDIT",
+        "REFUND"
+      ]
+    },
+    "public.anomaly_severity": {
+      "name": "anomaly_severity",
+      "schema": "public",
+      "values": [
+        "LOW",
+        "MEDIUM",
+        "HIGH"
+      ]
+    },
+    "public.app_role": {
+      "name": "app_role",
+      "schema": "public",
+      "values": [
+        "ADMIN",
+        "HEADMASTER",
+        "VICE_HEADMASTER_ACADEMIC",
+        "TEACHER",
+        "FORM_MASTER",
+        "HOUSEMASTER",
+        "STUDENT",
+        "PARENT",
+        "BURSAR",
+        "DEAN_OF_BOARDING",
+        "MATRON"
+      ]
+    },
+    "public.attendance_status": {
+      "name": "attendance_status",
+      "schema": "public",
+      "values": [
+        "PRESENT",
+        "ABSENT",
+        "LATE",
+        "EXCUSED",
+        "MEDICAL"
+      ]
+    },
+    "public.correction_status": {
+      "name": "correction_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPROVED",
+        "REJECTED"
+      ]
+    },
+    "public.guardian_relation": {
+      "name": "guardian_relation",
+      "schema": "public",
+      "values": [
+        "MOTHER",
+        "FATHER",
+        "GUARDIAN",
+        "OTHER"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "ISSUED",
+        "PARTIAL",
+        "PAID",
+        "OVERDUE",
+        "EXEMPT",
+        "VOIDED"
+      ]
+    },
+    "public.ownership_type": {
+      "name": "ownership_type",
+      "schema": "public",
+      "values": [
+        "PUBLIC",
+        "PRIVATE",
+        "MISSION",
+        "INTERNATIONAL"
+      ]
+    },
+    "public.payment_actor_type": {
+      "name": "payment_actor_type",
+      "schema": "public",
+      "values": [
+        "ADMIN",
+        "SYSTEM",
+        "WEBHOOK",
+        "RECONCILIATION_JOB"
+      ]
+    },
+    "public.payment_event_type": {
+      "name": "payment_event_type",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "ALLOCATION_ADDED",
+        "ALLOCATION_VOIDED",
+        "SETTLED",
+        "VOIDED",
+        "SMS_SENT",
+        "SMS_FAILED",
+        "REFUNDED",
+        "DISCOUNT_OVERRIDDEN"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "MTN_MOMO",
+        "TELECEL_CASH",
+        "AIRTELTIGO_MONEY",
+        "BANK_TRANSFER",
+        "CASH",
+        "CHEQUE",
+        "OTHER"
+      ]
+    },
+    "public.period_source": {
+      "name": "period_source",
+      "schema": "public",
+      "values": [
+        "GES_DEFAULT",
+        "SCHOOL_OVERRIDE"
+      ]
+    },
+    "public.period_type": {
+      "name": "period_type",
+      "schema": "public",
+      "values": [
+        "TERM",
+        "SEMESTER"
+      ]
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "public",
+      "values": [
+        "BASIC",
+        "SENIOR",
+        "OVERSIGHT"
+      ]
+    },
+    "public.school_type": {
+      "name": "school_type",
+      "schema": "public",
+      "values": [
+        "BASIC",
+        "SENIOR",
+        "COMBINED"
+      ]
+    },
+    "public.settlement_status": {
+      "name": "settlement_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "CONFIRMED",
+        "SETTLED",
+        "RECONCILED",
+        "DISPUTED"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "MALE",
+        "FEMALE"
+      ]
+    },
+    "public.shs_category": {
+      "name": "shs_category",
+      "schema": "public",
+      "values": [
+        "A",
+        "B",
+        "C",
+        "D",
+        "E",
+        "F"
+      ]
+    },
+    "public.student_status": {
+      "name": "student_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "INACTIVE",
+        "GRADUATED",
+        "WITHDRAWN",
+        "TRANSFERRED"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/omnischools/db/migrations/meta/_journal.json
+++ b/omnischools/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1780512680059,
       "tag": "0004_sticky_snowbird",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1780514679348,
+      "tag": "0005_bright_stone_men",
+      "breakpoints": true
     }
   ]
 }

--- a/omnischools/db/schema/gradebook.ts
+++ b/omnischools/db/schema/gradebook.ts
@@ -1,0 +1,103 @@
+import {
+  pgTable,
+  uuid,
+  text,
+  numeric,
+  smallint,
+  boolean,
+  timestamp,
+  unique,
+  index,
+} from "drizzle-orm/pg-core";
+import { schools } from "./tenancy";
+import { students } from "./students";
+import { users } from "./identity";
+import { academicPeriod } from "./periods";
+
+const score = (name: string) => numeric(name, { precision: 5, scale: 2 });
+
+/** Subjects taught at a school (English, Maths, Integrated Science, ...). */
+export const subjects = pgTable(
+  "subject",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    schoolId: uuid("school_id")
+      .notNull()
+      .references(() => schools.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    code: text("code"),
+    active: boolean("active").notNull().default(true),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({ uniqName: unique("uniq_subject_per_school").on(t.schoolId, t.name) }),
+);
+
+/** Per-school weighting for Basic's two-category model (defaults 50/50). */
+export const gradebookConfig = pgTable("gradebook_config", {
+  schoolId: uuid("school_id")
+    .primaryKey()
+    .references(() => schools.id, { onDelete: "cascade" }),
+  classWeight: smallint("class_weight").notNull().default(50),
+  examWeight: smallint("exam_weight").notNull().default(50),
+});
+
+/** A student's score for a subject in a period: class (CA) + exam → weighted total. */
+export const gradebookScores = pgTable(
+  "gradebook_score",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    schoolId: uuid("school_id")
+      .notNull()
+      .references(() => schools.id, { onDelete: "cascade" }),
+    studentId: uuid("student_id")
+      .notNull()
+      .references(() => students.id, { onDelete: "cascade" }),
+    subjectId: uuid("subject_id")
+      .notNull()
+      .references(() => subjects.id, { onDelete: "cascade" }),
+    periodId: uuid("period_id")
+      .notNull()
+      .references(() => academicPeriod.periodId, { onDelete: "cascade" }),
+    classScore: score("class_score"),
+    examScore: score("exam_score"),
+    total: score("total"),
+    grade: text("grade"),
+    updatedByUserId: uuid("updated_by_user_id").references(() => users.id),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    uniq: unique("uniq_score_student_subject_period").on(
+      t.schoolId,
+      t.studentId,
+      t.subjectId,
+      t.periodId,
+    ),
+    byPeriodSubject: index("score_period_subject_idx").on(t.periodId, t.subjectId),
+  }),
+);
+
+/** A generated term report card (overall summary; lines rendered from scores). */
+export const reportCards = pgTable(
+  "report_card",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    schoolId: uuid("school_id")
+      .notNull()
+      .references(() => schools.id, { onDelete: "cascade" }),
+    studentId: uuid("student_id")
+      .notNull()
+      .references(() => students.id, { onDelete: "cascade" }),
+    periodId: uuid("period_id")
+      .notNull()
+      .references(() => academicPeriod.periodId, { onDelete: "cascade" }),
+    overallTotal: score("overall_total"),
+    overallGrade: text("overall_grade"),
+    subjectCount: smallint("subject_count"),
+    remark: text("remark"),
+    generatedByUserId: uuid("generated_by_user_id").references(() => users.id),
+    generatedAt: timestamp("generated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    uniq: unique("uniq_report_student_period").on(t.schoolId, t.studentId, t.periodId),
+  }),
+);

--- a/omnischools/db/schema/index.ts
+++ b/omnischools/db/schema/index.ts
@@ -14,3 +14,4 @@ export * from "./students";
 export * from "./admissions";
 export * from "./fees";
 export * from "./attendance";
+export * from "./gradebook";

--- a/omnischools/db/sql/policies.sql
+++ b/omnischools/db/sql/policies.sql
@@ -60,7 +60,11 @@ BEGIN
     'payment_audit_log',
     'class',
     'attendance_record',
-    'attendance_correction'
+    'attendance_correction',
+    'subject',
+    'gradebook_config',
+    'gradebook_score',
+    'report_card'
   ]
   LOOP
     EXECUTE format('ALTER TABLE %I ENABLE ROW LEVEL SECURITY;', tbl);

--- a/omnischools/lib/actions/gradebook.ts
+++ b/omnischools/lib/actions/gradebook.ts
@@ -1,0 +1,255 @@
+"use server";
+import { and, eq, inArray } from "drizzle-orm";
+import { z } from "zod";
+import { withSchool } from "@/lib/db/rls";
+import { recordAudit } from "@/lib/db/audit";
+import { requireSchool, resolveActor } from "@/lib/auth/server";
+import { safeRevalidate } from "@/lib/revalidate";
+import { round2, gradeFor, weightedTotal } from "@/lib/gradebook-helpers";
+import type { Tx } from "@/lib/db";
+import {
+  students,
+  subjects,
+  gradebookConfig,
+  gradebookScores,
+  reportCards,
+} from "@/db/schema";
+
+// ----------------------------------------------------------------- subjects
+export async function createSubject(
+  input: unknown,
+): Promise<{ ok: boolean; error?: string; id?: string }> {
+  const { school } = await requireSchool();
+  const parsed = z
+    .object({
+      name: z.string().min(1).max(80),
+      code: z.string().max(20).optional().or(z.literal("")),
+    })
+    .safeParse(input);
+  if (!parsed.success) return { ok: false, error: "Invalid subject name." };
+  const actor = await resolveActor(school.id);
+  try {
+    const id = await withSchool(school.id, async (tx) => {
+      const [s] = await tx
+        .insert(subjects)
+        .values({
+          schoolId: school.id,
+          name: parsed.data.name,
+          code: parsed.data.code || null,
+        })
+        .returning();
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "created",
+        entityType: "subject",
+        entityId: s.id,
+        after: { name: s.name },
+      });
+      return s.id;
+    });
+    safeRevalidate("/gradebook");
+    return { ok: true, id };
+  } catch {
+    return { ok: false, error: "Could not create subject (name may already exist)." };
+  }
+}
+
+async function getWeights(tx: Tx, schoolId: string): Promise<{ cw: number; ew: number }> {
+  const [cfg] = await tx
+    .select()
+    .from(gradebookConfig)
+    .where(eq(gradebookConfig.schoolId, schoolId));
+  if (cfg) return { cw: cfg.classWeight, ew: cfg.examWeight };
+  await tx.insert(gradebookConfig).values({ schoolId }).onConflictDoNothing();
+  return { cw: 50, ew: 50 };
+}
+
+// ------------------------------------------------------------------- scores
+const SaveScoresSchema = z.object({
+  classId: z.string().uuid(),
+  subjectId: z.string().uuid(),
+  periodId: z.string().uuid(),
+  entries: z
+    .array(
+      z.object({
+        studentId: z.string().uuid(),
+        classScore: z.coerce.number().min(0).max(100).nullable().catch(null),
+        examScore: z.coerce.number().min(0).max(100).nullable().catch(null),
+      }),
+    )
+    .min(1, "No students"),
+});
+
+export type SaveScoresResult = { ok: true; saved: number } | { ok: false; error: string };
+
+export async function saveScores(input: unknown): Promise<SaveScoresResult> {
+  const { school } = await requireSchool();
+  const parsed = SaveScoresSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid scores" };
+  }
+  const d = parsed.data;
+  const actor = await resolveActor(school.id);
+
+  try {
+    const saved = await withSchool(school.id, async (tx) => {
+      const { cw, ew } = await getWeights(tx, school.id);
+      let n = 0;
+      for (const e of d.entries) {
+        const total = weightedTotal(e.classScore, e.examScore, cw, ew);
+        await tx
+          .insert(gradebookScores)
+          .values({
+            schoolId: school.id,
+            studentId: e.studentId,
+            subjectId: d.subjectId,
+            periodId: d.periodId,
+            classScore: e.classScore == null ? null : e.classScore.toFixed(2),
+            examScore: e.examScore == null ? null : e.examScore.toFixed(2),
+            total: total == null ? null : total.toFixed(2),
+            grade: total == null ? null : gradeFor(total),
+            updatedByUserId: actor.id ?? undefined,
+            updatedAt: new Date(),
+          })
+          .onConflictDoUpdate({
+            target: [
+              gradebookScores.schoolId,
+              gradebookScores.studentId,
+              gradebookScores.subjectId,
+              gradebookScores.periodId,
+            ],
+            set: {
+              classScore: e.classScore == null ? null : e.classScore.toFixed(2),
+              examScore: e.examScore == null ? null : e.examScore.toFixed(2),
+              total: total == null ? null : total.toFixed(2),
+              grade: total == null ? null : gradeFor(total),
+              updatedByUserId: actor.id ?? undefined,
+              updatedAt: new Date(),
+            },
+          });
+        n++;
+      }
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "updated",
+        entityType: "gradebook",
+        entityId: d.subjectId,
+        after: { periodId: d.periodId, scores: n, weights: `${cw}/${ew}` },
+        reason: "Scores entered",
+      });
+      return n;
+    });
+
+    safeRevalidate("/gradebook");
+    return { ok: true, saved };
+  } catch {
+    return { ok: false, error: "Could not save scores. Please try again." };
+  }
+}
+
+// ------------------------------------------------------------- report cards
+const ReportSchema = z.object({
+  classId: z.string().uuid(),
+  periodId: z.string().uuid(),
+  remark: z.string().max(500).optional().or(z.literal("")),
+});
+
+export type GenerateReportsResult =
+  | { ok: true; generated: number }
+  | { ok: false; error: string };
+
+export async function generateReportCards(
+  input: unknown,
+): Promise<GenerateReportsResult> {
+  const { school } = await requireSchool();
+  const parsed = ReportSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: "Invalid input." };
+  const d = parsed.data;
+  const actor = await resolveActor(school.id);
+
+  try {
+    const generated = await withSchool(school.id, async (tx) => {
+      const roster = await tx
+        .select({ id: students.id })
+        .from(students)
+        .where(
+          and(
+            eq(students.schoolId, school.id),
+            eq(students.classId, d.classId),
+            eq(students.status, "ACTIVE"),
+          ),
+        );
+      if (roster.length === 0) return 0;
+
+      const ids = roster.map((r) => r.id);
+      const scores = await tx
+        .select({
+          studentId: gradebookScores.studentId,
+          total: gradebookScores.total,
+        })
+        .from(gradebookScores)
+        .where(
+          and(
+            eq(gradebookScores.schoolId, school.id),
+            eq(gradebookScores.periodId, d.periodId),
+            inArray(gradebookScores.studentId, ids),
+          ),
+        );
+
+      let count = 0;
+      for (const r of roster) {
+        const totals = scores
+          .filter((s) => s.studentId === r.id && s.total != null)
+          .map((s) => Number(s.total));
+        const overall = totals.length
+          ? round2(totals.reduce((a, b) => a + b, 0) / totals.length)
+          : null;
+        await tx
+          .insert(reportCards)
+          .values({
+            schoolId: school.id,
+            studentId: r.id,
+            periodId: d.periodId,
+            overallTotal: overall == null ? null : overall.toFixed(2),
+            overallGrade: overall == null ? null : gradeFor(overall),
+            subjectCount: totals.length,
+            remark: d.remark || null,
+            generatedByUserId: actor.id ?? undefined,
+            generatedAt: new Date(),
+          })
+          .onConflictDoUpdate({
+            target: [reportCards.schoolId, reportCards.studentId, reportCards.periodId],
+            set: {
+              overallTotal: overall == null ? null : overall.toFixed(2),
+              overallGrade: overall == null ? null : gradeFor(overall),
+              subjectCount: totals.length,
+              remark: d.remark || null,
+              generatedByUserId: actor.id ?? undefined,
+              generatedAt: new Date(),
+            },
+          });
+        count++;
+      }
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "generated",
+        entityType: "report_cards",
+        entityId: d.classId,
+        after: { periodId: d.periodId, count },
+        reason: "Term report cards generated",
+      });
+      return count;
+    });
+
+    safeRevalidate("/gradebook/reports");
+    return { ok: true, generated };
+  } catch {
+    return { ok: false, error: "Could not generate report cards." };
+  }
+}

--- a/omnischools/lib/gradebook-helpers.ts
+++ b/omnischools/lib/gradebook-helpers.ts
@@ -1,0 +1,31 @@
+/** Round to 2 dp. */
+export function round2(n: number): number {
+  return Math.round((n + Number.EPSILON) * 100) / 100;
+}
+
+/** Simple Basic-tier letter grade from a 0–100 total. */
+export function gradeFor(total: number): string {
+  if (total >= 80) return "A";
+  if (total >= 70) return "B";
+  if (total >= 60) return "C";
+  if (total >= 50) return "D";
+  if (total >= 40) return "E";
+  return "F";
+}
+
+/** Weighted total (out of 100) from class + exam scores and weights (percent). */
+export function weightedTotal(
+  classScore: number | null,
+  examScore: number | null,
+  classWeight: number,
+  examWeight: number,
+): number | null {
+  if (classScore == null || examScore == null) return null;
+  return round2((classScore * classWeight) / 100 + (examScore * examWeight) / 100);
+}
+
+export function numOrNull(v: unknown): number | null {
+  if (v === "" || v == null) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}

--- a/omnischools/package.json
+++ b/omnischools/package.json
@@ -23,6 +23,7 @@
     "db:verify-admissions": "tsx scripts/verify-admissions.ts",
     "db:verify-payments": "tsx scripts/verify-payments.ts",
     "db:verify-attendance": "tsx scripts/verify-attendance.ts",
+    "db:verify-gradebook": "tsx scripts/verify-gradebook.ts",
     "db:setup": "drizzle-kit migrate && tsx scripts/apply-policies.ts && tsx db/seed/asankrangwa.ts"
   },
   "dependencies": {

--- a/omnischools/scripts/verify-gradebook.ts
+++ b/omnischools/scripts/verify-gradebook.ts
@@ -1,0 +1,117 @@
+import "@/db/_loadenv";
+import { and, eq } from "drizzle-orm";
+import { createStudent } from "@/lib/actions/students";
+import { createClass, setStudentClass } from "@/lib/actions/attendance";
+import { createSubject, saveScores, generateReportCards } from "@/lib/actions/gradebook";
+import { db } from "@/lib/db";
+import {
+  students,
+  subjects,
+  classes,
+  academicPeriod,
+  gradebookScores,
+  reportCards,
+  schools,
+} from "@/db/schema";
+
+let failures = 0;
+function check(label: string, cond: boolean, detail = "") {
+  console.log(`${cond ? "✓" : "✗"} ${label}${detail ? ` (${detail})` : ""}`);
+  if (!cond) failures++;
+}
+
+async function main() {
+  const [school] = await db
+    .select({ id: schools.id })
+    .from(schools)
+    .where(eq(schools.gesCode, "WR-WAW-014"));
+  const [period] = await db
+    .select()
+    .from(academicPeriod)
+    .where(eq(academicPeriod.schoolId, school.id))
+    .limit(1);
+  if (!period) {
+    console.error("no academic period seeded");
+    process.exit(1);
+  }
+
+  const cls = await createClass({ name: `GB-${Date.now() % 100000}` });
+  const sub = await createSubject({ name: `Maths-${Date.now() % 100000}` });
+  const stu = await createStudent({
+    firstName: "Esi",
+    lastName: "Scholar",
+    sex: "FEMALE",
+  });
+  if (!cls.ok || !sub.ok || !sub.id || !stu.ok) {
+    console.error("setup failed", { cls, sub, stu });
+    process.exit(1);
+  }
+  await setStudentClass({ studentId: stu.studentId, classId: cls.classId });
+
+  // class 80, exam 60, default 50/50 → total 70, grade B
+  const save = await saveScores({
+    classId: cls.classId,
+    subjectId: sub.id,
+    periodId: period.periodId,
+    entries: [{ studentId: stu.studentId, classScore: 80, examScore: 60 }],
+  });
+  check("save scores ok", save.ok);
+
+  const [sc] = await db
+    .select()
+    .from(gradebookScores)
+    .where(
+      and(
+        eq(gradebookScores.studentId, stu.studentId),
+        eq(gradebookScores.subjectId, sub.id),
+        eq(gradebookScores.periodId, period.periodId),
+      ),
+    );
+  check(
+    "total 70.00, grade B",
+    Number(sc?.total) === 70 && sc?.grade === "B",
+    `${sc?.total}/${sc?.grade}`,
+  );
+
+  const gen = await generateReportCards({
+    classId: cls.classId,
+    periodId: period.periodId,
+  });
+  check(
+    "generate ok",
+    gen.ok,
+    gen.ok ? `${gen.generated} card(s)` : (gen as { error: string }).error,
+  );
+
+  const [rc] = await db
+    .select()
+    .from(reportCards)
+    .where(
+      and(
+        eq(reportCards.studentId, stu.studentId),
+        eq(reportCards.periodId, period.periodId),
+      ),
+    );
+  check(
+    "report card overall 70.00 / B / 1 subject",
+    Number(rc?.overallTotal) === 70 && rc?.overallGrade === "B" && rc?.subjectCount === 1,
+    `${rc?.overallTotal}/${rc?.overallGrade}/${rc?.subjectCount}`,
+  );
+
+  // cleanup (student cascades scores + report cards; then subject, class)
+  await db.delete(students).where(eq(students.id, stu.studentId));
+  await db.delete(subjects).where(eq(subjects.id, sub.id));
+  await db.delete(classes).where(eq(classes.id, cls.classId));
+
+  console.log(
+    failures === 0
+      ? "\n✓ Gradebook flow verified."
+      : `\n✗ ${failures} assertion(s) failed.`,
+  );
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error("✗ verify-gradebook error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Fourth Phase-3 slice: the **gradebook & report cards**, on the `class` + `academic_period` foundation. Basic two-category model (class/CA + exam) with school-configurable weighting (default 50/50).

### Schema (migration 0005 · RLS)
`subject`, `gradebook_config` (class/exam weights), `gradebook_score` (student × subject × period → weighted total + letter grade), `report_card` (per student × period overall).

### Actions
- `createSubject`.
- `saveScores` — bulk upsert a class+subject+period; weighted total + grade; audited.
- `generateReportCards` — per class+period, averages each student's subject totals into an overall + grade (+ optional remark); audited.

### UI
`/gradebook` score grid (class·subject·period selectors, live total/grade preview, save, new subject); `/gradebook/reports` (generate term reports + roster); `/gradebook/report/[studentId]` printable terminal report card. Gradebook in the sidebar.

## Verification
`pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm build` ✓ · `pnpm db:verify-gradebook` ✓ (80/60 @ 50/50 → 70.00/B → report card 70.00/B/1 subject).

## Next (final MVP1 slice)
Parent communications (announcements + SMS templates → guardians), then **MVP1 ship**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
