### PR TITLE
Real Supabase phone-OTP auth + deploy runbook

### DIFF
--- a/omnischools/.env.example
+++ b/omnischools/.env.example
@@ -23,5 +23,10 @@ NEXT_PUBLIC_POSTHOG_HOST=https://eu.posthog.com
 # ---- Background jobs (generic HTTP cron shared secret) ----
 CRON_SECRET=
 
-# ---- Dev auth shim (true until Supabase Auth phone-OTP is wired) ----
+# ---- Public site URL (used for metadata/sitemap; set to your deploy URL in prod) ----
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+
+# ---- Dev auth shim ----
+# true = ADMIN dev session, no provider needed (local dev).
+# false + Supabase env set = real Supabase phone-OTP auth (see DEPLOY.md).
 AUTH_DEV_BYPASS=true

--- a/omnischools/DEPLOY.md
+++ b/omnischools/DEPLOY.md
@@ -1,0 +1,84 @@
+# Omnischools — Production Deploy (MVP1)
+
+The app is **portable** (BUILD_STACK): no Vercel-only services, auth behind `lib/auth`,
+SMS/email behind `lib/{sms,email}`, jobs as HTTP POST + shared secret. Hosting today is
+**Supabase Postgres + Supabase Auth + Vercel**.
+
+> Prerequisite: all MVP1 PRs merged into `main` (Students/Admissions, Fees, Attendance,
+> Gradebook, Communications). Deploy from `main`.
+
+## What you'll need
+- A Supabase account (free tier) → project **omnischools-prod**.
+- A Vercel account connected to the **Omnischools** GitHub org.
+- (Optional, can come later) Hubtel SMS, Resend, Sentry, PostHog keys — stubbed until set.
+
+---
+
+## 1 · Supabase project
+1. Create project **omnischools-prod**, region **EU (London / eu-west-2)** (closest to Ghana).
+2. **Settings → API** — copy:
+   - Project URL → `NEXT_PUBLIC_SUPABASE_URL`
+   - `anon` public key → `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+   - `service_role` key → `SUPABASE_SERVICE_ROLE_KEY` (secret — server only)
+3. **Settings → Database → Connection string**:
+   - **Direct** (port 5432) → use for migrations/policies/seed below (call it `DIRECT_URL`).
+   - **Transaction pooler** (port 6543, add `?pgbouncer=true`) → app runtime `DATABASE_URL`.
+4. **Authentication → Providers → Phone** — enable, and attach an SMS provider
+   (Twilio / MessageBird / Vonage) per Supabase docs. For first tests you can add test
+   phone numbers with fixed OTPs under Auth → Phone.
+
+## 2 · Apply schema + RLS to prod (run locally, once)
+Run from `omnischools/` with the **direct** connection string. These are safe on an empty DB.
+Run as the project's `postgres` user so the RLS bypass role is granted to it.
+
+```bash
+# point at prod just for these commands (do NOT commit this value)
+export DATABASE_URL="<DIRECT_URL>"
+pnpm db:migrate        # creates all tables (migrations 0000–0006)
+pnpm db:policies       # enables/forces RLS + tenant policies + app/admin roles
+pnpm db:seed           # optional: seeds the Asankrangwa demo school
+```
+Tip: `pnpm db:rls-test` against prod should pass (cross-tenant reads blocked).
+
+## 3 · Vercel
+1. **Add New → Project** → import `Omnischools/omnischools`.
+2. **Root Directory = `omnischools`** (important — the app lives in the subdir).
+3. Framework preset: **Next.js** (auto-detected). Build: `pnpm build`.
+4. **Environment Variables** (Production):
+
+   | Key | Value |
+   |---|---|
+   | `DATABASE_URL` | transaction-pooler URI (`...:6543/postgres?pgbouncer=true`) |
+   | `NEXT_PUBLIC_SUPABASE_URL` | project URL |
+   | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | anon key |
+   | `SUPABASE_SERVICE_ROLE_KEY` | service_role key |
+   | `AUTH_DEV_BYPASS` | `false`  ← flips on real phone-OTP auth |
+   | `NEXT_PUBLIC_SITE_URL` | your Vercel URL (e.g. `https://omnischools.vercel.app`) |
+   | `CRON_SECRET` | a long random string |
+   | `HUBTEL_CLIENT_ID` / `_SECRET` / `_SENDER_ID` | optional (SMS goes live when set) |
+   | `RESEND_API_KEY` | optional (email goes live when set) |
+
+5. **Deploy.** Pushes to `main` auto-deploy thereafter.
+
+## 4 · Smoke test the live URL
+1. `/` landing renders; `/pricing`, `/faq` OK.
+2. `/start` → onboard a school (creates the admin **ref_user** with the phone you enter).
+3. `/login` → enter that admin phone → receive OTP → verify → lands on `/dashboard`.
+4. Admissions: `/apply/<GES-code>` submit → `/admissions` accept → student appears.
+5. Fees: issue invoice → record payment → receipt + balance update.
+6. Attendance: create class, enroll, take register (absences would SMS once Hubtel is set).
+7. Gradebook: enter scores → generate report card → print.
+8. Communication: post an announcement; send a template SMS (logs as SENT once Hubtel is set).
+
+## Notes
+- **Migrations use the direct connection; the app uses the pooler.** Our `postgres.js`
+  client sets `prepare: false`, which is pgbouncer-safe.
+- **RLS in prod:** the app connects as the project `postgres` role; FORCE RLS + the
+  `tenant_isolation` policies enforce per-school isolation. `withSchool()` sets
+  `app.current_school`; identity/onboarding paths use the `omnischools_admin` bypass role
+  (granted to `postgres` when `db:policies` ran as `postgres`).
+- **Phone OTP:** `signInWithOtp` auto-creates the Supabase auth user; `getCurrentUser`
+  maps the verified phone to the `ref_user` created at onboarding. So onboard a school
+  before signing in with that admin's phone.
+- **Scaling later** (Scaling Plan.txt): Cloudflare in front → Hetzner+Coolify → self-hosted
+  Postgres. Nothing here is Vercel-locked.

--- a/omnischools/app/(app)/layout.tsx
+++ b/omnischools/app/(app)/layout.tsx
@@ -1,4 +1,5 @@
 import { requireSchool } from "@/lib/auth/server";
+import { signOutAction } from "@/lib/actions/auth";
 import { AppSidebar } from "@/components/app/sidebar";
 
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
@@ -17,9 +18,19 @@ export default async function AppLayout({ children }: { children: React.ReactNod
               {user.roles[0]?.replaceAll("_", " ").toLowerCase()}
             </div>
           </div>
-          <span className="flex shrink-0 items-center gap-1.5 rounded-pill bg-green-bg px-2.5 py-1 text-xs font-medium text-green">
-            ● Connected
-          </span>
+          <div className="flex shrink-0 items-center gap-3">
+            <span className="flex items-center gap-1.5 rounded-pill bg-green-bg px-2.5 py-1 text-xs font-medium text-green">
+              ● Connected
+            </span>
+            <form action={signOutAction}>
+              <button
+                type="submit"
+                className="hover:bg-bg rounded-md px-3 py-1.5 text-xs font-semibold text-navy-2 transition-colors"
+              >
+                Sign out
+              </button>
+            </form>
+          </div>
         </header>
         <main className="flex-1 p-6">{children}</main>
       </div>

--- a/omnischools/app/(marketing)/login/page.tsx
+++ b/omnischools/app/(marketing)/login/page.tsx
@@ -1,35 +1,45 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { authIsLive } from "@/lib/auth";
+import { LoginForm } from "@/components/auth/login-form";
 
 export const metadata: Metadata = {
   title: "Log in",
   description: "Sign in to manage your school on Omnischools.",
 };
 
-// Placeholder: phone-OTP sign-in is wired with the app tier (Phase 3). The auth
-// interface already exists at lib/auth; this page becomes the real login then.
+export const dynamic = "force-dynamic";
+
 export default function LoginPage() {
+  // Live: real Supabase phone-OTP. Dev bypass: a shortcut into the app.
+  if (authIsLive()) {
+    return (
+      <main className="mx-auto flex min-h-[70vh] max-w-content items-center justify-center px-6 py-20">
+        <LoginForm />
+      </main>
+    );
+  }
   return (
     <main className="mx-auto flex min-h-[70vh] max-w-content flex-col items-center justify-center px-6 py-24 text-center">
       <h1 className="mb-3 font-display text-4xl font-semibold text-navy">
         Welcome <em className="not-italic text-gold [font-style:italic]">back.</em>
       </h1>
       <p className="mb-8 max-w-[420px] text-base text-navy-2">
-        Phone sign-in (OTP) opens together with your school&apos;s app dashboard. If
-        you&apos;re setting up a new school, start here.
+        Phone sign-in (OTP) activates once Supabase Auth is configured. In dev mode you
+        can jump straight into the app.
       </p>
       <div className="flex flex-wrap justify-center gap-3">
         <Link
-          href="/start"
+          href="/dashboard"
           className="text-bg rounded-md bg-navy px-6 py-3 text-sm font-semibold transition-colors hover:bg-navy-deep"
         >
-          Onboard a school
+          Continue to dashboard (dev)
         </Link>
         <Link
-          href="/contact"
-          className="border-border-2 hover:bg-surface rounded-md border px-6 py-3 text-sm font-semibold text-navy transition-colors"
+          href="/start"
+          className="border-border-2 rounded-md border px-6 py-3 text-sm font-semibold text-navy transition-colors hover:bg-gold-bg"
         >
-          Talk to us
+          Onboard a school
         </Link>
       </div>
     </main>

--- a/omnischools/components/auth/login-form.tsx
+++ b/omnischools/components/auth/login-form.tsx
@@ -1,0 +1,95 @@
+"use client";
+import { useState } from "react";
+import { requestOtp, verifyLogin } from "@/lib/actions/auth";
+
+const fieldClass =
+  "w-full rounded-md border border-border-2 bg-bg px-3.5 py-2.5 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
+
+export function LoginForm() {
+  const [step, setStep] = useState<"phone" | "otp">("phone");
+  const [phone, setPhone] = useState("");
+  const [otp, setOtp] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function sendCode() {
+    setBusy(true);
+    setError(null);
+    const res = await requestOtp(phone);
+    setBusy(false);
+    if (res.ok) setStep("otp");
+    else setError(res.error ?? "Could not send code.");
+  }
+
+  async function verify() {
+    setBusy(true);
+    setError(null);
+    // On success this server action redirects; only errors return here.
+    const res = await verifyLogin(phone, otp);
+    setBusy(false);
+    if (res && !res.ok) setError(res.error);
+  }
+
+  return (
+    <div className="bg-surface mx-auto w-full max-w-sm rounded-2xl border border-border p-7 shadow-md">
+      <h1 className="mb-1 font-display text-3xl font-semibold text-navy">
+        Welcome <em className="not-italic text-gold [font-style:italic]">back.</em>
+      </h1>
+      <p className="mb-6 text-sm text-navy-3">
+        {step === "phone"
+          ? "Sign in with your phone number."
+          : `Enter the code we sent to ${phone}.`}
+      </p>
+
+      {step === "phone" ? (
+        <div className="space-y-3">
+          <input
+            className={fieldClass}
+            type="tel"
+            placeholder="024 000 0000"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && sendCode()}
+          />
+          <button
+            onClick={sendCode}
+            disabled={busy}
+            className="text-bg w-full rounded-md bg-navy px-5 py-3 text-sm font-semibold transition-colors hover:bg-navy-deep disabled:opacity-60"
+          >
+            {busy ? "Sending…" : "Send code"}
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <input
+            className={`${fieldClass} text-center font-mono text-lg tracking-[0.3em]`}
+            inputMode="numeric"
+            placeholder="••••••"
+            value={otp}
+            onChange={(e) => setOtp(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && verify()}
+          />
+          <button
+            onClick={verify}
+            disabled={busy}
+            className="text-bg w-full rounded-md bg-navy px-5 py-3 text-sm font-semibold transition-colors hover:bg-navy-deep disabled:opacity-60"
+          >
+            {busy ? "Verifying…" : "Verify & sign in"}
+          </button>
+          <button
+            onClick={() => {
+              setStep("phone");
+              setOtp("");
+              setError(null);
+            }}
+            className="w-full text-center text-sm text-navy-3 hover:text-gold"
+          >
+            ← Use a different number
+          </button>
+        </div>
+      )}
+
+      {error && <p className="mt-4 text-sm text-terra">{error}</p>}
+    </div>
+  );
+}

--- a/omnischools/lib/actions/auth.ts
+++ b/omnischools/lib/actions/auth.ts
@@ -1,0 +1,25 @@
+"use server";
+import { redirect } from "next/navigation";
+import { signInWithPhone, verifyPhoneOtp, signOut } from "@/lib/auth";
+
+export async function requestOtp(
+  phone: string,
+): Promise<{ ok: boolean; error?: string }> {
+  if (!phone || phone.length < 7)
+    return { ok: false, error: "Enter a valid phone number." };
+  return signInWithPhone(phone);
+}
+
+export async function verifyLogin(
+  phone: string,
+  token: string,
+): Promise<{ ok: false; error: string }> {
+  const res = await verifyPhoneOtp(phone, token);
+  if (!res.ok) return { ok: false, error: res.error ?? "Invalid code." };
+  redirect("/dashboard");
+}
+
+export async function signOutAction(): Promise<void> {
+  await signOut();
+  redirect("/");
+}

--- a/omnischools/lib/auth/index.ts
+++ b/omnischools/lib/auth/index.ts
@@ -2,8 +2,13 @@ import { env } from "@/lib/env";
 
 /**
  * Thin auth interface (BUILD_STACK portability rule): feature code calls these,
- * never `supabase.auth.*` directly. In dev (AUTH_DEV_BYPASS) a shim issues a
- * session so the app is buildable/runnable before Supabase Auth is wired.
+ * never `supabase.auth.*` directly.
+ *
+ * Two modes, chosen by env:
+ *  - Dev bypass (AUTH_DEV_BYPASS=true, no Supabase): a shim issues an ADMIN session
+ *    so the app is runnable locally without an auth provider.
+ *  - Real (Supabase URL set + AUTH_DEV_BYPASS=false): phone-OTP via Supabase Auth;
+ *    the authenticated phone is mapped to a ref_user + role assignments.
  */
 export type AppRole =
   | "ADMIN"
@@ -27,6 +32,18 @@ export interface AppUser {
   roles: AppRole[];
 }
 
+const DEV_USER: AppUser = {
+  id: "00000000-0000-0000-0000-000000000001",
+  phone: "+233200000000",
+  name: "Dev Admin",
+  roles: ["ADMIN"],
+};
+
+/** True when real Supabase Auth should be used. */
+export function authIsLive(): boolean {
+  return !env.AUTH_DEV_BYPASS && !!env.NEXT_PUBLIC_SUPABASE_URL;
+}
+
 /** Normalise Ghanaian phone numbers to E.164 (+233XXXXXXXXX). */
 export function normalizeGhanaPhone(input: string): string {
   const digits = input.replace(/[^\d+]/g, "");
@@ -37,36 +54,81 @@ export function normalizeGhanaPhone(input: string): string {
   return digits;
 }
 
-/** Begin phone-OTP sign-in. Real impl wraps supabase.auth.signInWithOtp at deploy. */
-export async function signInWithPhone(phone: string): Promise<void> {
+/** Begin phone-OTP sign-in (sends an SMS code in live mode). */
+export async function signInWithPhone(
+  phone: string,
+): Promise<{ ok: boolean; error?: string }> {
   const normalized = normalizeGhanaPhone(phone);
-  if (env.AUTH_DEV_BYPASS) {
+  if (!authIsLive()) {
     console.info(`[auth:dev] OTP requested for ${normalized} (bypass enabled)`);
-    return;
+    return { ok: true };
   }
-  throw new Error("Supabase Auth not wired yet — set AUTH_DEV_BYPASS or wire provider.");
+  const { createClient } = await import("@/lib/supabase/server");
+  const { error } = await createClient().auth.signInWithOtp({ phone: normalized });
+  return error ? { ok: false, error: error.message } : { ok: true };
+}
+
+/** Verify a phone-OTP code; establishes the session cookie in live mode. */
+export async function verifyPhoneOtp(
+  phone: string,
+  token: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const normalized = normalizeGhanaPhone(phone);
+  if (!authIsLive()) return { ok: true };
+  const { createClient } = await import("@/lib/supabase/server");
+  const { error } = await createClient().auth.verifyOtp({
+    phone: normalized,
+    token,
+    type: "sms",
+  });
+  return error ? { ok: false, error: error.message } : { ok: true };
+}
+
+export async function signOut(): Promise<void> {
+  if (!authIsLive()) return;
+  const { createClient } = await import("@/lib/supabase/server");
+  await createClient().auth.signOut();
 }
 
 /** Resolve the current authenticated user, or null. */
 export async function getCurrentUser(): Promise<AppUser | null> {
-  if (env.AUTH_DEV_BYPASS) {
+  if (!authIsLive()) return DEV_USER;
+
+  const { createClient } = await import("@/lib/supabase/server");
+  const {
+    data: { user },
+  } = await createClient().auth.getUser();
+  if (!user?.phone) return null;
+  const phone = user.phone.startsWith("+") ? user.phone : `+${user.phone}`;
+
+  // Privileged identity lookup (runs before tenant context) — bypass RLS.
+  const { withoutTenantScope } = await import("@/lib/db/rls");
+  const { users, roleAssignments, roles } = await import("@/db/schema");
+  const { eq } = await import("drizzle-orm");
+
+  return withoutTenantScope(async (tx) => {
+    const [u] = await tx.select().from(users).where(eq(users.phone, phone));
+    if (!u) return null;
+    const ra = await tx
+      .select({ code: roles.code, schoolId: roleAssignments.schoolId })
+      .from(roleAssignments)
+      .innerJoin(roles, eq(roleAssignments.roleId, roles.id))
+      .where(eq(roleAssignments.userId, u.id));
     return {
-      id: "00000000-0000-0000-0000-000000000001",
-      phone: "+233200000000",
-      name: "Dev Admin",
-      roles: ["ADMIN"],
-    };
-  }
-  // TODO(deploy): read Supabase session via lib/supabase/server and map to AppUser.
-  return null;
+      id: u.id,
+      phone,
+      email: u.email ?? undefined,
+      name: u.fullName ?? undefined,
+      schoolId: ra[0]?.schoolId,
+      roles: ra.map((r) => r.code) as AppRole[],
+    } satisfies AppUser;
+  });
 }
 
 /** Throw if the current user lacks the required role. */
 export async function requireRole(role: AppRole): Promise<AppUser> {
   const user = await getCurrentUser();
   if (!user) throw new Error("Not authenticated");
-  if (!user.roles.includes(role)) {
-    throw new Error(`Forbidden: requires role ${role}`);
-  }
+  if (!user.roles.includes(role)) throw new Error(`Forbidden: requires role ${role}`);
   return user;
 }

--- a/omnischools/lib/auth/server.ts
+++ b/omnischools/lib/auth/server.ts
@@ -1,7 +1,7 @@
 import { redirect } from "next/navigation";
 import { eq, and } from "drizzle-orm";
 import { env } from "@/lib/env";
-import { db } from "@/lib/db";
+import { withoutTenantScope } from "@/lib/db/rls";
 import { schools, roleAssignments, roles, users } from "@/db/schema";
 import { getCurrentUser, type AppUser } from "@/lib/auth";
 
@@ -17,6 +17,8 @@ export interface ActiveSchool {
  * Resolve the school the current user is operating.
  * Dev shim: the seeded demo school (Asankrangwa), else the first school.
  * Prod: the user's first active role assignment's school.
+ * Runs under the RLS-bypass role — identity/school resolution happens before a
+ * tenant context exists, so it cannot itself be tenant-scoped.
  */
 export async function getActiveSchool(): Promise<ActiveSchool | null> {
   const user = await getCurrentUser();
@@ -30,24 +32,25 @@ export async function getActiveSchool(): Promise<ActiveSchool | null> {
     schoolType: schools.schoolType,
   };
 
-  if (env.AUTH_DEV_BYPASS) {
-    const demo = await db
+  return withoutTenantScope(async (tx) => {
+    if (env.AUTH_DEV_BYPASS) {
+      const demo = await tx
+        .select(cols)
+        .from(schools)
+        .where(eq(schools.gesCode, "WR-WAW-014"))
+        .limit(1);
+      if (demo[0]) return demo[0];
+      const first = await tx.select(cols).from(schools).limit(1);
+      return first[0] ?? null;
+    }
+    const assigned = await tx
       .select(cols)
-      .from(schools)
-      .where(eq(schools.gesCode, "WR-WAW-014"))
+      .from(roleAssignments)
+      .innerJoin(schools, eq(roleAssignments.schoolId, schools.id))
+      .where(eq(roleAssignments.userId, user.id))
       .limit(1);
-    if (demo[0]) return demo[0];
-    const first = await db.select(cols).from(schools).limit(1);
-    return first[0] ?? null;
-  }
-
-  const assigned = await db
-    .select(cols)
-    .from(roleAssignments)
-    .innerJoin(schools, eq(roleAssignments.schoolId, schools.id))
-    .where(eq(roleAssignments.userId, user.id))
-    .limit(1);
-  return assigned[0] ?? null;
+    return assigned[0] ?? null;
+  });
 }
 
 /** For app pages: ensure a signed-in user, else send to login. */
@@ -75,12 +78,14 @@ export async function resolveActor(
   const user = await getCurrentUser();
   if (!user) return { id: null, role: "APPLICANT" };
   if (!env.AUTH_DEV_BYPASS) return { id: user.id, role: user.roles[0] ?? "ADMIN" };
-  const rows = await db
-    .select({ id: users.id })
-    .from(roleAssignments)
-    .innerJoin(roles, eq(roleAssignments.roleId, roles.id))
-    .innerJoin(users, eq(roleAssignments.userId, users.id))
-    .where(and(eq(roleAssignments.schoolId, schoolId), eq(roles.code, "ADMIN")))
-    .limit(1);
-  return { id: rows[0]?.id ?? null, role: "ADMIN" };
+  return withoutTenantScope(async (tx) => {
+    const rows = await tx
+      .select({ id: users.id })
+      .from(roleAssignments)
+      .innerJoin(roles, eq(roleAssignments.roleId, roles.id))
+      .innerJoin(users, eq(roleAssignments.userId, users.id))
+      .where(and(eq(roleAssignments.schoolId, schoolId), eq(roles.code, "ADMIN")))
+      .limit(1);
+    return { id: rows[0]?.id ?? null, role: "ADMIN" };
+  });
 }

--- a/omnischools/middleware.ts
+++ b/omnischools/middleware.ts
@@ -1,0 +1,36 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+
+/**
+ * Refreshes the Supabase auth session cookie on navigation so Server Components
+ * see a current session. No-ops when Supabase env is absent (dev bypass).
+ */
+export async function middleware(request: NextRequest) {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !key) return NextResponse.next();
+
+  let response = NextResponse.next({ request });
+  const supabase = createServerClient(url, key, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value));
+        response = NextResponse.next({ request });
+        cookiesToSet.forEach(({ name, value, options }) =>
+          response.cookies.set(name, value, options),
+        );
+      },
+    },
+  });
+  await supabase.auth.getUser();
+  return response;
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|sw.js|manifest.webmanifest|img/|.*\\.(?:png|jpg|jpeg|svg|ico)$).*)",
+  ],
+};


### PR DESCRIPTION
## Summary
Wires real **Supabase phone-OTP auth** behind the existing `lib/auth` interface and adds the production **deploy runbook**. Everything is env-gated, so local dev (`AUTH_DEV_BYPASS=true`) is unchanged.

- `signInWithPhone` / `verifyPhoneOtp` / `signOut` via Supabase Auth when live; dev stub otherwise. `getCurrentUser` maps the verified phone → `ref_user` + role assignments.
- `middleware.ts` refreshes the Supabase session (no-op without Supabase env).
- `/login`: real two-step phone→OTP form when live; dev shortcut otherwise. Sign-out in the app topbar.
- **Prod fix:** `getActiveSchool` / `resolveActor` resolve identity/school under the `omnischools_admin` RLS-bypass role (they run before a tenant context exists; the dev superuser bypassed RLS implicitly, the prod `postgres` role won't).
- `DEPLOY.md` runbook + `NEXT_PUBLIC_SITE_URL` in `.env.example`.

## Verification
`pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm build` ✓ (Middleware active) · dev flow intact (`pnpm db:verify-payments` ✓).

## After merge
MVP1 is feature-complete + deployable. Ship per `DEPLOY.md`: Supabase prod (migrations/policies/seed) → Vercel import (root `omnischools/`) → flip `AUTH_DEV_BYPASS=false` → smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
