### PR TITLE
fix(auth): call Supabase auth via explicit interface (fixes Vercel build)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,10 +12,14 @@ omnischools/next-env.d.ts
 # ---- env / secrets ----
 .env
 .env.*
+*.env
 !.env.example
 omnischools/.env
 omnischools/.env.*
 !omnischools/.env.example
+# local MCP server config can carry tokens / project refs
+.mcp.json
+.claude/settings.local.json
 
 # ---- local data / docker volumes ----
 .docker-data/

--- a/omnischools/lib/auth/index.ts
+++ b/omnischools/lib/auth/index.ts
@@ -54,6 +54,28 @@ export function normalizeGhanaPhone(input: string): string {
   return digits;
 }
 
+/**
+ * Minimal, explicitly-typed view of the Supabase auth client for the methods we use.
+ * We call through this instead of the inferred `.auth` type because duplicated
+ * @supabase/* type copies can drop methods from `SupabaseAuthClient` in some install
+ * layouts (passes locally, failed on Vercel). Runtime is unchanged — the methods exist.
+ */
+type SupabaseAuthApi = {
+  signInWithOtp(creds: { phone: string }): Promise<{ error: { message: string } | null }>;
+  verifyOtp(creds: {
+    phone: string;
+    token: string;
+    type: "sms";
+  }): Promise<{ error: { message: string } | null }>;
+  getUser(): Promise<{ data: { user: { phone?: string | null } | null } }>;
+  signOut(): Promise<unknown>;
+};
+
+async function authApi(): Promise<SupabaseAuthApi> {
+  const { createClient } = await import("@/lib/supabase/server");
+  return createClient().auth as unknown as SupabaseAuthApi;
+}
+
 /** Begin phone-OTP sign-in (sends an SMS code in live mode). */
 export async function signInWithPhone(
   phone: string,
@@ -63,8 +85,7 @@ export async function signInWithPhone(
     console.info(`[auth:dev] OTP requested for ${normalized} (bypass enabled)`);
     return { ok: true };
   }
-  const { createClient } = await import("@/lib/supabase/server");
-  const { error } = await createClient().auth.signInWithOtp({ phone: normalized });
+  const { error } = await (await authApi()).signInWithOtp({ phone: normalized });
   return error ? { ok: false, error: error.message } : { ok: true };
 }
 
@@ -75,8 +96,9 @@ export async function verifyPhoneOtp(
 ): Promise<{ ok: boolean; error?: string }> {
   const normalized = normalizeGhanaPhone(phone);
   if (!authIsLive()) return { ok: true };
-  const { createClient } = await import("@/lib/supabase/server");
-  const { error } = await createClient().auth.verifyOtp({
+  const { error } = await (
+    await authApi()
+  ).verifyOtp({
     phone: normalized,
     token,
     type: "sms",
@@ -86,18 +108,16 @@ export async function verifyPhoneOtp(
 
 export async function signOut(): Promise<void> {
   if (!authIsLive()) return;
-  const { createClient } = await import("@/lib/supabase/server");
-  await createClient().auth.signOut();
+  await (await authApi()).signOut();
 }
 
 /** Resolve the current authenticated user, or null. */
 export async function getCurrentUser(): Promise<AppUser | null> {
   if (!authIsLive()) return DEV_USER;
 
-  const { createClient } = await import("@/lib/supabase/server");
   const {
     data: { user },
-  } = await createClient().auth.getUser();
+  } = await (await authApi()).getUser();
   if (!user?.phone) return null;
   const phone = user.phone.startsWith("+") ? user.phone : `+${user.phone}`;
 

--- a/omnischools/middleware.ts
+++ b/omnischools/middleware.ts
@@ -25,7 +25,9 @@ export async function middleware(request: NextRequest) {
       },
     },
   });
-  await supabase.auth.getUser();
+  // Cast: see lib/auth — avoids a cross-version @supabase type-dup that drops methods
+  // from the inferred `.auth` type in some install layouts. Runtime is unaffected.
+  await (supabase.auth as unknown as { getUser(): Promise<unknown> }).getUser();
   return response;
 }
 


### PR DESCRIPTION
## What
Fixes the production Vercel build failure:
`middleware.ts(28,23): error TS2339: Property 'getUser' does not exist on type 'SupabaseAuthClient'`.

## Why
`getUser`/`signInWithOtp`/`verifyOtp`/`signOut` all exist at runtime. The error is a type-resolution quirk: a duplicated `@supabase/*` type copy in Vercel's install layout drops methods from the inferred `SupabaseAuthClient` type. It passes locally but fails on Vercel — and `lib/auth` calls the same methods, so those would fail there too.

## How
- `lib/auth/index.ts`: call the four auth methods through a small explicitly-typed `SupabaseAuthApi` interface (runtime-identical, immune to the upstream typing).
- `middleware.ts`: cast the `getUser` call the same way.
- `.gitignore`: also ignore `*.env`, `.mcp.json`, `.claude/settings.local.json` (closes a gap where `*.env` files weren't matched).

## Verified
`pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm build` ✓ locally. No runtime/behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)