### PR TITLE
fix(middleware): never let Supabase session refresh 500 the site

### DIFF
--- a/omnischools/middleware.ts
+++ b/omnischools/middleware.ts
@@ -6,28 +6,38 @@ import { createServerClient } from "@supabase/ssr";
  * see a current session. No-ops when Supabase env is absent (dev bypass).
  */
 export async function middleware(request: NextRequest) {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  // `.trim()` guards against a pasted trailing newline/space in the Vercel env value,
+  // which would otherwise make Supabase's internal `new URL()` throw and surface as
+  // MIDDLEWARE_INVOCATION_FAILED (a 500 on every route).
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL?.trim();
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY?.trim();
   if (!url || !key) return NextResponse.next();
 
   let response = NextResponse.next({ request });
-  const supabase = createServerClient(url, key, {
-    cookies: {
-      getAll() {
-        return request.cookies.getAll();
+  try {
+    const supabase = createServerClient(url, key, {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value));
+          response = NextResponse.next({ request });
+          cookiesToSet.forEach(({ name, value, options }) =>
+            response.cookies.set(name, value, options),
+          );
+        },
       },
-      setAll(cookiesToSet) {
-        cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value));
-        response = NextResponse.next({ request });
-        cookiesToSet.forEach(({ name, value, options }) =>
-          response.cookies.set(name, value, options),
-        );
-      },
-    },
-  });
-  // Cast: see lib/auth — avoids a cross-version @supabase type-dup that drops methods
-  // from the inferred `.auth` type in some install layouts. Runtime is unaffected.
-  await (supabase.auth as unknown as { getUser(): Promise<unknown> }).getUser();
+    });
+    // Cast: see lib/auth — avoids a cross-version @supabase type-dup that drops methods
+    // from the inferred `.auth` type in some install layouts. Runtime is unaffected.
+    await (supabase.auth as unknown as { getUser(): Promise<unknown> }).getUser();
+  } catch (err) {
+    // Proactive session refresh is best-effort: a failure here (bad env, network,
+    // Supabase down) must never 500 the whole site. Server Components still resolve
+    // the session on their own. Log and continue with the unmodified response.
+    console.error("[middleware] supabase session refresh skipped:", err);
+  }
   return response;
 }
 


### PR DESCRIPTION
## What
Production was returning **500 `MIDDLEWARE_INVOCATION_FAILED`** on every route. This is a *runtime* crash in `middleware.ts` (Edge runtime), separate from the build-time TS fix in #9.

## Why
Once the Supabase env vars were set, the middleware proceeded into `createServerClient`/`getUser`. A throw there — most likely a malformed `NEXT_PUBLIC_SUPABASE_URL` (pasted trailing newline → internal `new URL()` throws) — crashed the whole request.

## How
- `.trim()` the `NEXT_PUBLIC_SUPABASE_URL` / `ANON_KEY` env values.
- Wrap `createServerClient` + `getUser` in `try/catch`: proactive session refresh is best-effort and must never take the site down. Server Components still resolve the session independently. The caught error is logged (`[middleware] supabase session refresh skipped:`) so the true cause is visible in Runtime Logs.

## Verified
`pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm build` ✓. Runtime-only hardening, no behaviour change on the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)