### PR TITLE
fix(middleware): dynamic-import @supabase/ssr so Edge load failure can't 500

### DIFF
--- a/omnischools/middleware.ts
+++ b/omnischools/middleware.ts
@@ -1,20 +1,26 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { createServerClient } from "@supabase/ssr";
 
 /**
  * Refreshes the Supabase auth session cookie on navigation so Server Components
  * see a current session. No-ops when Supabase env is absent (dev bypass).
+ *
+ * `@supabase/ssr` is imported *dynamically inside the try* on purpose: a static
+ * top-level import is evaluated when the Edge function is instantiated, so if any
+ * transitive @supabase code is incompatible with the Edge runtime it crashes the
+ * whole invocation (MIDDLEWARE_INVOCATION_FAILED → 500 on every route) *before*
+ * this function body runs, where no try/catch can reach it. A dynamic import
+ * instead returns a rejected promise that the catch below handles, so a refresh
+ * failure degrades to a no-op rather than taking the site down.
  */
 export async function middleware(request: NextRequest) {
-  // `.trim()` guards against a pasted trailing newline/space in the Vercel env value,
-  // which would otherwise make Supabase's internal `new URL()` throw and surface as
-  // MIDDLEWARE_INVOCATION_FAILED (a 500 on every route).
+  // `.trim()` guards against a pasted trailing newline/space in the Vercel env value.
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL?.trim();
   const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY?.trim();
   if (!url || !key) return NextResponse.next();
 
   let response = NextResponse.next({ request });
   try {
+    const { createServerClient } = await import("@supabase/ssr");
     const supabase = createServerClient(url, key, {
       cookies: {
         getAll() {
@@ -33,7 +39,7 @@ export async function middleware(request: NextRequest) {
     // from the inferred `.auth` type in some install layouts. Runtime is unaffected.
     await (supabase.auth as unknown as { getUser(): Promise<unknown> }).getUser();
   } catch (err) {
-    // Proactive session refresh is best-effort: a failure here (bad env, network,
+    // Best-effort: a failure here (Edge-incompatible import, bad env, network,
     // Supabase down) must never 500 the whole site. Server Components still resolve
     // the session on their own. Log and continue with the unmodified response.
     console.error("[middleware] supabase session refresh skipped:", err);


### PR DESCRIPTION
## What
Production kept returning **500 `MIDDLEWARE_INVOCATION_FAILED`** on every middleware route even after #10 wrapped `getUser` in try/catch.

## Root cause
The static top-level `import { createServerClient } from "@supabase/ssr"` is evaluated when Vercel **instantiates** the Edge function — *before* the middleware body runs. An Edge-runtime incompatibility in transitive `@supabase` code therefore crashes the invocation at load time, which **no in-function `try/catch` can reach**. Probes confirmed it: middleware routes 500, while routes excluded by the matcher (`/manifest.webmanifest` → 200) are healthy.

## Fix
Move the import to a dynamic `await import("@supabase/ssr")` **inside** the existing `try`. A dynamic import *rejects* (catchable) instead of crashing at instantiation, so a load failure degrades to a logged no-op and the site stays up. Server Components still resolve the session independently, so auth is unaffected.

## Verified
`pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)