### PR TITLE
fix(ui): map bg/surface/border-2 design tokens in Tailwind (fixes invisible button text)

### DIFF
--- a/omnischools/tailwind.config.ts
+++ b/omnischools/tailwind.config.ts
@@ -31,6 +31,10 @@ const config: Config = {
         terra: { DEFAULT: "var(--terra)", bg: "var(--terra-bg)" },
         warn: { DEFAULT: "var(--warn)", bg: "var(--warn-bg)" },
 
+        // brand surfaces (used directly: bg-bg, text-bg, bg-surface)
+        bg: "var(--bg)",
+        surface: "var(--surface)",
+
         // semantic roles (shadcn/ui)
         background: "var(--background)",
         foreground: "var(--foreground)",
@@ -49,7 +53,11 @@ const config: Config = {
         },
         success: { DEFAULT: "var(--success)", foreground: "var(--success-foreground)" },
         warning: { DEFAULT: "var(--warning)", foreground: "var(--warning-foreground)" },
-        border: "var(--border)",
+        border: {
+          DEFAULT: "var(--border)",
+          1: "var(--border-1)",
+          2: "var(--border-2)",
+        },
         input: "var(--input)",
         ring: "var(--ring)",
       },


### PR DESCRIPTION
## What
Navy CTA buttons rendered with **invisible (navy-on-navy) text**.

## Root cause
Components use the design-token classes `text-bg`/`bg-bg` (27 + 56 uses), `bg-surface` (66) and `border-border-2` (45), but `tailwind.config.ts` never mapped the `--bg`, `--surface`, and `--border-2` CSS variables to color utilities. Those classes silently produced nothing, so the navy buttons got no `text-bg` (off-white) color and their label inherited the dark foreground.

## Fix
Add `bg` and `surface` colors and a nested `border` scale (DEFAULT / 1 / 2) bound to the existing CSS variables.

## Verified
`.text-bg`, `.bg-bg`, `.bg-surface`, `.border-border-2` now emit in the production CSS bundle. `pnpm typecheck` ✓ · `pnpm build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)