### PR TITLE
feat(settings): school settings hub at /settings

### DIFF
--- a/omnischools/app/(app)/settings/page.tsx
+++ b/omnischools/app/(app)/settings/page.tsx
@@ -1,0 +1,160 @@
+import Link from "next/link";
+import { asc, eq } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import {
+  schools,
+  gradebookConfig,
+  academicPeriodConfig,
+  academicPeriod,
+  smsTemplates,
+} from "@/db/schema";
+import { ProfileForm } from "@/components/settings/profile-form";
+import { WeightsForm } from "@/components/settings/weights-form";
+
+export const dynamic = "force-dynamic";
+
+const title = (s: string) => s.charAt(0) + s.slice(1).toLowerCase().replaceAll("_", " ");
+
+function Section({
+  heading,
+  description,
+  children,
+}: {
+  heading: string;
+  description?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-xl border border-border bg-surface p-6">
+      <h2 className="font-display text-lg font-semibold text-navy">{heading}</h2>
+      {description && <p className="mb-4 mt-0.5 text-sm text-navy-3">{description}</p>}
+      <div className={description ? "" : "mt-4"}>{children}</div>
+    </section>
+  );
+}
+
+export default async function SettingsPage() {
+  const { school } = await requireSchool();
+
+  const data = await withSchool(school.id, async (tx) => {
+    const [row] = await tx.select().from(schools).where(eq(schools.id, school.id));
+    const [cfg] = await tx
+      .select()
+      .from(gradebookConfig)
+      .where(eq(gradebookConfig.schoolId, school.id));
+    const [periodCfg] = await tx
+      .select()
+      .from(academicPeriodConfig)
+      .where(eq(academicPeriodConfig.schoolId, school.id));
+    const periods = await tx
+      .select()
+      .from(academicPeriod)
+      .where(eq(academicPeriod.schoolId, school.id))
+      .orderBy(asc(academicPeriod.periodNumber));
+    const templates = await tx
+      .select({ id: smsTemplates.id })
+      .from(smsTemplates)
+      .where(eq(smsTemplates.schoolId, school.id));
+    return { row, cfg, periodCfg, periods, templateCount: templates.length };
+  });
+
+  const cw = data.cfg?.classWeight ?? 50;
+
+  return (
+    <div className="mx-auto max-w-prose">
+      <div className="mb-5">
+        <h1 className="font-display text-3xl font-semibold text-navy">Settings</h1>
+        <p className="text-sm text-navy-3">
+          Configure your school profile, calendar, grading and messaging.
+        </p>
+      </div>
+
+      <div className="space-y-5">
+        {/* School profile */}
+        <Section heading="School profile">
+          <ProfileForm
+            initialName={data.row?.name ?? school.name}
+            initialShortName={data.row?.shortName ?? ""}
+          />
+          <dl className="mt-5 grid grid-cols-2 gap-x-6 gap-y-3 border-t border-border pt-5 text-sm sm:grid-cols-3">
+            <div>
+              <dt className="text-navy-3">GES code</dt>
+              <dd className="font-mono font-medium text-navy">{data.row?.gesCode}</dd>
+            </div>
+            <div>
+              <dt className="text-navy-3">Type</dt>
+              <dd className="font-medium text-navy">{title(school.schoolType)}</dd>
+            </div>
+            <div>
+              <dt className="text-navy-3">Ownership</dt>
+              <dd className="font-medium text-navy">
+                {data.row?.ownership ? title(data.row.ownership) : "—"}
+              </dd>
+            </div>
+          </dl>
+        </Section>
+
+        {/* Academic calendar */}
+        <Section
+          heading="Academic calendar"
+          description={
+            data.periodCfg
+              ? `${data.periodCfg.academicYear} · ${data.periodCfg.periodCount} ${title(
+                  data.periodCfg.periodType,
+                )}s (${title(data.periodCfg.source)})`
+              : "No calendar configured yet."
+          }
+        >
+          {data.periods.length > 0 ? (
+            <ul className="divide-y divide-border overflow-hidden rounded-lg border border-border">
+              {data.periods.map((p) => (
+                <li
+                  key={p.periodId}
+                  className="flex items-center justify-between px-4 py-2.5 text-sm"
+                >
+                  <span className="font-medium text-navy">{p.periodLabel}</span>
+                  <span className="font-mono text-navy-3">
+                    {p.startsOn} → {p.endsOn}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-navy-3">
+              Periods are seeded from GES defaults during onboarding.
+            </p>
+          )}
+        </Section>
+
+        {/* Grading */}
+        <Section
+          heading="Grading"
+          description="Set how class (continuous assessment) and exam scores combine into the term total."
+        >
+          <WeightsForm initialClassWeight={cw} />
+        </Section>
+
+        {/* Messaging */}
+        <Section heading="Messaging">
+          <p className="text-sm text-navy-2">
+            {data.templateCount > 0
+              ? `${data.templateCount} SMS template${data.templateCount === 1 ? "" : "s"} saved.`
+              : "No SMS templates yet."}{" "}
+            Messages sign off as{" "}
+            <span className="font-mono font-medium text-navy">
+              {data.row?.shortName || "your school name"}
+            </span>
+            .
+          </p>
+          <Link
+            href="/communication"
+            className="mt-4 inline-flex rounded-md border border-border-2 bg-surface px-4 py-2 text-sm font-semibold text-navy hover:bg-gold-bg"
+          >
+            Manage templates &amp; announcements →
+          </Link>
+        </Section>
+      </div>
+    </div>
+  );
+}

--- a/omnischools/components/app/sidebar.tsx
+++ b/omnischools/components/app/sidebar.tsx
@@ -11,6 +11,7 @@ const NAV = [
   { href: "/attendance", label: "Attendance", icon: "T" },
   { href: "/gradebook", label: "Gradebook", icon: "G" },
   { href: "/communication", label: "Communication", icon: "C" },
+  { href: "/settings", label: "Settings", icon: "⚙" },
 ];
 
 // Roadmap items (later phases) — shown disabled to convey the shape.
@@ -19,7 +20,7 @@ const SOON: { label: string; icon: string }[] = [];
 export function AppSidebar() {
   const pathname = usePathname();
   return (
-    <aside className="bg-surface hidden w-60 shrink-0 flex-col border-r border-border md:flex">
+    <aside className="hidden w-60 shrink-0 flex-col border-r border-border bg-surface md:flex">
       <div className="flex items-center gap-2.5 px-5 py-[18px]">
         <span className="flex h-8 w-8 items-center justify-center rounded-md bg-navy font-display text-[15px] font-semibold italic text-gold-soft">
           O
@@ -35,7 +36,7 @@ export function AppSidebar() {
               href={item.href}
               className={cn(
                 "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-                active ? "bg-gold-bg text-navy" : "hover:bg-bg text-navy-2",
+                active ? "bg-gold-bg text-navy" : "text-navy-2 hover:bg-bg",
               )}
             >
               <span
@@ -60,7 +61,7 @@ export function AppSidebar() {
                 key={item.label}
                 className="text-navy-3/60 flex cursor-not-allowed items-center gap-3 rounded-md px-3 py-2 text-sm font-medium"
               >
-                <span className="bg-bg text-navy-3/60 flex h-6 w-6 items-center justify-center rounded font-display text-xs italic">
+                <span className="text-navy-3/60 flex h-6 w-6 items-center justify-center rounded bg-bg font-display text-xs italic">
                   {item.icon}
                 </span>
                 {item.label}

--- a/omnischools/components/settings/profile-form.tsx
+++ b/omnischools/components/settings/profile-form.tsx
@@ -1,0 +1,77 @@
+"use client";
+import { useState } from "react";
+import { updateSchoolProfile } from "@/lib/actions/settings";
+
+const fieldClass =
+  "w-full rounded-md border border-border-2 bg-bg px-3.5 py-2.5 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
+
+export function ProfileForm({
+  initialName,
+  initialShortName,
+}: {
+  initialName: string;
+  initialShortName: string;
+}) {
+  const [name, setName] = useState(initialName);
+  const [shortName, setShortName] = useState(initialShortName);
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
+
+  const dirty = name !== initialName || shortName !== initialShortName;
+
+  async function save() {
+    setBusy(true);
+    setMsg(null);
+    const res = await updateSchoolProfile({ name, shortName });
+    setBusy(false);
+    setMsg(
+      res.ok
+        ? { ok: true, text: "Saved." }
+        : { ok: false, text: res.error ?? "Could not save." },
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-2">
+        <label className="block">
+          <span className="mb-1.5 block text-sm font-medium text-navy-2">
+            School name
+          </span>
+          <input
+            className={fieldClass}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </label>
+        <label className="block">
+          <span className="mb-1.5 block text-sm font-medium text-navy-2">
+            SMS sign-off{" "}
+            <span className="font-normal text-navy-3">(short name, e.g. ASANKSHS)</span>
+          </span>
+          <input
+            className={`${fieldClass} font-mono uppercase tracking-wide`}
+            value={shortName}
+            maxLength={12}
+            placeholder="OPTIONAL"
+            onChange={(e) => setShortName(e.target.value)}
+          />
+        </label>
+      </div>
+      <div className="flex items-center gap-3">
+        <button
+          onClick={save}
+          disabled={busy || !dirty || name.trim().length < 2}
+          className="rounded-md bg-navy px-5 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-50"
+        >
+          {busy ? "Saving…" : "Save changes"}
+        </button>
+        {msg && (
+          <span className={`text-sm ${msg.ok ? "text-green" : "text-terra"}`}>
+            {msg.text}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/omnischools/components/settings/weights-form.tsx
+++ b/omnischools/components/settings/weights-form.tsx
@@ -1,0 +1,71 @@
+"use client";
+import { useState } from "react";
+import { updateGradingWeights } from "@/lib/actions/settings";
+
+export function WeightsForm({ initialClassWeight }: { initialClassWeight: number }) {
+  const [classWeight, setClassWeight] = useState(initialClassWeight);
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
+
+  const examWeight = 100 - classWeight;
+  const dirty = classWeight !== initialClassWeight;
+
+  async function save() {
+    setBusy(true);
+    setMsg(null);
+    const res = await updateGradingWeights({ classWeight, examWeight });
+    setBusy(false);
+    setMsg(
+      res.ok
+        ? { ok: true, text: "Saved." }
+        : { ok: false, text: res.error ?? "Could not save." },
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-end gap-6">
+        <label className="block">
+          <span className="mb-1.5 block text-sm font-medium text-navy-2">
+            Class score (continuous assessment)
+          </span>
+          <div className="flex items-center gap-2">
+            <input
+              type="range"
+              min={0}
+              max={100}
+              step={5}
+              value={classWeight}
+              onChange={(e) => setClassWeight(Number(e.target.value))}
+              className="w-48 accent-gold"
+            />
+            <span className="w-12 text-right font-mono text-sm font-semibold text-navy">
+              {classWeight}%
+            </span>
+          </div>
+        </label>
+        <div className="text-sm text-navy-3">
+          Exam (terminal):{" "}
+          <span className="font-mono font-semibold text-navy">{examWeight}%</span>
+        </div>
+      </div>
+      <p className="text-xs text-navy-3">
+        Most JHS schools use 50 / 50 for BECE alignment. Weights always total 100%.
+      </p>
+      <div className="flex items-center gap-3">
+        <button
+          onClick={save}
+          disabled={busy || !dirty}
+          className="rounded-md bg-navy px-5 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-50"
+        >
+          {busy ? "Saving…" : "Save weights"}
+        </button>
+        {msg && (
+          <span className={`text-sm ${msg.ok ? "text-green" : "text-terra"}`}>
+            {msg.text}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/omnischools/lib/actions/settings.ts
+++ b/omnischools/lib/actions/settings.ts
@@ -1,0 +1,113 @@
+"use server";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { withSchool } from "@/lib/db/rls";
+import { recordAudit } from "@/lib/db/audit";
+import { requireSchool, resolveActor } from "@/lib/auth/server";
+import { safeRevalidate } from "@/lib/revalidate";
+import { schools, gradebookConfig } from "@/db/schema";
+
+// --------------------------------------------------------------- school profile
+const ProfileSchema = z.object({
+  name: z.string().min(2, "School name is too short").max(120),
+  shortName: z
+    .string()
+    .max(12, "Sign-off must be 12 characters or fewer")
+    .optional()
+    .or(z.literal("")),
+});
+
+export async function updateSchoolProfile(
+  input: unknown,
+): Promise<{ ok: boolean; error?: string }> {
+  const { school } = await requireSchool();
+  const parsed = ProfileSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };
+  }
+  const actor = await resolveActor(school.id);
+  try {
+    await withSchool(school.id, async (tx) => {
+      await tx
+        .update(schools)
+        .set({
+          name: parsed.data.name.trim(),
+          shortName: parsed.data.shortName
+            ? parsed.data.shortName.trim().toUpperCase()
+            : null,
+        })
+        .where(eq(schools.id, school.id));
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "updated",
+        entityType: "school",
+        entityId: school.id,
+        after: { name: parsed.data.name },
+        reason: "School profile updated",
+      });
+    });
+    safeRevalidate("/settings");
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Could not save changes. Please try again." };
+  }
+}
+
+// --------------------------------------------------------------- grading weights
+const WeightsSchema = z
+  .object({
+    classWeight: z.coerce.number().int().min(0).max(100),
+    examWeight: z.coerce.number().int().min(0).max(100),
+  })
+  .refine((d) => d.classWeight + d.examWeight === 100, {
+    message: "Class and exam weights must add up to 100%.",
+  });
+
+export async function updateGradingWeights(
+  input: unknown,
+): Promise<{ ok: boolean; error?: string }> {
+  const { school } = await requireSchool();
+  const parsed = WeightsSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid weights" };
+  }
+  const actor = await resolveActor(school.id);
+  try {
+    await withSchool(school.id, async (tx) => {
+      await tx
+        .insert(gradebookConfig)
+        .values({
+          schoolId: school.id,
+          classWeight: parsed.data.classWeight,
+          examWeight: parsed.data.examWeight,
+        })
+        .onConflictDoUpdate({
+          target: gradebookConfig.schoolId,
+          set: {
+            classWeight: parsed.data.classWeight,
+            examWeight: parsed.data.examWeight,
+          },
+        });
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "updated",
+        entityType: "gradebook_config",
+        entityId: school.id,
+        after: {
+          classWeight: parsed.data.classWeight,
+          examWeight: parsed.data.examWeight,
+        },
+        reason: "Grading weights updated",
+      });
+    });
+    safeRevalidate("/settings");
+    safeRevalidate("/gradebook");
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Could not save weights. Please try again." };
+  }
+}


### PR DESCRIPTION
## What
Adds the **Settings** module (`/settings`) — first of the cross-tier modules missing vs the planned surfaces.

Four sections:
- **School profile** — edit name + SMS sign-off (short name); shows GES code / type / ownership.
- **Academic calendar** — read-only view of the configured year + dated periods.
- **Grading** — class/exam weighting (sum-to-100), feeds the gradebook term total.
- **Messaging** — SMS template count + sign-off, links to Communication.

## Notes
- Uses **existing tables only** (`schools`, `gradebook_config`, `academic_period`, `sms_template`) — **no schema change, no migration**.
- Writes go through `withSchool()` so RLS applies. Added to the app sidebar.

## Verified
`pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm build` ✓ (`/settings` route emitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)