### PR TITLE
feat(staff): staff records + role management at /staff

### DIFF
--- a/omnischools/app/(app)/staff/page.tsx
+++ b/omnischools/app/(app)/staff/page.tsx
@@ -1,0 +1,104 @@
+import { and, asc, eq, inArray } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import { users, roles, roleAssignments } from "@/db/schema";
+import { STAFF_ROLE_CODES } from "@/lib/staff-roles";
+import { AddStaffForm } from "@/components/staff/add-staff-form";
+import { RoleEditor } from "@/components/staff/role-editor";
+
+export const dynamic = "force-dynamic";
+
+type StaffMember = {
+  userId: string;
+  name: string | null;
+  phone: string;
+  email: string | null;
+  roles: { assignmentId: string; code: string }[];
+};
+
+export default async function StaffPage() {
+  const { school } = await requireSchool();
+
+  const rows = await withSchool(school.id, (tx) =>
+    tx
+      .select({
+        assignmentId: roleAssignments.id,
+        userId: users.id,
+        name: users.fullName,
+        phone: users.phone,
+        email: users.email,
+        code: roles.code,
+      })
+      .from(roleAssignments)
+      .innerJoin(users, eq(roleAssignments.userId, users.id))
+      .innerJoin(roles, eq(roleAssignments.roleId, roles.id))
+      .where(
+        and(
+          eq(roleAssignments.schoolId, school.id),
+          inArray(roles.code, STAFF_ROLE_CODES),
+        ),
+      )
+      .orderBy(asc(users.fullName)),
+  );
+
+  const byUser = new Map<string, StaffMember>();
+  for (const r of rows) {
+    let g = byUser.get(r.userId);
+    if (!g) {
+      g = { userId: r.userId, name: r.name, phone: r.phone, email: r.email, roles: [] };
+      byUser.set(r.userId, g);
+    }
+    g.roles.push({ assignmentId: r.assignmentId, code: r.code });
+  }
+  const staff = Array.from(byUser.values());
+
+  return (
+    <div className="mx-auto max-w-page">
+      <div className="mb-6 flex items-center justify-between gap-3">
+        <div>
+          <h1 className="font-display text-3xl font-semibold text-navy">Staff</h1>
+          <p className="text-sm text-navy-3">
+            {staff.length} {staff.length === 1 ? "person" : "people"} · teachers, bursars
+            and admins who can sign in.
+          </p>
+        </div>
+        <AddStaffForm />
+      </div>
+
+      {staff.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border-2 bg-surface p-12 text-center">
+          <p className="font-display text-lg text-navy">No staff yet.</p>
+          <p className="mt-1 text-sm text-navy-3">
+            Add teachers and other staff so they can take attendance, enter scores and
+            collect fees.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-xl border border-border bg-surface">
+          <table className="w-full text-sm">
+            <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
+              <tr>
+                <th className="px-4 py-3 font-semibold">Name</th>
+                <th className="px-4 py-3 font-semibold">Phone</th>
+                <th className="px-4 py-3 font-semibold">Email</th>
+                <th className="px-4 py-3 font-semibold">Roles</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {staff.map((m) => (
+                <tr key={m.userId} className="transition-colors hover:bg-bg">
+                  <td className="px-4 py-3 font-medium text-navy">{m.name ?? "—"}</td>
+                  <td className="px-4 py-3 font-mono text-xs text-navy-2">{m.phone}</td>
+                  <td className="px-4 py-3 text-navy-2">{m.email ?? "—"}</td>
+                  <td className="px-4 py-3">
+                    <RoleEditor userId={m.userId} assignments={m.roles} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/omnischools/components/app/sidebar.tsx
+++ b/omnischools/components/app/sidebar.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 
 const NAV = [
   { href: "/dashboard", label: "Dashboard", icon: "D" },
+  { href: "/staff", label: "Staff", icon: "P" },
   { href: "/students", label: "Students", icon: "S" },
   { href: "/admissions", label: "Admissions", icon: "A" },
   { href: "/fees", label: "Fees", icon: "F" },

--- a/omnischools/components/staff/add-staff-form.tsx
+++ b/omnischools/components/staff/add-staff-form.tsx
@@ -1,0 +1,109 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { addStaff } from "@/lib/actions/staff";
+import { STAFF_ROLES } from "@/lib/staff-roles";
+
+const fieldClass =
+  "w-full rounded-md border border-border-2 bg-bg px-3.5 py-2.5 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
+const labelClass = "mb-1.5 block text-xs font-semibold text-navy-2";
+
+export function AddStaffForm() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function action(formData: FormData) {
+    setSaving(true);
+    setError(null);
+    const res = await addStaff({
+      fullName: formData.get("fullName"),
+      phone: formData.get("phone"),
+      email: formData.get("email"),
+      role: formData.get("role"),
+    });
+    setSaving(false);
+    if (res.ok) {
+      setOpen(false);
+      router.refresh();
+    } else {
+      setError(res.error ?? "Could not add staff.");
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="rounded-md bg-navy px-4 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep"
+      >
+        + Add staff
+      </button>
+    );
+  }
+
+  return (
+    <form
+      action={action}
+      className="mb-5 space-y-4 rounded-xl border border-border bg-surface p-6"
+    >
+      <h2 className="font-display text-lg font-semibold text-navy">Add staff member</h2>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div>
+          <label className={labelClass}>Full name</label>
+          <input name="fullName" required className={fieldClass} />
+        </div>
+        <div>
+          <label className={labelClass}>Phone (login)</label>
+          <input
+            name="phone"
+            required
+            placeholder="024 000 0000"
+            className={fieldClass}
+          />
+        </div>
+        <div>
+          <label className={labelClass}>
+            Email <span className="font-medium text-navy-3">— optional</span>
+          </label>
+          <input name="email" type="email" className={fieldClass} />
+        </div>
+        <div>
+          <label className={labelClass}>Role</label>
+          <select name="role" required defaultValue="TEACHER" className={fieldClass}>
+            {STAFF_ROLES.map((r) => (
+              <option key={r.code} value={r.code}>
+                {r.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      {error && <p className="text-sm text-terra">{error}</p>}
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={saving}
+          className="rounded-md bg-navy px-5 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-60"
+        >
+          {saving ? "Adding…" : "Add staff"}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setOpen(false);
+            setError(null);
+          }}
+          className="rounded-md px-4 py-2.5 text-sm font-semibold text-navy-2 hover:bg-bg"
+        >
+          Cancel
+        </button>
+      </div>
+      <p className="text-xs text-navy-3">
+        They sign in with this phone number via OTP. Phone numbers are normalised to Ghana
+        (+233) format.
+      </p>
+    </form>
+  );
+}

--- a/omnischools/components/staff/role-editor.tsx
+++ b/omnischools/components/staff/role-editor.tsx
@@ -1,0 +1,77 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { assignStaffRole, removeStaffRole } from "@/lib/actions/staff";
+import { STAFF_ROLES, STAFF_ROLE_LABEL } from "@/lib/staff-roles";
+
+export function RoleEditor({
+  userId,
+  assignments,
+}: {
+  userId: string;
+  assignments: { assignmentId: string; code: string }[];
+}) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const held = new Set(assignments.map((a) => a.code));
+  const available = STAFF_ROLES.filter((r) => !held.has(r.code));
+
+  async function remove(assignmentId: string) {
+    setBusy(true);
+    setError(null);
+    const res = await removeStaffRole({ assignmentId });
+    setBusy(false);
+    if (res.ok) router.refresh();
+    else setError(res.error ?? "Could not remove.");
+  }
+
+  async function add(role: string) {
+    if (!role) return;
+    setBusy(true);
+    setError(null);
+    const res = await assignStaffRole({ userId, role });
+    setBusy(false);
+    if (res.ok) router.refresh();
+    else setError(res.error ?? "Could not add.");
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {assignments.map((a) => (
+        <span
+          key={a.assignmentId}
+          className="inline-flex items-center gap-1 rounded-pill bg-gold-bg py-0.5 pl-2.5 pr-1 text-xs font-medium text-navy"
+        >
+          {STAFF_ROLE_LABEL[a.code] ?? a.code}
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => remove(a.assignmentId)}
+            aria-label={`Remove ${a.code}`}
+            className="flex h-4 w-4 items-center justify-center rounded-full text-navy-3 transition-colors hover:text-terra disabled:opacity-50"
+          >
+            ×
+          </button>
+        </span>
+      ))}
+      {available.length > 0 && (
+        <select
+          value=""
+          disabled={busy}
+          onChange={(e) => add(e.target.value)}
+          className="rounded-pill border border-border-2 bg-bg px-2 py-0.5 text-xs text-navy-3 outline-none focus:border-gold"
+        >
+          <option value="">+ role</option>
+          {available.map((r) => (
+            <option key={r.code} value={r.code}>
+              {r.label}
+            </option>
+          ))}
+        </select>
+      )}
+      {error && <span className="text-xs text-terra">{error}</span>}
+    </div>
+  );
+}

--- a/omnischools/lib/actions/staff.ts
+++ b/omnischools/lib/actions/staff.ts
@@ -1,0 +1,188 @@
+"use server";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import { withSchool } from "@/lib/db/rls";
+import { recordAudit } from "@/lib/db/audit";
+import { requireSchool, resolveActor } from "@/lib/auth/server";
+import { normalizeGhanaPhone } from "@/lib/auth";
+import { safeRevalidate } from "@/lib/revalidate";
+import { STAFF_ROLE_CODES, STAFF_ROLE_LABEL } from "@/lib/staff-roles";
+import type { Tx } from "@/lib/db";
+import { users, roles, roleAssignments } from "@/db/schema";
+
+type Result = { ok: boolean; error?: string };
+
+/** Ensure the ref_role row exists (prod onboarding seeds only ADMIN/HEADMASTER). */
+async function ensureRoleId(tx: Tx, code: (typeof STAFF_ROLE_CODES)[number]) {
+  await tx
+    .insert(roles)
+    .values({ code, label: STAFF_ROLE_LABEL[code] })
+    .onConflictDoNothing({ target: roles.code });
+  const [r] = await tx.select({ id: roles.id }).from(roles).where(eq(roles.code, code));
+  return r.id;
+}
+
+async function assign(
+  tx: Tx,
+  schoolId: string,
+  userId: string,
+  code: (typeof STAFF_ROLE_CODES)[number],
+): Promise<boolean> {
+  const roleId = await ensureRoleId(tx, code);
+  const existing = await tx
+    .select({ id: roleAssignments.id })
+    .from(roleAssignments)
+    .where(
+      and(
+        eq(roleAssignments.schoolId, schoolId),
+        eq(roleAssignments.userId, userId),
+        eq(roleAssignments.roleId, roleId),
+      ),
+    );
+  if (existing.length > 0) return false;
+  await tx.insert(roleAssignments).values({ userId, schoolId, roleId });
+  return true;
+}
+
+// ----------------------------------------------------------------- add staff
+const AddStaffSchema = z.object({
+  fullName: z.string().min(2, "Enter the staff member's name").max(120),
+  phone: z.string().min(7, "Enter a valid phone number"),
+  email: z.string().email("Invalid email").optional().or(z.literal("")),
+  role: z.enum(STAFF_ROLE_CODES),
+});
+
+export async function addStaff(input: unknown): Promise<Result> {
+  const { school } = await requireSchool();
+  const parsed = AddStaffSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };
+  }
+  const d = parsed.data;
+  const phone = normalizeGhanaPhone(d.phone);
+  const actor = await resolveActor(school.id);
+  try {
+    await withSchool(school.id, async (tx) => {
+      await tx
+        .insert(users)
+        .values({ phone, fullName: d.fullName.trim(), email: d.email || null })
+        .onConflictDoNothing({ target: users.phone });
+      const [u] = await tx
+        .select({ id: users.id })
+        .from(users)
+        .where(eq(users.phone, phone));
+      const added = await assign(tx, school.id, u.id, d.role);
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: added ? "created" : "updated",
+        entityType: "staff",
+        entityId: u.id,
+        after: { name: d.fullName, role: d.role },
+        reason: "Staff member added",
+      });
+    });
+    safeRevalidate("/staff");
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Could not add staff. Please try again." };
+  }
+}
+
+// ----------------------------------------------------------- assign more roles
+const AssignSchema = z.object({
+  userId: z.string().uuid(),
+  role: z.enum(STAFF_ROLE_CODES),
+});
+
+export async function assignStaffRole(input: unknown): Promise<Result> {
+  const { school } = await requireSchool();
+  const parsed = AssignSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: "Invalid input" };
+  const actor = await resolveActor(school.id);
+  try {
+    await withSchool(school.id, async (tx) => {
+      const added = await assign(tx, school.id, parsed.data.userId, parsed.data.role);
+      if (added) {
+        await recordAudit(tx, {
+          schoolId: school.id,
+          actorUserId: actor.id ?? undefined,
+          actorRole: actor.role,
+          actionType: "updated",
+          entityType: "staff",
+          entityId: parsed.data.userId,
+          after: { role: parsed.data.role },
+          reason: "Role assigned",
+        });
+      }
+    });
+    safeRevalidate("/staff");
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Could not assign role." };
+  }
+}
+
+// --------------------------------------------------------------- remove role
+const RemoveSchema = z.object({ assignmentId: z.string().uuid() });
+
+export async function removeStaffRole(input: unknown): Promise<Result> {
+  const { school } = await requireSchool();
+  const parsed = RemoveSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: "Invalid input" };
+  const actor = await resolveActor(school.id);
+  try {
+    const outcome = await withSchool(school.id, async (tx) => {
+      const [a] = await tx
+        .select({
+          id: roleAssignments.id,
+          userId: roleAssignments.userId,
+          code: roles.code,
+        })
+        .from(roleAssignments)
+        .innerJoin(roles, eq(roleAssignments.roleId, roles.id))
+        .where(
+          and(
+            eq(roleAssignments.id, parsed.data.assignmentId),
+            eq(roleAssignments.schoolId, school.id),
+          ),
+        );
+      if (!a) return { error: "Role not found." };
+      if (a.code === "ADMIN") {
+        const admins = await tx
+          .select({ id: roleAssignments.id })
+          .from(roleAssignments)
+          .innerJoin(roles, eq(roleAssignments.roleId, roles.id))
+          .where(and(eq(roleAssignments.schoolId, school.id), eq(roles.code, "ADMIN")));
+        if (admins.length <= 1) {
+          return { error: "Can't remove the only administrator." };
+        }
+      }
+      await tx
+        .delete(roleAssignments)
+        .where(
+          and(
+            eq(roleAssignments.id, parsed.data.assignmentId),
+            eq(roleAssignments.schoolId, school.id),
+          ),
+        );
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "deleted",
+        entityType: "staff",
+        entityId: a.userId,
+        before: { role: a.code },
+        reason: "Role removed",
+      });
+      return { ok: true as const };
+    });
+    if ("error" in outcome) return { ok: false, error: outcome.error };
+    safeRevalidate("/staff");
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Could not remove role." };
+  }
+}

--- a/omnischools/lib/staff-roles.ts
+++ b/omnischools/lib/staff-roles.ts
@@ -1,0 +1,29 @@
+import type { AppRole } from "@/lib/auth";
+
+/**
+ * Staff-assignable roles (excludes STUDENT / PARENT). Shared by the Staff module's
+ * server actions and UI so the catalogue stays in one place. Labels use Ghanaian
+ * school vocabulary. Boarding roles apply to Senior schools; harmless for Basic.
+ */
+export const STAFF_ROLES = [
+  { code: "ADMIN", label: "Administrator" },
+  { code: "HEADMASTER", label: "Headmaster" },
+  { code: "VICE_HEADMASTER_ACADEMIC", label: "Vice Headmaster (Academic)" },
+  { code: "TEACHER", label: "Teacher" },
+  { code: "FORM_MASTER", label: "Form Master" },
+  { code: "BURSAR", label: "Bursar" },
+  { code: "HOUSEMASTER", label: "Housemaster" },
+  { code: "DEAN_OF_BOARDING", label: "Dean of Boarding" },
+  { code: "MATRON", label: "Matron" },
+] as const satisfies ReadonlyArray<{ code: AppRole; label: string }>;
+
+export type StaffRoleCode = (typeof STAFF_ROLES)[number]["code"];
+
+export const STAFF_ROLE_CODES = STAFF_ROLES.map((r) => r.code) as [
+  StaffRoleCode,
+  ...StaffRoleCode[],
+];
+
+export const STAFF_ROLE_LABEL: Record<string, string> = Object.fromEntries(
+  STAFF_ROLES.map((r) => [r.code, r.label]),
+);


### PR DESCRIPTION
## What
Adds the **Staff** module (`/staff`) — manage the people who can sign in.

- Lists staff (teachers, bursars, admins) grouped by person with their roles.
- Add staff: name + phone (their OTP login) + email + initial role.
- Per-person role chips with add/remove; **guards against removing the only admin**.

## Notes
- **Existing tables only** (`ref_user`, `ref_role`, `role_assignment`) — **no schema change, no migration**.
- Ensures the `ref_role` row exists on assign (prod onboarding seeds only ADMIN/HEADMASTER).
- All writes go through `withSchool()` so RLS applies. Role catalogue centralised in `lib/staff-roles.ts`. Added to sidebar.

## Verified
`pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm build` ✓ (`/staff` route emitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)