### PR TITLE
feat(ui): navy navigation + lucide icons (redesign step 1)

### DIFF
--- a/omnischools/app/(app)/layout.tsx
+++ b/omnischools/app/(app)/layout.tsx
@@ -5,19 +5,23 @@ import { AppSidebar } from "@/components/app/sidebar";
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
   const { school, user } = await requireSchool();
   return (
-    <div className="bg-bg flex min-h-screen">
-      <AppSidebar />
+    <div className="flex min-h-screen bg-bg">
+      <AppSidebar
+        school={{
+          name: school.name,
+          shortName: school.shortName,
+          schoolType: school.schoolType,
+          location: school.location,
+        }}
+        user={{ name: user.name ?? null, role: user.roles[0] ?? null }}
+      />
       <div className="flex min-w-0 flex-1 flex-col">
-        <header className="bg-surface flex items-center justify-between gap-4 border-b border-border px-6 py-3">
-          <div className="min-w-0">
-            <div className="truncate font-display text-base font-semibold text-navy">
-              {school.name}
-            </div>
-            <div className="text-xs text-navy-3">
-              {school.schoolType.charAt(0) + school.schoolType.slice(1).toLowerCase()} ·{" "}
-              {user.roles[0]?.replaceAll("_", " ").toLowerCase()}
-            </div>
+        <header className="flex items-center justify-between gap-4 border-b border-border bg-surface px-6 py-3">
+          {/* School name shows on mobile (sidebar hidden < md); on desktop it lives in the sidebar. */}
+          <div className="truncate font-display text-base font-semibold text-navy md:hidden">
+            {school.name}
           </div>
+          <div className="hidden md:block" />
           <div className="flex shrink-0 items-center gap-3">
             <span className="flex items-center gap-1.5 rounded-pill bg-green-bg px-2.5 py-1 text-xs font-medium text-green">
               ● Connected
@@ -25,7 +29,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
             <form action={signOutAction}>
               <button
                 type="submit"
-                className="hover:bg-bg rounded-md px-3 py-1.5 text-xs font-semibold text-navy-2 transition-colors"
+                className="rounded-md px-3 py-1.5 text-xs font-semibold text-navy-2 transition-colors hover:bg-bg"
               >
                 Sign out
               </button>

--- a/omnischools/components/app/sidebar.tsx
+++ b/omnischools/components/app/sidebar.tsx
@@ -1,80 +1,140 @@
 "use client";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import {
+  LayoutDashboard,
+  Users,
+  GraduationCap,
+  BookOpen,
+  UserPlus,
+  Banknote,
+  ReceiptText,
+  BarChart3,
+  CalendarCheck,
+  ClipboardList,
+  Megaphone,
+  MessageSquare,
+  Settings,
+  type LucideIcon,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 
-const NAV = [
-  { href: "/dashboard", label: "Dashboard", icon: "D" },
-  { href: "/staff", label: "Staff", icon: "P" },
-  { href: "/students", label: "Students", icon: "S" },
-  { href: "/classes", label: "Classes", icon: "L" },
-  { href: "/admissions", label: "Admissions", icon: "A" },
-  { href: "/fees", label: "Fees", icon: "F" },
-  { href: "/billing", label: "Billing", icon: "B" },
-  { href: "/reports", label: "Reports", icon: "R" },
-  { href: "/attendance", label: "Attendance", icon: "T" },
-  { href: "/gradebook", label: "Gradebook", icon: "G" },
-  { href: "/communication", label: "Communication", icon: "C" },
-  { href: "/inbox", label: "Inbox", icon: "I" },
-  { href: "/settings", label: "Settings", icon: "⚙" },
+const NAV: { href: string; label: string; Icon: LucideIcon }[] = [
+  { href: "/dashboard", label: "Dashboard", Icon: LayoutDashboard },
+  { href: "/staff", label: "Staff", Icon: Users },
+  { href: "/students", label: "Students", Icon: GraduationCap },
+  { href: "/classes", label: "Classes", Icon: BookOpen },
+  { href: "/admissions", label: "Admissions", Icon: UserPlus },
+  { href: "/fees", label: "Fees", Icon: Banknote },
+  { href: "/billing", label: "Billing", Icon: ReceiptText },
+  { href: "/reports", label: "Reports", Icon: BarChart3 },
+  { href: "/attendance", label: "Attendance", Icon: CalendarCheck },
+  { href: "/gradebook", label: "Gradebook", Icon: ClipboardList },
+  { href: "/communication", label: "Communication", Icon: Megaphone },
+  { href: "/inbox", label: "Inbox", Icon: MessageSquare },
+  { href: "/settings", label: "Settings", Icon: Settings },
 ];
 
-// Roadmap items (later phases) — shown disabled to convey the shape.
-const SOON: { label: string; icon: string }[] = [];
+const TIER: Record<string, string> = {
+  BASIC: "Basic",
+  SENIOR: "Senior",
+  COMBINED: "Combined",
+};
 
-export function AppSidebar() {
+/** First letters of the first two words, uppercased (e.g. "Christ King" → "CK"). */
+function initials(s: string | null | undefined, fallback = "—"): string {
+  const parts = (s ?? "").trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return fallback;
+  return (parts[0][0] + (parts[1]?.[0] ?? "")).toUpperCase();
+}
+
+function titleCase(s: string): string {
+  return s
+    .replaceAll("_", " ")
+    .toLowerCase()
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function AppSidebar({
+  school,
+  user,
+}: {
+  school: {
+    name: string;
+    shortName: string | null;
+    schoolType: string;
+    location: string | null;
+  };
+  user: { name: string | null; role: string | null };
+}) {
   const pathname = usePathname();
+  const tierLoc = [TIER[school.schoolType] ?? school.schoolType, school.location]
+    .filter(Boolean)
+    .join(" · ");
+
   return (
-    <aside className="hidden w-60 shrink-0 flex-col border-r border-border bg-surface md:flex">
-      <div className="flex items-center gap-2.5 px-5 py-[18px]">
-        <span className="flex h-8 w-8 items-center justify-center rounded-md bg-navy font-display text-[15px] font-semibold italic text-gold-soft">
-          O
+    <aside className="hidden w-60 shrink-0 flex-col bg-navy text-bg md:flex">
+      {/* School block */}
+      <div className="flex items-center gap-3 border-b border-white/10 px-5 py-4">
+        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-gold font-display text-sm font-semibold text-navy">
+          {initials(school.shortName ?? school.name)}
         </span>
-        <span className="font-display text-lg font-semibold text-navy">Omnischools</span>
+        <div className="min-w-0">
+          <div className="truncate font-display text-sm font-medium text-bg">
+            {school.name}
+          </div>
+          <div className="truncate text-[10px] uppercase tracking-wider text-gold-soft">
+            {tierLoc}
+          </div>
+        </div>
       </div>
-      <nav className="flex-1 space-y-0.5 px-3 py-2">
-        {NAV.map((item) => {
-          const active = pathname === item.href || pathname.startsWith(item.href + "/");
+
+      {/* Nav */}
+      <nav className="flex-1 space-y-0.5 overflow-y-auto px-3 py-3">
+        {NAV.map(({ href, label, Icon }) => {
+          const active = pathname === href || pathname.startsWith(href + "/");
           return (
             <Link
-              key={item.href}
-              href={item.href}
+              key={href}
+              href={href}
               className={cn(
-                "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-                active ? "bg-gold-bg text-navy" : "text-navy-2 hover:bg-bg",
+                "flex items-center gap-3 rounded-md border-l-2 py-2 pl-3 pr-3 text-sm font-medium transition-colors",
+                active
+                  ? "bg-gold/10 border-gold text-bg"
+                  : "text-bg/70 border-transparent hover:bg-white/5 hover:text-bg",
               )}
             >
-              <span
-                className={cn(
-                  "flex h-6 w-6 items-center justify-center rounded font-display text-xs italic",
-                  active ? "bg-navy text-gold-soft" : "bg-bg text-navy-3",
-                )}
-              >
-                {item.icon}
-              </span>
-              {item.label}
+              <Icon
+                className="h-[18px] w-[18px] shrink-0"
+                strokeWidth={active ? 2.2 : 1.8}
+              />
+              {label}
             </Link>
           );
         })}
-        {SOON.length > 0 && (
-          <>
-            <div className="px-3 pb-1 pt-5 text-[10px] font-semibold uppercase tracking-[0.12em] text-navy-3">
-              Coming soon
-            </div>
-            {SOON.map((item) => (
-              <span
-                key={item.label}
-                className="text-navy-3/60 flex cursor-not-allowed items-center gap-3 rounded-md px-3 py-2 text-sm font-medium"
-              >
-                <span className="text-navy-3/60 flex h-6 w-6 items-center justify-center rounded bg-bg font-display text-xs italic">
-                  {item.icon}
-                </span>
-                {item.label}
-              </span>
-            ))}
-          </>
-        )}
       </nav>
+
+      {/* User block */}
+      <div className="flex items-center gap-2.5 border-t border-white/10 px-4 py-3">
+        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gold font-display text-xs font-semibold text-navy">
+          {initials(user.name)}
+        </span>
+        <div className="min-w-0">
+          <div className="truncate font-display text-xs font-semibold text-bg">
+            {user.name ?? "—"}
+          </div>
+          <div className="truncate text-[10px] text-gold-soft">
+            {user.role ? titleCase(user.role) : ""}
+          </div>
+        </div>
+      </div>
+
+      {/* On Omnischools */}
+      <div className="border-t border-white/5 px-4 py-3">
+        <span className="text-gold/60 text-[9px] font-bold uppercase tracking-[0.18em]">
+          ON <span className="text-gold/90">OMNISCHOOLS</span>
+        </span>
+      </div>
     </aside>
   );
 }

--- a/omnischools/lib/auth/server.ts
+++ b/omnischools/lib/auth/server.ts
@@ -2,7 +2,7 @@ import { redirect } from "next/navigation";
 import { eq, and } from "drizzle-orm";
 import { env } from "@/lib/env";
 import { withoutTenantScope } from "@/lib/db/rls";
-import { schools, roleAssignments, roles, users } from "@/db/schema";
+import { schools, roleAssignments, roles, users, districts, regions } from "@/db/schema";
 import { getCurrentUser, type AppUser } from "@/lib/auth";
 
 export interface ActiveSchool {
@@ -11,6 +11,8 @@ export interface ActiveSchool {
   shortName: string | null;
   gesCode: string;
   schoolType: "BASIC" | "SENIOR" | "COMBINED";
+  /** District (or region) name, for the sidebar "tier · location" line. */
+  location: string | null;
 }
 
 /**
@@ -30,27 +32,42 @@ export async function getActiveSchool(): Promise<ActiveSchool | null> {
     shortName: schools.shortName,
     gesCode: schools.gesCode,
     schoolType: schools.schoolType,
+    districtName: districts.name,
+    regionName: regions.name,
   };
 
-  return withoutTenantScope(async (tx) => {
+  const row = await withoutTenantScope(async (tx) => {
     if (env.AUTH_DEV_BYPASS) {
       const demo = await tx
         .select(cols)
         .from(schools)
+        .leftJoin(districts, eq(schools.districtId, districts.id))
+        .leftJoin(regions, eq(schools.regionId, regions.id))
         .where(eq(schools.gesCode, "WR-WAW-014"))
         .limit(1);
       if (demo[0]) return demo[0];
-      const first = await tx.select(cols).from(schools).limit(1);
+      const first = await tx
+        .select(cols)
+        .from(schools)
+        .leftJoin(districts, eq(schools.districtId, districts.id))
+        .leftJoin(regions, eq(schools.regionId, regions.id))
+        .limit(1);
       return first[0] ?? null;
     }
     const assigned = await tx
       .select(cols)
       .from(roleAssignments)
       .innerJoin(schools, eq(roleAssignments.schoolId, schools.id))
+      .leftJoin(districts, eq(schools.districtId, districts.id))
+      .leftJoin(regions, eq(schools.regionId, regions.id))
       .where(eq(roleAssignments.userId, user.id))
       .limit(1);
     return assigned[0] ?? null;
   });
+
+  if (!row) return null;
+  const { districtName, regionName, ...rest } = row;
+  return { ...rest, location: districtName ?? regionName ?? null };
 }
 
 /** For app pages: ensure a signed-in user, else send to login. */


### PR DESCRIPTION
## What — Redesign Step 1 of 8 (issues 1 & 2)
Aligns the app shell to the HTML mockups + `design-tokens`:
- **Sidebar is now navy `#1A2B47`** with off-white text.
- **Top: school block** — gold rounded-square initials + school name (Fraunces) + `tier · location`.
- **Nav items** use **lucide-react** icons; active item = gold left-border + gold-tint bg + white text.
- **Bottom: user block** — gold circle initials + name + role, with an **"ON OMNISCHOOLS"** gold label beneath.
- `getActiveSchool()` now resolves a district/region `location` for the school block.
- Top header slimmed to the connection pill + sign-out (identity moved into the sidebar); school name shows in the header on mobile only.

## Notes
- No schema change. `lucide-react` already in deps.
- `pnpm typecheck` ✓ · `lint` ✓ · `build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)