### PR TITLE
feat(ui): shared field primitives + dropdowns (redesign step 2, issue 9)

### DIFF
--- a/omnischools/app/(app)/billing/page.tsx
+++ b/omnischools/app/(app)/billing/page.tsx
@@ -4,6 +4,7 @@ import { withSchool } from "@/lib/db/rls";
 import {
   feeStructures,
   feeStructureItems,
+  feeCategories,
   discounts,
   classes,
   invoices,
@@ -25,8 +26,8 @@ function currentAcademicYear() {
 export default async function BillingPage() {
   const { school } = await requireSchool();
 
-  const [structureRows, itemRows, discountRows, classRows, [summary]] = await Promise.all(
-    [
+  const [structureRows, itemRows, discountRows, classRows, feeCatRows, [summary]] =
+    await Promise.all([
       withSchool(school.id, (tx) =>
         tx
           .select()
@@ -56,6 +57,13 @@ export default async function BillingPage() {
       ),
       withSchool(school.id, (tx) =>
         tx
+          .select({ name: feeCategories.name })
+          .from(feeCategories)
+          .where(eq(feeCategories.schoolId, school.id))
+          .orderBy(asc(feeCategories.name)),
+      ),
+      withSchool(school.id, (tx) =>
+        tx
           .select({
             families: sql<number>`count(distinct ${invoices.studentId})`,
             total: sql<string>`coalesce(sum(${invoices.balanceAmount}), 0)`,
@@ -69,8 +77,7 @@ export default async function BillingPage() {
             ),
           ),
       ),
-    ],
-  );
+    ]);
 
   const itemsByStructure = new Map<string, { description: string; amount: number }[]>();
   for (const it of itemRows) {
@@ -114,7 +121,10 @@ export default async function BillingPage() {
       <section>
         <div className="mb-4 flex items-center justify-between gap-3">
           <h2 className="font-display text-xl font-semibold text-navy">Fee structures</h2>
-          <CreateFeeStructureForm defaultYear={currentAcademicYear()} />
+          <CreateFeeStructureForm
+            defaultYear={currentAcademicYear()}
+            feeItemOptions={feeCatRows.map((c) => c.name)}
+          />
         </div>
         {structures.length === 0 ? (
           <p className="rounded-xl border border-dashed border-border-2 bg-surface p-10 text-center text-sm text-navy-3">

--- a/omnischools/app/(app)/students/new/page.tsx
+++ b/omnischools/app/(app)/students/new/page.tsx
@@ -1,9 +1,23 @@
 import Link from "next/link";
+import { and, asc, eq } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import { classes } from "@/db/schema";
 import { NewStudentForm } from "@/components/students/new-student-form";
 
 export const metadata = { title: "Add student" };
+export const dynamic = "force-dynamic";
 
-export default function NewStudentPage() {
+export default async function NewStudentPage() {
+  const { school } = await requireSchool();
+  const classRows = await withSchool(school.id, (tx) =>
+    tx
+      .select({ id: classes.id, name: classes.name })
+      .from(classes)
+      .where(and(eq(classes.schoolId, school.id), eq(classes.active, true)))
+      .orderBy(asc(classes.name)),
+  );
+
   return (
     <div className="mx-auto max-w-3xl">
       <Link href="/students" className="text-sm text-navy-3 hover:text-gold">
@@ -12,7 +26,7 @@ export default function NewStudentPage() {
       <h1 className="mb-6 mt-2 font-display text-3xl font-semibold text-navy">
         Add a student
       </h1>
-      <NewStudentForm />
+      <NewStudentForm classes={classRows} />
     </div>
   );
 }

--- a/omnischools/components/billing/create-fee-structure-form.tsx
+++ b/omnischools/components/billing/create-fee-structure-form.tsx
@@ -2,14 +2,19 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { createFeeStructure } from "@/lib/actions/billing";
-
-const fieldClass =
-  "w-full rounded-md border border-border-2 bg-bg px-3 py-2 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
-const labelClass = "mb-1 block text-xs font-semibold text-navy-2";
+import { Combobox, DataList, fieldClass, labelClass } from "@/components/ui/fields";
+import { DEFAULT_FEE_ITEMS } from "@/lib/field-options";
 
 type Item = { description: string; amount: string };
 
-export function CreateFeeStructureForm({ defaultYear }: { defaultYear: string }) {
+export function CreateFeeStructureForm({
+  defaultYear,
+  feeItemOptions = [],
+}: {
+  defaultYear: string;
+  feeItemOptions?: string[];
+}) {
+  const itemOptions = Array.from(new Set([...DEFAULT_FEE_ITEMS, ...feeItemOptions]));
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [items, setItems] = useState<Item[]>([{ description: "Tuition", amount: "" }]);
@@ -79,14 +84,16 @@ export function CreateFeeStructureForm({ defaultYear }: { defaultYear: string })
 
       <div>
         <label className={labelClass}>Line items</label>
+        <DataList id="fee-items" options={itemOptions} />
         <div className="space-y-2">
           {items.map((it, i) => (
             <div key={i} className="flex items-center gap-2">
-              <input
+              <Combobox
+                listId="fee-items"
                 value={it.description}
                 onChange={(e) => setItem(i, { description: e.target.value })}
-                placeholder="Description"
-                className={`${fieldClass} flex-1`}
+                placeholder="Item — pick or type (e.g. Tuition)"
+                className="flex-1"
               />
               <input
                 value={it.amount}
@@ -95,7 +102,7 @@ export function CreateFeeStructureForm({ defaultYear }: { defaultYear: string })
                 min={0}
                 step="0.01"
                 placeholder="0.00"
-                className={`${fieldClass} w-28`}
+                className={`${fieldClass} w-32`}
               />
               {items.length > 1 && (
                 <button

--- a/omnischools/components/classes/create-class-form.tsx
+++ b/omnischools/components/classes/create-class-form.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClass } from "@/lib/actions/classes";
+import { YEAR_GROUPS } from "@/lib/field-options";
 
 const fieldClass =
   "rounded-md border border-border-2 bg-bg px-3.5 py-2.5 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
@@ -52,7 +53,14 @@ export function CreateClassForm() {
         <label className="mb-1.5 block text-xs font-semibold text-navy-2">
           Level <span className="font-medium text-navy-3">— optional</span>
         </label>
-        <input name="level" placeholder="JHS 1" className={fieldClass} />
+        <select name="level" defaultValue="" className={fieldClass}>
+          <option value="">— choose —</option>
+          {YEAR_GROUPS.map((yg) => (
+            <option key={yg} value={yg}>
+              {yg}
+            </option>
+          ))}
+        </select>
       </div>
       <button
         type="submit"

--- a/omnischools/components/students/new-student-form.tsx
+++ b/omnischools/components/students/new-student-form.tsx
@@ -7,7 +7,7 @@ const fieldClass =
   "w-full rounded-md border border-border-2 bg-bg px-3.5 py-2.5 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
 const labelClass = "mb-1.5 block text-xs font-semibold text-navy-2";
 
-export function NewStudentForm() {
+export function NewStudentForm({ classes }: { classes: { id: string; name: string }[] }) {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
@@ -21,7 +21,7 @@ export function NewStudentForm() {
       otherNames: formData.get("otherNames"),
       sex: formData.get("sex"),
       dateOfBirth: formData.get("dateOfBirth"),
-      classLabel: formData.get("classLabel"),
+      classId: formData.get("classId"),
       guardianName: formData.get("guardianName"),
       guardianPhone: formData.get("guardianPhone"),
       guardianRelation: formData.get("guardianRelation"),
@@ -34,7 +34,7 @@ export function NewStudentForm() {
   return (
     <form
       action={action}
-      className="bg-surface space-y-5 rounded-xl border border-border p-6"
+      className="space-y-5 rounded-xl border border-border bg-surface p-6"
     >
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
         <div>
@@ -73,7 +73,14 @@ export function NewStudentForm() {
           <label className={labelClass}>
             Class <span className="font-medium text-navy-3">— optional</span>
           </label>
-          <input name="classLabel" placeholder="e.g. JHS 1A" className={fieldClass} />
+          <select name="classId" defaultValue="" className={fieldClass}>
+            <option value="">— unassigned —</option>
+            {classes.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
         </div>
       </div>
 
@@ -116,14 +123,14 @@ export function NewStudentForm() {
         <button
           type="submit"
           disabled={saving}
-          className="text-bg rounded-md bg-navy px-5 py-2.5 text-sm font-semibold transition-colors hover:bg-navy-deep disabled:opacity-60"
+          className="rounded-md bg-navy px-5 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-60"
         >
           {saving ? "Saving…" : "Create student"}
         </button>
         <button
           type="button"
           onClick={() => router.push("/students")}
-          className="hover:bg-bg rounded-md px-4 py-2.5 text-sm font-semibold text-navy-2"
+          className="rounded-md px-4 py-2.5 text-sm font-semibold text-navy-2 hover:bg-bg"
         >
           Cancel
         </button>

--- a/omnischools/components/ui/fields.tsx
+++ b/omnischools/components/ui/fields.tsx
@@ -1,0 +1,54 @@
+import type { InputHTMLAttributes, SelectHTMLAttributes } from "react";
+
+/**
+ * Shared form-field primitives (Issue 9). Hook-free + server-safe — they only
+ * render styled native elements, so a client parent supplies state/handlers.
+ *
+ * - <Select> — styled native dropdown (uniform class/subject/year-group fields).
+ * - <Combobox> + <DataList> — a dropdown of suggestions that also accepts a new,
+ *   typed value (the "add new item" affordance). Render one <DataList> and point
+ *   any number of <Combobox listId=…> inputs at it.
+ * - <DateInput> — tokenised native date picker.
+ */
+export const fieldClass =
+  "w-full rounded-md border border-border-2 bg-bg px-3 py-2 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
+export const labelClass = "mb-1 block text-xs font-semibold text-navy-2";
+
+export function Select({
+  className,
+  children,
+  ...props
+}: SelectHTMLAttributes<HTMLSelectElement>) {
+  return (
+    <select className={`${fieldClass} ${className ?? ""}`} {...props}>
+      {children}
+    </select>
+  );
+}
+
+export function DateInput({
+  className,
+  ...props
+}: InputHTMLAttributes<HTMLInputElement>) {
+  return <input type="date" className={`${fieldClass} ${className ?? ""}`} {...props} />;
+}
+
+export function Combobox({
+  listId,
+  className,
+  ...props
+}: InputHTMLAttributes<HTMLInputElement> & { listId: string }) {
+  return (
+    <input list={listId} className={`${fieldClass} ${className ?? ""}`} {...props} />
+  );
+}
+
+export function DataList({ id, options }: { id: string; options: readonly string[] }) {
+  return (
+    <datalist id={id}>
+      {options.map((o) => (
+        <option key={o} value={o} />
+      ))}
+    </datalist>
+  );
+}

--- a/omnischools/lib/actions/billing.ts
+++ b/omnischools/lib/actions/billing.ts
@@ -10,6 +10,7 @@ import { round2, toMoney, num, nextInvoiceNumber } from "@/lib/fees-helpers";
 import {
   feeStructures,
   feeStructureItems,
+  feeCategories,
   discounts,
   students,
   studentGuardians,
@@ -62,6 +63,16 @@ export async function createFeeStructure(input: unknown): Promise<Result> {
           amount: toMoney(li.amount),
         })),
       );
+      // Remember each item label as a fee category so it joins the dropdown next time.
+      const cats = Array.from(
+        new Set(d.items.map((li) => li.description.trim()).filter(Boolean)),
+      );
+      if (cats.length > 0) {
+        await tx
+          .insert(feeCategories)
+          .values(cats.map((name) => ({ schoolId: school.id, name })))
+          .onConflictDoNothing({ target: [feeCategories.schoolId, feeCategories.name] });
+      }
       await recordAudit(tx, {
         schoolId: school.id,
         actorUserId: actor.id ?? undefined,

--- a/omnischools/lib/actions/students.ts
+++ b/omnischools/lib/actions/students.ts
@@ -5,8 +5,9 @@ import { withSchool } from "@/lib/db/rls";
 import { recordAudit } from "@/lib/db/audit";
 import { requireSchool, resolveActor } from "@/lib/auth/server";
 import { normalizeGhanaPhone } from "@/lib/auth";
+import { and, eq } from "drizzle-orm";
 import { nextStudentCode } from "@/lib/students-helpers";
-import { students, studentGuardians } from "@/db/schema";
+import { students, studentGuardians, classes } from "@/db/schema";
 
 const CreateStudentSchema = z.object({
   firstName: z.string().min(1, "First name is required").max(120),
@@ -14,7 +15,7 @@ const CreateStudentSchema = z.object({
   otherNames: z.string().max(120).optional().or(z.literal("")),
   sex: z.enum(["MALE", "FEMALE"]),
   dateOfBirth: z.string().optional().or(z.literal("")),
-  classLabel: z.string().max(60).optional().or(z.literal("")),
+  classId: z.string().uuid().optional().or(z.literal("")),
   guardianName: z.string().max(160).optional().or(z.literal("")),
   guardianPhone: z.string().max(40).optional().or(z.literal("")),
   guardianRelation: z.enum(["MOTHER", "FATHER", "GUARDIAN", "OTHER"]).default("GUARDIAN"),
@@ -36,6 +37,14 @@ export async function createStudent(input: unknown): Promise<CreateStudentResult
   try {
     const out = await withSchool(school.id, async (tx) => {
       const studentCode = await nextStudentCode(tx, school.id);
+      let className: string | null = null;
+      if (d.classId) {
+        const [cls] = await tx
+          .select({ name: classes.name })
+          .from(classes)
+          .where(and(eq(classes.id, d.classId), eq(classes.schoolId, school.id)));
+        className = cls?.name ?? null;
+      }
       const [student] = await tx
         .insert(students)
         .values({
@@ -46,7 +55,8 @@ export async function createStudent(input: unknown): Promise<CreateStudentResult
           otherNames: d.otherNames || null,
           sex: d.sex,
           dateOfBirth: d.dateOfBirth || null,
-          currentClassLabel: d.classLabel || null,
+          classId: d.classId || null,
+          currentClassLabel: className,
           enrolledOn: new Date().toISOString().slice(0, 10),
         })
         .returning();

--- a/omnischools/lib/field-options.ts
+++ b/omnischools/lib/field-options.ts
@@ -1,0 +1,49 @@
+/** Shared option lists for dropdowns across the app (Issue 9: field uniformity). */
+
+/** Ghana year-groups (KG → SHS) for class level / year-group dropdowns. */
+export const YEAR_GROUPS = [
+  "KG 1",
+  "KG 2",
+  "Primary 1",
+  "Primary 2",
+  "Primary 3",
+  "Primary 4",
+  "Primary 5",
+  "Primary 6",
+  "JHS 1",
+  "JHS 2",
+  "JHS 3",
+  "SHS 1",
+  "SHS 2",
+  "SHS 3",
+] as const;
+
+/** Default fee line-item suggestions for the Billing combobox (users can add more). */
+export const DEFAULT_FEE_ITEMS = [
+  "Tuition",
+  "Books",
+  "Uniform",
+  "Feeding",
+  "Transport",
+  "PTA dues",
+  "Exam fees",
+  "Boarding",
+  "ICT levy",
+  "Sports",
+  "Other",
+] as const;
+
+/** Common Ghanaian basic-school subjects for subject dropdowns. */
+export const COMMON_SUBJECTS = [
+  "English Language",
+  "Mathematics",
+  "Integrated Science",
+  "Social Studies",
+  "Religious & Moral Education",
+  "Ghanaian Language",
+  "French",
+  "Computing / ICT",
+  "Creative Arts & Design",
+  "Career Technology",
+  "Physical Education",
+] as const;


### PR DESCRIPTION
- components/ui/fields.tsx: Select, Combobox + DataList (dropdown that also accepts a typed/new value), DateInput. lib/field-options.ts: YEAR_GROUPS, DEFAULT_FEE_ITEMS, COMMON_SUBJECTS.
- Billing fee structure: cramped free-text line-item → a Combobox (suggestions Tuition/Books/Uniform/… + add-new), widened; typed items persist to fee_category so they join the dropdown next time.
- Classes: level free-text → YEAR_GROUPS dropdown.
- Students /new: class free-text → dropdown of the school's classes (sets class_id + label).

No schema change (uses existing fee_category). typecheck/lint/build pass.