### PR TITLE
fix(ui): billing + classes field fixes (redesign step 2b)

### DIFF
--- a/omnischools/app/(app)/billing/page.tsx
+++ b/omnischools/app/(app)/billing/page.tsx
@@ -1,4 +1,4 @@
-import { and, asc, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, isNotNull, sql } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import {
@@ -8,6 +8,7 @@ import {
   discounts,
   classes,
   invoices,
+  academicPeriod,
 } from "@/db/schema";
 import { num } from "@/lib/fees-helpers";
 import { CreateFeeStructureForm } from "@/components/billing/create-fee-structure-form";
@@ -26,58 +27,80 @@ function currentAcademicYear() {
 export default async function BillingPage() {
   const { school } = await requireSchool();
 
-  const [structureRows, itemRows, discountRows, classRows, feeCatRows, [summary]] =
-    await Promise.all([
-      withSchool(school.id, (tx) =>
-        tx
-          .select()
-          .from(feeStructures)
-          .where(eq(feeStructures.schoolId, school.id))
-          .orderBy(asc(feeStructures.name)),
-      ),
-      withSchool(school.id, (tx) =>
-        tx
-          .select()
-          .from(feeStructureItems)
-          .where(eq(feeStructureItems.schoolId, school.id)),
-      ),
-      withSchool(school.id, (tx) =>
-        tx
-          .select()
-          .from(discounts)
-          .where(eq(discounts.schoolId, school.id))
-          .orderBy(asc(discounts.name)),
-      ),
-      withSchool(school.id, (tx) =>
-        tx
-          .select({ id: classes.id, name: classes.name })
-          .from(classes)
-          .where(and(eq(classes.schoolId, school.id), eq(classes.active, true)))
-          .orderBy(asc(classes.name)),
-      ),
-      withSchool(school.id, (tx) =>
-        tx
-          .select({ name: feeCategories.name })
-          .from(feeCategories)
-          .where(eq(feeCategories.schoolId, school.id))
-          .orderBy(asc(feeCategories.name)),
-      ),
-      withSchool(school.id, (tx) =>
-        tx
-          .select({
-            families: sql<number>`count(distinct ${invoices.studentId})`,
-            total: sql<string>`coalesce(sum(${invoices.balanceAmount}), 0)`,
-          })
-          .from(invoices)
-          .where(
-            and(
-              eq(invoices.schoolId, school.id),
-              inArray(invoices.status, ["ISSUED", "PARTIAL", "OVERDUE"]),
-              sql`${invoices.balanceAmount} > 0`,
-            ),
+  const [
+    structureRows,
+    itemRows,
+    discountRows,
+    classRows,
+    feeCatRows,
+    levelRows,
+    yearRows,
+    [summary],
+  ] = await Promise.all([
+    withSchool(school.id, (tx) =>
+      tx
+        .select()
+        .from(feeStructures)
+        .where(eq(feeStructures.schoolId, school.id))
+        .orderBy(asc(feeStructures.name)),
+    ),
+    withSchool(school.id, (tx) =>
+      tx
+        .select()
+        .from(feeStructureItems)
+        .where(eq(feeStructureItems.schoolId, school.id)),
+    ),
+    withSchool(school.id, (tx) =>
+      tx
+        .select()
+        .from(discounts)
+        .where(eq(discounts.schoolId, school.id))
+        .orderBy(asc(discounts.name)),
+    ),
+    withSchool(school.id, (tx) =>
+      tx
+        .select({ id: classes.id, name: classes.name })
+        .from(classes)
+        .where(and(eq(classes.schoolId, school.id), eq(classes.active, true)))
+        .orderBy(asc(classes.name)),
+    ),
+    withSchool(school.id, (tx) =>
+      tx
+        .select({ name: feeCategories.name })
+        .from(feeCategories)
+        .where(eq(feeCategories.schoolId, school.id))
+        .orderBy(asc(feeCategories.name)),
+    ),
+    withSchool(school.id, (tx) =>
+      tx
+        .selectDistinct({ level: classes.level })
+        .from(classes)
+        .where(and(eq(classes.schoolId, school.id), isNotNull(classes.level)))
+        .orderBy(asc(classes.level)),
+    ),
+    withSchool(school.id, (tx) =>
+      tx
+        .selectDistinct({ year: academicPeriod.academicYear })
+        .from(academicPeriod)
+        .where(eq(academicPeriod.schoolId, school.id))
+        .orderBy(asc(academicPeriod.academicYear)),
+    ),
+    withSchool(school.id, (tx) =>
+      tx
+        .select({
+          families: sql<number>`count(distinct ${invoices.studentId})`,
+          total: sql<string>`coalesce(sum(${invoices.balanceAmount}), 0)`,
+        })
+        .from(invoices)
+        .where(
+          and(
+            eq(invoices.schoolId, school.id),
+            inArray(invoices.status, ["ISSUED", "PARTIAL", "OVERDUE"]),
+            sql`${invoices.balanceAmount} > 0`,
           ),
-      ),
-    ]);
+        ),
+    ),
+  ]);
 
   const itemsByStructure = new Map<string, { description: string; amount: number }[]>();
   for (const it of itemRows) {
@@ -124,6 +147,8 @@ export default async function BillingPage() {
           <CreateFeeStructureForm
             defaultYear={currentAcademicYear()}
             feeItemOptions={feeCatRows.map((c) => c.name)}
+            levelOptions={levelRows.map((l) => l.level).filter((l): l is string => !!l)}
+            yearOptions={yearRows.map((y) => y.year)}
           />
         </div>
         {structures.length === 0 ? (

--- a/omnischools/app/(app)/classes/[id]/page.tsx
+++ b/omnischools/app/(app)/classes/[id]/page.tsx
@@ -7,6 +7,7 @@ import { classes, students, subjects, timetableSlots, users } from "@/db/schema"
 import { loadStaffOptions } from "@/lib/data/staff-options";
 import { ClassTeacherSelect } from "@/components/classes/class-teacher-select";
 import { RosterManager } from "@/components/classes/roster-manager";
+import { SubjectsManager } from "@/components/classes/subjects-manager";
 import { TimetableBuilder } from "@/components/classes/timetable-builder";
 
 export const dynamic = "force-dynamic";
@@ -111,6 +112,8 @@ export default async function ClassDetailPage({ params }: { params: { id: string
       </div>
 
       <RosterManager classId={cls.id} inClass={inClass} unassigned={free} />
+
+      <SubjectsManager subjects={subjectRows} />
 
       <TimetableBuilder
         classId={cls.id}

--- a/omnischools/components/billing/create-fee-structure-form.tsx
+++ b/omnischools/components/billing/create-fee-structure-form.tsx
@@ -2,24 +2,34 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { createFeeStructure } from "@/lib/actions/billing";
-import { Combobox, DataList, fieldClass, labelClass } from "@/components/ui/fields";
-import { DEFAULT_FEE_ITEMS } from "@/lib/field-options";
+import { DataList, fieldClass, labelClass } from "@/components/ui/fields";
+import { DEFAULT_FEE_ITEMS, YEAR_GROUPS } from "@/lib/field-options";
+
+const lineInput =
+  "rounded-md border border-border-2 bg-bg px-3 py-2 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
 
 type Item = { description: string; amount: string };
 
 export function CreateFeeStructureForm({
   defaultYear,
   feeItemOptions = [],
+  levelOptions = [],
+  yearOptions = [],
 }: {
   defaultYear: string;
   feeItemOptions?: string[];
+  levelOptions?: string[];
+  yearOptions?: string[];
 }) {
-  const itemOptions = Array.from(new Set([...DEFAULT_FEE_ITEMS, ...feeItemOptions]));
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [items, setItems] = useState<Item[]>([{ description: "Tuition", amount: "" }]);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const itemOptions = Array.from(new Set([...DEFAULT_FEE_ITEMS, ...feeItemOptions]));
+  const levels = levelOptions.length > 0 ? levelOptions : [...YEAR_GROUPS];
+  const years = Array.from(new Set([defaultYear, ...yearOptions]));
 
   function setItem(i: number, patch: Partial<Item>) {
     setItems((prev) => prev.map((it, idx) => (idx === i ? { ...it, ...patch } : it)));
@@ -66,19 +76,25 @@ export function CreateFeeStructureForm({
           <input name="name" required placeholder="JHS 1 fees" className={fieldClass} />
         </div>
         <div>
-          <label className={labelClass}>
-            Level <span className="font-medium text-navy-3">— optional</span>
-          </label>
-          <input name="level" placeholder="JHS 1" className={fieldClass} />
+          <label className={labelClass}>Level</label>
+          <select name="level" defaultValue="" className={fieldClass}>
+            <option value="">— choose —</option>
+            {levels.map((l) => (
+              <option key={l} value={l}>
+                {l}
+              </option>
+            ))}
+          </select>
         </div>
         <div>
           <label className={labelClass}>Academic year</label>
-          <input
-            name="academicYear"
-            required
-            defaultValue={defaultYear}
-            className={fieldClass}
-          />
+          <select name="academicYear" defaultValue={defaultYear} className={fieldClass}>
+            {years.map((y) => (
+              <option key={y} value={y}>
+                {y}
+              </option>
+            ))}
+          </select>
         </div>
       </div>
 
@@ -88,12 +104,12 @@ export function CreateFeeStructureForm({
         <div className="space-y-2">
           {items.map((it, i) => (
             <div key={i} className="flex items-center gap-2">
-              <Combobox
-                listId="fee-items"
+              <input
+                list="fee-items"
                 value={it.description}
                 onChange={(e) => setItem(i, { description: e.target.value })}
                 placeholder="Item — pick or type (e.g. Tuition)"
-                className="flex-1"
+                className={`${lineInput} min-w-0 flex-1`}
               />
               <input
                 value={it.amount}
@@ -102,13 +118,13 @@ export function CreateFeeStructureForm({
                 min={0}
                 step="0.01"
                 placeholder="0.00"
-                className={`${fieldClass} w-32`}
+                className={`${lineInput} w-28 shrink-0`}
               />
               {items.length > 1 && (
                 <button
                   type="button"
                   onClick={() => setItems((prev) => prev.filter((_, idx) => idx !== i))}
-                  className="px-1 text-navy-3 hover:text-terra"
+                  className="shrink-0 px-1 text-navy-3 hover:text-terra"
                   aria-label="Remove line"
                 >
                   ×

--- a/omnischools/components/billing/discount-manager.tsx
+++ b/omnischools/components/billing/discount-manager.tsx
@@ -2,6 +2,8 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { createDiscount, deleteDiscount } from "@/lib/actions/billing";
+import { DataList } from "@/components/ui/fields";
+import { DEFAULT_DISCOUNTS } from "@/lib/field-options";
 
 const ghs = (n: number) => `GH₵ ${n.toFixed(2)}`;
 const fieldClass =
@@ -41,7 +43,14 @@ export function DiscountManager({ discounts }: { discounts: DiscountOpt[] }) {
       <form id="discount-form" action={add} className="flex flex-wrap items-end gap-2">
         <div>
           <label className="mb-1 block text-xs font-semibold text-navy-2">Name</label>
-          <input name="name" required placeholder="Staff ward" className={fieldClass} />
+          <input
+            name="name"
+            list="discount-names"
+            required
+            placeholder="Pick or type"
+            className={fieldClass}
+          />
+          <DataList id="discount-names" options={DEFAULT_DISCOUNTS} />
         </div>
         <div>
           <label className="mb-1 block text-xs font-semibold text-navy-2">Type</label>

--- a/omnischools/components/classes/subjects-manager.tsx
+++ b/omnischools/components/classes/subjects-manager.tsx
@@ -1,0 +1,136 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { addSubject, renameSubject, setSubjectActive } from "@/lib/actions/classes";
+import { Combobox, DataList } from "@/components/ui/fields";
+import { COMMON_SUBJECTS } from "@/lib/field-options";
+
+type Subject = { id: string; name: string };
+
+export function SubjectsManager({ subjects }: { subjects: Subject[] }) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  async function add(formData: FormData) {
+    const name = String(formData.get("name") ?? "").trim();
+    if (!name) return;
+    setBusy(true);
+    setError(null);
+    const res = await addSubject({ name });
+    setBusy(false);
+    if (res.ok) {
+      (document.getElementById("subj-add") as HTMLFormElement | null)?.reset();
+      router.refresh();
+    } else setError(res.error ?? "Could not add subject.");
+  }
+
+  async function saveRename(id: string) {
+    if (!editName.trim()) return;
+    setBusy(true);
+    setError(null);
+    const res = await renameSubject({ id, name: editName });
+    setBusy(false);
+    if (res.ok) {
+      setEditingId(null);
+      router.refresh();
+    } else setError(res.error ?? "Could not rename.");
+  }
+
+  async function deactivate(id: string) {
+    setBusy(true);
+    await setSubjectActive({ id, active: false });
+    setBusy(false);
+    router.refresh();
+  }
+
+  return (
+    <div>
+      <h2 className="mb-3 font-display text-lg font-semibold text-navy">Subjects</h2>
+      <div className="rounded-xl border border-border bg-surface p-4">
+        <form id="subj-add" action={add} className="flex items-center gap-2">
+          <Combobox
+            listId="subj-suggest"
+            name="name"
+            placeholder="Add a subject (e.g. Twi, Ga, Dagbani)"
+            className="flex-1"
+          />
+          <DataList id="subj-suggest" options={COMMON_SUBJECTS} />
+          <button
+            type="submit"
+            disabled={busy}
+            className="rounded-md bg-navy px-4 py-2 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-60"
+          >
+            + Add
+          </button>
+        </form>
+        {error && <p className="mt-2 text-sm text-terra">{error}</p>}
+
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {subjects.length === 0 && (
+            <span className="text-sm text-navy-3">No subjects yet.</span>
+          )}
+          {subjects.map((s) =>
+            editingId === s.id ? (
+              <span
+                key={s.id}
+                className="inline-flex items-center gap-1 rounded-pill border border-gold bg-gold-bg py-0.5 pl-2 pr-1"
+              >
+                <input
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                  className="w-28 bg-transparent text-xs text-navy outline-none"
+                  autoFocus
+                />
+                <button
+                  type="button"
+                  onClick={() => saveRename(s.id)}
+                  disabled={busy}
+                  className="text-xs font-semibold text-green"
+                >
+                  Save
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setEditingId(null)}
+                  className="px-1 text-navy-3"
+                >
+                  ×
+                </button>
+              </span>
+            ) : (
+              <span
+                key={s.id}
+                className="inline-flex items-center gap-1.5 rounded-pill bg-bg py-0.5 pl-2.5 pr-1 text-xs font-medium text-navy"
+              >
+                {s.name}
+                <button
+                  type="button"
+                  onClick={() => {
+                    setEditingId(s.id);
+                    setEditName(s.name);
+                  }}
+                  aria-label={`Rename ${s.name}`}
+                  className="text-navy-3 hover:text-gold"
+                >
+                  ✎
+                </button>
+                <button
+                  type="button"
+                  onClick={() => deactivate(s.id)}
+                  disabled={busy}
+                  aria-label={`Remove ${s.name}`}
+                  className="flex h-4 w-4 items-center justify-center rounded-full text-navy-3 hover:text-terra disabled:opacity-50"
+                >
+                  ×
+                </button>
+              </span>
+            ),
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/omnischools/components/classes/timetable-builder.tsx
+++ b/omnischools/components/classes/timetable-builder.tsx
@@ -1,8 +1,10 @@
 "use client";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { addTimetableSlot, removeTimetableSlot, addSubject } from "@/lib/actions/classes";
+import { addTimetableSlots, removeTimetableSlot } from "@/lib/actions/classes";
 import { DAYS, DAY_LABEL } from "@/lib/timetable-days";
+import { COMMON_SUBJECTS } from "@/lib/field-options";
+import { Combobox, DataList } from "@/components/ui/fields";
 import type { StaffOption } from "@/lib/data/staff-options";
 
 type Slot = {
@@ -33,23 +35,37 @@ export function TimetableBuilder({
   const router = useRouter();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [newSubject, setNewSubject] = useState("");
+  const [msg, setMsg] = useState<string | null>(null);
+
+  const subjectOptions = Array.from(
+    new Set([...COMMON_SUBJECTS, ...subjects.map((s) => s.name)]),
+  );
 
   async function add(formData: FormData) {
+    const days = formData.getAll("day");
+    if (days.length === 0) {
+      setError("Pick at least one day.");
+      return;
+    }
     setBusy(true);
     setError(null);
-    const res = await addTimetableSlot({
+    setMsg(null);
+    const res = await addTimetableSlots({
       classId,
-      dayOfWeek: formData.get("dayOfWeek"),
+      days,
       periodIndex: formData.get("periodIndex"),
-      subjectId: formData.get("subjectId"),
+      subjectName: formData.get("subjectName"),
       teacherUserId: formData.get("teacherUserId"),
       startTime: formData.get("startTime"),
       endTime: formData.get("endTime"),
     });
     setBusy(false);
-    if (res.ok) router.refresh();
-    else setError(res.error ?? "Could not add lesson.");
+    if (res.ok) {
+      setMsg(
+        `Added ${res.created} lesson${res.created === 1 ? "" : "s"}${res.skipped ? ` · skipped ${res.skipped} (clash/duplicate)` : ""}.`,
+      );
+      router.refresh();
+    } else setError(res.error ?? "Could not add lessons.");
   }
 
   async function remove(slotId: string) {
@@ -57,17 +73,6 @@ export function TimetableBuilder({
     await removeTimetableSlot({ slotId });
     setBusy(false);
     router.refresh();
-  }
-
-  async function createSubject() {
-    if (!newSubject.trim()) return;
-    setBusy(true);
-    const res = await addSubject({ name: newSubject });
-    setBusy(false);
-    if (res.ok) {
-      setNewSubject("");
-      router.refresh();
-    } else setError(res.error ?? "Could not add subject.");
   }
 
   const ordered = [...slots].sort(
@@ -123,93 +128,100 @@ export function TimetableBuilder({
 
       <form
         action={add}
-        className="flex flex-wrap items-end gap-2 rounded-xl border border-border bg-surface p-4"
+        className="space-y-3 rounded-xl border border-border bg-surface p-4"
       >
         <div>
-          <label className="mb-1 block text-[11px] font-semibold text-navy-2">Day</label>
-          <select name="dayOfWeek" defaultValue="1" className={fieldClass}>
+          <label className="mb-1.5 block text-[11px] font-semibold text-navy-2">
+            Days <span className="font-normal text-navy-3">— pick one or more</span>
+          </label>
+          <div className="flex flex-wrap gap-1.5">
             {DAYS.map((d) => (
-              <option key={d.value} value={d.value}>
+              <label
+                key={d.value}
+                className="flex cursor-pointer items-center gap-1.5 rounded-md border border-border-2 px-2.5 py-1.5 text-sm text-navy-2 has-[:checked]:border-gold has-[:checked]:bg-gold-bg has-[:checked]:text-navy"
+              >
+                <input
+                  type="checkbox"
+                  name="day"
+                  value={d.value}
+                  defaultChecked={d.value === 1}
+                />
                 {d.label}
-              </option>
+              </label>
             ))}
-          </select>
+          </div>
         </div>
-        <div>
-          <label className="mb-1 block text-[11px] font-semibold text-navy-2">
-            Period
-          </label>
-          <input
-            name="periodIndex"
-            type="number"
-            min={1}
-            max={15}
-            defaultValue={1}
-            className={`${fieldClass} w-16`}
-          />
+        <div className="flex flex-wrap items-end gap-2">
+          <div>
+            <label className="mb-1 block text-[11px] font-semibold text-navy-2">
+              Period
+            </label>
+            <input
+              name="periodIndex"
+              type="number"
+              min={1}
+              max={15}
+              defaultValue={1}
+              className={`${fieldClass} w-16`}
+            />
+          </div>
+          <div className="min-w-44 flex-1">
+            <label className="mb-1 block text-[11px] font-semibold text-navy-2">
+              Subject
+            </label>
+            <Combobox
+              listId="subjects-list"
+              name="subjectName"
+              placeholder="Pick or type (e.g. Twi)"
+              className="px-2.5 py-1.5"
+            />
+            <DataList id="subjects-list" options={subjectOptions} />
+          </div>
+          <div className="min-w-40 flex-1">
+            <label className="mb-1 block text-[11px] font-semibold text-navy-2">
+              Teacher
+            </label>
+            <select
+              name="teacherUserId"
+              defaultValue=""
+              className={`${fieldClass} w-full`}
+            >
+              <option value="">—</option>
+              {teachers.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="mb-1 block text-[11px] font-semibold text-navy-2">
+              Start
+            </label>
+            <input
+              name="startTime"
+              placeholder="11:15"
+              className={`${fieldClass} w-20`}
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-[11px] font-semibold text-navy-2">
+              End
+            </label>
+            <input name="endTime" placeholder="12:05" className={`${fieldClass} w-20`} />
+          </div>
+          <button
+            type="submit"
+            disabled={busy}
+            className="rounded-md bg-navy px-4 py-1.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-60"
+          >
+            Add lesson(s)
+          </button>
         </div>
-        <div>
-          <label className="mb-1 block text-[11px] font-semibold text-navy-2">
-            Subject
-          </label>
-          <select name="subjectId" defaultValue="" className={fieldClass}>
-            <option value="">—</option>
-            {subjects.map((s) => (
-              <option key={s.id} value={s.id}>
-                {s.name}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div>
-          <label className="mb-1 block text-[11px] font-semibold text-navy-2">
-            Teacher
-          </label>
-          <select name="teacherUserId" defaultValue="" className={fieldClass}>
-            <option value="">—</option>
-            {teachers.map((t) => (
-              <option key={t.id} value={t.id}>
-                {t.name}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div>
-          <label className="mb-1 block text-[11px] font-semibold text-navy-2">
-            Start
-          </label>
-          <input name="startTime" placeholder="08:00" className={`${fieldClass} w-20`} />
-        </div>
-        <div>
-          <label className="mb-1 block text-[11px] font-semibold text-navy-2">End</label>
-          <input name="endTime" placeholder="08:40" className={`${fieldClass} w-20`} />
-        </div>
-        <button
-          type="submit"
-          disabled={busy}
-          className="rounded-md bg-navy px-4 py-1.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-60"
-        >
-          Add lesson
-        </button>
       </form>
 
+      {msg && <p className="mt-2 text-sm font-medium text-green">{msg}</p>}
       {error && <p className="mt-2 text-sm text-terra">{error}</p>}
-
-      <div className="mt-3 flex items-center gap-2">
-        <input
-          value={newSubject}
-          onChange={(e) => setNewSubject(e.target.value)}
-          placeholder="New subject (e.g. Integrated Science)"
-          className={fieldClass}
-        />
-        <button
-          onClick={createSubject}
-          disabled={busy || !newSubject.trim()}
-          className="rounded-md border border-border-2 px-3 py-1.5 text-sm font-semibold text-navy-2 transition-colors hover:bg-bg disabled:opacity-50"
-        >
-          + Add subject
-        </button>
-      </div>
     </div>
   );
 }

--- a/omnischools/lib/actions/classes.ts
+++ b/omnischools/lib/actions/classes.ts
@@ -161,6 +161,51 @@ export async function addSubject(input: unknown): Promise<Result> {
   }
 }
 
+const RenameSubjectSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1, "Enter a subject name").max(60),
+});
+
+export async function renameSubject(input: unknown): Promise<Result> {
+  const { school } = await requireSchool();
+  const parsed = RenameSubjectSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };
+  }
+  try {
+    await withSchool(school.id, (tx) =>
+      tx
+        .update(subjects)
+        .set({ name: parsed.data.name.trim() })
+        .where(and(eq(subjects.id, parsed.data.id), eq(subjects.schoolId, school.id))),
+    );
+    safeRevalidate("/classes");
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Could not rename — that name may already exist." };
+  }
+}
+
+const SubjectActiveSchema = z.object({ id: z.string().uuid(), active: z.boolean() });
+
+export async function setSubjectActive(input: unknown): Promise<Result> {
+  const { school } = await requireSchool();
+  const parsed = SubjectActiveSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: "Invalid input" };
+  try {
+    await withSchool(school.id, (tx) =>
+      tx
+        .update(subjects)
+        .set({ active: parsed.data.active })
+        .where(and(eq(subjects.id, parsed.data.id), eq(subjects.schoolId, school.id))),
+    );
+    safeRevalidate("/classes");
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Could not update subject." };
+  }
+}
+
 // ----------------------------------------------------------------- timetable
 const AddSlotSchema = z.object({
   classId: z.string().uuid(),
@@ -213,6 +258,98 @@ export async function addTimetableSlot(input: unknown): Promise<Result> {
     return { ok: true };
   } catch {
     return { ok: false, error: "This class already has a lesson in that slot." };
+  }
+}
+
+// Multi-day: lay the same lesson (subject·teacher·time·period) across several days.
+const AddSlotsSchema = z.object({
+  classId: z.string().uuid(),
+  days: z.array(z.coerce.number().int().min(1).max(7)).min(1, "Pick at least one day"),
+  periodIndex: z.coerce.number().int().min(1).max(15),
+  subjectName: z.string().max(60).optional().nullable(),
+  teacherUserId: z.string().optional().nullable(),
+  startTime: z.string().optional().nullable(),
+  endTime: z.string().optional().nullable(),
+});
+
+export async function addTimetableSlots(
+  input: unknown,
+): Promise<Result & { created?: number; skipped?: number }> {
+  const { school } = await requireSchool();
+  const parsed = AddSlotsSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };
+  }
+  const d = parsed.data;
+  const teacherUserId = nz(d.teacherUserId);
+  const days = Array.from(new Set(d.days));
+  try {
+    const out = await withSchool(school.id, async (tx) => {
+      // find-or-create the subject by name (allows custom subjects e.g. Twi, Ga)
+      let subjectId: string | null = null;
+      const subjName = nz(d.subjectName);
+      if (subjName) {
+        await tx
+          .insert(subjects)
+          .values({ schoolId: school.id, name: subjName })
+          .onConflictDoNothing({ target: [subjects.schoolId, subjects.name] });
+        const [s] = await tx
+          .select({ id: subjects.id })
+          .from(subjects)
+          .where(and(eq(subjects.schoolId, school.id), eq(subjects.name, subjName)));
+        subjectId = s?.id ?? null;
+      }
+
+      let created = 0;
+      let skipped = 0;
+      for (const day of days) {
+        if (teacherUserId) {
+          const clash = await tx
+            .select({ id: timetableSlots.id })
+            .from(timetableSlots)
+            .where(
+              and(
+                eq(timetableSlots.schoolId, school.id),
+                eq(timetableSlots.teacherUserId, teacherUserId),
+                eq(timetableSlots.dayOfWeek, day),
+                eq(timetableSlots.periodIndex, d.periodIndex),
+              ),
+            );
+          if (clash.length > 0) {
+            skipped++;
+            continue;
+          }
+        }
+        const ins = await tx
+          .insert(timetableSlots)
+          .values({
+            schoolId: school.id,
+            classId: d.classId,
+            dayOfWeek: day,
+            periodIndex: d.periodIndex,
+            subjectId,
+            teacherUserId,
+            startTime: nz(d.startTime),
+            endTime: nz(d.endTime),
+          })
+          .onConflictDoNothing({
+            target: [
+              timetableSlots.schoolId,
+              timetableSlots.classId,
+              timetableSlots.dayOfWeek,
+              timetableSlots.periodIndex,
+            ],
+          })
+          .returning({ id: timetableSlots.id });
+        if (ins.length > 0) created++;
+        else skipped++;
+      }
+      return { created, skipped };
+    });
+    safeRevalidate(`/classes/${d.classId}`);
+    return { ok: true, ...out };
+  } catch {
+    return { ok: false, error: "Could not add the lessons. Please try again." };
   }
 }
 

--- a/omnischools/lib/field-options.ts
+++ b/omnischools/lib/field-options.ts
@@ -33,6 +33,18 @@ export const DEFAULT_FEE_ITEMS = [
   "Other",
 ] as const;
 
+/** Common discount names (managed under Settings → Fee structure). */
+export const DEFAULT_DISCOUNTS = [
+  "Sibling discount",
+  "Staff ward",
+  "Scholarship",
+  "Bursary",
+  "Need-based",
+  "Early payment",
+  "Sports / talent",
+  "Bereavement",
+] as const;
+
 /** Common Ghanaian basic-school subjects for subject dropdowns. */
 export const COMMON_SUBJECTS = [
   "English Language",


### PR DESCRIPTION
Follow-up fixes from Step 2 review.

## Billing (fee structures)
- **Line-item row fixed** — description grows, amount is a fixed narrow field (no more inverted/cramped widths).
- **Level** → dropdown of the school's class levels (falls back to KG–SHS year groups).
- **Academic year** → dropdown of the school's configured academic years.
- **Discount name** → dropdown of common discounts (Sibling, Staff ward, Scholarship…), still accepts a custom typed value.

## Classes
- **Timetable Day → multi-select** (checkbox chips): lay one lesson (subject·teacher·time·period) across several days at once. New `addTimetableSlots` action loops days with per-day teacher-clash + duplicate skipping.
- **Subject → combobox** (common subjects + the school's own + custom like Twi/Ga/Dagbani); find-or-create on use.
- New **SubjectsManager** on the class page: add / rename / remove subjects after creation.

No schema change. `typecheck`/`lint`/`build` pass.

> Discount *setup* relocation into Settings → Fee structure is scheduled for Step 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)