### PR TITLE
feat(students): edit records after creation (redesign step 2c)

### DIFF
--- a/omnischools/app/(app)/students/[id]/edit/page.tsx
+++ b/omnischools/app/(app)/students/[id]/edit/page.tsx
@@ -1,0 +1,76 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { and, asc, eq } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import { students, studentGuardians, classes } from "@/db/schema";
+import { EditStudentForm } from "@/components/students/edit-student-form";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Edit student" };
+
+export default async function EditStudentPage({ params }: { params: { id: string } }) {
+  const { school } = await requireSchool();
+
+  const data = await withSchool(school.id, async (tx) => {
+    const [student] = await tx
+      .select()
+      .from(students)
+      .where(and(eq(students.id, params.id), eq(students.schoolId, school.id)));
+    if (!student) return null;
+    const [guardian] = await tx
+      .select()
+      .from(studentGuardians)
+      .where(
+        and(
+          eq(studentGuardians.studentId, student.id),
+          eq(studentGuardians.isPrimary, true),
+        ),
+      );
+    const classRows = await tx
+      .select({ id: classes.id, name: classes.name })
+      .from(classes)
+      .where(and(eq(classes.schoolId, school.id), eq(classes.active, true)))
+      .orderBy(asc(classes.name));
+    return { student, guardian, classRows };
+  });
+
+  if (!data) notFound();
+  const { student, guardian, classRows } = data;
+
+  return (
+    <div className="mx-auto max-w-3xl">
+      <Link
+        href={`/students/${student.id}`}
+        className="text-sm text-navy-3 hover:text-gold"
+      >
+        ← Back to student
+      </Link>
+      <h1 className="mb-6 mt-2 font-display text-3xl font-semibold text-navy">
+        Edit {student.firstName} {student.lastName}
+      </h1>
+      <EditStudentForm
+        student={{
+          id: student.id,
+          firstName: student.firstName,
+          lastName: student.lastName,
+          otherNames: student.otherNames,
+          sex: student.sex,
+          dateOfBirth: student.dateOfBirth,
+          classId: student.classId,
+          status: student.status,
+        }}
+        classes={classRows}
+        guardian={
+          guardian
+            ? {
+                name: guardian.name,
+                phone: guardian.phone,
+                relationship: guardian.relationship,
+              }
+            : null
+        }
+      />
+    </div>
+  );
+}

--- a/omnischools/app/(app)/students/[id]/page.tsx
+++ b/omnischools/app/(app)/students/[id]/page.tsx
@@ -39,12 +39,23 @@ export default async function StudentDetailPage({ params }: { params: { id: stri
       <Link href="/students" className="text-sm text-navy-3 hover:text-gold">
         ← Students
       </Link>
-      <h1 className="mb-1 mt-2 font-display text-3xl font-semibold text-navy">
-        {student.firstName} {student.otherNames ?? ""} {student.lastName}
-      </h1>
-      <p className="mb-6 font-mono text-xs text-navy-3">{student.studentCode}</p>
+      <div className="mt-2 flex items-start justify-between gap-3">
+        <div>
+          <h1 className="mb-1 font-display text-3xl font-semibold text-navy">
+            {student.firstName} {student.otherNames ?? ""} {student.lastName}
+          </h1>
+          <p className="font-mono text-xs text-navy-3">{student.studentCode}</p>
+        </div>
+        <Link
+          href={`/students/${student.id}/edit`}
+          className="shrink-0 rounded-md border border-border-2 px-4 py-2 text-sm font-semibold text-navy-2 transition-colors hover:bg-bg"
+        >
+          Edit
+        </Link>
+      </div>
+      <div className="mt-6" />
 
-      <div className="bg-surface rounded-xl border border-border p-6">
+      <div className="rounded-xl border border-border bg-surface p-6">
         <dl className="grid grid-cols-1 gap-x-8 gap-y-3 sm:grid-cols-2">
           {facts.map(([k, v]) => (
             <div
@@ -68,7 +79,7 @@ export default async function StudentDetailPage({ params }: { params: { id: stri
           {guardians.map((g) => (
             <div
               key={g.id}
-              className="bg-surface flex items-center justify-between rounded-lg border border-border px-4 py-3"
+              className="flex items-center justify-between rounded-lg border border-border bg-surface px-4 py-3"
             >
               <div>
                 <div className="text-sm font-medium text-navy">

--- a/omnischools/components/students/edit-student-form.tsx
+++ b/omnischools/components/students/edit-student-form.tsx
@@ -1,0 +1,195 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { updateStudent } from "@/lib/actions/students";
+
+const fieldClass =
+  "w-full rounded-md border border-border-2 bg-bg px-3.5 py-2.5 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
+const labelClass = "mb-1.5 block text-xs font-semibold text-navy-2";
+
+const STATUSES = ["ACTIVE", "INACTIVE", "GRADUATED", "WITHDRAWN", "TRANSFERRED"] as const;
+const title = (s: string) => s.charAt(0) + s.slice(1).toLowerCase();
+
+type Student = {
+  id: string;
+  firstName: string;
+  lastName: string;
+  otherNames: string | null;
+  sex: "MALE" | "FEMALE";
+  dateOfBirth: string | null;
+  classId: string | null;
+  status: string;
+};
+type Guardian = { name: string; phone: string; relationship: string } | null;
+
+export function EditStudentForm({
+  student,
+  classes,
+  guardian,
+}: {
+  student: Student;
+  classes: { id: string; name: string }[];
+  guardian: Guardian;
+}) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  async function action(formData: FormData) {
+    setSaving(true);
+    setError(null);
+    const res = await updateStudent({
+      id: student.id,
+      firstName: formData.get("firstName"),
+      lastName: formData.get("lastName"),
+      otherNames: formData.get("otherNames"),
+      sex: formData.get("sex"),
+      dateOfBirth: formData.get("dateOfBirth"),
+      classId: formData.get("classId"),
+      status: formData.get("status"),
+      guardianName: formData.get("guardianName"),
+      guardianPhone: formData.get("guardianPhone"),
+      guardianRelation: formData.get("guardianRelation"),
+    });
+    setSaving(false);
+    if (res.ok) router.push(`/students/${student.id}`);
+    else setError(res.error);
+  }
+
+  return (
+    <form
+      action={action}
+      className="space-y-5 rounded-xl border border-border bg-surface p-6"
+    >
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div>
+          <label className={labelClass}>First name</label>
+          <input
+            name="firstName"
+            required
+            defaultValue={student.firstName}
+            className={fieldClass}
+          />
+        </div>
+        <div>
+          <label className={labelClass}>Last name</label>
+          <input
+            name="lastName"
+            required
+            defaultValue={student.lastName}
+            className={fieldClass}
+          />
+        </div>
+        <div>
+          <label className={labelClass}>
+            Other names <span className="font-medium text-navy-3">— optional</span>
+          </label>
+          <input
+            name="otherNames"
+            defaultValue={student.otherNames ?? ""}
+            className={fieldClass}
+          />
+        </div>
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-4">
+        <div>
+          <label className={labelClass}>Sex</label>
+          <select name="sex" defaultValue={student.sex} className={fieldClass}>
+            <option value="MALE">Male</option>
+            <option value="FEMALE">Female</option>
+          </select>
+        </div>
+        <div>
+          <label className={labelClass}>Date of birth</label>
+          <input
+            name="dateOfBirth"
+            type="date"
+            defaultValue={student.dateOfBirth ?? ""}
+            className={fieldClass}
+          />
+        </div>
+        <div>
+          <label className={labelClass}>Class</label>
+          <select
+            name="classId"
+            defaultValue={student.classId ?? ""}
+            className={fieldClass}
+          >
+            <option value="">— unassigned —</option>
+            {classes.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className={labelClass}>Status</label>
+          <select name="status" defaultValue={student.status} className={fieldClass}>
+            {STATUSES.map((s) => (
+              <option key={s} value={s}>
+                {title(s)}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="border-t border-border pt-5">
+        <h3 className="mb-3 font-display text-base font-semibold text-navy">
+          Primary guardian
+        </h3>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div>
+            <label className={labelClass}>Name</label>
+            <input
+              name="guardianName"
+              defaultValue={guardian?.name ?? ""}
+              className={fieldClass}
+            />
+          </div>
+          <div>
+            <label className={labelClass}>Phone</label>
+            <input
+              name="guardianPhone"
+              defaultValue={guardian?.phone ?? ""}
+              placeholder="024 000 0000"
+              className={fieldClass}
+            />
+          </div>
+          <div>
+            <label className={labelClass}>Relationship</label>
+            <select
+              name="guardianRelation"
+              defaultValue={guardian?.relationship ?? "GUARDIAN"}
+              className={fieldClass}
+            >
+              <option value="MOTHER">Mother</option>
+              <option value="FATHER">Father</option>
+              <option value="GUARDIAN">Guardian</option>
+              <option value="OTHER">Other</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      {error && <p className="text-sm text-terra">{error}</p>}
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={saving}
+          className="rounded-md bg-navy px-5 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-60"
+        >
+          {saving ? "Saving…" : "Save changes"}
+        </button>
+        <button
+          type="button"
+          onClick={() => router.push(`/students/${student.id}`)}
+          className="rounded-md px-4 py-2.5 text-sm font-semibold text-navy-2 hover:bg-bg"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/omnischools/lib/actions/students.ts
+++ b/omnischools/lib/actions/students.ts
@@ -92,3 +92,110 @@ export async function createStudent(input: unknown): Promise<CreateStudentResult
     return { ok: false, error: "Could not create the student. Please try again." };
   }
 }
+
+// ------------------------------------------------------------- update student
+const UpdateStudentSchema = z.object({
+  id: z.string().uuid(),
+  firstName: z.string().min(1, "First name is required").max(120),
+  lastName: z.string().min(1, "Last name is required").max(120),
+  otherNames: z.string().max(120).optional().or(z.literal("")),
+  sex: z.enum(["MALE", "FEMALE"]),
+  dateOfBirth: z.string().optional().or(z.literal("")),
+  classId: z.string().uuid().optional().or(z.literal("")),
+  status: z.enum(["ACTIVE", "INACTIVE", "GRADUATED", "WITHDRAWN", "TRANSFERRED"]),
+  guardianName: z.string().max(160).optional().or(z.literal("")),
+  guardianPhone: z.string().max(40).optional().or(z.literal("")),
+  guardianRelation: z.enum(["MOTHER", "FATHER", "GUARDIAN", "OTHER"]).default("GUARDIAN"),
+});
+
+export async function updateStudent(input: unknown): Promise<CreateStudentResult> {
+  const { school } = await requireSchool();
+  const parsed = UpdateStudentSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid student" };
+  }
+  const d = parsed.data;
+  const actor = await resolveActor(school.id);
+
+  try {
+    const out = await withSchool(school.id, async (tx) => {
+      const [existing] = await tx
+        .select({ code: students.studentCode })
+        .from(students)
+        .where(and(eq(students.id, d.id), eq(students.schoolId, school.id)));
+      if (!existing) return { ok: false as const, error: "Student not found." };
+
+      let className: string | null = null;
+      if (d.classId) {
+        const [cls] = await tx
+          .select({ name: classes.name })
+          .from(classes)
+          .where(and(eq(classes.id, d.classId), eq(classes.schoolId, school.id)));
+        className = cls?.name ?? null;
+      }
+
+      await tx
+        .update(students)
+        .set({
+          firstName: d.firstName,
+          lastName: d.lastName,
+          otherNames: d.otherNames || null,
+          sex: d.sex,
+          dateOfBirth: d.dateOfBirth || null,
+          classId: d.classId || null,
+          currentClassLabel: className,
+          status: d.status,
+        })
+        .where(and(eq(students.id, d.id), eq(students.schoolId, school.id)));
+
+      // Update (or create) the primary guardian when provided.
+      if (d.guardianName && d.guardianPhone) {
+        const [primary] = await tx
+          .select({ id: studentGuardians.id })
+          .from(studentGuardians)
+          .where(
+            and(
+              eq(studentGuardians.studentId, d.id),
+              eq(studentGuardians.isPrimary, true),
+            ),
+          );
+        const phone = normalizeGhanaPhone(d.guardianPhone);
+        if (primary) {
+          await tx
+            .update(studentGuardians)
+            .set({ name: d.guardianName, phone, relationship: d.guardianRelation })
+            .where(eq(studentGuardians.id, primary.id));
+        } else {
+          await tx.insert(studentGuardians).values({
+            schoolId: school.id,
+            studentId: d.id,
+            name: d.guardianName,
+            relationship: d.guardianRelation,
+            phone,
+            isPrimary: true,
+          });
+        }
+      }
+
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "updated",
+        entityType: "student",
+        entityId: d.id,
+        after: { name: `${d.firstName} ${d.lastName}`, status: d.status },
+        reason: "Student record edited",
+      });
+
+      return { ok: true as const, studentId: d.id, studentCode: existing.code };
+    });
+
+    if (!out.ok) return out;
+    safeRevalidate("/students");
+    safeRevalidate(`/students/${d.id}`);
+    return out;
+  } catch {
+    return { ok: false, error: "Could not update the student. Please try again." };
+  }
+}


### PR DESCRIPTION
Implements the "records should be editable after creation" rule, starting with students.

- **updateStudent** action: edit name, sex, DOB, class, status + the primary guardian (updates the existing primary or creates one); writes an `updated` audit event.
- **/students/[id]/edit** page + EditStudentForm (pre-filled; class & status dropdowns).
- **Edit** button on the student detail page.

The same edit-after-create pattern will be extended to staff and class name/level during Step 8 (section fidelity). Subjects already gained add/rename/remove in #24.

No schema change. `typecheck`/`lint`/`build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)