### PR TITLE
feat(import): bulk-import engine + Students CSV import (redesign step 3)

### DIFF
--- a/omnischools/app/(app)/students/import/page.tsx
+++ b/omnischools/app/(app)/students/import/page.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+import { and, eq } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import { classes } from "@/db/schema";
+import { StudentImport } from "@/components/students/student-import";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Import students" };
+
+export default async function ImportStudentsPage() {
+  const { school } = await requireSchool();
+  const classRows = await withSchool(school.id, (tx) =>
+    tx
+      .select({ id: classes.id, name: classes.name })
+      .from(classes)
+      .where(and(eq(classes.schoolId, school.id), eq(classes.active, true))),
+  );
+  const classByName: Record<string, string> = Object.fromEntries(
+    classRows.map((c) => [c.name, c.id]),
+  );
+
+  return (
+    <div className="mx-auto max-w-page">
+      <Link href="/students" className="text-sm text-navy-3 hover:text-gold">
+        ← Students
+      </Link>
+      <div className="mb-6 mt-2 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="font-display text-3xl font-semibold text-navy">
+            Import students
+          </h1>
+          <p className="text-sm text-navy-3">
+            Add many students at once from a CSV, or{" "}
+            <Link href="/students/new" className="text-gold underline">
+              add a single student
+            </Link>
+            .
+          </p>
+        </div>
+      </div>
+      <StudentImport classByName={classByName} />
+    </div>
+  );
+}

--- a/omnischools/app/(app)/students/page.tsx
+++ b/omnischools/app/(app)/students/page.tsx
@@ -32,16 +32,24 @@ export default async function StudentsPage() {
           <h1 className="font-display text-3xl font-semibold text-navy">Students</h1>
           <p className="text-sm text-navy-3">{rows.length} on roll</p>
         </div>
-        <Link
-          href="/students/new"
-          className="text-bg rounded-md bg-navy px-4 py-2.5 text-sm font-semibold transition-colors hover:bg-navy-deep"
-        >
-          + Add student
-        </Link>
+        <div className="flex items-center gap-2">
+          <Link
+            href="/students/import"
+            className="rounded-md border border-border-2 px-4 py-2.5 text-sm font-semibold text-navy-2 transition-colors hover:bg-bg"
+          >
+            Import
+          </Link>
+          <Link
+            href="/students/new"
+            className="rounded-md bg-navy px-4 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep"
+          >
+            + Add student
+          </Link>
+        </div>
       </div>
 
       {rows.length === 0 ? (
-        <div className="border-border-2 bg-surface rounded-xl border border-dashed p-12 text-center">
+        <div className="rounded-xl border border-dashed border-border-2 bg-surface p-12 text-center">
           <p className="font-display text-lg text-navy">No students yet.</p>
           <p className="mt-1 text-sm text-navy-3">
             Add one directly, or accept an application from{" "}
@@ -52,9 +60,9 @@ export default async function StudentsPage() {
           </p>
         </div>
       ) : (
-        <div className="bg-surface overflow-hidden rounded-xl border border-border">
+        <div className="overflow-hidden rounded-xl border border-border bg-surface">
           <table className="w-full text-sm">
-            <thead className="bg-bg border-b border-border text-left text-xs uppercase tracking-wide text-navy-3">
+            <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
               <tr>
                 <th className="px-4 py-3 font-semibold">Code</th>
                 <th className="px-4 py-3 font-semibold">Name</th>
@@ -65,7 +73,7 @@ export default async function StudentsPage() {
             </thead>
             <tbody className="divide-y divide-border">
               {rows.map((s) => (
-                <tr key={s.id} className="hover:bg-bg transition-colors">
+                <tr key={s.id} className="transition-colors hover:bg-bg">
                   <td className="px-4 py-3 font-mono text-xs text-navy-2">
                     <Link href={`/students/${s.id}`} className="hover:text-gold">
                       {s.studentCode}

--- a/omnischools/components/students/student-import.tsx
+++ b/omnischools/components/students/student-import.tsx
@@ -1,0 +1,226 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { parseCsv, csvTemplate } from "@/lib/import/csv";
+import {
+  validateStudentRows,
+  STUDENT_IMPORT_HEADERS,
+  STUDENT_IMPORT_SAMPLE,
+  type StudentRow,
+  type ImportSummary,
+} from "@/lib/import/student-import";
+import { importStudents } from "@/lib/actions/students";
+
+type Filter = "all" | "ready" | "warning" | "error";
+
+export function StudentImport({ classByName }: { classByName: Record<string, string> }) {
+  const router = useRouter();
+  const [rows, setRows] = useState<StudentRow[]>([]);
+  const [summary, setSummary] = useState<ImportSummary | null>(null);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [filter, setFilter] = useState<Filter>("all");
+  const [busy, setBusy] = useState(false);
+  const [done, setDone] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  function downloadTemplate() {
+    const csv = csvTemplate(STUDENT_IMPORT_HEADERS, STUDENT_IMPORT_SAMPLE);
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "omnischools-students-template.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  async function onFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setFileName(file.name);
+    setDone(null);
+    setError(null);
+    const text = await file.text();
+    const parsed = parseCsv(text);
+    const data = parsed.slice(1); // drop header row
+    const { rows, summary } = validateStudentRows(data, classByName);
+    setRows(rows);
+    setSummary(summary);
+    setFilter("all");
+  }
+
+  async function runImport() {
+    const importable = rows.filter((r) => r.errors.length === 0);
+    if (importable.length === 0) return;
+    setBusy(true);
+    setError(null);
+    const res = await importStudents({
+      rows: importable.map((r) => ({
+        firstName: r.firstName,
+        lastName: r.lastName,
+        otherNames: r.otherNames,
+        sex: r.sex,
+        dateOfBirth: r.dateOfBirth ?? "",
+        classId: r.classId ?? "",
+        guardianName: r.guardianName,
+        guardianPhone: r.guardianPhone,
+        guardianRelation: r.relationship,
+      })),
+    });
+    setBusy(false);
+    if (res.ok) {
+      setDone(`Imported ${res.created} student${res.created === 1 ? "" : "s"}.`);
+      setRows([]);
+      setSummary(null);
+      setFileName(null);
+      router.refresh();
+    } else setError(res.error);
+  }
+
+  const shown = rows.filter((r) =>
+    filter === "all"
+      ? true
+      : filter === "error"
+        ? r.errors.length > 0
+        : filter === "warning"
+          ? r.errors.length === 0 && r.warnings.length > 0
+          : r.errors.length === 0 && r.warnings.length === 0,
+  );
+  const importable = rows.filter((r) => r.errors.length === 0).length;
+
+  const pill = (f: Filter, label: string, tone: string) => (
+    <button
+      onClick={() => setFilter(f)}
+      className={`rounded-pill px-3 py-1 text-xs font-semibold ${
+        filter === f ? tone : "bg-bg text-navy-3"
+      }`}
+    >
+      {label}
+    </button>
+  );
+
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-wrap items-center gap-3 rounded-xl border border-border bg-surface p-5">
+        <div className="min-w-0 flex-1">
+          <h2 className="font-display text-lg font-semibold text-navy">
+            Bulk import from CSV
+          </h2>
+          <p className="text-sm text-navy-3">
+            Download the template, fill it in, and upload. We validate every row before
+            anything is saved.
+          </p>
+        </div>
+        <button
+          onClick={downloadTemplate}
+          className="rounded-md border border-border-2 px-4 py-2 text-sm font-semibold text-navy-2 transition-colors hover:bg-bg"
+        >
+          ↓ Template
+        </button>
+        <label className="cursor-pointer rounded-md bg-navy px-4 py-2 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep">
+          Upload CSV
+          <input
+            type="file"
+            accept=".csv,text/csv"
+            onChange={onFile}
+            className="hidden"
+          />
+        </label>
+      </div>
+
+      {done && (
+        <p className="rounded-md bg-green-bg px-4 py-3 text-sm font-medium text-green">
+          {done}
+        </p>
+      )}
+      {error && <p className="text-sm text-terra">{error}</p>}
+
+      {summary && (
+        <>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            {[
+              ["Total rows", summary.total, "text-navy"],
+              ["Ready", summary.ready, "text-green"],
+              ["Warnings", summary.warning, "text-warn"],
+              ["Errors", summary.error, "text-terra"],
+            ].map(([label, n, tone]) => (
+              <div
+                key={label as string}
+                className="rounded-xl border border-border bg-surface p-4"
+              >
+                <div className="text-xs font-semibold uppercase tracking-wide text-navy-3">
+                  {label}
+                </div>
+                <div className={`mt-1 font-display text-2xl font-semibold ${tone}`}>
+                  {n}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex flex-wrap gap-1.5">
+              {pill("all", `All ${summary.total}`, "bg-navy text-bg")}
+              {pill("ready", `Ready ${summary.ready}`, "bg-green text-bg")}
+              {pill("warning", `Warnings ${summary.warning}`, "bg-warn text-bg")}
+              {pill("error", `Errors ${summary.error}`, "bg-terra text-bg")}
+            </div>
+            <button
+              onClick={runImport}
+              disabled={busy || importable === 0}
+              className="rounded-md bg-navy px-5 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-50"
+            >
+              {busy
+                ? "Importing…"
+                : summary.error > 0
+                  ? `Skip errors & import ${importable}`
+                  : `Import ${importable}`}
+            </button>
+          </div>
+
+          <div className="overflow-x-auto rounded-xl border border-border bg-surface">
+            <table className="w-full text-sm">
+              <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
+                <tr>
+                  <th className="px-3 py-2.5 font-semibold">#</th>
+                  <th className="px-3 py-2.5 font-semibold">Name</th>
+                  <th className="px-3 py-2.5 font-semibold">Sex</th>
+                  <th className="px-3 py-2.5 font-semibold">DOB</th>
+                  <th className="px-3 py-2.5 font-semibold">Class</th>
+                  <th className="px-3 py-2.5 font-semibold">Guardian</th>
+                  <th className="px-3 py-2.5 font-semibold">Status</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {shown.map((r) => (
+                  <tr key={r.index} className="align-top">
+                    <td className="px-3 py-2.5 font-mono text-xs text-navy-3">
+                      {r.index}
+                    </td>
+                    <td className="px-3 py-2.5 font-medium text-navy">
+                      {r.lastName}, {r.firstName} {r.otherNames}
+                    </td>
+                    <td className="px-3 py-2.5 text-navy-2">{r.sex ?? "—"}</td>
+                    <td className="px-3 py-2.5 text-navy-2">{r.dateOfBirth ?? "—"}</td>
+                    <td className="px-3 py-2.5 text-navy-2">{r.className || "—"}</td>
+                    <td className="px-3 py-2.5 text-navy-2">{r.guardianName || "—"}</td>
+                    <td className="px-3 py-2.5">
+                      {r.errors.length > 0 ? (
+                        <span className="text-xs text-terra">{r.errors.join("; ")}</span>
+                      ) : r.warnings.length > 0 ? (
+                        <span className="text-xs text-warn">{r.warnings.join("; ")}</span>
+                      ) : (
+                        <span className="text-xs font-medium text-green">Ready</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          {fileName && <p className="text-xs text-navy-3">{fileName}</p>}
+        </>
+      )}
+    </div>
+  );
+}

--- a/omnischools/lib/actions/students.ts
+++ b/omnischools/lib/actions/students.ts
@@ -199,3 +199,90 @@ export async function updateStudent(input: unknown): Promise<CreateStudentResult
     return { ok: false, error: "Could not update the student. Please try again." };
   }
 }
+
+// ------------------------------------------------------------- bulk import
+const ImportRowSchema = z.object({
+  firstName: z.string().min(1).max(120),
+  lastName: z.string().min(1).max(120),
+  otherNames: z.string().max(120).optional().or(z.literal("")),
+  sex: z.enum(["MALE", "FEMALE"]),
+  dateOfBirth: z.string().optional().or(z.literal("")),
+  classId: z.string().uuid().optional().or(z.literal("")),
+  guardianName: z.string().max(160).optional().or(z.literal("")),
+  guardianPhone: z.string().max(40).optional().or(z.literal("")),
+  guardianRelation: z.enum(["MOTHER", "FATHER", "GUARDIAN", "OTHER"]).default("GUARDIAN"),
+});
+const ImportStudentsSchema = z.object({
+  rows: z.array(ImportRowSchema).min(1, "No rows to import").max(1000),
+});
+
+export type ImportStudentsResult =
+  | { ok: true; created: number }
+  | { ok: false; error: string };
+
+export async function importStudents(input: unknown): Promise<ImportStudentsResult> {
+  const { school } = await requireSchool();
+  const parsed = ImportStudentsSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid import" };
+  }
+  const actor = await resolveActor(school.id);
+
+  try {
+    const created = await withSchool(school.id, async (tx) => {
+      const classRows = await tx
+        .select({ id: classes.id, name: classes.name })
+        .from(classes)
+        .where(eq(classes.schoolId, school.id));
+      const classNameById = new Map(classRows.map((c) => [c.id, c.name]));
+
+      let n = 0;
+      for (const r of parsed.data.rows) {
+        const studentCode = await nextStudentCode(tx, school.id);
+        const [student] = await tx
+          .insert(students)
+          .values({
+            schoolId: school.id,
+            studentCode,
+            firstName: r.firstName,
+            lastName: r.lastName,
+            otherNames: r.otherNames || null,
+            sex: r.sex,
+            dateOfBirth: r.dateOfBirth || null,
+            classId: r.classId || null,
+            currentClassLabel: r.classId ? (classNameById.get(r.classId) ?? null) : null,
+            enrolledOn: new Date().toISOString().slice(0, 10),
+          })
+          .returning({ id: students.id });
+
+        if (r.guardianName && r.guardianPhone) {
+          await tx.insert(studentGuardians).values({
+            schoolId: school.id,
+            studentId: student.id,
+            name: r.guardianName,
+            relationship: r.guardianRelation,
+            phone: normalizeGhanaPhone(r.guardianPhone),
+            isPrimary: true,
+          });
+        }
+        n++;
+      }
+
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "created",
+        entityType: "student_batch",
+        after: { count: n },
+        reason: "Bulk student import",
+      });
+      return n;
+    });
+
+    safeRevalidate("/students");
+    return { ok: true, created };
+  } catch {
+    return { ok: false, error: "Could not import students. Please try again." };
+  }
+}

--- a/omnischools/lib/import/csv.ts
+++ b/omnischools/lib/import/csv.ts
@@ -1,0 +1,63 @@
+/**
+ * Tiny dependency-free CSV layer shared by the import flows (students, staff).
+ * Pure + client-safe (no DOM, no DB).
+ */
+
+/** Parse CSV text into rows of string cells (handles quotes, commas, CRLF). */
+export function parseCsv(text: string): string[][] {
+  const rows: string[][] = [];
+  let cur: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (inQuotes) {
+      if (c === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else inQuotes = false;
+      } else field += c;
+    } else if (c === '"') {
+      inQuotes = true;
+    } else if (c === ",") {
+      cur.push(field);
+      field = "";
+    } else if (c === "\r") {
+      // ignore — handled by \n
+    } else if (c === "\n") {
+      cur.push(field);
+      rows.push(cur);
+      cur = [];
+      field = "";
+    } else {
+      field += c;
+    }
+  }
+  if (field.length > 0 || cur.length > 0) {
+    cur.push(field);
+    rows.push(cur);
+  }
+  // drop fully-blank rows
+  return rows.filter((r) => r.some((cell) => cell.trim() !== ""));
+}
+
+/** Build a CSV string (header row + optional sample rows) for a download template. */
+export function csvTemplate(headers: string[], samples: string[][] = []): string {
+  const esc = (v: string) => (/[",\n]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v);
+  return [headers, ...samples].map((r) => r.map(esc).join(",")).join("\n");
+}
+
+/** Normalise a Ghanaian phone to E.164 (+233…). Client-safe duplicate of lib/auth. */
+export function normalizePhone(input: string): string {
+  const digits = input.replace(/[^\d+]/g, "");
+  if (digits.startsWith("+233")) return digits;
+  if (digits.startsWith("233")) return `+${digits}`;
+  if (digits.startsWith("0")) return `+233${digits.slice(1)}`;
+  if (/^\d{9}$/.test(digits)) return `+233${digits}`;
+  return digits;
+}
+
+export function isValidGhanaPhone(input: string): boolean {
+  return /^\+233\d{9}$/.test(normalizePhone(input));
+}

--- a/omnischools/lib/import/student-import.ts
+++ b/omnischools/lib/import/student-import.ts
@@ -1,0 +1,154 @@
+import { isValidGhanaPhone, normalizePhone } from "./csv";
+
+/**
+ * Student bulk-import spec + validator. Pure + client-safe so the review table can
+ * validate live. Column order matches the downloadable template.
+ */
+export const STUDENT_IMPORT_HEADERS = [
+  "First name",
+  "Last name",
+  "Other names",
+  "Sex (M/F)",
+  "Date of birth (YYYY-MM-DD)",
+  "Class",
+  "Guardian name",
+  "Guardian phone",
+  "Relationship (Mother/Father/Guardian)",
+];
+
+export const STUDENT_IMPORT_SAMPLE: string[][] = [
+  [
+    "Akosua",
+    "Boateng",
+    "",
+    "F",
+    "2014-05-12",
+    "JHS 1A",
+    "Ama Boateng",
+    "0241112222",
+    "Mother",
+  ],
+  ["Kw4me", "Mensah", "Kofi", "M", "2013-09-01", "", "", "", ""],
+];
+
+export type RelationCode = "MOTHER" | "FATHER" | "GUARDIAN" | "OTHER";
+
+export type StudentRow = {
+  index: number; // 1-based data-row number for display
+  firstName: string;
+  lastName: string;
+  otherNames: string;
+  sex: "MALE" | "FEMALE" | null;
+  dateOfBirth: string | null;
+  className: string;
+  classId: string | null;
+  guardianName: string;
+  guardianPhone: string; // normalised E.164 when valid
+  relationship: RelationCode;
+  errors: string[];
+  warnings: string[];
+};
+
+export type ImportSummary = {
+  total: number;
+  ready: number;
+  warning: number;
+  error: number;
+};
+
+const isIsoDate = (s: string) => {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return false;
+  const d = new Date(s + "T00:00:00Z");
+  return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === s;
+};
+
+function normSex(v: string): "MALE" | "FEMALE" | null {
+  const s = v.trim().toUpperCase();
+  if (["M", "MALE", "BOY"].includes(s)) return "MALE";
+  if (["F", "FEMALE", "GIRL"].includes(s)) return "FEMALE";
+  return null;
+}
+
+function normRelation(v: string): RelationCode {
+  const s = v.trim().toUpperCase();
+  if (s.startsWith("MOTH")) return "MOTHER";
+  if (s.startsWith("FATH")) return "FATHER";
+  if (s === "OTHER") return "OTHER";
+  return "GUARDIAN";
+}
+
+/** Validate parsed data rows (excluding the header) against the school's classes. */
+export function validateStudentRows(
+  dataRows: string[][],
+  classByName: Record<string, string>,
+): { rows: StudentRow[]; summary: ImportSummary } {
+  const lookup = new Map(
+    Object.entries(classByName).map(([name, id]) => [name.trim().toLowerCase(), id]),
+  );
+
+  const rows = dataRows.map((cells, i): StudentRow => {
+    const get = (n: number) => (cells[n] ?? "").trim();
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    const firstName = get(0);
+    const lastName = get(1);
+    const otherNames = get(2);
+    if (!firstName) errors.push("First name is required");
+    if (!lastName) errors.push("Last name is required");
+
+    const sex = normSex(get(3));
+    if (!sex) errors.push("Sex must be M or F");
+
+    const dobRaw = get(4);
+    let dateOfBirth: string | null = null;
+    if (dobRaw) {
+      if (isIsoDate(dobRaw)) dateOfBirth = dobRaw;
+      else errors.push("Date of birth must be YYYY-MM-DD");
+    }
+
+    const className = get(5);
+    let classId: string | null = null;
+    if (className) {
+      classId = lookup.get(className.toLowerCase()) ?? null;
+      if (!classId) warnings.push(`Class "${className}" not found — imported unassigned`);
+    }
+
+    const guardianName = get(6);
+    const guardianPhoneRaw = get(7);
+    let guardianPhone = "";
+    if (guardianPhoneRaw) {
+      if (isValidGhanaPhone(guardianPhoneRaw))
+        guardianPhone = normalizePhone(guardianPhoneRaw);
+      else errors.push("Guardian phone is invalid (10 digits or +233…)");
+    }
+    if (guardianName && !guardianPhoneRaw)
+      warnings.push("Guardian has no phone — won't be invited");
+    if (!guardianName && !guardianPhoneRaw)
+      warnings.push("No guardian — parent won't be invited");
+
+    return {
+      index: i + 1,
+      firstName,
+      lastName,
+      otherNames,
+      sex,
+      dateOfBirth,
+      className,
+      classId,
+      guardianName,
+      guardianPhone,
+      relationship: normRelation(get(8)),
+      errors,
+      warnings,
+    };
+  });
+
+  const summary: ImportSummary = {
+    total: rows.length,
+    ready: rows.filter((r) => r.errors.length === 0 && r.warnings.length === 0).length,
+    warning: rows.filter((r) => r.errors.length === 0 && r.warnings.length > 0).length,
+    error: rows.filter((r) => r.errors.length > 0).length,
+  };
+  return { rows, summary };
+}


### PR DESCRIPTION
## Step 3 of 8 — issues 4 & (Students part of) 5
Shared **import engine** + its first consumer, the **Students import** page.

### lib/import (reusable)
- `csv.ts` — dependency-free CSV parser, template generator, Ghana-phone normaliser.
- `student-import.ts` — pure row validator: required name/sex, ISO date-of-birth, class-name match (→ unassigned warning), phone format, missing-guardian warning; returns rows + Total/Ready/Warnings/Errors summary.

### Students import (`/students/import`)
- Download template → upload CSV → **live-validated review table** (KPI cards + filter pills + per-row issues) → **Skip errors & import**.
- `importStudents` server action: one-transaction bulk insert (sequential student codes, primary guardians, batch audit).
- **Import** button on the Students list; single-entry link retained.

The CSV core + review pattern is reused by Staff import + onboarding (Steps 4–6).
No schema change. `typecheck`/`lint`/`build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)