### PR TITLE
feat(records): edit + delete + bulk-delete for classes, staff, students (redesign step 4c)

### DIFF
--- a/omnischools/app/(app)/classes/page.tsx
+++ b/omnischools/app/(app)/classes/page.tsx
@@ -1,11 +1,10 @@
-import Link from "next/link";
 import { asc, count, eq } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import { classes, students } from "@/db/schema";
 import { loadStaffOptions } from "@/lib/data/staff-options";
 import { CreateClassForm } from "@/components/classes/create-class-form";
-import { ClassTeacherSelect } from "@/components/classes/class-teacher-select";
+import { ClassesTable } from "@/components/classes/classes-table";
 
 export const dynamic = "force-dynamic";
 
@@ -37,6 +36,13 @@ export default async function ClassesPage() {
   ]);
 
   const sizeOf = new Map(countRows.map((r) => [r.classId, Number(r.n)]));
+  const tableRows = classRows.map((c) => ({
+    id: c.id,
+    name: c.name,
+    level: c.level,
+    teacherId: c.teacherId,
+    size: sizeOf.get(c.id) ?? 0,
+  }));
 
   return (
     <div className="mx-auto max-w-page">
@@ -60,47 +66,7 @@ export default async function ClassesPage() {
           </p>
         </div>
       ) : (
-        <div className="overflow-hidden rounded-xl border border-border bg-surface">
-          <table className="w-full text-sm">
-            <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
-              <tr>
-                <th className="px-4 py-3 font-semibold">Class</th>
-                <th className="px-4 py-3 font-semibold">Level</th>
-                <th className="px-4 py-3 font-semibold">Class teacher</th>
-                <th className="px-4 py-3 font-semibold">Students</th>
-                <th className="px-4 py-3" />
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              {classRows.map((c) => (
-                <tr key={c.id} className="transition-colors hover:bg-bg">
-                  <td className="px-4 py-3 font-medium text-navy">
-                    <Link href={`/classes/${c.id}`} className="hover:text-gold">
-                      {c.name}
-                    </Link>
-                  </td>
-                  <td className="px-4 py-3 text-navy-2">{c.level ?? "—"}</td>
-                  <td className="px-4 py-3">
-                    <ClassTeacherSelect
-                      classId={c.id}
-                      current={c.teacherId}
-                      staff={staff}
-                    />
-                  </td>
-                  <td className="px-4 py-3 text-navy-2">{sizeOf.get(c.id) ?? 0}</td>
-                  <td className="px-4 py-3 text-right">
-                    <Link
-                      href={`/classes/${c.id}`}
-                      className="text-sm font-semibold text-gold hover:underline"
-                    >
-                      Open →
-                    </Link>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <ClassesTable rows={tableRows} staff={staff} />
       )}
     </div>
   );

--- a/omnischools/app/(app)/staff/page.tsx
+++ b/omnischools/app/(app)/staff/page.tsx
@@ -4,7 +4,7 @@ import { withSchool } from "@/lib/db/rls";
 import { users, roles, roleAssignments } from "@/db/schema";
 import { STAFF_ROLE_CODES } from "@/lib/staff-roles";
 import { AddStaffForm } from "@/components/staff/add-staff-form";
-import { StaffRow } from "@/components/staff/staff-row";
+import { StaffTable } from "@/components/staff/staff-table";
 
 export const dynamic = "force-dynamic";
 
@@ -74,24 +74,7 @@ export default async function StaffPage() {
           </p>
         </div>
       ) : (
-        <div className="overflow-hidden rounded-xl border border-border bg-surface">
-          <table className="w-full text-sm">
-            <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
-              <tr>
-                <th className="px-4 py-3 font-semibold">Name</th>
-                <th className="px-4 py-3 font-semibold">Phone</th>
-                <th className="px-4 py-3 font-semibold">Email</th>
-                <th className="px-4 py-3 font-semibold">Roles</th>
-                <th className="px-4 py-3" />
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              {staff.map((m) => (
-                <StaffRow key={m.userId} member={m} />
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <StaffTable staff={staff} />
       )}
     </div>
   );

--- a/omnischools/app/(app)/students/page.tsx
+++ b/omnischools/app/(app)/students/page.tsx
@@ -3,22 +3,24 @@ import { desc, eq } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import { students } from "@/db/schema";
+import { StudentsTable } from "@/components/students/students-table";
 
 export const dynamic = "force-dynamic";
-
-const STATUS_STYLES: Record<string, string> = {
-  ACTIVE: "bg-green-bg text-green",
-  INACTIVE: "bg-bg text-navy-3",
-  GRADUATED: "bg-gold-bg text-navy",
-  WITHDRAWN: "bg-terra-bg text-terra",
-  TRANSFERRED: "bg-warn-bg text-warn",
-};
 
 export default async function StudentsPage() {
   const { school } = await requireSchool();
   const rows = await withSchool(school.id, (tx) =>
     tx
-      .select()
+      .select({
+        id: students.id,
+        studentCode: students.studentCode,
+        firstName: students.firstName,
+        lastName: students.lastName,
+        otherNames: students.otherNames,
+        sex: students.sex,
+        currentClassLabel: students.currentClassLabel,
+        status: students.status,
+      })
       .from(students)
       .where(eq(students.schoolId, school.id))
       .orderBy(desc(students.createdAt))
@@ -60,46 +62,7 @@ export default async function StudentsPage() {
           </p>
         </div>
       ) : (
-        <div className="overflow-hidden rounded-xl border border-border bg-surface">
-          <table className="w-full text-sm">
-            <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
-              <tr>
-                <th className="px-4 py-3 font-semibold">Code</th>
-                <th className="px-4 py-3 font-semibold">Name</th>
-                <th className="px-4 py-3 font-semibold">Sex</th>
-                <th className="px-4 py-3 font-semibold">Class</th>
-                <th className="px-4 py-3 font-semibold">Status</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              {rows.map((s) => (
-                <tr key={s.id} className="transition-colors hover:bg-bg">
-                  <td className="px-4 py-3 font-mono text-xs text-navy-2">
-                    <Link href={`/students/${s.id}`} className="hover:text-gold">
-                      {s.studentCode}
-                    </Link>
-                  </td>
-                  <td className="px-4 py-3 font-medium text-navy">
-                    <Link href={`/students/${s.id}`} className="hover:text-gold">
-                      {s.lastName}, {s.firstName} {s.otherNames ?? ""}
-                    </Link>
-                  </td>
-                  <td className="px-4 py-3 text-navy-2">
-                    {s.sex.charAt(0) + s.sex.slice(1).toLowerCase()}
-                  </td>
-                  <td className="px-4 py-3 text-navy-2">{s.currentClassLabel ?? "—"}</td>
-                  <td className="px-4 py-3">
-                    <span
-                      className={`rounded-pill px-2 py-0.5 text-xs font-medium ${STATUS_STYLES[s.status]}`}
-                    >
-                      {s.status.charAt(0) + s.status.slice(1).toLowerCase()}
-                    </span>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <StudentsTable rows={rows} />
       )}
     </div>
   );

--- a/omnischools/components/classes/classes-table.tsx
+++ b/omnischools/components/classes/classes-table.tsx
@@ -1,0 +1,276 @@
+"use client";
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { updateClass, deleteClass, deleteClasses } from "@/lib/actions/classes";
+import { ClassTeacherSelect } from "@/components/classes/class-teacher-select";
+import { YEAR_GROUPS } from "@/lib/field-options";
+import type { StaffOption } from "@/lib/data/staff-options";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import {
+  BulkBar,
+  HeaderCheckbox,
+  RowCheckbox,
+  useSelection,
+} from "@/components/ui/selection";
+
+const inputClass =
+  "w-full rounded-md border border-border-2 bg-bg px-2.5 py-1.5 text-sm text-navy outline-none focus:border-gold focus:bg-surface";
+
+type ClassRow = {
+  id: string;
+  name: string;
+  level: string | null;
+  teacherId: string | null;
+  size: number;
+};
+
+export function ClassesTable({
+  rows,
+  staff,
+}: {
+  rows: ClassRow[];
+  staff: StaffOption[];
+}) {
+  const router = useRouter();
+  const ids = rows.map((r) => r.id);
+  const { selected, toggle, setAll, clear, count } = useSelection();
+  const allSelected = ids.length > 0 && ids.every((id) => selected.has(id));
+  const someSelected = count > 0 && !allSelected;
+
+  const [editId, setEditId] = useState<string | null>(null);
+  const [name, setName] = useState("");
+  const [level, setLevel] = useState("");
+  const [rowBusy, setRowBusy] = useState(false);
+  const [rowError, setRowError] = useState<string | null>(null);
+
+  const [toDelete, setToDelete] = useState<ClassRow | null>(null);
+  const [bulkOpen, setBulkOpen] = useState(false);
+  const [delBusy, setDelBusy] = useState(false);
+  const [delError, setDelError] = useState<string | null>(null);
+
+  function startEdit(c: ClassRow) {
+    setEditId(c.id);
+    setName(c.name);
+    setLevel(c.level ?? "");
+    setRowError(null);
+  }
+
+  async function saveEdit() {
+    if (!editId) return;
+    setRowBusy(true);
+    setRowError(null);
+    const res = await updateClass({ classId: editId, name, level: level || null });
+    setRowBusy(false);
+    if (res.ok) {
+      setEditId(null);
+      router.refresh();
+    } else setRowError(res.error ?? "Could not save.");
+  }
+
+  async function confirmSingle() {
+    if (!toDelete) return;
+    setDelBusy(true);
+    setDelError(null);
+    const res = await deleteClass({ classId: toDelete.id });
+    setDelBusy(false);
+    if (res.ok) {
+      setToDelete(null);
+      router.refresh();
+    } else setDelError(res.error ?? "Could not delete.");
+  }
+
+  async function confirmBulk() {
+    setDelBusy(true);
+    setDelError(null);
+    const res = await deleteClasses({ classIds: Array.from(selected) });
+    setDelBusy(false);
+    if (res.ok) {
+      setBulkOpen(false);
+      clear();
+      router.refresh();
+    } else setDelError(res.error ?? "Could not delete.");
+  }
+
+  return (
+    <>
+      <BulkBar
+        count={count}
+        singular="class"
+        plural="classes"
+        onClear={clear}
+        onDelete={() => {
+          setDelError(null);
+          setBulkOpen(true);
+        }}
+      />
+      <div className="overflow-hidden rounded-xl border border-border bg-surface">
+        <table className="w-full text-sm">
+          <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
+            <tr>
+              <th className="w-10 px-4 py-3">
+                <HeaderCheckbox
+                  checked={allSelected}
+                  indeterminate={someSelected}
+                  onChange={() => setAll(ids, !allSelected)}
+                />
+              </th>
+              <th className="px-4 py-3 font-semibold">Class</th>
+              <th className="px-4 py-3 font-semibold">Level</th>
+              <th className="px-4 py-3 font-semibold">Class teacher</th>
+              <th className="px-4 py-3 font-semibold">Students</th>
+              <th className="px-4 py-3" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {rows.map((c) => {
+              const editing = editId === c.id;
+              return (
+                <tr key={c.id} className="align-top transition-colors hover:bg-bg">
+                  <td className="px-4 py-3">
+                    <RowCheckbox
+                      checked={selected.has(c.id)}
+                      onChange={() => toggle(c.id)}
+                      label={`Select ${c.name}`}
+                    />
+                  </td>
+                  <td className="px-4 py-3 font-medium text-navy">
+                    {editing ? (
+                      <input
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        className={inputClass}
+                      />
+                    ) : (
+                      <Link href={`/classes/${c.id}`} className="hover:text-gold">
+                        {c.name}
+                      </Link>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-navy-2">
+                    {editing ? (
+                      <select
+                        value={level}
+                        onChange={(e) => setLevel(e.target.value)}
+                        className={inputClass}
+                      >
+                        <option value="">— none —</option>
+                        {YEAR_GROUPS.map((yg) => (
+                          <option key={yg} value={yg}>
+                            {yg}
+                          </option>
+                        ))}
+                      </select>
+                    ) : (
+                      (c.level ?? "—")
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    <ClassTeacherSelect
+                      classId={c.id}
+                      current={c.teacherId}
+                      staff={staff}
+                    />
+                  </td>
+                  <td className="px-4 py-3 text-navy-2">{c.size}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-right">
+                    {editing ? (
+                      <>
+                        <button
+                          onClick={saveEdit}
+                          disabled={rowBusy}
+                          className="mr-3 text-xs font-semibold text-green disabled:opacity-50"
+                        >
+                          Save
+                        </button>
+                        <button
+                          onClick={() => {
+                            setEditId(null);
+                            setRowError(null);
+                          }}
+                          className="text-xs font-semibold text-navy-3 hover:text-navy"
+                        >
+                          Cancel
+                        </button>
+                        {rowError && (
+                          <div className="mt-1 text-xs text-terra">{rowError}</div>
+                        )}
+                      </>
+                    ) : (
+                      <>
+                        <button
+                          onClick={() => startEdit(c)}
+                          className="mr-3 text-xs font-semibold text-navy-3 transition-colors hover:text-gold"
+                        >
+                          Edit
+                        </button>
+                        <Link
+                          href={`/classes/${c.id}`}
+                          className="mr-3 text-xs font-semibold text-gold hover:underline"
+                        >
+                          Open
+                        </Link>
+                        <button
+                          onClick={() => {
+                            setDelError(null);
+                            setToDelete(c);
+                          }}
+                          className="text-xs font-semibold text-navy-3 transition-colors hover:text-terra"
+                        >
+                          Delete
+                        </button>
+                      </>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <ConfirmDialog
+        open={!!toDelete}
+        title="Delete class?"
+        busy={delBusy}
+        error={delError}
+        confirmLabel="Delete class"
+        onClose={() => setToDelete(null)}
+        onConfirm={confirmSingle}
+        message={
+          toDelete ? (
+            <>
+              Delete <strong className="text-navy">{toDelete.name}</strong>?{" "}
+              {toDelete.size > 0 ? (
+                <>
+                  Its {toDelete.size} student{toDelete.size === 1 ? "" : "s"} will be
+                  unassigned (not deleted).{" "}
+                </>
+              ) : null}
+              Its timetable and attendance records will be removed. This can&apos;t be
+              undone.
+            </>
+          ) : null
+        }
+      />
+
+      <ConfirmDialog
+        open={bulkOpen}
+        title="Delete classes?"
+        busy={delBusy}
+        error={delError}
+        confirmLabel={`Delete ${count} ${count === 1 ? "class" : "classes"}`}
+        onClose={() => setBulkOpen(false)}
+        onConfirm={confirmBulk}
+        message={
+          <>
+            Delete <strong className="text-navy">{count}</strong> selected{" "}
+            {count === 1 ? "class" : "classes"}? Students in them will be unassigned (not
+            deleted); their timetables and attendance records will be removed. This
+            can&apos;t be undone.
+          </>
+        }
+      />
+    </>
+  );
+}

--- a/omnischools/components/staff/staff-row.tsx
+++ b/omnischools/components/staff/staff-row.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { updateStaff } from "@/lib/actions/staff";
 import { createInvite } from "@/lib/actions/invites";
 import { RoleEditor } from "@/components/staff/role-editor";
+import { RowCheckbox } from "@/components/ui/selection";
 
 const inputClass =
   "w-full rounded-md border border-border-2 bg-bg px-2.5 py-1.5 text-sm text-navy outline-none focus:border-gold focus:bg-surface";
@@ -16,20 +17,44 @@ type Member = {
   roles: { assignmentId: string; code: string }[];
 };
 
-export function StaffRow({ member }: { member: Member }) {
+export function StaffRow({
+  member,
+  selected,
+  onToggle,
+  onRequestDelete,
+}: {
+  member: Member;
+  selected: boolean;
+  onToggle: () => void;
+  onRequestDelete: () => void;
+}) {
   const router = useRouter();
   const [editing, setEditing] = useState(false);
   const [name, setName] = useState(member.name ?? "");
+  const [phone, setPhone] = useState(member.phone);
   const [email, setEmail] = useState(member.email ?? "");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [link, setLink] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
 
+  function cancel() {
+    setEditing(false);
+    setName(member.name ?? "");
+    setPhone(member.phone);
+    setEmail(member.email ?? "");
+    setError(null);
+  }
+
   async function save() {
     setBusy(true);
     setError(null);
-    const res = await updateStaff({ userId: member.userId, fullName: name, email });
+    const res = await updateStaff({
+      userId: member.userId,
+      fullName: name,
+      phone,
+      email,
+    });
     setBusy(false);
     if (res.ok) {
       setEditing(false);
@@ -53,6 +78,13 @@ export function StaffRow({ member }: { member: Member }) {
 
   return (
     <tr className="align-top hover:bg-bg">
+      <td className="px-4 py-3">
+        <RowCheckbox
+          checked={selected}
+          onChange={onToggle}
+          label={`Select ${member.name ?? "staff"}`}
+        />
+      </td>
       <td className="px-4 py-3 font-medium text-navy">
         {editing ? (
           <input
@@ -64,7 +96,18 @@ export function StaffRow({ member }: { member: Member }) {
           (member.name ?? "—")
         )}
       </td>
-      <td className="px-4 py-3 font-mono text-xs text-navy-2">{member.phone}</td>
+      <td className="px-4 py-3 font-mono text-xs text-navy-2">
+        {editing ? (
+          <input
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            type="tel"
+            className={`${inputClass} font-sans`}
+          />
+        ) : (
+          member.phone
+        )}
+      </td>
       <td className="px-4 py-3 text-navy-2">
         {editing ? (
           <input
@@ -92,11 +135,7 @@ export function StaffRow({ member }: { member: Member }) {
               Save
             </button>
             <button
-              onClick={() => {
-                setEditing(false);
-                setName(member.name ?? "");
-                setEmail(member.email ?? "");
-              }}
+              onClick={cancel}
               className="text-xs font-semibold text-navy-3 hover:text-navy"
             >
               Cancel
@@ -124,9 +163,16 @@ export function StaffRow({ member }: { member: Member }) {
             <button
               onClick={invite}
               disabled={busy}
-              className="text-xs font-semibold text-navy-3 transition-colors hover:text-gold disabled:opacity-50"
+              className="mr-3 text-xs font-semibold text-navy-3 transition-colors hover:text-gold disabled:opacity-50"
             >
               {busy ? "…" : "Invite"}
+            </button>
+            <button
+              onClick={onRequestDelete}
+              disabled={busy}
+              className="text-xs font-semibold text-navy-3 transition-colors hover:text-terra disabled:opacity-50"
+            >
+              Delete
             </button>
           </>
         )}

--- a/omnischools/components/staff/staff-table.tsx
+++ b/omnischools/components/staff/staff-table.tsx
@@ -1,0 +1,138 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { deleteStaff, deleteStaffBulk } from "@/lib/actions/staff";
+import { StaffRow } from "@/components/staff/staff-row";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { BulkBar, HeaderCheckbox, useSelection } from "@/components/ui/selection";
+
+type Member = {
+  userId: string;
+  name: string | null;
+  phone: string;
+  email: string | null;
+  roles: { assignmentId: string; code: string }[];
+};
+
+export function StaffTable({ staff }: { staff: Member[] }) {
+  const router = useRouter();
+  const ids = staff.map((m) => m.userId);
+  const { selected, toggle, setAll, clear, count } = useSelection();
+  const allSelected = ids.length > 0 && ids.every((id) => selected.has(id));
+  const someSelected = count > 0 && !allSelected;
+
+  const [toDelete, setToDelete] = useState<Member | null>(null);
+  const [bulkOpen, setBulkOpen] = useState(false);
+  const [delBusy, setDelBusy] = useState(false);
+  const [delError, setDelError] = useState<string | null>(null);
+
+  async function confirmSingle() {
+    if (!toDelete) return;
+    setDelBusy(true);
+    setDelError(null);
+    const res = await deleteStaff({ userId: toDelete.userId });
+    setDelBusy(false);
+    if (res.ok) {
+      setToDelete(null);
+      router.refresh();
+    } else setDelError(res.error ?? "Could not remove.");
+  }
+
+  async function confirmBulk() {
+    setDelBusy(true);
+    setDelError(null);
+    const res = await deleteStaffBulk({ userIds: Array.from(selected) });
+    setDelBusy(false);
+    if (res.ok) {
+      setBulkOpen(false);
+      clear();
+      router.refresh();
+    } else setDelError(res.error ?? "Could not remove.");
+  }
+
+  return (
+    <>
+      <BulkBar
+        count={count}
+        singular="person"
+        plural="people"
+        onClear={clear}
+        onDelete={() => {
+          setDelError(null);
+          setBulkOpen(true);
+        }}
+      />
+      <div className="overflow-hidden rounded-xl border border-border bg-surface">
+        <table className="w-full text-sm">
+          <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
+            <tr>
+              <th className="w-10 px-4 py-3">
+                <HeaderCheckbox
+                  checked={allSelected}
+                  indeterminate={someSelected}
+                  onChange={() => setAll(ids, !allSelected)}
+                />
+              </th>
+              <th className="px-4 py-3 font-semibold">Name</th>
+              <th className="px-4 py-3 font-semibold">Phone</th>
+              <th className="px-4 py-3 font-semibold">Email</th>
+              <th className="px-4 py-3 font-semibold">Roles</th>
+              <th className="px-4 py-3" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {staff.map((m) => (
+              <StaffRow
+                key={m.userId}
+                member={m}
+                selected={selected.has(m.userId)}
+                onToggle={() => toggle(m.userId)}
+                onRequestDelete={() => {
+                  setDelError(null);
+                  setToDelete(m);
+                }}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <ConfirmDialog
+        open={!!toDelete}
+        title="Remove staff?"
+        busy={delBusy}
+        error={delError}
+        confirmLabel="Remove"
+        onClose={() => setToDelete(null)}
+        onConfirm={confirmSingle}
+        message={
+          toDelete ? (
+            <>
+              Remove{" "}
+              <strong className="text-navy">{toDelete.name ?? "this person"}</strong> from
+              your school? They lose all roles and access here. Their login isn&apos;t
+              deleted (they may belong to other schools). This can&apos;t be undone.
+            </>
+          ) : null
+        }
+      />
+
+      <ConfirmDialog
+        open={bulkOpen}
+        title="Remove staff?"
+        busy={delBusy}
+        error={delError}
+        confirmLabel={`Remove ${count}`}
+        onClose={() => setBulkOpen(false)}
+        onConfirm={confirmBulk}
+        message={
+          <>
+            Remove <strong className="text-navy">{count}</strong>{" "}
+            {count === 1 ? "person" : "people"} from your school? They lose all roles and
+            access here. Their logins aren&apos;t deleted. This can&apos;t be undone.
+          </>
+        }
+      />
+    </>
+  );
+}

--- a/omnischools/components/students/students-table.tsx
+++ b/omnischools/components/students/students-table.tsx
@@ -1,0 +1,200 @@
+"use client";
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { deleteStudent, deleteStudents } from "@/lib/actions/students";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import {
+  BulkBar,
+  HeaderCheckbox,
+  RowCheckbox,
+  useSelection,
+} from "@/components/ui/selection";
+
+const STATUS_STYLES: Record<string, string> = {
+  ACTIVE: "bg-green-bg text-green",
+  INACTIVE: "bg-bg text-navy-3",
+  GRADUATED: "bg-gold-bg text-navy",
+  WITHDRAWN: "bg-terra-bg text-terra",
+  TRANSFERRED: "bg-warn-bg text-warn",
+};
+
+type StudentRow = {
+  id: string;
+  studentCode: string;
+  firstName: string;
+  lastName: string;
+  otherNames: string | null;
+  sex: string;
+  currentClassLabel: string | null;
+  status: string;
+};
+
+const cap = (s: string) => s.charAt(0) + s.slice(1).toLowerCase();
+
+export function StudentsTable({ rows }: { rows: StudentRow[] }) {
+  const router = useRouter();
+  const ids = rows.map((r) => r.id);
+  const { selected, toggle, setAll, clear, count } = useSelection();
+  const allSelected = ids.length > 0 && ids.every((id) => selected.has(id));
+  const someSelected = count > 0 && !allSelected;
+
+  const [toDelete, setToDelete] = useState<StudentRow | null>(null);
+  const [bulkOpen, setBulkOpen] = useState(false);
+  const [delBusy, setDelBusy] = useState(false);
+  const [delError, setDelError] = useState<string | null>(null);
+
+  async function confirmSingle() {
+    if (!toDelete) return;
+    setDelBusy(true);
+    setDelError(null);
+    const res = await deleteStudent({ id: toDelete.id });
+    setDelBusy(false);
+    if (res.ok) {
+      setToDelete(null);
+      router.refresh();
+    } else setDelError(res.error ?? "Could not delete.");
+  }
+
+  async function confirmBulk() {
+    setDelBusy(true);
+    setDelError(null);
+    const res = await deleteStudents({ ids: Array.from(selected) });
+    setDelBusy(false);
+    if (!res.ok) {
+      setDelError(res.error ?? "Could not delete.");
+      return;
+    }
+    router.refresh();
+    if (res.blocked && res.blocked.length) {
+      const lines = res.blocked
+        .map((b) => `${b.name} (${b.reasons.join(", ")})`)
+        .join("; ");
+      setDelError(
+        `Deleted ${res.deleted ?? 0}. Couldn't delete ${res.blocked.length}: ${lines}. Set their status to Withdrawn or Transferred instead.`,
+      );
+      clear();
+    } else {
+      setBulkOpen(false);
+      clear();
+    }
+  }
+
+  return (
+    <>
+      <BulkBar
+        count={count}
+        singular="student"
+        plural="students"
+        onClear={clear}
+        onDelete={() => {
+          setDelError(null);
+          setBulkOpen(true);
+        }}
+      />
+      <div className="overflow-hidden rounded-xl border border-border bg-surface">
+        <table className="w-full text-sm">
+          <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
+            <tr>
+              <th className="w-10 px-4 py-3">
+                <HeaderCheckbox
+                  checked={allSelected}
+                  indeterminate={someSelected}
+                  onChange={() => setAll(ids, !allSelected)}
+                />
+              </th>
+              <th className="px-4 py-3 font-semibold">Code</th>
+              <th className="px-4 py-3 font-semibold">Name</th>
+              <th className="px-4 py-3 font-semibold">Sex</th>
+              <th className="px-4 py-3 font-semibold">Class</th>
+              <th className="px-4 py-3 font-semibold">Status</th>
+              <th className="px-4 py-3" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {rows.map((s) => (
+              <tr key={s.id} className="transition-colors hover:bg-bg">
+                <td className="px-4 py-3">
+                  <RowCheckbox
+                    checked={selected.has(s.id)}
+                    onChange={() => toggle(s.id)}
+                    label={`Select ${s.firstName} ${s.lastName}`}
+                  />
+                </td>
+                <td className="px-4 py-3 font-mono text-xs text-navy-2">
+                  <Link href={`/students/${s.id}`} className="hover:text-gold">
+                    {s.studentCode}
+                  </Link>
+                </td>
+                <td className="px-4 py-3 font-medium text-navy">
+                  <Link href={`/students/${s.id}`} className="hover:text-gold">
+                    {s.lastName}, {s.firstName} {s.otherNames ?? ""}
+                  </Link>
+                </td>
+                <td className="px-4 py-3 text-navy-2">{cap(s.sex)}</td>
+                <td className="px-4 py-3 text-navy-2">{s.currentClassLabel ?? "—"}</td>
+                <td className="px-4 py-3">
+                  <span
+                    className={`rounded-pill px-2 py-0.5 text-xs font-medium ${STATUS_STYLES[s.status]}`}
+                  >
+                    {cap(s.status)}
+                  </span>
+                </td>
+                <td className="whitespace-nowrap px-4 py-3 text-right">
+                  <button
+                    onClick={() => {
+                      setDelError(null);
+                      setToDelete(s);
+                    }}
+                    className="text-xs font-semibold text-navy-3 transition-colors hover:text-terra"
+                  >
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <ConfirmDialog
+        open={!!toDelete}
+        title="Delete student?"
+        busy={delBusy}
+        error={delError}
+        confirmLabel="Delete student"
+        onClose={() => setToDelete(null)}
+        onConfirm={confirmSingle}
+        message={
+          toDelete ? (
+            <>
+              Permanently delete{" "}
+              <strong className="text-navy">
+                {toDelete.firstName} {toDelete.lastName}
+              </strong>
+              ? If they have any fee, attendance or grade history, deletion will be
+              blocked — set their status to Withdrawn or Transferred instead.
+            </>
+          ) : null
+        }
+      />
+
+      <ConfirmDialog
+        open={bulkOpen}
+        title="Delete students?"
+        busy={delBusy}
+        error={delError}
+        confirmLabel={`Delete ${count} ${count === 1 ? "student" : "students"}`}
+        onClose={() => setBulkOpen(false)}
+        onConfirm={confirmBulk}
+        message={
+          <>
+            Permanently delete <strong className="text-navy">{count}</strong> selected{" "}
+            {count === 1 ? "student" : "students"}? Any with fee, attendance or grade
+            history will be skipped and listed here. This can&apos;t be undone.
+          </>
+        }
+      />
+    </>
+  );
+}

--- a/omnischools/components/ui/confirm-dialog.tsx
+++ b/omnischools/components/ui/confirm-dialog.tsx
@@ -1,0 +1,57 @@
+"use client";
+import { Modal } from "./modal";
+
+/**
+ * Destructive-action confirmation built on Modal. Used for both single-row and
+ * bulk deletes. The confirm button is terra (danger); `message` spells out the
+ * consequences so the user understands what's being removed before they commit.
+ * While `busy`, the dialog can't be dismissed (no double-fire).
+ */
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel = "Delete",
+  busy = false,
+  error,
+  onConfirm,
+  onClose,
+}: {
+  open: boolean;
+  title: string;
+  message: React.ReactNode;
+  confirmLabel?: string;
+  busy?: boolean;
+  error?: string | null;
+  onConfirm: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <Modal open={open} onClose={busy ? () => {} : onClose} title={title}>
+      <div className="space-y-4">
+        <div className="text-sm leading-relaxed text-navy-2">{message}</div>
+        {error && (
+          <p className="rounded-md bg-terra-bg px-3 py-2 text-sm text-terra">{error}</p>
+        )}
+        <div className="flex items-center justify-end gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={busy}
+            className="text-sm font-semibold text-navy-2 transition-colors hover:text-navy disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={busy}
+            className="rounded-md bg-terra px-4 py-2 text-sm font-semibold text-bg transition-colors hover:opacity-90 disabled:opacity-60"
+          >
+            {busy ? "Deleting…" : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/omnischools/components/ui/selection.tsx
+++ b/omnischools/components/ui/selection.tsx
@@ -1,0 +1,114 @@
+"use client";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/** Row-selection state for tables that support multi-select + bulk actions. */
+export function useSelection() {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  const toggle = useCallback((id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const setAll = useCallback((ids: string[], on: boolean) => {
+    setSelected(on ? new Set(ids) : new Set());
+  }, []);
+
+  const clear = useCallback(() => setSelected(new Set()), []);
+
+  return { selected, toggle, setAll, clear, count: selected.size };
+}
+
+const boxClass =
+  "h-4 w-4 cursor-pointer rounded border-border-2 accent-gold align-middle";
+
+export function RowCheckbox({
+  checked,
+  onChange,
+  label = "Select row",
+}: {
+  checked: boolean;
+  onChange: () => void;
+  label?: string;
+}) {
+  return (
+    <input
+      type="checkbox"
+      aria-label={label}
+      checked={checked}
+      onChange={onChange}
+      onClick={(e) => e.stopPropagation()}
+      className={boxClass}
+    />
+  );
+}
+
+/** Header checkbox with an indeterminate state when only some rows are selected. */
+export function HeaderCheckbox({
+  checked,
+  indeterminate,
+  onChange,
+}: {
+  checked: boolean;
+  indeterminate: boolean;
+  onChange: () => void;
+}) {
+  const ref = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (ref.current) ref.current.indeterminate = indeterminate;
+  }, [indeterminate]);
+  return (
+    <input
+      ref={ref}
+      type="checkbox"
+      aria-label="Select all"
+      checked={checked}
+      onChange={onChange}
+      className={boxClass}
+    />
+  );
+}
+
+/** Sticky action bar shown above a table when one or more rows are selected. */
+export function BulkBar({
+  count,
+  singular,
+  plural,
+  onDelete,
+  onClear,
+}: {
+  count: number;
+  singular: string;
+  plural: string;
+  onDelete: () => void;
+  onClear: () => void;
+}) {
+  if (count === 0) return null;
+  return (
+    <div className="mb-3 flex items-center justify-between gap-3 rounded-xl border border-gold-soft bg-gold-bg px-4 py-2.5 duration-150 animate-in fade-in">
+      <span className="text-sm font-medium text-navy">
+        {count} {count === 1 ? singular : plural} selected
+      </span>
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={onClear}
+          className="text-sm font-semibold text-navy-2 transition-colors hover:text-navy"
+        >
+          Clear
+        </button>
+        <button
+          type="button"
+          onClick={onDelete}
+          className="rounded-md bg-terra px-3.5 py-1.5 text-sm font-semibold text-bg transition-colors hover:opacity-90"
+        >
+          Delete selected
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/omnischools/lib/actions/classes.ts
+++ b/omnischools/lib/actions/classes.ts
@@ -5,6 +5,7 @@ import { withSchool } from "@/lib/db/rls";
 import { recordAudit } from "@/lib/db/audit";
 import { requireSchool, resolveActor } from "@/lib/auth/server";
 import { safeRevalidate } from "@/lib/revalidate";
+import type { Tx } from "@/lib/db";
 import { classes, students, subjects, timetableSlots } from "@/db/schema";
 
 type Result = { ok: boolean; error?: string; id?: string };
@@ -53,6 +54,132 @@ export async function createClass(input: unknown): Promise<Result> {
     return { ok: true, id };
   } catch {
     return { ok: false, error: "Could not create class — that name may already exist." };
+  }
+}
+
+// edit a class (name + level) after creation
+const UpdateClassSchema = z.object({
+  classId: z.string().uuid(),
+  name: z.string().min(1, "Enter a class name").max(60),
+  level: z.string().max(40).optional().nullable(),
+});
+
+export async function updateClass(input: unknown): Promise<Result> {
+  const { school } = await requireSchool();
+  const parsed = UpdateClassSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };
+  }
+  const name = parsed.data.name.trim();
+  const actor = await resolveActor(school.id);
+  try {
+    await withSchool(school.id, async (tx) => {
+      await tx
+        .update(classes)
+        .set({ name, level: nz(parsed.data.level) })
+        .where(
+          and(eq(classes.id, parsed.data.classId), eq(classes.schoolId, school.id)),
+        );
+      // keep students' display label in sync with the renamed class
+      await tx
+        .update(students)
+        .set({ currentClassLabel: name })
+        .where(
+          and(
+            eq(students.schoolId, school.id),
+            eq(students.classId, parsed.data.classId),
+          ),
+        );
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "updated",
+        entityType: "class",
+        entityId: parsed.data.classId,
+        after: { name },
+        reason: "Class edited",
+      });
+    });
+    safeRevalidate("/classes");
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Could not update class — that name may already exist." };
+  }
+}
+
+// delete one or more classes. Students in them are unassigned (kept); the
+// timetable and attendance for those classes cascade away at the DB level.
+async function removeClasses(
+  tx: Tx,
+  schoolId: string,
+  ids: string[],
+): Promise<void> {
+  await tx
+    .update(students)
+    .set({ classId: null, currentClassLabel: null })
+    .where(and(eq(students.schoolId, schoolId), inArray(students.classId, ids)));
+  await tx
+    .delete(classes)
+    .where(and(eq(classes.schoolId, schoolId), inArray(classes.id, ids)));
+}
+
+const DeleteClassSchema = z.object({ classId: z.string().uuid() });
+
+export async function deleteClass(input: unknown): Promise<Result> {
+  const { school } = await requireSchool();
+  const parsed = DeleteClassSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: "Invalid input" };
+  const actor = await resolveActor(school.id);
+  try {
+    await withSchool(school.id, async (tx) => {
+      await removeClasses(tx, school.id, [parsed.data.classId]);
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "deleted",
+        entityType: "class",
+        entityId: parsed.data.classId,
+        reason: "Class deleted",
+      });
+    });
+    safeRevalidate("/classes");
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Could not delete class." };
+  }
+}
+
+const DeleteClassesSchema = z.object({
+  classIds: z.array(z.string().uuid()).min(1).max(200),
+});
+
+export async function deleteClasses(
+  input: unknown,
+): Promise<Result & { deleted?: number }> {
+  const { school } = await requireSchool();
+  const parsed = DeleteClassesSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: "Select at least one class" };
+  const ids = Array.from(new Set(parsed.data.classIds));
+  const actor = await resolveActor(school.id);
+  try {
+    await withSchool(school.id, async (tx) => {
+      await removeClasses(tx, school.id, ids);
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "deleted",
+        entityType: "class_batch",
+        after: { count: ids.length },
+        reason: "Classes deleted (bulk)",
+      });
+    });
+    safeRevalidate("/classes");
+    return { ok: true, deleted: ids.length };
+  } catch {
+    return { ok: false, error: "Could not delete the selected classes." };
   }
 }
 

--- a/omnischools/lib/actions/staff.ts
+++ b/omnischools/lib/actions/staff.ts
@@ -1,5 +1,5 @@
 "use server";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 import { withSchool } from "@/lib/db/rls";
 import { recordAudit } from "@/lib/db/audit";
@@ -8,7 +8,13 @@ import { normalizeGhanaPhone } from "@/lib/auth";
 import { safeRevalidate } from "@/lib/revalidate";
 import { STAFF_ROLE_CODES, STAFF_ROLE_LABEL } from "@/lib/staff-roles";
 import type { Tx } from "@/lib/db";
-import { users, roles, roleAssignments } from "@/db/schema";
+import {
+  users,
+  roles,
+  roleAssignments,
+  classes,
+  timetableSlots,
+} from "@/db/schema";
 
 type Result = { ok: boolean; error?: string };
 
@@ -94,6 +100,7 @@ export async function addStaff(input: unknown): Promise<Result> {
 const UpdateStaffSchema = z.object({
   userId: z.string().uuid(),
   fullName: z.string().min(2, "Enter the staff member's name").max(120),
+  phone: z.string().min(7, "Enter a valid phone number"),
   email: z.string().email("Invalid email").optional().or(z.literal("")),
 });
 
@@ -104,6 +111,7 @@ export async function updateStaff(input: unknown): Promise<Result> {
     return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };
   }
   const d = parsed.data;
+  const phone = normalizeGhanaPhone(d.phone);
   const actor = await resolveActor(school.id);
   try {
     const outcome = await withSchool(school.id, async (tx) => {
@@ -119,9 +127,18 @@ export async function updateStaff(input: unknown): Promise<Result> {
         )
         .limit(1);
       if (!ra) return { error: "Not a staff member at this school." };
+      // phone is the login identity — make sure it isn't already taken
+      const [clash] = await tx
+        .select({ id: users.id })
+        .from(users)
+        .where(eq(users.phone, phone))
+        .limit(1);
+      if (clash && clash.id !== d.userId) {
+        return { error: "Another account already uses that phone number." };
+      }
       await tx
         .update(users)
-        .set({ fullName: d.fullName.trim(), email: d.email || null })
+        .set({ fullName: d.fullName.trim(), phone, email: d.email || null })
         .where(eq(users.id, d.userId));
       await recordAudit(tx, {
         schoolId: school.id,
@@ -140,6 +157,123 @@ export async function updateStaff(input: unknown): Promise<Result> {
     return { ok: true };
   } catch {
     return { ok: false, error: "Could not update staff." };
+  }
+}
+
+// --------------------------------------------------------------- delete staff
+/**
+ * Remove staff from THIS school: drop all their role assignments here and clear
+ * them as class-teacher / timetable teacher. Their login identity (the user row,
+ * keyed by phone) is kept — they may belong to other schools. Refuses to delete
+ * the last administrator. Returns an error string (not throwing) when blocked.
+ */
+async function removeStaffMembers(
+  tx: Tx,
+  schoolId: string,
+  userIds: string[],
+): Promise<{ error?: string }> {
+  const admins = await tx
+    .select({ userId: roleAssignments.userId })
+    .from(roleAssignments)
+    .innerJoin(roles, eq(roleAssignments.roleId, roles.id))
+    .where(and(eq(roleAssignments.schoolId, schoolId), eq(roles.code, "ADMIN")));
+  const adminIds = new Set(admins.map((a) => a.userId));
+  const removingAdmins = userIds.filter((id) => adminIds.has(id));
+  if (removingAdmins.length > 0 && removingAdmins.length >= adminIds.size) {
+    return { error: "Can't remove the only administrator." };
+  }
+
+  await tx
+    .update(classes)
+    .set({ classTeacherUserId: null })
+    .where(
+      and(
+        eq(classes.schoolId, schoolId),
+        inArray(classes.classTeacherUserId, userIds),
+      ),
+    );
+  await tx
+    .update(timetableSlots)
+    .set({ teacherUserId: null })
+    .where(
+      and(
+        eq(timetableSlots.schoolId, schoolId),
+        inArray(timetableSlots.teacherUserId, userIds),
+      ),
+    );
+  await tx
+    .delete(roleAssignments)
+    .where(
+      and(
+        eq(roleAssignments.schoolId, schoolId),
+        inArray(roleAssignments.userId, userIds),
+      ),
+    );
+  return {};
+}
+
+const DeleteStaffSchema = z.object({ userId: z.string().uuid() });
+
+export async function deleteStaff(input: unknown): Promise<Result> {
+  const { school } = await requireSchool();
+  const parsed = DeleteStaffSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: "Invalid input" };
+  const actor = await resolveActor(school.id);
+  try {
+    const outcome = await withSchool(school.id, async (tx) => {
+      const res = await removeStaffMembers(tx, school.id, [parsed.data.userId]);
+      if (res.error) return res;
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "deleted",
+        entityType: "staff",
+        entityId: parsed.data.userId,
+        reason: "Staff removed from school",
+      });
+      return { ok: true as const };
+    });
+    if ("error" in outcome) return { ok: false, error: outcome.error };
+    safeRevalidate("/staff");
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Could not remove staff." };
+  }
+}
+
+const DeleteStaffBulkSchema = z.object({
+  userIds: z.array(z.string().uuid()).min(1).max(200),
+});
+
+export async function deleteStaffBulk(
+  input: unknown,
+): Promise<Result & { deleted?: number }> {
+  const { school } = await requireSchool();
+  const parsed = DeleteStaffBulkSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: "Select at least one staff member" };
+  const ids = Array.from(new Set(parsed.data.userIds));
+  const actor = await resolveActor(school.id);
+  try {
+    const outcome = await withSchool(school.id, async (tx) => {
+      const res = await removeStaffMembers(tx, school.id, ids);
+      if (res.error) return res;
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "deleted",
+        entityType: "staff_batch",
+        after: { count: ids.length },
+        reason: "Staff removed from school (bulk)",
+      });
+      return { ok: true as const };
+    });
+    if ("error" in outcome) return { ok: false, error: outcome.error };
+    safeRevalidate("/staff");
+    return { ok: true, deleted: ids.length };
+  } catch {
+    return { ok: false, error: "Could not remove the selected staff." };
   }
 }
 

--- a/omnischools/lib/actions/students.ts
+++ b/omnischools/lib/actions/students.ts
@@ -5,9 +5,20 @@ import { withSchool } from "@/lib/db/rls";
 import { recordAudit } from "@/lib/db/audit";
 import { requireSchool, resolveActor } from "@/lib/auth/server";
 import { normalizeGhanaPhone } from "@/lib/auth";
-import { and, eq } from "drizzle-orm";
+import { and, count, eq, inArray } from "drizzle-orm";
 import { nextStudentCode } from "@/lib/students-helpers";
-import { students, studentGuardians, classes } from "@/db/schema";
+import type { Tx } from "@/lib/db";
+import {
+  students,
+  studentGuardians,
+  classes,
+  invoices,
+  payments,
+  gradebookScores,
+  reportCards,
+  attendanceRecords,
+  admissionApplications,
+} from "@/db/schema";
 
 const CreateStudentSchema = z.object({
   firstName: z.string().min(1, "First name is required").max(120),
@@ -284,5 +295,172 @@ export async function importStudents(input: unknown): Promise<ImportStudentsResu
     return { ok: true, created };
   } catch {
     return { ok: false, error: "Could not import students. Please try again." };
+  }
+}
+
+// ------------------------------------------------------------- delete student
+type DeleteResult = { ok: boolean; error?: string };
+
+function listJoin(items: string[]): string {
+  if (items.length <= 1) return items.join("");
+  return `${items.slice(0, -1).join(", ")} and ${items[items.length - 1]}`;
+}
+
+/**
+ * Linked records that make a hard delete unsafe (would destroy financial /
+ * academic history). When any exist, deletion is blocked and the user is told to
+ * set a status (Withdrawn / Transferred) instead. Guardians don't block — they
+ * cascade away with the student.
+ */
+async function studentBlockers(
+  tx: Tx,
+  schoolId: string,
+  id: string,
+): Promise<string[]> {
+  const reasons: string[] = [];
+  const [p] = await tx
+    .select({ n: count() })
+    .from(payments)
+    .where(and(eq(payments.schoolId, schoolId), eq(payments.studentId, id)));
+  if (Number(p?.n ?? 0) > 0) reasons.push("payments");
+  const [iv] = await tx
+    .select({ n: count() })
+    .from(invoices)
+    .where(and(eq(invoices.schoolId, schoolId), eq(invoices.studentId, id)));
+  if (Number(iv?.n ?? 0) > 0) reasons.push("invoices");
+  const [g] = await tx
+    .select({ n: count() })
+    .from(gradebookScores)
+    .where(
+      and(eq(gradebookScores.schoolId, schoolId), eq(gradebookScores.studentId, id)),
+    );
+  if (Number(g?.n ?? 0) > 0) reasons.push("grades");
+  const [rc] = await tx
+    .select({ n: count() })
+    .from(reportCards)
+    .where(and(eq(reportCards.schoolId, schoolId), eq(reportCards.studentId, id)));
+  if (Number(rc?.n ?? 0) > 0) reasons.push("report cards");
+  const [at] = await tx
+    .select({ n: count() })
+    .from(attendanceRecords)
+    .where(
+      and(eq(attendanceRecords.schoolId, schoolId), eq(attendanceRecords.studentId, id)),
+    );
+  if (Number(at?.n ?? 0) > 0) reasons.push("attendance");
+  return reasons;
+}
+
+const DeleteStudentSchema = z.object({ id: z.string().uuid() });
+
+export async function deleteStudent(input: unknown): Promise<DeleteResult> {
+  const { school } = await requireSchool();
+  const parsed = DeleteStudentSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: "Invalid input" };
+  const actor = await resolveActor(school.id);
+  try {
+    const outcome = await withSchool(school.id, async (tx) => {
+      const [s] = await tx
+        .select({ first: students.firstName, last: students.lastName })
+        .from(students)
+        .where(and(eq(students.id, parsed.data.id), eq(students.schoolId, school.id)));
+      if (!s) return { error: "Student not found." };
+      const blockers = await studentBlockers(tx, school.id, parsed.data.id);
+      if (blockers.length) {
+        return {
+          error: `Can't delete — ${s.first} ${s.last} has ${listJoin(blockers)} on record. Set their status to Withdrawn or Transferred instead.`,
+        };
+      }
+      // detach any admission link first (its FK would otherwise block the delete)
+      await tx
+        .update(admissionApplications)
+        .set({ studentId: null })
+        .where(
+          and(
+            eq(admissionApplications.schoolId, school.id),
+            eq(admissionApplications.studentId, parsed.data.id),
+          ),
+        );
+      await tx
+        .delete(students)
+        .where(and(eq(students.id, parsed.data.id), eq(students.schoolId, school.id)));
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "deleted",
+        entityType: "student",
+        entityId: parsed.data.id,
+        before: { name: `${s.first} ${s.last}` },
+        reason: "Student deleted",
+      });
+      return { ok: true as const };
+    });
+    if ("error" in outcome) return { ok: false, error: outcome.error };
+    safeRevalidate("/students");
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Could not delete the student." };
+  }
+}
+
+const DeleteStudentsSchema = z.object({
+  ids: z.array(z.string().uuid()).min(1).max(500),
+});
+
+export type DeleteStudentsResult = {
+  ok: boolean;
+  error?: string;
+  deleted?: number;
+  blocked?: { name: string; reasons: string[] }[];
+};
+
+export async function deleteStudents(input: unknown): Promise<DeleteStudentsResult> {
+  const { school } = await requireSchool();
+  const parsed = DeleteStudentsSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: "Select at least one student" };
+  const ids = Array.from(new Set(parsed.data.ids));
+  const actor = await resolveActor(school.id);
+  try {
+    const result = await withSchool(school.id, async (tx) => {
+      const rows = await tx
+        .select({ id: students.id, first: students.firstName, last: students.lastName })
+        .from(students)
+        .where(and(eq(students.schoolId, school.id), inArray(students.id, ids)));
+      const blocked: { name: string; reasons: string[] }[] = [];
+      const deletable: string[] = [];
+      for (const r of rows) {
+        const reasons = await studentBlockers(tx, school.id, r.id);
+        if (reasons.length) blocked.push({ name: `${r.first} ${r.last}`, reasons });
+        else deletable.push(r.id);
+      }
+      if (deletable.length) {
+        await tx
+          .update(admissionApplications)
+          .set({ studentId: null })
+          .where(
+            and(
+              eq(admissionApplications.schoolId, school.id),
+              inArray(admissionApplications.studentId, deletable),
+            ),
+          );
+        await tx
+          .delete(students)
+          .where(and(eq(students.schoolId, school.id), inArray(students.id, deletable)));
+        await recordAudit(tx, {
+          schoolId: school.id,
+          actorUserId: actor.id ?? undefined,
+          actorRole: actor.role,
+          actionType: "deleted",
+          entityType: "student_batch",
+          after: { count: deletable.length },
+          reason: "Students deleted (bulk)",
+        });
+      }
+      return { deleted: deletable.length, blocked };
+    });
+    safeRevalidate("/students");
+    return { ok: true, ...result };
+  } catch {
+    return { ok: false, error: "Could not delete the selected students." };
   }
 }


### PR DESCRIPTION
## Step 4c — Edit & delete with multi-select

Follow-up to the staff redesign: make Classes/Staff/Students records editable and deletable after creation, with multi-check bulk delete and an "Are you sure?" confirm for both single and bulk deletes.

### Classes
- Inline **edit** of name + level (Edit → Save/Cancel). Renaming syncs the class label shown on its students.
- **Delete** (single + bulk): students are **unassigned (kept)**; timetable + attendance cascade away. Confirm dialog spells out the consequences.

### Staff
- **Phone is now editable** (it's the login identity); blocked if the phone already belongs to another account.
- **Delete** (single + bulk): drops the person's roles + class-teacher/timetable references at this school, keeps the global login (they may belong to other schools), and **refuses to remove the only administrator**.

### Students
- **Delete** (single + bulk) with **block-with-reason** (per the chosen policy): a student carrying fee, payment, attendance or grade history can't be hard-deleted — the dialog explains why and points to setting status to Withdrawn/Transferred. Bulk deletes the clean ones and lists which were skipped and why.

### Shared UI
- `components/ui/confirm-dialog.tsx` — destructive confirm built on Modal (terra button, locked while deleting).
- `components/ui/selection.tsx` — `useSelection` hook + row/header checkboxes (indeterminate) + `BulkBar`.
- New per-table client components: `classes-table`, `students-table`, `staff-table` + reworked `staff-row`.

### Verification
- `pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm build` ✓ (`/staff` 5.21 kB · `/students` 3.33 kB · `/classes` built)
- **No schema change → no migration / SQL paste.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)