### PR TITLE
feat(onboarding): unified wizard shell + steps 1–2 + 3-card school type (redesign step 5a)

### DIFF
--- a/omnischools/app/(marketing)/start/page.tsx
+++ b/omnischools/app/(marketing)/start/page.tsx
@@ -4,13 +4,13 @@ import { OnboardingWizard } from "@/components/onboarding/wizard";
 export const metadata: Metadata = {
   title: "Onboard your school",
   description:
-    "Set up your school on Omnischools in a few steps — details, product, headmaster, and admin. Your GES-standard academic calendar is configured automatically.",
+    "Set up your school on Omnischools — identity, school type, calendar, structure, staff and billing. Basic schools finish in six steps; SHS adds residency and WAEC. Your GES-standard calendar is configured automatically.",
 };
 
 export default function StartPage() {
   return (
-    <main className="mx-auto max-w-content px-6 py-16">
-      <div className="mb-8 text-center">
+    <main className="mx-auto max-w-5xl px-4 py-12 sm:px-6">
+      <div className="mb-7 text-center">
         <div className="mb-3 inline-block text-[11px] font-bold uppercase tracking-[0.18em] text-gold">
           Get started
         </div>
@@ -19,8 +19,8 @@ export default function StartPage() {
           <em className="not-italic text-gold [font-style:italic]">school.</em>
         </h1>
         <p className="mt-3 text-base text-navy-2">
-          Five short steps. No card, no commitment — a 30-day trial starts the moment
-          you&apos;re in.
+          Six short steps — Basic schools finish at six; SHS adds two. No card, no
+          commitment — a 30-day trial starts the moment you&apos;re in.
         </p>
       </div>
       <OnboardingWizard />

--- a/omnischools/components/onboarding/wizard.tsx
+++ b/omnischools/components/onboarding/wizard.tsx
@@ -6,7 +6,10 @@ import {
   GH_REGIONS,
   OWNERSHIPS,
   SCHOOL_TYPE_CARDS,
+  SENIOR_TRACKS,
   cardForSubtype,
+  cardById,
+  type CardId,
   type OnboardInput,
   type OnboardResult,
   type SchoolSubtype,
@@ -142,12 +145,16 @@ export function OnboardingWizard() {
     }
   };
 
-  const pickType = (key: SchoolSubtype) => {
-    const c = cardForSubtype(key);
-    setForm((f) => ({ ...f, subtype: key, product: c.product }));
+  const pickCard = (id: CardId) => {
+    const c = cardById(id);
+    setForm((f) => ({ ...f, subtype: c.defaultSubtype, product: c.product }));
     setSaved(false);
     // Leaving the SHS branch shouldn't strand us on a now-hidden step.
     if (c.steps === 6 && stepIdx > 5) setStepIdx(5);
+  };
+  const setSeniorTrack = (t: SchoolSubtype) => {
+    setForm((f) => ({ ...f, subtype: t }));
+    setSaved(false);
   };
 
   const saveForLater = () => {
@@ -339,7 +346,8 @@ export function OnboardingWizard() {
                 stepKey={current?.key ?? "identity"}
                 form={form}
                 set={set}
-                pickType={pickType}
+                pickCard={pickCard}
+                setSeniorTrack={setSeniorTrack}
                 isShs={isShs}
                 periodWord={periodWord}
                 stepNo={stepIdx + 1}
@@ -454,7 +462,8 @@ function StepBody({
   stepKey,
   form,
   set,
-  pickType,
+  pickCard,
+  setSeniorTrack,
   isShs,
   periodWord,
   stepNo,
@@ -463,13 +472,15 @@ function StepBody({
   stepKey: string;
   form: Form;
   set: (k: keyof Form, v: string) => void;
-  pickType: (k: SchoolSubtype) => void;
+  pickCard: (id: CardId) => void;
+  setSeniorTrack: (t: SchoolSubtype) => void;
   isShs: boolean;
   periodWord: string;
   stepNo: number;
   total: number;
 }) {
   const f = (k: keyof Form) => (form[k] as string) ?? "";
+  const selectedCard = form.subtype ? cardForSubtype(form.subtype) : null;
 
   if (stepKey === "identity") {
     return (
@@ -587,14 +598,14 @@ function StepBody({
           em="school are you?"
           lede="This is the only step that changes what steps 4–8 look like. Basic & JHS finish at step 6; SHS, SHTS and Multi-tier add residency + WAEC (8 steps)."
         />
-        <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-3">
           {SCHOOL_TYPE_CARDS.map((c) => {
-            const selected = form.subtype === c.key;
+            const selected = selectedCard?.id === c.id;
             return (
               <button
-                key={c.key}
+                key={c.id}
                 type="button"
-                onClick={() => pickType(c.key)}
+                onClick={() => pickCard(c.id)}
                 className={cn(
                   "relative rounded-[10px] border-2 p-5 text-left transition-colors",
                   selected
@@ -621,16 +632,48 @@ function StepBody({
               </button>
             );
           })}
-          <div className="rounded-[10px] border-2 border-dashed border-border-2 p-5 opacity-50">
-            <div className="font-display text-base font-medium text-navy-3">TVET-only</div>
-            <p className="mb-2.5 mt-1.5 text-[11px] leading-snug text-navy-3">
-              Technical/Vocational Institution under Ghana TVET Service. Coming Q3 2026.
-            </p>
-            <div className="border-t border-border pt-2 text-[10px] font-semibold uppercase tracking-[0.08em] text-navy-3">
-              Not yet available
+        </div>
+
+        {/* Senior sub-track — SHS vs SHTS (recorded now; SHTS curriculum is built in the Senior release) */}
+        {selectedCard?.id === "SENIOR" && (
+          <div className="mt-4">
+            <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.06em] text-navy-3">
+              Senior track
+            </div>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              {SENIOR_TRACKS.map((t) => {
+                const on = form.subtype === t.key;
+                return (
+                  <button
+                    key={t.key}
+                    type="button"
+                    onClick={() => setSeniorTrack(t.key)}
+                    className={cn(
+                      "rounded-lg border-2 p-4 text-left transition-colors",
+                      on
+                        ? "border-gold bg-gold-bg"
+                        : "border-border-2 bg-surface hover:border-gold-soft",
+                    )}
+                  >
+                    <div className="flex items-center gap-2">
+                      <span
+                        className={cn(
+                          "flex h-4 w-4 items-center justify-center rounded-full border-2",
+                          on ? "border-gold bg-gold" : "border-border-2",
+                        )}
+                      >
+                        {on && <span className="h-1.5 w-1.5 rounded-full bg-navy" />}
+                      </span>
+                      <span className="text-sm font-semibold text-navy">{t.label}</span>
+                    </div>
+                    <p className="mt-1.5 pl-6 text-[11px] leading-snug text-navy-3">{t.desc}</p>
+                  </button>
+                );
+              })}
             </div>
           </div>
-        </div>
+        )}
+
         <div className="mt-5 rounded-r-lg border-l-[3px] border-gold bg-gold-bg px-4 py-3.5 text-[12px] leading-relaxed text-navy-2">
           <b className="text-navy">Why this matters:</b> your answer determines whether later
           surfaces show class-based or programme-based structure, and whether residency &amp; WAEC
@@ -862,7 +905,14 @@ function ReviewPanel({
       step: "School type",
       key: "type",
       rows: [
-        ["Type", card ? `${card.name} · ${card.steps}-step path` : "—"],
+        [
+          "Type",
+          card
+            ? `${card.name}${
+                form.subtype === "SHTS" ? " (SHTS)" : form.subtype === "SHS" ? " (SHS)" : ""
+              } · ${card.steps}-step path`
+            : "—",
+        ],
         ["Tier", card?.product ?? "—"],
       ],
     },

--- a/omnischools/components/onboarding/wizard.tsx
+++ b/omnischools/components/onboarding/wizard.tsx
@@ -1,24 +1,55 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import {
   GH_REGIONS,
   OWNERSHIPS,
-  ONBOARD_PRODUCTS,
-  PRODUCT_LABELS,
+  SCHOOL_TYPE_CARDS,
+  cardForSubtype,
   type OnboardInput,
   type OnboardResult,
+  type SchoolSubtype,
 } from "@/lib/onboarding";
 import { onboardSchool } from "@/lib/actions/onboarding";
 
-const STEPS = ["School", "Product", "Headmaster", "Admin", "Confirm"];
+type Form = Partial<OnboardInput> & { subtype?: SchoolSubtype };
 
-const fieldClass =
-  "w-full rounded-md border border-border-2 bg-bg px-3.5 py-2.5 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
-const labelClass = "mb-1.5 block text-xs font-semibold text-navy-2";
+const DRAFT_KEY = "omnischools:onboarding-draft";
 
-type Form = Partial<OnboardInput>;
+type StepDef = { key: string; title: string; sub: string; shsOnly?: boolean };
+const ALL_STEPS: StepDef[] = [
+  { key: "identity", title: "School identity", sub: "Name, GES code, CSSPS code, district" },
+  { key: "type", title: "School type", sub: "Branch point · determines steps 4–8" },
+  { key: "calendar", title: "Academic calendar", sub: "Terms, holidays, week numbering" },
+  {
+    key: "structure",
+    title: "Academic structure",
+    sub: "Classes / programmes · adapts to type",
+  },
+  { key: "staff", title: "Staff & roles", sub: "Headmaster, senior staff, role grants" },
+  { key: "billing", title: "Billing & payments", sub: "Fee structure, MoMo, Free SHS" },
+  {
+    key: "residency",
+    title: "Residency & boarding",
+    sub: "Day, mixed, or boarding · house system",
+    shsOnly: true,
+  },
+  {
+    key: "waec",
+    title: "WAEC centre & WASSCE",
+    sub: "Centre code, programmes offered",
+    shsOnly: true,
+  },
+];
+
+const labelCls = "flex items-center gap-1.5 text-xs font-semibold text-navy";
+const helpCls = "text-[11px] leading-snug text-navy-3";
+const inputCls = (filled: boolean) =>
+  cn(
+    "w-full rounded-lg border bg-surface px-3 py-2.5 text-sm text-navy outline-none transition-colors focus:border-gold",
+    filled ? "border-gold-soft bg-gold-bg" : "border-border-2",
+  );
 
 function academicYearLabel(now = new Date()): string {
   const y = now.getFullYear();
@@ -27,26 +58,63 @@ function academicYearLabel(now = new Date()): string {
 }
 
 export function OnboardingWizard() {
-  const [step, setStep] = useState(0);
-  const [form, setForm] = useState<Form>({ product: "BASIC", ownership: "PUBLIC" });
+  const [form, setForm] = useState<Form>({ ownership: "PUBLIC" });
+  const [phase, setPhase] = useState<"steps" | "review" | "done">("steps");
+  const [stepIdx, setStepIdx] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [saved, setSaved] = useState(false);
   const [result, setResult] = useState<Extract<OnboardResult, { ok: true }> | null>(null);
+  const hydrated = useRef(false);
 
-  const set = (k: keyof Form, v: string) => setForm((f) => ({ ...f, [k]: v }));
+  // Restore an in-progress draft (autosave / "continue later").
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(DRAFT_KEY);
+      if (raw) {
+        const d = JSON.parse(raw) as { form?: Form; stepIdx?: number };
+        if (d.form) setForm(d.form);
+        if (typeof d.stepIdx === "number") setStepIdx(d.stepIdx);
+      }
+    } catch {
+      /* ignore corrupt draft */
+    }
+    hydrated.current = true;
+  }, []);
+
+  // Persist the draft whenever it changes (after initial hydration).
+  useEffect(() => {
+    if (!hydrated.current) return;
+    try {
+      localStorage.setItem(DRAFT_KEY, JSON.stringify({ form, stepIdx }));
+    } catch {
+      /* storage full / unavailable */
+    }
+  }, [form, stepIdx]);
+
+  const set = (k: keyof Form, v: string) => {
+    setForm((f) => ({ ...f, [k]: v }));
+    setSaved(false);
+  };
+
+  const card = form.subtype ? cardForSubtype(form.subtype) : null;
+  const isShs = card ? card.steps === 8 : false;
+  const visible = ALL_STEPS.filter((s) => !s.shsOnly || isShs);
+  const total = visible.length;
+  const current = visible[stepIdx];
 
   const stepValid = (): string | null => {
-    if (step === 0) {
+    if (!current) return null;
+    if (current.key === "identity") {
       if (!form.schoolName) return "Enter the school name.";
       if (!form.gesCode) return "Enter the GES code.";
       if (!form.region) return "Choose a region.";
       if (!form.district) return "Enter the district.";
     }
-    if (step === 2) {
+    if (current.key === "type" && !form.subtype) return "Choose a school type.";
+    if (current.key === "staff") {
       if (!form.headmasterName) return "Enter the headmaster's name.";
       if (!form.headmasterPhone) return "Enter the headmaster's phone.";
-    }
-    if (step === 3) {
       if (!form.adminName) return "Enter the admin's name.";
       if (!form.adminPhone) return "Enter the admin's phone.";
     }
@@ -57,119 +125,411 @@ export function OnboardingWizard() {
     const err = stepValid();
     if (err) return setError(err);
     setError(null);
-    setStep((s) => Math.min(s + 1, STEPS.length - 1));
+    if (stepIdx >= total - 1) setPhase("review");
+    else setStepIdx((s) => s + 1);
   };
   const back = () => {
     setError(null);
-    setStep((s) => Math.max(s - 1, 0));
+    if (phase === "review") return setPhase("steps");
+    setStepIdx((s) => Math.max(s - 1, 0));
+  };
+  const jumpTo = (key: string) => {
+    const i = visible.findIndex((s) => s.key === key);
+    if (i >= 0) {
+      setPhase("steps");
+      setStepIdx(i);
+      setError(null);
+    }
   };
 
-  async function submit() {
+  const pickType = (key: SchoolSubtype) => {
+    const c = cardForSubtype(key);
+    setForm((f) => ({ ...f, subtype: key, product: c.product }));
+    setSaved(false);
+    // Leaving the SHS branch shouldn't strand us on a now-hidden step.
+    if (c.steps === 6 && stepIdx > 5) setStepIdx(5);
+  };
+
+  const saveForLater = () => {
+    try {
+      localStorage.setItem(DRAFT_KEY, JSON.stringify({ form, stepIdx }));
+      setSaved(true);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  async function launch() {
     setSubmitting(true);
     setError(null);
     const res = await onboardSchool(form);
     setSubmitting(false);
-    if (res.ok) setResult(res);
-    else setError(res.error);
+    if (res.ok) {
+      try {
+        localStorage.removeItem(DRAFT_KEY);
+      } catch {
+        /* ignore */
+      }
+      setResult(res);
+      setPhase("done");
+    } else setError(res.error);
   }
 
-  if (result) {
-    return (
-      <div className="bg-surface rounded-2xl border border-border p-9 text-center shadow-md">
-        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-green-bg font-display text-xl text-green">
-          ✓
+  const schoolInitial = (form.schoolName?.trim()?.[0] ?? "S").toUpperCase();
+  const periodWord = card?.product === "SENIOR" ? "2 semesters" : "3 terms";
+
+  return (
+    <div className="overflow-hidden rounded-2xl border border-border bg-bg shadow-md">
+      {/* Top bar */}
+      <div className="flex items-center gap-4 border-b border-border bg-surface px-5 py-3.5 md:px-7">
+        <div className="flex items-center gap-3">
+          <div className="flex h-9 w-9 items-center justify-center rounded-[9px] bg-gold font-display text-lg font-semibold text-navy">
+            {schoolInitial}
+          </div>
+          <div>
+            <div className="font-display text-base font-medium text-navy">
+              Omnischools <em className="not-italic text-gold [font-style:italic]">onboarding</em>
+            </div>
+            <div className="text-[11px] text-navy-3">
+              Setting up
+              {form.schoolName ? (
+                <>
+                  {" · "}
+                  <b className="text-navy">{form.schoolName}</b>
+                </>
+              ) : (
+                " your school"
+              )}
+            </div>
+          </div>
         </div>
-        <h2 className="mb-2 font-display text-3xl font-semibold text-navy">
-          {form.schoolName} is{" "}
-          <em className="not-italic text-gold [font-style:italic]">live.</em>
-        </h2>
-        <p className="mx-auto mb-6 max-w-[420px] text-sm text-navy-2">
-          Academic year <b className="text-navy">{result.academicYear}</b> configured with{" "}
-          {result.periodsCreated > 0
-            ? `${result.periodsCreated} ${form.product === "SENIOR" ? "semesters" : "terms"}`
-            : "its period structure"}
-          . A welcome SMS is on its way to your admin number.
-        </p>
-        <p className="mb-7 font-mono text-xs text-navy-3">
-          school id · {result.schoolId}
-        </p>
-        <div className="flex flex-wrap justify-center gap-3">
-          <Link
-            href="/login"
-            className="text-bg rounded-md bg-navy px-6 py-3 text-sm font-semibold transition-colors hover:bg-navy-deep"
-          >
-            Go to sign in
-          </Link>
+        <div className="ml-auto flex gap-2">
+          {phase !== "done" && (
+            <button
+              onClick={saveForLater}
+              className="rounded-md px-3 py-1.5 text-xs font-semibold text-navy-3 transition-colors hover:text-navy"
+            >
+              {saved ? "Saved ✓" : "Save & continue later"}
+            </button>
+          )}
           <Link
             href="/"
-            className="border-border-2 hover:bg-bg rounded-md border px-6 py-3 text-sm font-semibold text-navy transition-colors"
+            className="rounded-md border border-border-2 bg-surface px-3 py-1.5 text-xs font-semibold text-navy transition-colors hover:bg-bg"
           >
-            Back to home
+            Exit
           </Link>
         </div>
       </div>
-    );
-  }
 
-  return (
-    <div className="bg-surface rounded-2xl border border-border p-7 shadow-md md:p-9">
-      {/* stepper */}
-      <ol className="mb-8 flex items-center gap-2">
-        {STEPS.map((label, i) => (
-          <li key={label} className="flex flex-1 items-center gap-2">
-            <span
-              className={cn(
-                "flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full text-xs font-bold transition-colors",
-                i < step && "bg-green text-white",
-                i === step && "text-bg bg-navy",
-                i > step && "bg-gold-bg text-navy-3",
-              )}
-            >
-              {i < step ? "✓" : i + 1}
-            </span>
-            <span
-              className={cn(
-                "hidden text-xs font-semibold sm:inline",
-                i === step ? "text-navy" : "text-navy-3",
-              )}
-            >
-              {label}
-            </span>
-            {i < STEPS.length - 1 && <span className="h-px flex-1 bg-border" />}
-          </li>
-        ))}
-      </ol>
-
-      {/* steps */}
-      {step === 0 && (
-        <div className="space-y-[18px]">
-          <h2 className="font-display text-2xl font-semibold text-navy">
-            School details
-          </h2>
-          <div>
-            <label className={labelClass}>School name</label>
-            <input
-              className={fieldClass}
-              value={form.schoolName ?? ""}
-              onChange={(e) => set("schoolName", e.target.value)}
-              placeholder="e.g. Asankrangwa Senior High School"
-            />
-          </div>
-          <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2">
-            <div>
-              <label className={labelClass}>GES code</label>
-              <input
-                className={fieldClass}
-                value={form.gesCode ?? ""}
-                onChange={(e) => set("gesCode", e.target.value)}
-                placeholder="e.g. WR-WAW-014"
-              />
+      <div className="md:grid md:grid-cols-[280px_1fr]">
+        {/* Vertical step nav */}
+        <nav className="hidden border-r border-border bg-bg py-6 md:block">
+          <div className="mb-4 border-b border-border px-6 pb-4">
+            <div className="mb-1.5 text-[10px] font-bold uppercase tracking-[0.14em] text-gold">
+              {phase === "done" ? "Setup complete" : "Setup progress"}
             </div>
-            <div>
-              <label className={labelClass}>Ownership</label>
+            <div
+              className={cn(
+                "font-display text-base font-medium",
+                phase === "done" ? "text-green" : "text-navy",
+              )}
+            >
+              {phase === "done" || phase === "review"
+                ? `${total} of ${total} ${phase === "done" ? "done" : "complete"}`
+                : `Step ${stepIdx + 1} of ${total}`}
+              {phase === "steps" && !isShs && (
+                <span className="font-normal text-navy-3"> · or 8 for SHS</span>
+              )}
+              {phase === "steps" && isShs && (
+                <span className="font-normal text-gold"> · SHS path</span>
+              )}
+            </div>
+            {phase === "steps" && (
+              <div className="mt-1.5 text-[11px] text-navy-3">
+                <b className="text-navy">
+                  {stepIdx} of {total}
+                </b>{" "}
+                complete
+              </div>
+            )}
+          </div>
+
+          <ol className="px-0">
+            {ALL_STEPS.map((s, ai) => {
+              const greyed = !!s.shsOnly && !isShs;
+              const visIdx = visible.findIndex((v) => v.key === s.key);
+              const done =
+                !greyed && (phase !== "steps" ? visIdx >= 0 : visIdx >= 0 && visIdx < stepIdx);
+              const active = phase === "steps" && !greyed && visIdx === stepIdx;
+              return (
+                <li
+                  key={s.key}
+                  onClick={() => !greyed && done && jumpTo(s.key)}
+                  className={cn(
+                    "relative grid grid-cols-[40px_1fr] gap-3 px-6 py-3.5",
+                    greyed ? "opacity-45" : done ? "cursor-pointer" : "",
+                  )}
+                >
+                  {ai < ALL_STEPS.length - 1 && (
+                    <span
+                      className={cn(
+                        "absolute left-[39px] top-9 -bottom-3.5 z-0 w-0.5",
+                        done ? "bg-green" : active ? "bg-gold" : "bg-border",
+                      )}
+                    />
+                  )}
+                  <span
+                    className={cn(
+                      "relative z-10 flex h-7 w-7 items-center justify-center rounded-full border-2 font-display text-[11px] font-semibold",
+                      done
+                        ? "border-green bg-green text-surface"
+                        : active
+                          ? "border-gold bg-gold text-navy shadow-[0_0_0_4px_rgba(200,151,91,0.18)]"
+                          : "border-border-2 bg-surface text-navy-3",
+                      greyed && "border-dashed",
+                    )}
+                  >
+                    {done ? "✓" : ai + 1}
+                  </span>
+                  <span className="min-w-0 pt-0.5">
+                    <span className="flex items-center gap-1.5 text-[13px] font-semibold leading-tight text-navy">
+                      {s.title}
+                      {s.shsOnly && (
+                        <span className="rounded-full bg-green-bg px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.1em] text-green">
+                          SHS
+                        </span>
+                      )}
+                    </span>
+                    <span className="mt-0.5 block text-[11px] leading-snug text-navy-3">
+                      {s.sub}
+                    </span>
+                  </span>
+                </li>
+              );
+            })}
+          </ol>
+
+          <div className="mt-3.5 border-t border-border px-6 pt-4 text-[11px] leading-relaxed text-navy-3">
+            Steps 7–8 are conditional on school type. Basic schools finish at step 6.
+          </div>
+        </nav>
+
+        {/* Content panel */}
+        <div className="bg-surface">
+          {/* Mobile step indicator */}
+          {phase === "steps" && (
+            <div className="border-b border-border px-6 py-3 text-xs font-semibold text-navy-3 md:hidden">
+              Step {stepIdx + 1} of {total}
+              {!isShs && <span className="font-normal"> · or 8 for SHS</span>}
+            </div>
+          )}
+
+          <div className="px-6 py-7 md:px-10">
+            {phase === "done" && result ? (
+              <DonePanel result={result} schoolName={form.schoolName ?? "Your school"} />
+            ) : phase === "review" ? (
+              <ReviewPanel
+                form={form}
+                isShs={isShs}
+                periodWord={periodWord}
+                onEdit={jumpTo}
+              />
+            ) : (
+              <StepBody
+                stepKey={current?.key ?? "identity"}
+                form={form}
+                set={set}
+                pickType={pickType}
+                isShs={isShs}
+                periodWord={periodWord}
+                stepNo={stepIdx + 1}
+                total={total}
+              />
+            )}
+
+            {error && <p className="mt-4 text-sm text-terra">{error}</p>}
+          </div>
+
+          {/* Footer controls */}
+          {phase !== "done" && (
+            <div className="flex items-center gap-3.5 border-t border-border bg-bg px-6 py-4 md:px-10">
+              <div className="hidden text-[11px] text-navy-3 sm:block">
+                {phase === "review" ? (
+                  <>
+                    <b className="text-navy">All steps reviewed</b> · launch initialises your
+                    dashboard
+                  </>
+                ) : (
+                  <>
+                    <b className="text-navy">
+                      {stepIdx} of {total} complete
+                    </b>{" "}
+                    · entries saved automatically
+                  </>
+                )}
+              </div>
+              <div className="ml-auto flex gap-2.5">
+                <button
+                  onClick={back}
+                  disabled={(phase === "steps" && stepIdx === 0) || submitting}
+                  className="rounded-lg px-4 py-2.5 text-sm font-semibold text-navy-3 transition-colors hover:text-navy disabled:opacity-0"
+                >
+                  ← Back
+                </button>
+                {phase === "review" ? (
+                  <button
+                    onClick={launch}
+                    disabled={submitting}
+                    className="rounded-lg bg-gold px-6 py-2.5 text-sm font-bold text-navy transition-colors hover:brightness-95 disabled:opacity-60"
+                  >
+                    {submitting ? "Launching…" : "Launch school →"}
+                  </button>
+                ) : (
+                  <button
+                    onClick={next}
+                    className="rounded-lg bg-navy px-6 py-2.5 text-sm font-bold text-bg transition-colors hover:bg-navy-deep"
+                  >
+                    Save &amp; continue →
+                  </button>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ----------------------------------------------------------------- step bodies */
+
+function Head({ pill, title, em, lede }: { pill: string; title: string; em?: string; lede: string }) {
+  return (
+    <div className="mb-7 border-b border-border pb-5">
+      <div className="mb-2 text-[10px] font-bold uppercase tracking-[0.14em] text-gold">{pill}</div>
+      <h2 className="font-display text-[26px] font-medium leading-tight text-navy">
+        {title} {em && <em className="not-italic text-gold [font-style:italic]">{em}</em>}
+      </h2>
+      <p className="mt-2 max-w-[620px] text-[13px] leading-relaxed text-navy-3">{lede}</p>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  req,
+  help,
+  children,
+}: {
+  label: string;
+  req?: boolean;
+  help?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className={labelCls}>
+        {label}
+        {req && <span className="text-terra">*</span>}
+      </div>
+      {children}
+      {help && <div className={helpCls}>{help}</div>}
+    </div>
+  );
+}
+
+function InterimNote({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="rounded-xl border border-dashed border-border-2 bg-bg p-6">
+      <div className="font-display text-base font-medium text-navy">{title}</div>
+      <p className="mt-1.5 max-w-[560px] text-[13px] leading-relaxed text-navy-3">{body}</p>
+      <div className="mt-3 inline-block rounded-full bg-gold-bg px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.1em] text-gold">
+        Configured after launch
+      </div>
+    </div>
+  );
+}
+
+function StepBody({
+  stepKey,
+  form,
+  set,
+  pickType,
+  isShs,
+  periodWord,
+  stepNo,
+  total,
+}: {
+  stepKey: string;
+  form: Form;
+  set: (k: keyof Form, v: string) => void;
+  pickType: (k: SchoolSubtype) => void;
+  isShs: boolean;
+  periodWord: string;
+  stepNo: number;
+  total: number;
+}) {
+  const f = (k: keyof Form) => (form[k] as string) ?? "";
+
+  if (stepKey === "identity") {
+    return (
+      <div>
+        <Head
+          pill={`Step ${stepNo} of ${total} · School identity`}
+          title="Tell us about"
+          em="your school."
+          lede="The basics — name, official codes, and where you sit on the Ghana education map. These are one-time identifiers; changing them later needs Headmaster + GES re-verification."
+        />
+        <div className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-[2fr_1fr]">
+            <Field label="School name" req help="Official name as registered with GES.">
+              <input
+                className={inputCls(!!f("schoolName"))}
+                value={f("schoolName")}
+                onChange={(e) => set("schoolName", e.target.value)}
+                placeholder="e.g. St. Theresa's Senior High School"
+              />
+            </Field>
+            <Field label="Short name / alias" help="Used in app navigation & SMS sign-off.">
+              <input
+                className={inputCls(!!f("shortName"))}
+                value={f("shortName")}
+                onChange={(e) => set("shortName", e.target.value)}
+                placeholder="St. Theresa's"
+              />
+            </Field>
+          </div>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <Field label="GES school code" req help={<>From EMIS. Format <b className="text-navy-2">RG-DIST-NNN</b>.</>}>
+              <input
+                className={cn(inputCls(!!f("gesCode")), "font-mono")}
+                value={f("gesCode")}
+                onChange={(e) => set("gesCode", e.target.value)}
+                placeholder="BR-SUN-018"
+              />
+            </Field>
+            <Field label="CSSPS school code" help="SHS / TVI only · hm.cssps.gov.gh">
+              <input
+                className={cn(inputCls(!!f("csspsCode")), "font-mono")}
+                value={f("csspsCode")}
+                onChange={(e) => set("csspsCode", e.target.value)}
+                placeholder="ST-0741"
+              />
+            </Field>
+            <Field label="Year founded">
+              <input
+                className={inputCls(!!f("yearFounded"))}
+                value={f("yearFounded")}
+                onChange={(e) => set("yearFounded", e.target.value)}
+                placeholder="1965"
+              />
+            </Field>
+          </div>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <Field label="Ownership" req help="Public schools are Free SHS eligible.">
               <select
-                className={fieldClass}
-                value={form.ownership}
+                className={inputCls(true)}
+                value={form.ownership ?? "PUBLIC"}
                 onChange={(e) => set("ownership", e.target.value)}
               >
                 {OWNERSHIPS.map((o) => (
@@ -178,14 +538,11 @@ export function OnboardingWizard() {
                   </option>
                 ))}
               </select>
-            </div>
-          </div>
-          <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2">
-            <div>
-              <label className={labelClass}>Region</label>
+            </Field>
+            <Field label="Region" req>
               <select
-                className={fieldClass}
-                value={form.region ?? ""}
+                className={inputCls(!!f("region"))}
+                value={f("region")}
                 onChange={(e) => set("region", e.target.value)}
               >
                 <option value="" disabled>
@@ -195,201 +552,452 @@ export function OnboardingWizard() {
                   <option key={r}>{r}</option>
                 ))}
               </select>
-            </div>
-            <div>
-              <label className={labelClass}>District</label>
+            </Field>
+            <Field label="District" req>
               <input
-                className={fieldClass}
-                value={form.district ?? ""}
+                className={inputCls(!!f("district"))}
+                value={f("district")}
                 onChange={(e) => set("district", e.target.value)}
-                placeholder="e.g. Wassa Amenfi West"
+                placeholder="Sunyani Municipal"
               />
-            </div>
+            </Field>
           </div>
+          <Field
+            label="School address (postal + GPS)"
+            help="Postal address for official correspondence; GPS Ghana Post code for navigation."
+          >
+            <input
+              className={inputCls(!!f("address"))}
+              value={f("address")}
+              onChange={(e) => set("address", e.target.value)}
+              placeholder="P.O. Box 18, Sunyani · GA-077-0418"
+            />
+          </Field>
         </div>
-      )}
+      </div>
+    );
+  }
 
-      {step === 1 && (
-        <div className="space-y-[18px]">
-          <h2 className="font-display text-2xl font-semibold text-navy">
-            Which product?
-          </h2>
-          <p className="text-sm text-navy-2">
-            This sets your default academic calendar — Basic uses 3 terms, Senior uses 2
-            semesters (the GES standard).
-          </p>
-          <div className="space-y-3">
-            {ONBOARD_PRODUCTS.map((p) => (
+  if (stepKey === "type") {
+    return (
+      <div>
+        <Head
+          pill={`Step ${stepNo} of ${total} · School type — the branch point`}
+          title="What kind of"
+          em="school are you?"
+          lede="This is the only step that changes what steps 4–8 look like. Basic & JHS finish at step 6; SHS, SHTS and Multi-tier add residency + WAEC (8 steps)."
+        />
+        <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2 lg:grid-cols-3">
+          {SCHOOL_TYPE_CARDS.map((c) => {
+            const selected = form.subtype === c.key;
+            return (
               <button
-                key={p}
+                key={c.key}
                 type="button"
-                onClick={() => set("product", p)}
+                onClick={() => pickType(c.key)}
                 className={cn(
-                  "flex w-full items-center justify-between rounded-xl border px-5 py-4 text-left transition-colors",
-                  form.product === p
-                    ? "border-gold bg-gold-bg"
-                    : "bg-bg border-border hover:border-gold-soft",
+                  "relative rounded-[10px] border-2 p-5 text-left transition-colors",
+                  selected
+                    ? "border-gold bg-gradient-to-br from-gold-bg to-surface"
+                    : "border-border-2 bg-surface hover:border-gold-soft",
                 )}
               >
-                <span className="font-display text-base font-semibold text-navy">
-                  {PRODUCT_LABELS[p]}
-                </span>
-                <span
+                {selected && (
+                  <span className="absolute right-3.5 top-3.5 flex h-5 w-5 items-center justify-center rounded-full bg-gold text-xs font-bold text-navy">
+                    ✓
+                  </span>
+                )}
+                <div className="font-display text-base font-medium text-navy">{c.name}</div>
+                <p className="mb-2.5 mt-1.5 text-[11px] leading-snug text-navy-3">{c.desc}</p>
+                <div
                   className={cn(
-                    "flex h-5 w-5 items-center justify-center rounded-full border",
-                    form.product === p
-                      ? "border-gold bg-gold text-navy"
-                      : "border-border-2",
+                    "border-t border-border pt-2 text-[10px] font-semibold uppercase tracking-[0.08em]",
+                    c.steps === 8 ? "text-green" : "text-navy-3",
                   )}
                 >
-                  {form.product === p && "✓"}
-                </span>
+                  <b className={c.steps === 8 ? "text-green" : "text-navy"}>{c.steps} steps</b>
+                  {c.steps === 8 ? " · residency + WAEC" : " · finishes at billing"}
+                </div>
               </button>
-            ))}
+            );
+          })}
+          <div className="rounded-[10px] border-2 border-dashed border-border-2 p-5 opacity-50">
+            <div className="font-display text-base font-medium text-navy-3">TVET-only</div>
+            <p className="mb-2.5 mt-1.5 text-[11px] leading-snug text-navy-3">
+              Technical/Vocational Institution under Ghana TVET Service. Coming Q3 2026.
+            </p>
+            <div className="border-t border-border pt-2 text-[10px] font-semibold uppercase tracking-[0.08em] text-navy-3">
+              Not yet available
+            </div>
           </div>
         </div>
-      )}
+        <div className="mt-5 rounded-r-lg border-l-[3px] border-gold bg-gold-bg px-4 py-3.5 text-[12px] leading-relaxed text-navy-2">
+          <b className="text-navy">Why this matters:</b> your answer determines whether later
+          surfaces show class-based or programme-based structure, and whether residency &amp; WAEC
+          setup appear. Changing it later needs a Headmaster + GES code re-verification.
+        </div>
+      </div>
+    );
+  }
 
-      {step === 2 && (
-        <div className="space-y-[18px]">
-          <h2 className="font-display text-2xl font-semibold text-navy">Headmaster</h2>
+  if (stepKey === "calendar") {
+    return (
+      <div>
+        <Head
+          pill={`Step ${stepNo} of ${total} · Academic calendar`}
+          title="Your academic"
+          em="year."
+          lede="Omnischools seeds the GES-standard calendar for your tier automatically. You'll be able to fine-tune term dates, holidays and week numbering once you're in."
+        />
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <SummaryCell label="Academic year" value={academicYearLabel()} sub="GES default" />
+          <SummaryCell label="Structure" value={periodWord} sub="per the GES standard" />
+          <SummaryCell label="Source" value="GES default" sub="editable in Settings" />
+        </div>
+        <div className="mt-4">
+          <InterimNote
+            title="Full calendar editor is coming next"
+            body="Per-term date pickers, holidays and the grading scale arrive in the next setup release. For now the GES default is applied so you can finish onboarding."
+          />
+        </div>
+      </div>
+    );
+  }
+
+  if (stepKey === "structure") {
+    return (
+      <div>
+        <Head
+          pill={`Step ${stepNo} of ${total} · Academic structure`}
+          title="Your classes"
+          em={isShs ? "& programmes." : "& subjects."}
+          lede={
+            isShs
+              ? "SHS schools build a programmes matrix — Science, Business, General Arts, Home Econ — with 4 universal cores and electives per programme."
+              : "Basic & JHS schools build a class list with subjects per class, loaded from the GES syllabus."
+          }
+        />
+        <InterimNote
+          title={isShs ? "Programmes, cores & electives" : "Classes & subjects"}
+          body={
+            isShs
+              ? "The WAEC programme matrix (cores + per-programme electives) is built here in the next release. For now, set programmes up from Classes after launch."
+              : "The GES class + subject builder is added here in the next release. For now, create your classes and subjects from Classes after launch."
+          }
+        />
+      </div>
+    );
+  }
+
+  if (stepKey === "staff") {
+    return (
+      <div>
+        <Head
+          pill={`Step ${stepNo} of ${total} · Staff & roles`}
+          title="Who runs"
+          em="the school?"
+          lede="Two people to start: the Headmaster, and the admin who signs in first and sets up the rest. Both log in with their phone number; email is optional. You can bulk-add the rest of your staff after launch."
+        />
+        <div className="space-y-6">
           <div>
-            <label className={labelClass}>Full name</label>
-            <input
-              className={fieldClass}
-              value={form.headmasterName ?? ""}
-              onChange={(e) => set("headmasterName", e.target.value)}
-              placeholder="e.g. V. Yanney"
-            />
-          </div>
-          <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2">
-            <div>
-              <label className={labelClass}>Phone (Ghana)</label>
-              <input
-                className={fieldClass}
-                value={form.headmasterPhone ?? ""}
-                onChange={(e) => set("headmasterPhone", e.target.value)}
-                placeholder="024 000 0000"
-              />
+            <div className="mb-2.5 text-[11px] font-semibold uppercase tracking-[0.06em] text-navy-3">
+              Headmaster
             </div>
-            <div>
-              <label className={labelClass}>
-                Email <span className="font-medium text-navy-3">— optional</span>
-              </label>
-              <input
-                className={fieldClass}
-                type="email"
-                value={form.headmasterEmail ?? ""}
-                onChange={(e) => set("headmasterEmail", e.target.value)}
-              />
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+              <Field label="Full name" req>
+                <input
+                  className={inputCls(!!f("headmasterName"))}
+                  value={f("headmasterName")}
+                  onChange={(e) => set("headmasterName", e.target.value)}
+                  placeholder="Mr K. Owusu-Frempong"
+                />
+              </Field>
+              <Field label="Phone (login)" req>
+                <input
+                  className={inputCls(!!f("headmasterPhone"))}
+                  value={f("headmasterPhone")}
+                  onChange={(e) => set("headmasterPhone", e.target.value)}
+                  placeholder="024 000 0000"
+                />
+              </Field>
+              <Field label="Email — optional">
+                <input
+                  className={inputCls(!!f("headmasterEmail"))}
+                  type="email"
+                  value={f("headmasterEmail")}
+                  onChange={(e) => set("headmasterEmail", e.target.value)}
+                />
+              </Field>
             </div>
           </div>
-        </div>
-      )}
-
-      {step === 3 && (
-        <div className="space-y-[18px]">
-          <h2 className="font-display text-2xl font-semibold text-navy">
-            Initial admin user
-          </h2>
-          <p className="text-sm text-navy-2">
-            This person signs in first and sets up the rest of the school. They&apos;ll
-            get the ADMIN role.
-          </p>
           <div>
-            <label className={labelClass}>Full name</label>
-            <input
-              className={fieldClass}
-              value={form.adminName ?? ""}
-              onChange={(e) => set("adminName", e.target.value)}
-              placeholder="e.g. School Office"
-            />
-          </div>
-          <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2">
-            <div>
-              <label className={labelClass}>Phone (Ghana)</label>
-              <input
-                className={fieldClass}
-                value={form.adminPhone ?? ""}
-                onChange={(e) => set("adminPhone", e.target.value)}
-                placeholder="024 000 0000"
-              />
+            <div className="mb-2.5 text-[11px] font-semibold uppercase tracking-[0.06em] text-navy-3">
+              Admin (first sign-in)
             </div>
-            <div>
-              <label className={labelClass}>
-                Email <span className="font-medium text-navy-3">— optional</span>
-              </label>
-              <input
-                className={fieldClass}
-                type="email"
-                value={form.adminEmail ?? ""}
-                onChange={(e) => set("adminEmail", e.target.value)}
-              />
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+              <Field label="Full name" req>
+                <input
+                  className={inputCls(!!f("adminName"))}
+                  value={f("adminName")}
+                  onChange={(e) => set("adminName", e.target.value)}
+                  placeholder="School Office"
+                />
+              </Field>
+              <Field label="Phone (login)" req>
+                <input
+                  className={inputCls(!!f("adminPhone"))}
+                  value={f("adminPhone")}
+                  onChange={(e) => set("adminPhone", e.target.value)}
+                  placeholder="024 000 0000"
+                />
+              </Field>
+              <Field label="Email — optional">
+                <input
+                  className={inputCls(!!f("adminEmail"))}
+                  type="email"
+                  value={f("adminEmail")}
+                  onChange={(e) => set("adminEmail", e.target.value)}
+                />
+              </Field>
             </div>
           </div>
         </div>
-      )}
+      </div>
+    );
+  }
 
-      {step === 4 && (
-        <div className="space-y-4">
-          <h2 className="font-display text-2xl font-semibold text-navy">
-            Confirm &amp; create
-          </h2>
-          <dl className="bg-bg divide-y divide-border rounded-xl border border-border">
-            {[
-              ["School", `${form.schoolName} · ${form.gesCode}`],
-              ["Location", `${form.district}, ${form.region} Region`],
-              ["Product", PRODUCT_LABELS[form.product ?? "BASIC"]],
-              ["Ownership", form.ownership],
-              ["Headmaster", `${form.headmasterName} · ${form.headmasterPhone}`],
-              ["Admin", `${form.adminName} · ${form.adminPhone}`],
-            ].map(([k, v]) => (
-              <div key={k} className="flex justify-between gap-4 px-4 py-2.5 text-sm">
-                <dt className="font-semibold text-navy-3">{k}</dt>
-                <dd className="text-right text-navy">{v}</dd>
+  if (stepKey === "billing") {
+    return (
+      <div>
+        <Head
+          pill={`Step ${stepNo} of ${total} · Billing & payments`}
+          title="Fees &"
+          em="payments."
+          lede="Fee structure, Mobile Money collection and (for public SHS) Free SHS handling. The full fee builder lives in Billing — set it up there once you're in."
+        />
+        <InterimNote
+          title="Fee structure & payments"
+          body="The fee-category builder, MoMo setup and Terms & Privacy acceptance are added to this step in the next release. For now you can configure fees from Billing after launch."
+        />
+      </div>
+    );
+  }
+
+  if (stepKey === "residency") {
+    return (
+      <div>
+        <Head
+          pill={`Step ${stepNo} of ${total} · Residency & boarding · SHS only`}
+          title="How do students"
+          em="live on campus?"
+          lede="Day, mixed or boarding — and an optional house system. This activates the Boarding and Sickbay modules. Captured here in a later release."
+        />
+        <InterimNote
+          title="Residency model & houses"
+          body="The residency picker (day / mixed / boarding), house system and visiting-day cadence are added here in the SHS setup release. Onboarding completes without them for now."
+        />
+      </div>
+    );
+  }
+
+  if (stepKey === "waec") {
+    return (
+      <div>
+        <Head
+          pill={`Step ${stepNo} of ${total} · WAEC centre & WASSCE · SHS only`}
+          title="Connect to"
+          em="WAEC."
+          lede="Your WAEC centre code unlocks the WASSCE module — registration, results and timetable sync. Captured here in a later release."
+        />
+        <InterimNote
+          title="WAEC centre & WASSCE programmes"
+          body="The centre code, regional office and first-cohort year are added here in the SHS setup release. Onboarding completes without them for now."
+        />
+      </div>
+    );
+  }
+
+  return null;
+}
+
+function SummaryCell({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="rounded-lg border border-border bg-surface p-3.5">
+      <div className="mb-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-navy-3">
+        {label}
+      </div>
+      <div className="font-display text-base font-medium text-navy">{value}</div>
+      {sub && <div className="mt-0.5 text-[11px] text-navy-3">{sub}</div>}
+    </div>
+  );
+}
+
+/* --------------------------------------------------------------------- review */
+
+function ReviewPanel({
+  form,
+  isShs,
+  periodWord,
+  onEdit,
+}: {
+  form: Form;
+  isShs: boolean;
+  periodWord: string;
+  onEdit: (key: string) => void;
+}) {
+  const card = form.subtype ? cardForSubtype(form.subtype) : null;
+  const cards: { step: string; key: string; rows: [string, string][] }[] = [
+    {
+      step: "School identity",
+      key: "identity",
+      rows: [
+        ["Name", form.schoolName ?? "—"],
+        ["GES code", form.gesCode ?? "—"],
+        ["CSSPS code", form.csspsCode || "—"],
+        ["Region · District", `${form.region ?? "—"} · ${form.district ?? "—"}`],
+        ["Ownership", form.ownership ?? "—"],
+      ],
+    },
+    {
+      step: "School type",
+      key: "type",
+      rows: [
+        ["Type", card ? `${card.name} · ${card.steps}-step path` : "—"],
+        ["Tier", card?.product ?? "—"],
+      ],
+    },
+    {
+      step: "Academic calendar",
+      key: "calendar",
+      rows: [
+        ["Year", academicYearLabel()],
+        ["Structure", `${periodWord} · GES default`],
+      ],
+    },
+    {
+      step: "Staff & roles",
+      key: "staff",
+      rows: [
+        ["Headmaster", `${form.headmasterName ?? "—"} · ${form.headmasterPhone ?? "—"}`],
+        ["Admin", `${form.adminName ?? "—"} · ${form.adminPhone ?? "—"}`],
+      ],
+    },
+  ];
+
+  return (
+    <div>
+      <div className="mb-6 rounded-xl border-2 border-green bg-gradient-to-br from-green-bg to-surface px-6 py-5">
+        <div className="grid grid-cols-[auto_1fr] items-center gap-4">
+          <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-green font-display text-2xl font-semibold text-surface">
+            ✓
+          </div>
+          <div>
+            <h3 className="font-display text-xl font-medium text-navy">
+              Ready to <em className="not-italic text-gold [font-style:italic]">launch.</em>
+            </h3>
+            <p className="mt-1 max-w-[520px] text-[13px] leading-relaxed text-navy-2">
+              Review the summary below — edit any step if needed. Launching creates your school,
+              its admin &amp; headmaster logins, and seeds the {periodWord} {academicYearLabel()}{" "}
+              calendar.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2">
+        {cards.map((c) => (
+          <div key={c.key} className="rounded-lg border border-border bg-bg p-4">
+            <div className="mb-2 flex items-baseline justify-between border-b border-border pb-2">
+              <div className="font-display text-sm font-semibold text-navy">{c.step}</div>
+              <button
+                onClick={() => onEdit(c.key)}
+                className="text-[11px] font-semibold text-gold hover:underline"
+              >
+                Edit →
+              </button>
+            </div>
+            {c.rows.map(([k, v]) => (
+              <div key={k} className="grid grid-cols-[110px_1fr] gap-2.5 py-1 text-[12px]">
+                <div className="text-navy-3">{k}</div>
+                <div className="font-semibold text-navy">{v}</div>
               </div>
             ))}
-          </dl>
-          <div className="rounded-xl border border-gold-soft bg-gold-bg p-4 text-sm text-navy-2">
-            We&apos;ll create the school, its product subscription, the admin &amp;
-            headmaster users, and seed the{" "}
-            <b className="text-navy">{academicYearLabel()}</b> calendar (
-            {form.product === "SENIOR" ? "2 semesters" : "3 terms"} per the GES standard).
           </div>
+        ))}
+      </div>
+
+      {isShs && (
+        <div className="mt-4 rounded-lg border border-gold-soft bg-gold-bg px-4 py-3 text-[12px] leading-relaxed text-navy-2">
+          Residency and WAEC setup (steps 7–8) will be captured in the SHS setup release — your
+          school launches as an SHS and those settings open afterwards.
         </div>
       )}
+    </div>
+  );
+}
 
-      {error && <p className="mt-4 text-sm text-terra">{error}</p>}
+/* ----------------------------------------------------------------------- done */
 
-      {/* controls */}
-      <div className="mt-8 flex items-center justify-between">
-        <button
-          type="button"
-          onClick={back}
-          disabled={step === 0 || submitting}
-          className="hover:bg-bg rounded-md px-4 py-2.5 text-sm font-semibold text-navy-2 transition-colors disabled:opacity-0"
-        >
-          ← Back
-        </button>
-        {step < STEPS.length - 1 ? (
-          <button
-            type="button"
-            onClick={next}
-            className="text-bg rounded-md bg-navy px-6 py-2.5 text-sm font-semibold transition-colors hover:bg-navy-deep"
+function DonePanel({
+  result,
+  schoolName,
+}: {
+  result: Extract<OnboardResult, { ok: true }>;
+  schoolName: string;
+}) {
+  return (
+    <div>
+      <div className="rounded-xl border-2 border-green bg-gradient-to-br from-green-bg to-surface px-7 py-7">
+        <div className="grid grid-cols-1 items-center gap-5 sm:grid-cols-[auto_1fr_auto]">
+          <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-green font-display text-2xl font-semibold text-surface">
+            ✓
+          </div>
+          <div>
+            <h3 className="font-display text-2xl font-medium text-navy">
+              You&apos;re <em className="not-italic text-gold [font-style:italic]">set up.</em>{" "}
+              Welcome to Omnischools.
+            </h3>
+            <p className="mt-1.5 max-w-[520px] text-[13px] leading-relaxed text-navy-2">
+              <b className="text-navy">{schoolName}</b> is configured. Academic year{" "}
+              <b className="text-navy">{result.academicYear}</b>{" "}
+              {result.periodsCreated > 0
+                ? `with ${result.periodsCreated} periods`
+                : "is set"}{" "}
+              and a welcome SMS is on its way to your admin number.
+            </p>
+          </div>
+          <Link
+            href="/login"
+            className="rounded-lg bg-gold px-6 py-3.5 text-sm font-bold text-navy transition-colors hover:brightness-95"
           >
-            Continue
-          </button>
-        ) : (
-          <button
-            type="button"
-            onClick={submit}
-            disabled={submitting}
-            className="rounded-md bg-gold px-6 py-2.5 text-sm font-semibold text-navy transition-colors hover:brightness-95 disabled:opacity-60"
-          >
-            {submitting ? "Creating…" : "Create school"}
-          </button>
-        )}
+            Go to sign in →
+          </Link>
+        </div>
       </div>
+
+      <div className="mt-6">
+        <div className="mb-3 font-display text-base font-medium text-navy">
+          Next steps · suggested order
+        </div>
+        <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2">
+          {[
+            ["First · this week", "Admit your students", "Enter or import your student list from Admissions or Students."],
+            ["Second · this week", "Invite your staff", "Bulk-add teachers and staff; each gets an invite to set a password."],
+            ["Third · before term", "Build your timetable", "The timetable reads your classes, subjects and staff from setup."],
+            ["Anytime · ongoing", "Customise settings", "Holidays, grading scale, fee categories and more in Settings."],
+          ].map(([tag, title, body]) => (
+            <div key={title} className="rounded-lg border border-border bg-bg px-5 py-4">
+              <div className="mb-1.5 text-[10px] font-bold uppercase tracking-[0.12em] text-gold">
+                {tag}
+              </div>
+              <div className="font-display text-sm font-semibold text-navy">{title}</div>
+              <p className="mt-1 text-[12px] leading-relaxed text-navy-3">{body}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <p className="mt-6 font-mono text-[11px] text-navy-3">school id · {result.schoolId}</p>
     </div>
   );
 }

--- a/omnischools/db/migrations/0011_real_hellfire_club.sql
+++ b/omnischools/db/migrations/0011_real_hellfire_club.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "ref_school" ADD COLUMN "cssps_code" text;--> statement-breakpoint
+ALTER TABLE "ref_school" ADD COLUMN "subtype" text;--> statement-breakpoint
+ALTER TABLE "ref_school" ADD COLUMN "year_founded" text;--> statement-breakpoint
+ALTER TABLE "ref_school" ADD COLUMN "address" text;

--- a/omnischools/db/migrations/meta/0011_snapshot.json
+++ b/omnischools/db/migrations/meta/0011_snapshot.json
@@ -1,0 +1,4854 @@
+{
+  "id": "680a5b01-f84f-473a-a7ec-791f8c9a3425",
+  "prevId": "46c7c3d7-ac8a-4a70-a83d-a295db80e578",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ref_district": {
+      "name": "ref_district",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_district_region_id_ref_region_id_fk": {
+          "name": "ref_district_region_id_ref_region_id_fk",
+          "tableFrom": "ref_district",
+          "tableTo": "ref_region",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_district_code_unique": {
+          "name": "ref_district_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_region": {
+      "name": "ref_region",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_region_code_unique": {
+          "name": "ref_region_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_school_product": {
+      "name": "ref_school_product",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product": {
+          "name": "product",
+          "type": "product",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_school_product_school_id_ref_school_id_fk": {
+          "name": "ref_school_product_school_id_ref_school_id_fk",
+          "tableFrom": "ref_school_product",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_school_product": {
+          "name": "uniq_school_product",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "product"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_school": {
+      "name": "ref_school",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ges_code": {
+          "name": "ges_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cssps_code": {
+          "name": "cssps_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_type": {
+          "name": "school_type",
+          "type": "school_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'BASIC'"
+        },
+        "subtype": {
+          "name": "subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shs_category": {
+          "name": "shs_category",
+          "type": "shs_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownership_type": {
+          "name": "ownership_type",
+          "type": "ownership_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRIVATE'"
+        },
+        "year_founded": {
+          "name": "year_founded",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "district_id": {
+          "name": "district_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_school_district_id_ref_district_id_fk": {
+          "name": "ref_school_district_id_ref_district_id_fk",
+          "tableFrom": "ref_school",
+          "tableTo": "ref_district",
+          "columnsFrom": [
+            "district_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ref_school_region_id_ref_region_id_fk": {
+          "name": "ref_school_region_id_ref_region_id_fk",
+          "tableFrom": "ref_school",
+          "tableTo": "ref_region",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_school_ges_code_unique": {
+          "name": "ref_school_ges_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "ges_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_assignment": {
+      "name": "role_assignment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_ref": {
+          "name": "scope_ref",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_assignment_user_id_ref_user_id_fk": {
+          "name": "role_assignment_user_id_ref_user_id_fk",
+          "tableFrom": "role_assignment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_assignment_school_id_ref_school_id_fk": {
+          "name": "role_assignment_school_id_ref_school_id_fk",
+          "tableFrom": "role_assignment",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_assignment_role_id_ref_role_id_fk": {
+          "name": "role_assignment_role_id_ref_role_id_fk",
+          "tableFrom": "role_assignment",
+          "tableTo": "ref_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_role": {
+      "name": "ref_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "app_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_role_code_unique": {
+          "name": "ref_role_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_user": {
+      "name": "ref_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_user_phone_unique": {
+          "name": "ref_user_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.academic_period": {
+      "name": "academic_period",
+      "schema": "",
+      "columns": {
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_number": {
+          "name": "period_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_label": {
+          "name": "period_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_on": {
+          "name": "ends_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "academic_period_school_id_academic_year_ref_academic_period_config_school_id_academic_year_fk": {
+          "name": "academic_period_school_id_academic_year_ref_academic_period_config_school_id_academic_year_fk",
+          "tableFrom": "academic_period",
+          "tableTo": "ref_academic_period_config",
+          "columnsFrom": [
+            "school_id",
+            "academic_year"
+          ],
+          "columnsTo": [
+            "school_id",
+            "academic_year"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_academic_period_config": {
+      "name": "ref_academic_period_config",
+      "schema": "",
+      "columns": {
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_type": {
+          "name": "period_type",
+          "type": "period_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_count": {
+          "name": "period_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "period_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured_at": {
+          "name": "configured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "configured_by": {
+          "name": "configured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_academic_period_config_school_id_ref_school_id_fk": {
+          "name": "ref_academic_period_config_school_id_ref_school_id_fk",
+          "tableFrom": "ref_academic_period_config",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ref_academic_period_config_configured_by_ref_user_id_fk": {
+          "name": "ref_academic_period_config_configured_by_ref_user_id_fk",
+          "tableFrom": "ref_academic_period_config",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "configured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ref_academic_period_config_school_id_academic_year_pk": {
+          "name": "ref_academic_period_config_school_id_academic_year_pk",
+          "columns": [
+            "school_id",
+            "academic_year"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gen_period_defaults": {
+      "name": "gen_period_defaults",
+      "schema": "",
+      "columns": {
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_line": {
+          "name": "product_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_number": {
+          "name": "period_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_label": {
+          "name": "period_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_on": {
+          "name": "ends_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_at": {
+          "name": "extracted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gen_period_defaults_reviewed_by_ref_user_id_fk": {
+          "name": "gen_period_defaults_reviewed_by_ref_user_id_fk",
+          "tableFrom": "gen_period_defaults",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gen_period_defaults_academic_year_product_line_period_number_pk": {
+          "name": "gen_period_defaults_academic_year_product_line_period_number_pk",
+          "columns": [
+            "academic_year",
+            "product_line",
+            "period_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "audit_id": {
+          "name": "audit_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_role": {
+          "name": "actor_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before_jsonb": {
+          "name": "before_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_jsonb": {
+          "name": "after_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_school_time_idx": {
+          "name": "audit_school_time_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_entity_idx": {
+          "name": "audit_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_school_id_ref_school_id_fk": {
+          "name": "audit_log_school_id_ref_school_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_log_actor_user_id_ref_user_id_fk": {
+          "name": "audit_log_actor_user_id_ref_user_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_anomaly_rule": {
+      "name": "ref_anomaly_rule",
+      "schema": "",
+      "columns": {
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_code": {
+          "name": "rule_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "anomaly_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applies_to": {
+          "name": "applies_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold_jsonb": {
+          "name": "threshold_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_anomaly_rule_rule_code_unique": {
+          "name": "ref_anomaly_rule_rule_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rule_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.marketing_lead": {
+      "name": "marketing_lead",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organisation": {
+          "name": "organisation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'demo_form'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.class": {
+      "name": "class",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_teacher_user_id": {
+          "name": "class_teacher_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "class_school_id_ref_school_id_fk": {
+          "name": "class_school_id_ref_school_id_fk",
+          "tableFrom": "class",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "class_class_teacher_user_id_ref_user_id_fk": {
+          "name": "class_class_teacher_user_id_ref_user_id_fk",
+          "tableFrom": "class",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "class_teacher_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_class_per_school": {
+          "name": "uniq_class_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_guardian": {
+      "name": "student_guardian",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "guardian_relation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GUARDIAN'"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "guardian_student_idx": {
+          "name": "guardian_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_guardian_school_id_ref_school_id_fk": {
+          "name": "student_guardian_school_id_ref_school_id_fk",
+          "tableFrom": "student_guardian",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_guardian_student_id_students_id_fk": {
+          "name": "student_guardian_student_id_students_id_fk",
+          "tableFrom": "student_guardian",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.students": {
+      "name": "students",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_code": {
+          "name": "student_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "other_names": {
+          "name": "other_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "student_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "current_class_label": {
+          "name": "current_class_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrolled_on": {
+          "name": "enrolled_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admission_application_id": {
+          "name": "admission_application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "students_school_idx": {
+          "name": "students_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "students_school_id_ref_school_id_fk": {
+          "name": "students_school_id_ref_school_id_fk",
+          "tableFrom": "students",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "students_class_id_class_id_fk": {
+          "name": "students_class_id_class_id_fk",
+          "tableFrom": "students",
+          "tableTo": "class",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_student_code_per_school": {
+          "name": "uniq_student_code_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admission_application": {
+      "name": "admission_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_first_name": {
+          "name": "applicant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_last_name": {
+          "name": "applicant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_other_names": {
+          "name": "applicant_other_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desired_class_label": {
+          "name": "desired_class_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guardian_name": {
+          "name": "guardian_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guardian_phone": {
+          "name": "guardian_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guardian_email": {
+          "name": "guardian_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "admission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SUBMITTED'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admission_school_status_idx": {
+          "name": "admission_school_status_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admission_application_school_id_ref_school_id_fk": {
+          "name": "admission_application_school_id_ref_school_id_fk",
+          "tableFrom": "admission_application",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admission_application_student_id_students_id_fk": {
+          "name": "admission_application_student_id_students_id_fk",
+          "tableFrom": "admission_application",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "admission_application_decided_by_user_id_ref_user_id_fk": {
+          "name": "admission_application_decided_by_user_id_ref_user_id_fk",
+          "tableFrom": "admission_application",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admission_document": {
+      "name": "admission_document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admission_document_school_id_ref_school_id_fk": {
+          "name": "admission_document_school_id_ref_school_id_fk",
+          "tableFrom": "admission_document",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admission_document_application_id_admission_application_id_fk": {
+          "name": "admission_document_application_id_admission_application_id_fk",
+          "tableFrom": "admission_document",
+          "tableTo": "admission_application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_category": {
+      "name": "fee_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_category_school_id_ref_school_id_fk": {
+          "name": "fee_category_school_id_ref_school_id_fk",
+          "tableFrom": "fee_category",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_fee_category_per_school": {
+          "name": "uniq_fee_category_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_line_item": {
+      "name": "invoice_line_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_category_id": {
+          "name": "fee_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_optional": {
+          "name": "is_optional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_line_item_school_id_ref_school_id_fk": {
+          "name": "invoice_line_item_school_id_ref_school_id_fk",
+          "tableFrom": "invoice_line_item",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_line_item_invoice_id_invoice_id_fk": {
+          "name": "invoice_line_item_invoice_id_invoice_id_fk",
+          "tableFrom": "invoice_line_item",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_line_item_fee_category_id_fee_category_id_fk": {
+          "name": "invoice_line_item_fee_category_id_fee_category_id_fk",
+          "tableFrom": "invoice_line_item",
+          "tableTo": "fee_category",
+          "columnsFrom": [
+            "fee_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice": {
+      "name": "invoice",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal_amount": {
+          "name": "subtotal_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "billed_amount": {
+          "name": "billed_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "balance_amount": {
+          "name": "balance_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ISSUED'"
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_student_idx": {
+          "name": "invoice_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_school_id_ref_school_id_fk": {
+          "name": "invoice_school_id_ref_school_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_student_id_students_id_fk": {
+          "name": "invoice_student_id_students_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_period_id_academic_period_period_id_fk": {
+          "name": "invoice_period_id_academic_period_period_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "period_id"
+          ],
+          "columnsTo": [
+            "period_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_invoice_number_per_school": {
+          "name": "uniq_invoice_number_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "invoice_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_allocation": {
+      "name": "payment_allocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allocation_type": {
+          "name": "allocation_type",
+          "type": "allocation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INVOICE'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allocation_method": {
+          "name": "allocation_method",
+          "type": "allocation_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MANUAL'"
+        },
+        "allocated_by_user_id": {
+          "name": "allocated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allocated_at": {
+          "name": "allocated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payment_allocation_school_id_ref_school_id_fk": {
+          "name": "payment_allocation_school_id_ref_school_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_allocation_payment_id_payment_id_fk": {
+          "name": "payment_allocation_payment_id_payment_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "payment",
+          "columnsFrom": [
+            "payment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_allocation_invoice_id_invoice_id_fk": {
+          "name": "payment_allocation_invoice_id_invoice_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_allocation_allocated_by_user_id_ref_user_id_fk": {
+          "name": "payment_allocation_allocated_by_user_id_ref_user_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "allocated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_audit_log": {
+      "name": "payment_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "payment_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "payment_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ADMIN'"
+        },
+        "before_state": {
+          "name": "before_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_state": {
+          "name": "after_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_audit_school_time_idx": {
+          "name": "payment_audit_school_time_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_audit_log_school_id_ref_school_id_fk": {
+          "name": "payment_audit_log_school_id_ref_school_id_fk",
+          "tableFrom": "payment_audit_log",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_audit_log_actor_user_id_ref_user_id_fk": {
+          "name": "payment_audit_log_actor_user_id_ref_user_id_fk",
+          "tableFrom": "payment_audit_log",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment": {
+      "name": "payment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gross_amount": {
+          "name": "gross_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_amount": {
+          "name": "fee_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "net_amount": {
+          "name": "net_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GHS'"
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method_reference": {
+          "name": "method_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregator": {
+          "name": "aggregator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settlement_status": {
+          "name": "settlement_status",
+          "type": "settlement_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_by_user_id": {
+          "name": "voided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payment_student_idx": {
+          "name": "payment_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_school_id_ref_school_id_fk": {
+          "name": "payment_school_id_ref_school_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_student_id_students_id_fk": {
+          "name": "payment_student_id_students_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_recorded_by_user_id_ref_user_id_fk": {
+          "name": "payment_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_voided_by_user_id_ref_user_id_fk": {
+          "name": "payment_voided_by_user_id_ref_user_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "voided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.receipt": {
+      "name": "receipt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receipt_number": {
+          "name": "receipt_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_replacement_id": {
+          "name": "void_replacement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "receipt_school_id_ref_school_id_fk": {
+          "name": "receipt_school_id_ref_school_id_fk",
+          "tableFrom": "receipt",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "receipt_payment_id_payment_id_fk": {
+          "name": "receipt_payment_id_payment_id_fk",
+          "tableFrom": "receipt",
+          "tableTo": "payment",
+          "columnsFrom": [
+            "payment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "receipt_student_id_students_id_fk": {
+          "name": "receipt_student_id_students_id_fk",
+          "tableFrom": "receipt",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "receipt_payment_id_unique": {
+          "name": "receipt_payment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "payment_id"
+          ]
+        },
+        "uniq_receipt_number_per_school": {
+          "name": "uniq_receipt_number_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "receipt_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discount": {
+      "name": "discount",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "discount_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'FIXED'"
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "discount_school_id_ref_school_id_fk": {
+          "name": "discount_school_id_ref_school_id_fk",
+          "tableFrom": "discount",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_discount_per_school": {
+          "name": "uniq_discount_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_structure_item": {
+      "name": "fee_structure_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_structure_id": {
+          "name": "fee_structure_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_category_id": {
+          "name": "fee_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_structure_item_school_id_ref_school_id_fk": {
+          "name": "fee_structure_item_school_id_ref_school_id_fk",
+          "tableFrom": "fee_structure_item",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fee_structure_item_fee_structure_id_fee_structure_id_fk": {
+          "name": "fee_structure_item_fee_structure_id_fee_structure_id_fk",
+          "tableFrom": "fee_structure_item",
+          "tableTo": "fee_structure",
+          "columnsFrom": [
+            "fee_structure_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fee_structure_item_fee_category_id_fee_category_id_fk": {
+          "name": "fee_structure_item_fee_category_id_fee_category_id_fk",
+          "tableFrom": "fee_structure_item",
+          "tableTo": "fee_category",
+          "columnsFrom": [
+            "fee_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_structure": {
+      "name": "fee_structure",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_structure_school_id_ref_school_id_fk": {
+          "name": "fee_structure_school_id_ref_school_id_fk",
+          "tableFrom": "fee_structure",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_fee_structure_per_school": {
+          "name": "uniq_fee_structure_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attendance_correction": {
+      "name": "attendance_correction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_record_id": {
+          "name": "attendance_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_status": {
+          "name": "requested_status",
+          "type": "attendance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "correction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attendance_correction_school_id_ref_school_id_fk": {
+          "name": "attendance_correction_school_id_ref_school_id_fk",
+          "tableFrom": "attendance_correction",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_correction_attendance_record_id_attendance_record_id_fk": {
+          "name": "attendance_correction_attendance_record_id_attendance_record_id_fk",
+          "tableFrom": "attendance_correction",
+          "tableTo": "attendance_record",
+          "columnsFrom": [
+            "attendance_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_correction_requested_by_user_id_ref_user_id_fk": {
+          "name": "attendance_correction_requested_by_user_id_ref_user_id_fk",
+          "tableFrom": "attendance_correction",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attendance_correction_decided_by_user_id_ref_user_id_fk": {
+          "name": "attendance_correction_decided_by_user_id_ref_user_id_fk",
+          "tableFrom": "attendance_correction",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attendance_record": {
+      "name": "attendance_record",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "attendance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marked_by_user_id": {
+          "name": "marked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marked_at": {
+          "name": "marked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attendance_class_date_idx": {
+          "name": "attendance_class_date_idx",
+          "columns": [
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attendance_record_school_id_ref_school_id_fk": {
+          "name": "attendance_record_school_id_ref_school_id_fk",
+          "tableFrom": "attendance_record",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_record_student_id_students_id_fk": {
+          "name": "attendance_record_student_id_students_id_fk",
+          "tableFrom": "attendance_record",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_record_class_id_class_id_fk": {
+          "name": "attendance_record_class_id_class_id_fk",
+          "tableFrom": "attendance_record",
+          "tableTo": "class",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_record_marked_by_user_id_ref_user_id_fk": {
+          "name": "attendance_record_marked_by_user_id_ref_user_id_fk",
+          "tableFrom": "attendance_record",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "marked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_attendance_student_day": {
+          "name": "uniq_attendance_student_day",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gradebook_config": {
+      "name": "gradebook_config",
+      "schema": "",
+      "columns": {
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "class_weight": {
+          "name": "class_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "exam_weight": {
+          "name": "exam_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gradebook_config_school_id_ref_school_id_fk": {
+          "name": "gradebook_config_school_id_ref_school_id_fk",
+          "tableFrom": "gradebook_config",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gradebook_score": {
+      "name": "gradebook_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_score": {
+          "name": "class_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exam_score": {
+          "name": "exam_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "score_period_subject_idx": {
+          "name": "score_period_subject_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gradebook_score_school_id_ref_school_id_fk": {
+          "name": "gradebook_score_school_id_ref_school_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_score_student_id_students_id_fk": {
+          "name": "gradebook_score_student_id_students_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_score_subject_id_subject_id_fk": {
+          "name": "gradebook_score_subject_id_subject_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_score_period_id_academic_period_period_id_fk": {
+          "name": "gradebook_score_period_id_academic_period_period_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "period_id"
+          ],
+          "columnsTo": [
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_score_updated_by_user_id_ref_user_id_fk": {
+          "name": "gradebook_score_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_score_student_subject_period": {
+          "name": "uniq_score_student_subject_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "subject_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_card": {
+      "name": "report_card",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overall_total": {
+          "name": "overall_total",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overall_grade": {
+          "name": "overall_grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_count": {
+          "name": "subject_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "report_card_school_id_ref_school_id_fk": {
+          "name": "report_card_school_id_ref_school_id_fk",
+          "tableFrom": "report_card",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "report_card_student_id_students_id_fk": {
+          "name": "report_card_student_id_students_id_fk",
+          "tableFrom": "report_card",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "report_card_period_id_academic_period_period_id_fk": {
+          "name": "report_card_period_id_academic_period_period_id_fk",
+          "tableFrom": "report_card",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "period_id"
+          ],
+          "columnsTo": [
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "report_card_generated_by_user_id_ref_user_id_fk": {
+          "name": "report_card_generated_by_user_id_ref_user_id_fk",
+          "tableFrom": "report_card",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_report_student_period": {
+          "name": "uniq_report_student_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subject": {
+      "name": "subject",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subject_school_id_ref_school_id_fk": {
+          "name": "subject_school_id_ref_school_id_fk",
+          "tableFrom": "subject",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_subject_per_school": {
+          "name": "uniq_subject_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.timetable_slot": {
+      "name": "timetable_slot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_index": {
+          "name": "period_index",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teacher_user_id": {
+          "name": "teacher_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "timetable_teacher_slot_idx": {
+          "name": "timetable_teacher_slot_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "teacher_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "timetable_slot_school_id_ref_school_id_fk": {
+          "name": "timetable_slot_school_id_ref_school_id_fk",
+          "tableFrom": "timetable_slot",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "timetable_slot_class_id_class_id_fk": {
+          "name": "timetable_slot_class_id_class_id_fk",
+          "tableFrom": "timetable_slot",
+          "tableTo": "class",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "timetable_slot_subject_id_subject_id_fk": {
+          "name": "timetable_slot_subject_id_subject_id_fk",
+          "tableFrom": "timetable_slot",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "timetable_slot_teacher_user_id_ref_user_id_fk": {
+          "name": "timetable_slot_teacher_user_id_ref_user_id_fk",
+          "tableFrom": "timetable_slot",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "teacher_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_timetable_class_slot": {
+          "name": "uniq_timetable_class_slot",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "class_id",
+            "day_of_week",
+            "period_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.announcement": {
+      "name": "announcement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "audience",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'WHOLE_SCHOOL'"
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_by_user_id": {
+          "name": "posted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "announcement_school_id_ref_school_id_fk": {
+          "name": "announcement_school_id_ref_school_id_fk",
+          "tableFrom": "announcement",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "announcement_class_id_class_id_fk": {
+          "name": "announcement_class_id_class_id_fk",
+          "tableFrom": "announcement",
+          "tableTo": "class",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "announcement_posted_by_user_id_ref_user_id_fk": {
+          "name": "announcement_posted_by_user_id_ref_user_id_fk",
+          "tableFrom": "announcement",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "posted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "notif_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'QUEUED'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_ref": {
+          "name": "provider_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_by_user_id": {
+          "name": "sent_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notif_school_time_idx": {
+          "name": "notif_school_time_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_log_school_id_ref_school_id_fk": {
+          "name": "notification_log_school_id_ref_school_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_log_student_id_students_id_fk": {
+          "name": "notification_log_student_id_students_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_log_template_id_sms_template_id_fk": {
+          "name": "notification_log_template_id_sms_template_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "sms_template",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_log_sent_by_user_id_ref_user_id_fk": {
+          "name": "notification_log_sent_by_user_id_ref_user_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "sent_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_template": {
+      "name": "sms_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sms_template_school_id_ref_school_id_fk": {
+          "name": "sms_template_school_id_ref_school_id_fk",
+          "tableFrom": "sms_template",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_template_per_school": {
+          "name": "uniq_template_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "conversation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "assigned_to_user_id": {
+          "name": "assigned_to_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_school_activity_idx": {
+          "name": "conversation_school_activity_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_phone_idx": {
+          "name": "conversation_phone_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_school_id_ref_school_id_fk": {
+          "name": "conversation_school_id_ref_school_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_student_id_students_id_fk": {
+          "name": "conversation_student_id_students_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "conversation_assigned_to_user_id_ref_user_id_fk": {
+          "name": "conversation_assigned_to_user_id_ref_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "assigned_to_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbox_message": {
+      "name": "inbox_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "message_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_by_user_id": {
+          "name": "sent_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inbox_message_conversation_idx": {
+          "name": "inbox_message_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbox_message_school_id_ref_school_id_fk": {
+          "name": "inbox_message_school_id_ref_school_id_fk",
+          "tableFrom": "inbox_message",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbox_message_conversation_id_conversation_id_fk": {
+          "name": "inbox_message_conversation_id_conversation_id_fk",
+          "tableFrom": "inbox_message",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbox_message_sent_by_user_id_ref_user_id_fk": {
+          "name": "inbox_message_sent_by_user_id_ref_user_id_fk",
+          "tableFrom": "inbox_message",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "sent_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite": {
+      "name": "invite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "app_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignments": {
+          "name": "assignments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_user_id": {
+          "name": "accepted_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invite_school_status_idx": {
+          "name": "invite_school_status_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_school_id_ref_school_id_fk": {
+          "name": "invite_school_id_ref_school_id_fk",
+          "tableFrom": "invite",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_invited_by_user_id_ref_user_id_fk": {
+          "name": "invite_invited_by_user_id_ref_user_id_fk",
+          "tableFrom": "invite",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invite_accepted_user_id_ref_user_id_fk": {
+          "name": "invite_accepted_user_id_ref_user_id_fk",
+          "tableFrom": "invite",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "accepted_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_token_unique": {
+          "name": "invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.admission_status": {
+      "name": "admission_status",
+      "schema": "public",
+      "values": [
+        "SUBMITTED",
+        "UNDER_REVIEW",
+        "ACCEPTED",
+        "REJECTED",
+        "WAITLISTED"
+      ]
+    },
+    "public.allocation_method": {
+      "name": "allocation_method",
+      "schema": "public",
+      "values": [
+        "MANUAL",
+        "AUTO_OLDEST_FIRST",
+        "AUTO_NEWEST_FIRST"
+      ]
+    },
+    "public.allocation_type": {
+      "name": "allocation_type",
+      "schema": "public",
+      "values": [
+        "INVOICE",
+        "CREDIT",
+        "REFUND"
+      ]
+    },
+    "public.anomaly_severity": {
+      "name": "anomaly_severity",
+      "schema": "public",
+      "values": [
+        "LOW",
+        "MEDIUM",
+        "HIGH"
+      ]
+    },
+    "public.app_role": {
+      "name": "app_role",
+      "schema": "public",
+      "values": [
+        "ADMIN",
+        "HEADMASTER",
+        "VICE_HEADMASTER_ACADEMIC",
+        "TEACHER",
+        "FORM_MASTER",
+        "HOUSEMASTER",
+        "STUDENT",
+        "PARENT",
+        "BURSAR",
+        "DEAN_OF_BOARDING",
+        "MATRON"
+      ]
+    },
+    "public.attendance_status": {
+      "name": "attendance_status",
+      "schema": "public",
+      "values": [
+        "PRESENT",
+        "ABSENT",
+        "LATE",
+        "EXCUSED",
+        "MEDICAL"
+      ]
+    },
+    "public.audience": {
+      "name": "audience",
+      "schema": "public",
+      "values": [
+        "WHOLE_SCHOOL",
+        "CLASS"
+      ]
+    },
+    "public.conversation_status": {
+      "name": "conversation_status",
+      "schema": "public",
+      "values": [
+        "OPEN",
+        "CLOSED"
+      ]
+    },
+    "public.correction_status": {
+      "name": "correction_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPROVED",
+        "REJECTED"
+      ]
+    },
+    "public.discount_kind": {
+      "name": "discount_kind",
+      "schema": "public",
+      "values": [
+        "PERCENT",
+        "FIXED"
+      ]
+    },
+    "public.guardian_relation": {
+      "name": "guardian_relation",
+      "schema": "public",
+      "values": [
+        "MOTHER",
+        "FATHER",
+        "GUARDIAN",
+        "OTHER"
+      ]
+    },
+    "public.invite_status": {
+      "name": "invite_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "REVOKED",
+        "EXPIRED"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "ISSUED",
+        "PARTIAL",
+        "PAID",
+        "OVERDUE",
+        "EXEMPT",
+        "VOIDED"
+      ]
+    },
+    "public.message_direction": {
+      "name": "message_direction",
+      "schema": "public",
+      "values": [
+        "INBOUND",
+        "OUTBOUND"
+      ]
+    },
+    "public.notif_status": {
+      "name": "notif_status",
+      "schema": "public",
+      "values": [
+        "QUEUED",
+        "SENT",
+        "FAILED"
+      ]
+    },
+    "public.ownership_type": {
+      "name": "ownership_type",
+      "schema": "public",
+      "values": [
+        "PUBLIC",
+        "PRIVATE",
+        "MISSION",
+        "INTERNATIONAL"
+      ]
+    },
+    "public.payment_actor_type": {
+      "name": "payment_actor_type",
+      "schema": "public",
+      "values": [
+        "ADMIN",
+        "SYSTEM",
+        "WEBHOOK",
+        "RECONCILIATION_JOB"
+      ]
+    },
+    "public.payment_event_type": {
+      "name": "payment_event_type",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "ALLOCATION_ADDED",
+        "ALLOCATION_VOIDED",
+        "SETTLED",
+        "VOIDED",
+        "SMS_SENT",
+        "SMS_FAILED",
+        "REFUNDED",
+        "DISCOUNT_OVERRIDDEN"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "MTN_MOMO",
+        "TELECEL_CASH",
+        "AIRTELTIGO_MONEY",
+        "BANK_TRANSFER",
+        "CASH",
+        "CHEQUE",
+        "OTHER"
+      ]
+    },
+    "public.period_source": {
+      "name": "period_source",
+      "schema": "public",
+      "values": [
+        "GES_DEFAULT",
+        "SCHOOL_OVERRIDE"
+      ]
+    },
+    "public.period_type": {
+      "name": "period_type",
+      "schema": "public",
+      "values": [
+        "TERM",
+        "SEMESTER"
+      ]
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "public",
+      "values": [
+        "BASIC",
+        "SENIOR",
+        "OVERSIGHT"
+      ]
+    },
+    "public.school_type": {
+      "name": "school_type",
+      "schema": "public",
+      "values": [
+        "BASIC",
+        "SENIOR",
+        "COMBINED"
+      ]
+    },
+    "public.settlement_status": {
+      "name": "settlement_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "CONFIRMED",
+        "SETTLED",
+        "RECONCILED",
+        "DISPUTED"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "MALE",
+        "FEMALE"
+      ]
+    },
+    "public.shs_category": {
+      "name": "shs_category",
+      "schema": "public",
+      "values": [
+        "A",
+        "B",
+        "C",
+        "D",
+        "E",
+        "F"
+      ]
+    },
+    "public.student_status": {
+      "name": "student_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "INACTIVE",
+        "GRADUATED",
+        "WITHDRAWN",
+        "TRANSFERRED"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/omnischools/db/migrations/meta/_journal.json
+++ b/omnischools/db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1781391173179,
       "tag": "0010_modern_the_captain",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1781438482769,
+      "tag": "0011_real_hellfire_club",
+      "breakpoints": true
     }
   ]
 }

--- a/omnischools/db/schema/tenancy.ts
+++ b/omnischools/db/schema/tenancy.ts
@@ -23,9 +23,14 @@ export const schools = pgTable("ref_school", {
   name: text("name").notNull(),
   shortName: text("short_name"), // SMS sign-off (e.g. ASANKSHS)
   gesCode: text("ges_code").notNull().unique(),
+  csspsCode: text("cssps_code"), // CSSPS placement code (SHS/TVI) — hm.cssps.gov.gh
   schoolType: schoolTypeEnum("school_type").notNull().default("BASIC"),
+  // Exact onboarding choice (BASIC/JHS/SHS/SHTS/MULTI) — finer than school_type enum.
+  subtype: text("subtype"),
   shsCategory: shsCategoryEnum("shs_category"),
   ownership: ownershipEnum("ownership_type").notNull().default("PRIVATE"),
+  yearFounded: text("year_founded"),
+  address: text("address"), // postal + GPS Ghana Post code
   districtId: uuid("district_id").references(() => districts.id),
   regionId: uuid("region_id").references(() => regions.id),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),

--- a/omnischools/lib/actions/onboarding.ts
+++ b/omnischools/lib/actions/onboarding.ts
@@ -53,6 +53,7 @@ export async function onboardSchool(input: unknown): Promise<OnboardResult> {
   const academicYear = currentAcademicYear();
   const schoolType = d.product === "COMBINED" ? "COMBINED" : d.product;
   const productLine = d.product === "SENIOR" ? "SENIOR" : "BASIC";
+  const nz = (v?: string) => (v && v.trim() ? v.trim() : null);
   const periodType = productLine === "SENIOR" ? "SEMESTER" : "TERM";
   const periodCount = productLine === "SENIOR" ? 2 : 3;
   const productRows: ("BASIC" | "SENIOR")[] =
@@ -113,10 +114,14 @@ export async function onboardSchool(input: unknown): Promise<OnboardResult> {
         .insert(schools)
         .values({
           name: d.schoolName,
-          shortName: shortName(d.schoolName),
+          shortName: nz(d.shortName) ?? shortName(d.schoolName),
           gesCode: d.gesCode,
+          csspsCode: nz(d.csspsCode),
           schoolType,
+          subtype: d.subtype ?? null,
           ownership: d.ownership,
+          yearFounded: nz(d.yearFounded),
+          address: nz(d.address),
           districtId,
           regionId,
         })

--- a/omnischools/lib/onboarding.ts
+++ b/omnischools/lib/onboarding.ts
@@ -30,12 +30,81 @@ export const PRODUCT_LABELS: Record<(typeof ONBOARD_PRODUCTS)[number], string> =
   COMBINED: "Combined — Basic + Senior",
 };
 
+/**
+ * School-type cards shown at step 2 — the branch point. The five live options map
+ * onto the coarser `school_type` enum (BASIC/SENIOR/COMBINED) + a `product`, while the
+ * exact card is kept in `subtype` for downstream fidelity (e.g. SHS vs SHTS programmes).
+ * Basic/JHS finish at step 6; SHS/SHTS/Multi-tier reveal the two SHS-only steps (7–8).
+ */
+export const SCHOOL_SUBTYPES = ["BASIC", "JHS", "SHS", "SHTS", "MULTI"] as const;
+export type SchoolSubtype = (typeof SCHOOL_SUBTYPES)[number];
+
+export type SchoolTypeCard = {
+  key: SchoolSubtype;
+  name: string;
+  desc: string;
+  steps: 6 | 8;
+  product: (typeof ONBOARD_PRODUCTS)[number];
+  schoolType: "BASIC" | "SENIOR" | "COMBINED";
+};
+
+export const SCHOOL_TYPE_CARDS: SchoolTypeCard[] = [
+  {
+    key: "BASIC",
+    name: "Basic",
+    desc: "KG + Primary, sometimes through P6. Class-based academic structure, subject teachers.",
+    steps: 6,
+    product: "BASIC",
+    schoolType: "BASIC",
+  },
+  {
+    key: "JHS",
+    name: "JHS",
+    desc: "Junior High School only. Class-based, BECE preparation in JHS3, standard GES syllabus.",
+    steps: 6,
+    product: "BASIC",
+    schoolType: "BASIC",
+  },
+  {
+    key: "SHS",
+    name: "SHS",
+    desc: "Senior High School. Programme-based (Science / Business / GA / Home Econ), 4 cores, WASSCE-bound.",
+    steps: 8,
+    product: "SENIOR",
+    schoolType: "SENIOR",
+  },
+  {
+    key: "SHTS",
+    name: "SHTS",
+    desc: "Senior High Technical School. Same WASSCE base + technical programmes (engineering, IT, building).",
+    steps: 8,
+    product: "SENIOR",
+    schoolType: "SENIOR",
+  },
+  {
+    key: "MULTI",
+    name: "Multi-tier",
+    desc: "Combined campus running two or more tiers (e.g. JHS + SHS, or Basic + JHS). Both structures coexist.",
+    steps: 8,
+    product: "COMBINED",
+    schoolType: "COMBINED",
+  },
+];
+
+export const cardForSubtype = (k: SchoolSubtype): SchoolTypeCard =>
+  SCHOOL_TYPE_CARDS.find((c) => c.key === k) ?? SCHOOL_TYPE_CARDS[0];
+
 export const OnboardSchema = z.object({
   schoolName: z.string().min(2, "School name is required").max(200),
+  shortName: z.string().max(60).optional().or(z.literal("")),
   gesCode: z.string().min(2, "GES code is required").max(40),
+  csspsCode: z.string().max(40).optional().or(z.literal("")),
+  yearFounded: z.string().max(8).optional().or(z.literal("")),
+  address: z.string().max(200).optional().or(z.literal("")),
   region: z.enum(GH_REGIONS),
   district: z.string().min(2, "District is required").max(120),
   product: z.enum(ONBOARD_PRODUCTS),
+  subtype: z.enum(SCHOOL_SUBTYPES).optional(),
   ownership: z.enum(OWNERSHIPS),
   headmasterName: z.string().min(2, "Headmaster name is required").max(160),
   headmasterPhone: z.string().min(7, "Headmaster phone is required").max(40),

--- a/omnischools/lib/onboarding.ts
+++ b/omnischools/lib/onboarding.ts
@@ -31,68 +31,80 @@ export const PRODUCT_LABELS: Record<(typeof ONBOARD_PRODUCTS)[number], string> =
 };
 
 /**
- * School-type cards shown at step 2 — the branch point. The five live options map
- * onto the coarser `school_type` enum (BASIC/SENIOR/COMBINED) + a `product`, while the
- * exact card is kept in `subtype` for downstream fidelity (e.g. SHS vs SHTS programmes).
- * Basic/JHS finish at step 6; SHS/SHTS/Multi-tier reveal the two SHS-only steps (7–8).
+ * School-type cards shown at step 2 — the branch point. Three cards map 1:1 onto the
+ * `school_type` enum: Basic (KG·Primary·JHS), Senior (SHS/SHTS), Multi-tier (Basic+Senior).
+ * Basic finishes at step 6; Senior and Multi-tier reveal the two SHS-only steps (7–8).
+ *
+ * `subtype` records the finer choice — for Senior it captures the SHS-vs-SHTS toggle so a
+ * later release can branch the Senior academic structure (SHTS ≈ TVET, different curriculum).
  */
-export const SCHOOL_SUBTYPES = ["BASIC", "JHS", "SHS", "SHTS", "MULTI"] as const;
+export const SCHOOL_SUBTYPES = ["BASIC", "SHS", "SHTS", "MULTI"] as const;
 export type SchoolSubtype = (typeof SCHOOL_SUBTYPES)[number];
 
+export type CardId = "BASIC" | "SENIOR" | "MULTI";
+
 export type SchoolTypeCard = {
-  key: SchoolSubtype;
+  id: CardId;
   name: string;
   desc: string;
   steps: 6 | 8;
   product: (typeof ONBOARD_PRODUCTS)[number];
   schoolType: "BASIC" | "SENIOR" | "COMBINED";
+  defaultSubtype: SchoolSubtype;
 };
 
 export const SCHOOL_TYPE_CARDS: SchoolTypeCard[] = [
   {
-    key: "BASIC",
+    id: "BASIC",
     name: "Basic",
-    desc: "KG + Primary, sometimes through P6. Class-based academic structure, subject teachers.",
+    desc: "KG · Primary · JHS. Class-based academic structure with subject teachers; BECE prep in JHS 3.",
     steps: 6,
     product: "BASIC",
     schoolType: "BASIC",
+    defaultSubtype: "BASIC",
   },
   {
-    key: "JHS",
-    name: "JHS",
-    desc: "Junior High School only. Class-based, BECE preparation in JHS3, standard GES syllabus.",
-    steps: 6,
-    product: "BASIC",
-    schoolType: "BASIC",
-  },
-  {
-    key: "SHS",
-    name: "SHS",
-    desc: "Senior High School. Programme-based (Science / Business / GA / Home Econ), 4 cores, WASSCE-bound.",
+    id: "SENIOR",
+    name: "Senior",
+    desc: "SHS / SHTS. Programme-based (Science / Business / GA / Home Econ), 4 cores, WASSCE-bound.",
     steps: 8,
     product: "SENIOR",
     schoolType: "SENIOR",
+    defaultSubtype: "SHS",
   },
   {
-    key: "SHTS",
-    name: "SHTS",
-    desc: "Senior High Technical School. Same WASSCE base + technical programmes (engineering, IT, building).",
-    steps: 8,
-    product: "SENIOR",
-    schoolType: "SENIOR",
-  },
-  {
-    key: "MULTI",
+    id: "MULTI",
     name: "Multi-tier",
-    desc: "Combined campus running two or more tiers (e.g. JHS + SHS, or Basic + JHS). Both structures coexist.",
+    desc: "Basic + Senior on one campus. Both structures coexist; follows the Senior path through setup.",
     steps: 8,
     product: "COMBINED",
     schoolType: "COMBINED",
+    defaultSubtype: "MULTI",
   },
 ];
 
-export const cardForSubtype = (k: SchoolSubtype): SchoolTypeCard =>
-  SCHOOL_TYPE_CARDS.find((c) => c.key === k) ?? SCHOOL_TYPE_CARDS[0];
+/** The SHS-vs-SHTS toggle shown once the Senior card is chosen (recorded in `subtype`). */
+export const SENIOR_TRACKS = [
+  {
+    key: "SHS",
+    label: "SHS",
+    desc: "Standard senior high — 4 WASSCE cores + electives per programme.",
+  },
+  {
+    key: "SHTS",
+    label: "SHTS / TVET",
+    desc: "Technical & vocational — curriculum differs; built out in the Senior release.",
+  },
+] as const;
+
+export const cardForSubtype = (s?: SchoolSubtype): SchoolTypeCard => {
+  if (s === "SHS" || s === "SHTS") return SCHOOL_TYPE_CARDS[1];
+  if (s === "MULTI") return SCHOOL_TYPE_CARDS[2];
+  return SCHOOL_TYPE_CARDS[0];
+};
+
+export const cardById = (id: CardId): SchoolTypeCard =>
+  SCHOOL_TYPE_CARDS.find((c) => c.id === id) ?? SCHOOL_TYPE_CARDS[0];
 
 export const OnboardSchema = z.object({
   schoolName: z.string().min(2, "School name is required").max(200),


### PR DESCRIPTION
## Step 5a — Unified onboarding: shell + identity + branch point

Rebuilds `/start` as the surface's unified onboarding wizard. First of the 5a–5d onboarding sub-PRs.

### Wizard shell (matches `schoolup-unified-onboarding`)
- Navy top bar (logo · "Omnischools onboarding" · school name · **Save & continue later** / **Exit**).
- **Vertical step nav** (dots + connectors, done/active/greyed states, progress header), with the two **SHS-only steps (7–8) shown greyed** for Basic schools.
- **localStorage autosave** ("Save & continue later" / restore on return).
- **Final review** screen (summary cards + per-step Edit →) → **Launch** → celebration + next-steps.
- Responsive: the vertical nav collapses on mobile to an inline step indicator.

### Step 1 — School identity (expanded)
Short name, **CSSPS code**, year founded, ownership, region/district, postal+GPS address. Entered fields get a gold "filled" tint. 5 of 7 required.

### Step 2 — School type (branch point) — **3 cards**
- **Basic** (KG·Primary·JHS) — 6 steps · `BASIC`
- **Senior** (SHS / SHTS) — 8 steps · `SENIOR` — reveals an **SHS / SHTS toggle**
- **Multi-tier** (Basic + Senior) — 8 steps · `COMBINED`

Maps 1:1 onto the existing `school_type` enum. Picking Senior/Multi-tier recalibrates the nav 6 → 8 and activates steps 7–8; Basic returns to 6. The SHS/SHTS choice is recorded in `subtype` — **SHTS (≈ TVET) curriculum handling is deferred to the Senior MVP** (its differentiated Step-4 structure is noted in the plan).

### Interim panels (kept functional, fleshed out in 5b–5d)
Steps 3 (calendar), 4 (structure), 6 (billing) and SHS stubs 7–8 render honest "configured after launch" panels so onboarding completes end-to-end. Step 5 captures the headmaster + admin the action needs.

### Schema — migration 0011
`ref_school` gains `cssps_code`, `subtype`, `year_founded`, `address` (all nullable). `onboardSchool` persists them. **Idempotent prod paste** (no RLS change — new columns inherit `ref_school`'s policy):
```sql
ALTER TABLE "ref_school" ADD COLUMN IF NOT EXISTS "cssps_code"   text;
ALTER TABLE "ref_school" ADD COLUMN IF NOT EXISTS "subtype"      text;
ALTER TABLE "ref_school" ADD COLUMN IF NOT EXISTS "year_founded" text;
ALTER TABLE "ref_school" ADD COLUMN IF NOT EXISTS "address"      text;
```

### Verification
- `pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm build` ✓ (`/start` 24.6 kB)
- Browser walk-through on the dev server: Step 1 identity, Step 2 3-card branch (Basic↔Senior toggles nav 6↔8), Senior SHS/SHTS toggle, full Basic flow → review screen; no console errors. Mobile nav collapse confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)