### PR TITLE
feat(onboarding): step 4 academic structure + autosave fix (redesign step 5b-ii)

### DIFF
--- a/omnischools/components/onboarding/wizard.tsx
+++ b/omnischools/components/onboarding/wizard.tsx
@@ -9,8 +9,14 @@ import {
   SENIOR_TRACKS,
   PERIOD_CHOICES,
   GRADE_SCALE_PRESETS,
+  SHS_PROGRAMMES,
+  WASSCE_CORE_SUBJECTS,
   currentAcademicYearLabel,
   defaultGradePreset,
+  defaultClasses,
+  defaultSubjects,
+  hasClassWing,
+  hasSeniorWing,
   cardForSubtype,
   cardById,
   type CardId,
@@ -90,9 +96,13 @@ export function OnboardingWizard() {
     hydrated.current = true;
   }, []);
 
-  // Persist the draft whenever it changes (after initial hydration).
+  // Persist the draft whenever it changes (after initial hydration). Never write the
+  // empty initial form — that would clobber a saved draft on mount, before the restore
+  // effect's state has committed (and again under StrictMode's double-invoked effects).
   useEffect(() => {
     if (!hydrated.current) return;
+    const untouched = !form.schoolName && !form.subtype && stepIdx === 0;
+    if (untouched) return;
     try {
       localStorage.setItem(DRAFT_KEY, JSON.stringify({ form, stepIdx }));
     } catch {
@@ -463,6 +473,81 @@ function InterimNote({ title, body }: { title: string; body: string }) {
   );
 }
 
+/** Editable chip list — removable tags + an add input. Used for classes & subjects. */
+function ChipEditor({
+  title,
+  hint,
+  items,
+  onAdd,
+  onRemove,
+  value,
+  setValue,
+  placeholder,
+}: {
+  title: string;
+  hint: string;
+  items: string[];
+  onAdd: (v: string) => void;
+  onRemove: (i: number) => void;
+  value: string;
+  setValue: (v: string) => void;
+  placeholder: string;
+}) {
+  const commit = () => {
+    onAdd(value);
+    setValue("");
+  };
+  return (
+    <div className="rounded-xl border border-border bg-bg p-5">
+      <div className="font-display text-base font-medium text-navy">
+        {title} <span className="text-navy-3">· {items.length}</span>
+      </div>
+      <p className="mb-3 mt-0.5 text-[12px] text-navy-3">{hint}</p>
+      {items.length > 0 && (
+        <div className="mb-3 flex flex-wrap gap-1.5">
+          {items.map((it, i) => (
+            <span
+              key={`${it}-${i}`}
+              className="inline-flex items-center gap-1.5 rounded-full border border-border-2 bg-surface py-1 pl-3 pr-1.5 text-[12px] font-medium text-navy"
+            >
+              {it}
+              <button
+                type="button"
+                onClick={() => onRemove(i)}
+                aria-label={`Remove ${it}`}
+                className="flex h-4 w-4 items-center justify-center rounded-full text-navy-3 transition-colors hover:bg-terra-bg hover:text-terra"
+              >
+                ✕
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+      <div className="flex gap-2">
+        <input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              commit();
+            }
+          }}
+          placeholder={placeholder}
+          className={inputCls(false)}
+        />
+        <button
+          type="button"
+          onClick={commit}
+          className="shrink-0 rounded-lg border border-border-2 bg-surface px-4 py-2.5 text-sm font-semibold text-navy transition-colors hover:bg-gold-bg"
+        >
+          Add
+        </button>
+      </div>
+    </div>
+  );
+}
+
 function StepBody({
   stepKey,
   form,
@@ -486,6 +571,8 @@ function StepBody({
 }) {
   const f = (k: keyof Form) => (form[k] as string) ?? "";
   const selectedCard = form.subtype ? cardForSubtype(form.subtype) : null;
+  const [newClass, setNewClass] = useState("");
+  const [newSubject, setNewSubject] = useState("");
 
   if (stepKey === "identity") {
     return (
@@ -867,26 +954,110 @@ function StepBody({
   }
 
   if (stepKey === "structure") {
+    const showClasses = hasClassWing(form.subtype);
+    const showProgrammes = hasSeniorWing(form.subtype);
+    const classList = form.classes ?? defaultClasses(form.subtype);
+    const subjectList = form.subjects ?? defaultSubjects(form.subtype);
+    const listFor = (key: "classes" | "subjects") =>
+      key === "classes" ? classList : subjectList;
+
+    const addItem = (key: "classes" | "subjects", val: string) => {
+      const v = val.trim();
+      if (!v) return;
+      setForm((prev) => {
+        const base = (prev[key] as string[] | undefined) ?? listFor(key);
+        if (base.some((x) => x.toLowerCase() === v.toLowerCase())) return prev;
+        return { ...prev, [key]: [...base, v] };
+      });
+    };
+    const removeItem = (key: "classes" | "subjects", idx: number) =>
+      setForm((prev) => {
+        const base = (prev[key] as string[] | undefined) ?? listFor(key);
+        return { ...prev, [key]: base.filter((_, i) => i !== idx) };
+      });
+
     return (
       <div>
         <Head
           pill={`Step ${stepNo} of ${total} · Academic structure`}
           title="Your classes"
-          em={isShs ? "& programmes." : "& subjects."}
+          em={showProgrammes && !showClasses ? "& programmes." : "& subjects."}
           lede={
-            isShs
-              ? "SHS schools build a programmes matrix — Science, Business, General Arts, Home Econ — with 4 universal cores and electives per programme."
-              : "Basic & JHS schools build a class list with subjects per class, loaded from the GES syllabus."
+            showProgrammes && !showClasses
+              ? "Senior schools are programme-based — Science, Business, General Arts, Home Econ — over four universal WASSCE cores. Confirm the cores now; the full programme matrix is built in the Senior release."
+              : "Build your class list and the subjects you teach. We've pre-filled the GES defaults — add or remove to match your school."
           }
         />
-        <InterimNote
-          title={isShs ? "Programmes, cores & electives" : "Classes & subjects"}
-          body={
-            isShs
-              ? "The WAEC programme matrix (cores + per-programme electives) is built here in the next release. For now, set programmes up from Classes after launch."
-              : "The GES class + subject builder is added here in the next release. For now, create your classes and subjects from Classes after launch."
-          }
-        />
+
+        {showClasses && (
+          <ChipEditor
+            title="Classes"
+            hint="Forms / classes students belong to. Attendance and the timetable hang off these."
+            items={classList}
+            onAdd={(v) => addItem("classes", v)}
+            onRemove={(i) => removeItem("classes", i)}
+            value={newClass}
+            setValue={setNewClass}
+            placeholder="e.g. JHS 1"
+          />
+        )}
+
+        <div className={showClasses ? "mt-4" : ""}>
+          <ChipEditor
+            title={showProgrammes && !showClasses ? "Core subjects" : "Subjects"}
+            hint={
+              showProgrammes && !showClasses
+                ? "The four universal WASSCE cores. Programme electives are added with the programme builder in the Senior release."
+                : "Subjects taught across the school. These feed the gradebook and report cards."
+            }
+            items={subjectList}
+            onAdd={(v) => addItem("subjects", v)}
+            onRemove={(i) => removeItem("subjects", i)}
+            value={newSubject}
+            setValue={setNewSubject}
+            placeholder="e.g. Twi"
+          />
+        </div>
+
+        {showProgrammes && (
+          <div className="mt-4 rounded-xl border border-border bg-bg p-5">
+            <div className="flex items-baseline justify-between gap-3">
+              <div className="font-display text-base font-medium text-navy">
+                Programmes <span className="text-navy-3">· preview</span>
+              </div>
+              <span className="rounded-full bg-gold-bg px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.1em] text-gold">
+                Senior release
+              </span>
+            </div>
+            <p className="mt-0.5 text-[12px] text-navy-3">
+              The WASSCE programme matrix (electives per programme) is built after launch.
+              Here&apos;s what your Senior wing will offer:
+            </p>
+            <div className="mt-3 grid grid-cols-1 gap-2.5 sm:grid-cols-2">
+              {SHS_PROGRAMMES.map((p) => (
+                <div key={p.name} className="rounded-lg border border-border bg-surface p-3">
+                  <div className="font-display text-[13px] font-semibold text-navy">
+                    {p.name}
+                  </div>
+                  <div className="mt-1.5 flex flex-wrap gap-1.5">
+                    {p.electives.map((e) => (
+                      <span
+                        key={e}
+                        className="rounded-full border border-gold-soft bg-gold-bg px-2 py-0.5 text-[10px] font-medium text-gold"
+                      >
+                        {e}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+            <p className="mt-3 text-[11px] text-navy-3">
+              Cores ({WASSCE_CORE_SUBJECTS.length}) apply to every programme · electives shown
+              are GES defaults you&apos;ll confirm later.
+            </p>
+          </div>
+        )}
       </div>
     );
   }
@@ -1041,6 +1212,8 @@ function ReviewPanel({
     PERIOD_CHOICES[isShs ? 1 : 0];
   const datedCount = (form.terms ?? []).filter((t) => t.startsOn && t.endsOn).length;
   const grades = form.gradeScale ?? GRADE_SCALE_PRESETS[defaultGradePreset(form.subtype)];
+  const classCount = (form.classes ?? defaultClasses(form.subtype)).length;
+  const subjectCount = (form.subjects ?? defaultSubjects(form.subtype)).length;
   const cards: { step: string; key: string; rows: [string, string][] }[] = [
     {
       step: "School identity",
@@ -1078,6 +1251,20 @@ function ReviewPanel({
           `${calChoice.label}${datedCount > 0 ? ` · ${datedCount} dated` : " · GES default"}`,
         ],
         ["Grade scale", `${grades.length} grades (${grades.map((g) => g.grade).join(", ")})`],
+      ],
+    },
+    {
+      step: "Academic structure",
+      key: "structure",
+      rows: [
+        ["Classes", classCount > 0 ? `${classCount} classes` : "Programme-based"],
+        ["Subjects", `${subjectCount} subjects`],
+        ...(hasSeniorWing(form.subtype)
+          ? ([["Programmes", `${SHS_PROGRAMMES.length} (Senior release)`]] as [
+              string,
+              string,
+            ][])
+          : []),
       ],
     },
     {

--- a/omnischools/lib/actions/onboarding.ts
+++ b/omnischools/lib/actions/onboarding.ts
@@ -5,6 +5,8 @@ import {
   type OnboardResult,
   GRADE_SCALE_PRESETS,
   defaultGradePreset,
+  defaultClasses,
+  defaultSubjects,
 } from "@/lib/onboarding";
 import { withoutTenantScope } from "@/lib/db/rls";
 import { recordAudit } from "@/lib/db/audit";
@@ -24,6 +26,8 @@ import {
   academicPeriod,
   genPeriodDefaults,
   gradeScale,
+  classes,
+  subjects,
 } from "@/db/schema";
 
 const FOUNDER_EMAIL = "hello@omnischools.gh";
@@ -71,6 +75,11 @@ export async function onboardSchool(input: unknown): Promise<OnboardResult> {
     d.gradeScale && d.gradeScale.length > 0
       ? d.gradeScale
       : GRADE_SCALE_PRESETS[defaultGradePreset(d.subtype)];
+  // Academic structure — the wizard's lists, else the tier defaults.
+  const uniqTrim = (xs: string[]) =>
+    Array.from(new Set(xs.map((s) => s.trim()).filter(Boolean)));
+  const classNames = uniqTrim(d.classes ?? defaultClasses(d.subtype));
+  const subjectNames = uniqTrim(d.subjects ?? defaultSubjects(d.subtype));
   const productRows: ("BASIC" | "SENIOR")[] =
     d.product === "COMBINED" ? ["BASIC", "SENIOR"] : [d.product];
 
@@ -250,6 +259,20 @@ export async function onboardSchool(input: unknown): Promise<OnboardResult> {
           ordinal: i,
         })),
       );
+
+      // academic structure — seed classes + subjects (wizard lists or tier defaults)
+      if (classNames.length > 0) {
+        await tx
+          .insert(classes)
+          .values(classNames.map((name) => ({ schoolId: school.id, name })))
+          .onConflictDoNothing({ target: [classes.schoolId, classes.name] });
+      }
+      if (subjectNames.length > 0) {
+        await tx
+          .insert(subjects)
+          .values(subjectNames.map((name) => ({ schoolId: school.id, name })))
+          .onConflictDoNothing({ target: [subjects.schoolId, subjects.name] });
+      }
 
       await recordAudit(tx, {
         schoolId: school.id,

--- a/omnischools/lib/onboarding.ts
+++ b/omnischools/lib/onboarding.ts
@@ -170,6 +170,88 @@ export const GRADE_SCALE_PRESETS: Record<"BASIC" | "WASSCE", GradeRow[]> = {
 export const defaultGradePreset = (subtype?: SchoolSubtype): "BASIC" | "WASSCE" =>
   subtype === "SHS" || subtype === "SHTS" ? "WASSCE" : "BASIC";
 
+/* --------------------------------------------- academic structure (step 4) */
+
+/** GES Basic ladder — KG through JHS. Seeded as editable class rows for Basic/Multi. */
+export const GES_BASIC_CLASSES = [
+  "KG 1",
+  "KG 2",
+  "Basic 1",
+  "Basic 2",
+  "Basic 3",
+  "Basic 4",
+  "Basic 5",
+  "Basic 6",
+  "JHS 1",
+  "JHS 2",
+  "JHS 3",
+];
+
+/** Common GES Basic-school subjects. */
+export const GES_BASIC_SUBJECTS = [
+  "English Language",
+  "Mathematics",
+  "Integrated Science",
+  "Our World Our People",
+  "Computing (ICT)",
+  "Creative Arts & Design",
+  "Ghanaian Language",
+  "Religious & Moral Education",
+  "French",
+  "Physical Education",
+];
+
+/** The four universal WASSCE cores (every SHS programme). */
+export const WASSCE_CORE_SUBJECTS = [
+  "English Language",
+  "Mathematics (Core)",
+  "Integrated Science",
+  "Social Studies",
+];
+
+/** SHS programmes shown as a stub at step 4 — the full matrix lands in the Senior MVP. */
+export const SHS_PROGRAMMES = [
+  { name: "Science", electives: ["Chemistry", "Physics", "Biology", "Elective Maths"] },
+  {
+    name: "Business",
+    electives: [
+      "Financial Accounting",
+      "Cost Accounting",
+      "Business Management",
+      "Economics",
+    ],
+  },
+  {
+    name: "General Arts",
+    electives: ["Literature", "Geography", "Government", "History / CRS / French"],
+  },
+  {
+    name: "Home Economics",
+    electives: [
+      "Management in Living",
+      "Food & Nutrition",
+      "Clothing & Textiles",
+      "Biology",
+    ],
+  },
+];
+
+/** Has a class-based wing (Basic or Multi-tier) → show the classes builder. */
+export const hasClassWing = (s?: SchoolSubtype): boolean => s !== "SHS" && s !== "SHTS";
+/** Has a senior wing (SHS/SHTS/Multi-tier) → show the programmes stub. */
+export const hasSeniorWing = (s?: SchoolSubtype): boolean =>
+  s === "SHS" || s === "SHTS" || s === "MULTI";
+
+export const defaultClasses = (s?: SchoolSubtype): string[] =>
+  hasClassWing(s) ? GES_BASIC_CLASSES : [];
+
+export const defaultSubjects = (s?: SchoolSubtype): string[] =>
+  s === "SHS" || s === "SHTS"
+    ? WASSCE_CORE_SUBJECTS
+    : s === "MULTI"
+      ? Array.from(new Set([...GES_BASIC_SUBJECTS, ...WASSCE_CORE_SUBJECTS]))
+      : GES_BASIC_SUBJECTS;
+
 export const OnboardSchema = z.object({
   schoolName: z.string().min(2, "School name is required").max(200),
   shortName: z.string().max(60).optional().or(z.literal("")),
@@ -207,6 +289,9 @@ export const OnboardSchema = z.object({
     )
     .max(15)
     .optional(),
+  // Step 4 — academic structure (optional; falls back to tier defaults)
+  classes: z.array(z.string().max(60)).max(60).optional(),
+  subjects: z.array(z.string().max(60)).max(80).optional(),
   headmasterName: z.string().min(2, "Headmaster name is required").max(160),
   headmasterPhone: z.string().min(7, "Headmaster phone is required").max(40),
   headmasterEmail: z.string().email().optional().or(z.literal("")),


### PR DESCRIPTION
## Step 5b-ii — Academic structure (Step 4)

Replaces the interim Step 4 panel with a working academic-structure builder. Final slice of 5b. **No migration** — uses the existing `class` / `subject` tables.

### Step 4 — Academic structure
- **Basic / Multi-tier:** editable **Classes** + **Subjects** chip lists, pre-filled with the GES Basic ladder (KG–JHS 3) and common GES subjects. Add via input, remove via chip ✕.
- **Senior (SHS/SHTS):** the four universal **WASSCE cores** as an editable list, plus a read-only **Programmes preview** (Science / Business / General Arts / Home Econ with electives) flagged **"Senior release"** — the full programme matrix is deferred to the Senior MVP (per the earlier SHTS scope decision).
- **Multi-tier** shows both the class builder and the programme preview.

### Persistence (`onboardSchool`)
- Seeds `class` + `subject` rows from the wizard lists, else the tier defaults (`onConflictDoNothing` on the per-school unique names).
- Review screen gains an **Academic structure** card (classes / subjects / programmes).

### Autosave fix (bonus)
The draft persist effect no longer writes the empty initial form. On mount — and under React StrictMode's double-invoked effects — it could otherwise **clobber a saved "continue later" draft** before the restore effect's state committed. Restore-from-draft is now reliable. (Real user-facing flaw in the 5a autosave, surfaced while verifying this step.)

### Verification
- `pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm build` ✓ (`/start` 30.2 kB)
- Browser walk-through on a clean dev server: Basic classes/subjects add+remove (remove KG 1 → 10 classes; add Twi → 11 subjects); SHS cores (4) + programme stub (4 programmes + electives, "Senior release"); draft restore lands on Step 4; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)