### PR TITLE
feat(staff): in-app bulk CSV import with invites (redesign step 6)

### DIFF
--- a/omnischools/app/(app)/staff/import/page.tsx
+++ b/omnischools/app/(app)/staff/import/page.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import { requireSchool } from "@/lib/auth/server";
+import { StaffImport } from "@/components/staff/staff-import";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Import staff" };
+
+export default async function ImportStaffPage() {
+  await requireSchool();
+
+  return (
+    <div className="mx-auto max-w-page">
+      <Link href="/staff" className="text-sm text-navy-3 hover:text-gold">
+        ← Staff
+      </Link>
+      <div className="mb-6 mt-2 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="font-display text-3xl font-semibold text-navy">Import staff</h1>
+          <p className="text-sm text-navy-3">
+            Add many staff at once from a CSV — each can be invited to set their own
+            password — or{" "}
+            <Link href="/staff" className="text-gold underline">
+              add a single staff member
+            </Link>
+            .
+          </p>
+        </div>
+      </div>
+      <StaffImport />
+    </div>
+  );
+}

--- a/omnischools/app/(app)/staff/page.tsx
+++ b/omnischools/app/(app)/staff/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { and, asc, eq, inArray } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
@@ -62,7 +63,15 @@ export default async function StaffPage() {
             and admins who can sign in.
           </p>
         </div>
-        <AddStaffForm />
+        <div className="flex items-center gap-2">
+          <Link
+            href="/staff/import"
+            className="rounded-md border border-border-2 px-4 py-2.5 text-sm font-semibold text-navy-2 transition-colors hover:bg-bg"
+          >
+            Import
+          </Link>
+          <AddStaffForm />
+        </div>
       </div>
 
       {staff.length === 0 ? (

--- a/omnischools/components/staff/staff-import.tsx
+++ b/omnischools/components/staff/staff-import.tsx
@@ -1,0 +1,223 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { parseCsv, csvTemplate } from "@/lib/import/csv";
+import {
+  validateStaffRows,
+  STAFF_IMPORT_HEADERS,
+  STAFF_IMPORT_SAMPLE,
+  type StaffImportRow,
+  type ImportSummary,
+} from "@/lib/import/staff-import";
+import { importStaff } from "@/lib/actions/staff";
+
+type Filter = "all" | "ready" | "warning" | "error";
+
+export function StaffImport() {
+  const router = useRouter();
+  const [rows, setRows] = useState<StaffImportRow[]>([]);
+  const [summary, setSummary] = useState<ImportSummary | null>(null);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [filter, setFilter] = useState<Filter>("all");
+  const [invite, setInvite] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [done, setDone] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  function downloadTemplate() {
+    const csv = csvTemplate(STAFF_IMPORT_HEADERS, STAFF_IMPORT_SAMPLE);
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "omnischools-staff-template.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  async function onFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setFileName(file.name);
+    setDone(null);
+    setError(null);
+    const text = await file.text();
+    const data = parseCsv(text).slice(1); // drop header row
+    const { rows, summary } = validateStaffRows(data);
+    setRows(rows);
+    setSummary(summary);
+    setFilter("all");
+  }
+
+  async function runImport() {
+    const importable = rows.filter((r) => r.errors.length === 0);
+    if (importable.length === 0) return;
+    setBusy(true);
+    setError(null);
+    const res = await importStaff({
+      rows: importable.map((r) => ({
+        fullName: r.fullName,
+        phone: r.phone,
+        email: r.email,
+        role: r.role,
+      })),
+      sendInvites: invite,
+    });
+    setBusy(false);
+    if (res.ok) {
+      const inv = invite && res.invited ? ` · ${res.invited} invited` : "";
+      setDone(`Added ${res.created} staff member${res.created === 1 ? "" : "s"}${inv}.`);
+      setRows([]);
+      setSummary(null);
+      setFileName(null);
+      router.refresh();
+    } else setError(res.error ?? "Could not import staff.");
+  }
+
+  const shown = rows.filter((r) =>
+    filter === "all"
+      ? true
+      : filter === "error"
+        ? r.errors.length > 0
+        : filter === "warning"
+          ? r.errors.length === 0 && r.warnings.length > 0
+          : r.errors.length === 0 && r.warnings.length === 0,
+  );
+  const importable = rows.filter((r) => r.errors.length === 0).length;
+
+  const pill = (f: Filter, label: string, tone: string) => (
+    <button
+      onClick={() => setFilter(f)}
+      className={`rounded-pill px-3 py-1 text-xs font-semibold ${
+        filter === f ? tone : "bg-bg text-navy-3"
+      }`}
+    >
+      {label}
+    </button>
+  );
+
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-wrap items-center gap-3 rounded-xl border border-border bg-surface p-5">
+        <div className="min-w-0 flex-1">
+          <h2 className="font-display text-lg font-semibold text-navy">
+            Bulk import from CSV
+          </h2>
+          <p className="text-sm text-navy-3">
+            Download the template, fill it in, and upload. We validate every row before
+            anything is saved. Staff sign in with their phone number.
+          </p>
+        </div>
+        <button
+          onClick={downloadTemplate}
+          className="rounded-md border border-border-2 px-4 py-2 text-sm font-semibold text-navy-2 transition-colors hover:bg-bg"
+        >
+          ↓ Template
+        </button>
+        <label className="cursor-pointer rounded-md bg-navy px-4 py-2 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep">
+          Upload CSV
+          <input type="file" accept=".csv,text/csv" onChange={onFile} className="hidden" />
+        </label>
+      </div>
+
+      {done && (
+        <p className="rounded-md bg-green-bg px-4 py-3 text-sm font-medium text-green">
+          {done}
+        </p>
+      )}
+      {error && <p className="text-sm text-terra">{error}</p>}
+
+      {summary && (
+        <>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            {[
+              ["Total rows", summary.total, "text-navy"],
+              ["Ready", summary.ready, "text-green"],
+              ["Warnings", summary.warning, "text-warn"],
+              ["Errors", summary.error, "text-terra"],
+            ].map(([label, n, tone]) => (
+              <div
+                key={label as string}
+                className="rounded-xl border border-border bg-surface p-4"
+              >
+                <div className="text-xs font-semibold uppercase tracking-wide text-navy-3">
+                  {label}
+                </div>
+                <div className={`mt-1 font-display text-2xl font-semibold ${tone}`}>{n}</div>
+              </div>
+            ))}
+          </div>
+
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex flex-wrap gap-1.5">
+              {pill("all", `All ${summary.total}`, "bg-navy text-bg")}
+              {pill("ready", `Ready ${summary.ready}`, "bg-green text-bg")}
+              {pill("warning", `Warnings ${summary.warning}`, "bg-warn text-bg")}
+              {pill("error", `Errors ${summary.error}`, "bg-terra text-bg")}
+            </div>
+            <div className="flex items-center gap-4">
+              <label className="flex items-center gap-2 text-sm text-navy-2">
+                <input
+                  type="checkbox"
+                  checked={invite}
+                  onChange={(e) => setInvite(e.target.checked)}
+                  className="h-4 w-4 accent-gold"
+                />
+                Send password-setup invites
+              </label>
+              <button
+                onClick={runImport}
+                disabled={busy || importable === 0}
+                className="rounded-md bg-navy px-5 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-50"
+              >
+                {busy
+                  ? "Importing…"
+                  : summary.error > 0
+                    ? `Skip errors & import ${importable}`
+                    : `Import ${importable}`}
+              </button>
+            </div>
+          </div>
+
+          <div className="overflow-x-auto rounded-xl border border-border bg-surface">
+            <table className="w-full text-sm">
+              <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
+                <tr>
+                  <th className="px-3 py-2.5 font-semibold">#</th>
+                  <th className="px-3 py-2.5 font-semibold">Name</th>
+                  <th className="px-3 py-2.5 font-semibold">Phone</th>
+                  <th className="px-3 py-2.5 font-semibold">Email</th>
+                  <th className="px-3 py-2.5 font-semibold">Role</th>
+                  <th className="px-3 py-2.5 font-semibold">Status</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {shown.map((r) => (
+                  <tr key={r.index} className="align-top">
+                    <td className="px-3 py-2.5 font-mono text-xs text-navy-3">{r.index}</td>
+                    <td className="px-3 py-2.5 font-medium text-navy">{r.fullName || "—"}</td>
+                    <td className="px-3 py-2.5 font-mono text-xs text-navy-2">
+                      {r.phone || "—"}
+                    </td>
+                    <td className="px-3 py-2.5 text-navy-2">{r.email || "—"}</td>
+                    <td className="px-3 py-2.5 text-navy-2">{r.roleLabel}</td>
+                    <td className="px-3 py-2.5">
+                      {r.errors.length > 0 ? (
+                        <span className="text-xs text-terra">{r.errors.join("; ")}</span>
+                      ) : r.warnings.length > 0 ? (
+                        <span className="text-xs text-warn">{r.warnings.join("; ")}</span>
+                      ) : (
+                        <span className="text-xs font-medium text-green">Ready</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          {fileName && <p className="text-xs text-navy-3">{fileName}</p>}
+        </>
+      )}
+    </div>
+  );
+}

--- a/omnischools/lib/actions/staff.ts
+++ b/omnischools/lib/actions/staff.ts
@@ -5,6 +5,8 @@ import { withSchool } from "@/lib/db/rls";
 import { recordAudit } from "@/lib/db/audit";
 import { requireSchool, resolveActor } from "@/lib/auth/server";
 import { normalizeGhanaPhone } from "@/lib/auth";
+import { sendSms } from "@/lib/sms";
+import { sendEmail } from "@/lib/email";
 import { safeRevalidate } from "@/lib/revalidate";
 import { STAFF_ROLE_CODES, STAFF_ROLE_LABEL } from "@/lib/staff-roles";
 import type { Tx } from "@/lib/db";
@@ -14,6 +16,7 @@ import {
   roleAssignments,
   classes,
   timetableSlots,
+  invites,
 } from "@/db/schema";
 
 type Result = { ok: boolean; error?: string };
@@ -93,6 +96,114 @@ export async function addStaff(input: unknown): Promise<Result> {
     return { ok: true };
   } catch {
     return { ok: false, error: "Could not add staff. Please try again." };
+  }
+}
+
+// --------------------------------------------------------------- bulk import
+const INVITE_TTL_DAYS = 14;
+const ImportStaffSchema = z.object({
+  rows: z
+    .array(
+      z.object({
+        fullName: z.string().min(2).max(120),
+        phone: z.string().min(7),
+        email: z.string().email().optional().or(z.literal("")),
+        role: z.enum(STAFF_ROLE_CODES),
+      }),
+    )
+    .min(1, "No rows to import")
+    .max(500),
+  sendInvites: z.boolean().optional(),
+});
+
+export async function importStaff(
+  input: unknown,
+): Promise<Result & { created?: number; invited?: number }> {
+  const { school } = await requireSchool();
+  const parsed = ImportStaffSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid import" };
+  }
+  const { rows, sendInvites } = parsed.data;
+  const actor = await resolveActor(school.id);
+
+  try {
+    const out = await withSchool(school.id, async (tx) => {
+      let created = 0;
+      let invited = 0;
+      const notify: { phone: string; email: string | null; role: string; token: string }[] =
+        [];
+
+      for (const r of rows) {
+        const phone = normalizeGhanaPhone(r.phone);
+        await tx
+          .insert(users)
+          .values({ phone, fullName: r.fullName.trim(), email: r.email || null })
+          .onConflictDoNothing({ target: users.phone });
+        const [u] = await tx
+          .select({ id: users.id })
+          .from(users)
+          .where(eq(users.phone, phone));
+        const added = await assign(tx, school.id, u.id, r.role);
+        if (added) created++;
+
+        if (sendInvites) {
+          const token = crypto.randomUUID().replace(/-/g, "").slice(0, 24);
+          await tx.insert(invites).values({
+            schoolId: school.id,
+            token,
+            role: r.role,
+            fullName: r.fullName.trim(),
+            email: r.email || null,
+            phone,
+            expiresAt: new Date(Date.now() + INVITE_TTL_DAYS * 86400_000),
+            invitedByUserId: actor.id ?? null,
+          });
+          invited++;
+          notify.push({ phone, email: r.email || null, role: r.role, token });
+        }
+      }
+
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "created",
+        entityType: "staff_batch",
+        after: { count: created, invited },
+        reason: "Bulk staff import",
+      });
+      return { created, invited, notify };
+    });
+
+    // best-effort invite notifications (stubbed providers; mirrors createInvite)
+    if (sendInvites && out.notify.length > 0) {
+      const base = process.env.NEXT_PUBLIC_SITE_URL ?? "";
+      const sender = school.shortName ?? "Omnischools";
+      for (const n of out.notify) {
+        const link = `${base}/accept/${n.token}`;
+        try {
+          await sendSms(
+            n.phone,
+            `${sender}: You've been added as ${STAFF_ROLE_LABEL[n.role]}. Set up your account: ${link}`,
+          );
+          if (n.email) {
+            await sendEmail({
+              to: n.email,
+              subject: `You're invited to ${school.name} on Omnischools`,
+              html: `<p>You've been added as <b>${STAFF_ROLE_LABEL[n.role]}</b> at ${school.name}.</p><p><a href="${link}">Accept the invite & set your password</a>.</p>`,
+            });
+          }
+        } catch {
+          /* ignore provider failures — invite rows still exist */
+        }
+      }
+    }
+
+    safeRevalidate("/staff");
+    return { ok: true, created: out.created, invited: out.invited };
+  } catch {
+    return { ok: false, error: "Could not import staff. Please try again." };
   }
 }
 

--- a/omnischools/lib/import/staff-import.ts
+++ b/omnischools/lib/import/staff-import.ts
@@ -1,0 +1,104 @@
+import { isValidGhanaPhone, normalizePhone } from "./csv";
+import { STAFF_ROLES, type StaffRoleCode } from "@/lib/staff-roles";
+
+/**
+ * Staff bulk-import spec + validator. Pure + client-safe so the review table can
+ * validate live. Column order matches the downloadable template. Mirrors the student
+ * importer; phone is the login identity, email optional, role maps by label or code.
+ */
+export const STAFF_IMPORT_HEADERS = [
+  "Full name",
+  "Phone (login)",
+  "Email",
+  "Role",
+];
+
+export const STAFF_IMPORT_SAMPLE: string[][] = [
+  ["Ama Owusu", "0244000001", "ama.owusu@example.com", "Teacher"],
+  ["Kojo Mensah", "0209876543", "", "Bursar"],
+  ["Yaa Asantewaa", "0271234567", "", "Form Master"],
+];
+
+export type StaffImportRow = {
+  index: number; // 1-based data-row number for display
+  fullName: string;
+  phone: string; // normalised E.164 when valid
+  email: string;
+  role: StaffRoleCode;
+  roleLabel: string;
+  errors: string[];
+  warnings: string[];
+};
+
+export type ImportSummary = {
+  total: number;
+  ready: number;
+  warning: number;
+  error: number;
+};
+
+const ROLE_BY_KEY = new Map<string, (typeof STAFF_ROLES)[number]>();
+for (const r of STAFF_ROLES) {
+  ROLE_BY_KEY.set(r.code.toLowerCase(), r);
+  ROLE_BY_KEY.set(r.label.toLowerCase(), r);
+}
+const ROLE_NAMES = STAFF_ROLES.map((r) => r.label).join(", ");
+
+const isEmail = (s: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s);
+
+/** Validate parsed data rows (excluding the header). Flags duplicate phones in-file. */
+export function validateStaffRows(dataRows: string[][]): {
+  rows: StaffImportRow[];
+  summary: ImportSummary;
+} {
+  const seenPhones = new Set<string>();
+
+  const rows = dataRows.map((cells, i): StaffImportRow => {
+    const get = (n: number) => (cells[n] ?? "").trim();
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    const fullName = get(0);
+    if (fullName.length < 2) errors.push("Full name is required");
+
+    const phoneRaw = get(1);
+    let phone = "";
+    if (!phoneRaw) {
+      errors.push("Phone is required (it's their login)");
+    } else if (isValidGhanaPhone(phoneRaw)) {
+      phone = normalizePhone(phoneRaw);
+      if (seenPhones.has(phone)) errors.push("Duplicate phone in this file");
+      else seenPhones.add(phone);
+    } else {
+      errors.push("Phone is invalid (10 digits or +233…)");
+    }
+
+    const email = get(2);
+    if (email && !isEmail(email)) errors.push("Email is invalid");
+
+    const roleRaw = get(3);
+    let role: StaffRoleCode = "TEACHER";
+    let roleLabel = "Teacher";
+    if (!roleRaw) {
+      warnings.push("Role blank — defaulting to Teacher");
+    } else {
+      const match = ROLE_BY_KEY.get(roleRaw.toLowerCase());
+      if (match) {
+        role = match.code;
+        roleLabel = match.label;
+      } else {
+        errors.push(`Unknown role "${roleRaw}" — use one of: ${ROLE_NAMES}`);
+      }
+    }
+
+    return { index: i + 1, fullName, phone, email, role, roleLabel, errors, warnings };
+  });
+
+  const summary: ImportSummary = {
+    total: rows.length,
+    ready: rows.filter((r) => r.errors.length === 0 && r.warnings.length === 0).length,
+    warning: rows.filter((r) => r.errors.length === 0 && r.warnings.length > 0).length,
+    error: rows.filter((r) => r.errors.length > 0).length,
+  };
+  return { rows, summary };
+}


### PR DESCRIPTION
## Step 6 — In-app Students & Staff import

Brings the bulk-import flow into the running app for **Staff** (Students import already shipped in Step 3), reusing the shared `lib/import/csv` engine. **No migration.**

### Staff bulk import
- **`lib/import/staff-import.ts`** — `STAFF_IMPORT_HEADERS` / sample + `validateStaffRows`: pure, client-safe validator.
  - Full name + valid Ghana phone **required** (phone is the login), email optional.
  - Role mapped by **label or code**; blank role → Teacher (warning); unknown role → error listing valid roles; **duplicate phone in file** → error.
- **`lib/actions/staff.ts` → `importStaff`** — bulk upserts users + role assignments in one transaction; when **Send invites** is on, also creates invite rows + best-effort SMS/email (mirrors `createInvite`, sender = school short name). Returns `created` + `invited`; audited as `staff_batch`.
- **`components/staff/staff-import.tsx`** — template download / upload / live review table with Total·Ready·Warnings·Errors summary + filter pills, and a "Send password-setup invites" toggle (default on).
- **`app/(app)/staff/import/page.tsx`** + an **Import** link in the Staff header.

Imported staff flow through the Step-4 invite → accept-and-set-password screen.

### Verification
- `pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm build` ✓ (`/staff/import` 3.83 kB)
- `validateStaffRows` sanity-checked across ready / blank-role-warning / invalid-phone / duplicate-phone / unknown-role + bad-email cases.
- Auth-gated page (needs a logged-in school), so verified via build + the pure-validator check rather than preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)