### PR TITLE
feat(settings): real logo/stamp upload to Supabase Storage (branding 7b)

### DIFF
--- a/omnischools/components/settings/branding-form.tsx
+++ b/omnischools/components/settings/branding-form.tsx
@@ -2,13 +2,13 @@
 import { useState } from "react";
 /* eslint-disable @next/next/no-img-element */
 import { useRouter } from "next/navigation";
-import { updateSchoolBranding } from "@/lib/actions/settings";
+import { uploadBrandingImage, updateSchoolBranding } from "@/lib/actions/settings";
 
 const fieldClass =
   "w-full rounded-md border border-border-2 bg-bg px-3.5 py-2.5 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
-const labelClass = "mb-1.5 block text-xs font-semibold text-navy-2";
+const ACCEPT = "image/png,image/jpeg,image/webp,image/svg+xml";
 
-const isUrl = (s: string) => /^https?:\/\/\S+$/.test(s.trim());
+type Kind = "logo" | "stamp";
 
 export function BrandingForm({
   initial,
@@ -18,148 +18,167 @@ export function BrandingForm({
   schoolName: string;
 }) {
   const router = useRouter();
-  const [f, setF] = useState(initial);
-  const [busy, setBusy] = useState(false);
+  const [logo, setLogo] = useState(initial.logoUrl);
+  const [stamp, setStamp] = useState(initial.stampUrl);
+  const [color, setColor] = useState(initial.brandColor);
+  const [busy, setBusy] = useState<Kind | "color" | null>(null);
   const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
 
-  const set = (k: keyof typeof f, v: string) => {
-    setF((p) => ({ ...p, [k]: v }));
-    setMsg(null);
-  };
-  const dirty = (Object.keys(initial) as (keyof typeof f)[]).some(
-    (k) => f[k] !== initial[k],
-  );
-  const color = /^#[0-9a-fA-F]{6}$/.test(f.brandColor) ? f.brandColor : "#1A2B47";
+  const swatch = /^#[0-9a-fA-F]{6}$/.test(color) ? color : "#1A2B47";
   const initials = (schoolName.trim()[0] ?? "S").toUpperCase();
 
-  async function save() {
-    setBusy(true);
+  async function onPick(kind: Kind, e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file) return;
+    setBusy(kind);
     setMsg(null);
-    const res = await updateSchoolBranding(f);
-    setBusy(false);
+    const fd = new FormData();
+    fd.set("kind", kind);
+    fd.set("file", file);
+    const res = await uploadBrandingImage(fd);
+    setBusy(null);
+    if (res.ok && res.url) {
+      if (kind === "logo") setLogo(res.url);
+      else setStamp(res.url);
+      setMsg({ ok: true, text: `${kind === "logo" ? "Logo" : "Stamp"} updated.` });
+      router.refresh();
+    } else setMsg({ ok: false, text: res.error ?? "Upload failed." });
+  }
+
+  async function removeImg(kind: Kind) {
+    setBusy(kind);
+    setMsg(null);
+    const res = await updateSchoolBranding(
+      kind === "logo" ? { logoUrl: "" } : { stampUrl: "" },
+    );
+    setBusy(null);
     if (res.ok) {
-      setMsg({ ok: true, text: "Saved." });
+      if (kind === "logo") setLogo("");
+      else setStamp("");
+      router.refresh();
+    } else setMsg({ ok: false, text: res.error ?? "Could not remove." });
+  }
+
+  async function saveColor() {
+    setBusy("color");
+    setMsg(null);
+    const res = await updateSchoolBranding({ brandColor: color });
+    setBusy(null);
+    if (res.ok) {
+      setMsg({ ok: true, text: "Colour saved." });
       router.refresh();
     } else setMsg({ ok: false, text: res.error ?? "Could not save." });
   }
 
-  return (
-    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_320px]">
-      {/* Form */}
-      <div className="space-y-5 rounded-xl border border-border bg-surface p-6">
-        <div>
-          <label className={labelClass}>Logo URL</label>
-          <input
-            className={fieldClass}
-            value={f.logoUrl}
-            placeholder="https://…/logo.png"
-            onChange={(e) => set("logoUrl", e.target.value)}
+  const uploader = (kind: Kind, url: string, isStamp: boolean) => (
+    <div className="rounded-xl border border-border bg-surface p-5">
+      <div className="font-display text-base font-medium text-navy">
+        {isStamp ? "Official stamp" : "School logo"}
+      </div>
+      <p className="mb-4 mt-0.5 text-[12px] text-navy-3">
+        {isStamp
+          ? "Appears on every generated PDF (statements, report cards)."
+          : "Shown on receipts and announcements."}{" "}
+        PNG, JPG, WebP or SVG · max 2 MB.
+      </p>
+      <div className="flex items-center gap-4">
+        {url ? (
+          <img
+            src={url}
+            alt={isStamp ? "Official stamp" : "School logo"}
+            className={
+              isStamp
+                ? "h-20 w-20 rounded-full border border-border bg-bg object-contain p-1"
+                : "h-16 w-auto max-w-[160px] rounded-md border border-border bg-bg object-contain p-1"
+            }
           />
-          <p className="mt-1 text-[11px] text-navy-3">
-            A hosted PNG/SVG. Shown on receipts and announcements. (Direct uploads come
-            later — paste a link for now.)
-          </p>
-        </div>
-        <div>
-          <label className={labelClass}>Official stamp URL</label>
-          <input
-            className={fieldClass}
-            value={f.stampUrl}
-            placeholder="https://…/stamp.png"
-            onChange={(e) => set("stampUrl", e.target.value)}
-          />
-          <p className="mt-1 text-[11px] text-navy-3">
-            Appears on every generated PDF (statements, report cards).
-          </p>
-        </div>
-        <div>
-          <label className={labelClass}>Brand colour</label>
-          <div className="flex items-center gap-3">
-            <input
-              type="color"
-              value={color}
-              onChange={(e) => set("brandColor", e.target.value)}
-              className="h-10 w-12 shrink-0 cursor-pointer rounded-md border border-border-2 bg-bg"
-              aria-label="Brand colour picker"
-            />
-            <input
-              className={`${fieldClass} font-mono uppercase`}
-              value={f.brandColor}
-              placeholder="#1A2B47"
-              maxLength={7}
-              onChange={(e) => set("brandColor", e.target.value)}
-            />
+        ) : isStamp ? (
+          <div className="flex h-20 w-20 items-center justify-center rounded-full border-2 border-dashed border-border-2 text-[10px] text-navy-3">
+            No stamp
           </div>
-          <p className="mt-1 text-[11px] text-navy-3">
-            Used as an accent on your branded documents. App theming stays navy/gold.
-          </p>
-        </div>
-
-        <div className="flex items-center gap-3 border-t border-border pt-5">
-          <button
-            onClick={save}
-            disabled={busy || !dirty}
-            className="rounded-md bg-navy px-5 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-50"
+        ) : (
+          <div
+            className="flex h-16 w-16 items-center justify-center rounded-md font-display text-2xl font-semibold text-white"
+            style={{ background: swatch }}
           >
-            {busy ? "Saving…" : "Save branding"}
-          </button>
-          {msg && (
-            <span className={`text-sm ${msg.ok ? "text-green" : "text-terra"}`}>
-              {msg.text}
-            </span>
+            {initials}
+          </div>
+        )}
+        <div className="flex flex-col gap-2">
+          <label
+            className={`cursor-pointer rounded-md bg-navy px-4 py-2 text-center text-sm font-semibold text-bg transition-colors hover:bg-navy-deep ${
+              busy === kind ? "pointer-events-none opacity-60" : ""
+            }`}
+          >
+            {busy === kind ? "Uploading…" : url ? "Replace" : "Upload"}
+            <input
+              type="file"
+              accept={ACCEPT}
+              className="hidden"
+              onChange={(e) => onPick(kind, e)}
+            />
+          </label>
+          {url && (
+            <button
+              type="button"
+              disabled={busy === kind}
+              onClick={() => removeImg(kind)}
+              className="text-xs font-semibold text-navy-3 transition-colors hover:text-terra disabled:opacity-50"
+            >
+              Remove
+            </button>
           )}
         </div>
       </div>
+    </div>
+  );
 
-      {/* Live preview */}
-      <div className="rounded-xl border border-border bg-surface p-6">
-        <div className="mb-3 text-[11px] font-bold uppercase tracking-[0.14em] text-gold">
-          Preview
-        </div>
-        <div className="space-y-4">
-          <div>
-            <div className="mb-1.5 text-xs font-semibold text-navy-2">Logo</div>
-            {isUrl(f.logoUrl) ? (
-              <img
-                src={f.logoUrl}
-                alt="School logo"
-                className="h-16 w-auto max-w-full rounded-md border border-border bg-bg object-contain p-1"
-              />
-            ) : (
-              <div
-                className="flex h-16 w-16 items-center justify-center rounded-md font-display text-2xl font-semibold text-white"
-                style={{ background: color }}
-              >
-                {initials}
-              </div>
-            )}
-          </div>
-          <div>
-            <div className="mb-1.5 text-xs font-semibold text-navy-2">Stamp</div>
-            {isUrl(f.stampUrl) ? (
-              <img
-                src={f.stampUrl}
-                alt="Official stamp"
-                className="h-20 w-20 rounded-full border border-border bg-bg object-contain p-1"
-              />
-            ) : (
-              <div className="flex h-20 w-20 items-center justify-center rounded-full border-2 border-dashed border-border-2 text-[10px] text-navy-3">
-                No stamp
-              </div>
-            )}
-          </div>
-          <div>
-            <div className="mb-1.5 text-xs font-semibold text-navy-2">Accent</div>
-            <div className="flex items-center gap-2">
-              <span
-                className="h-6 w-6 rounded-md border border-border"
-                style={{ background: color }}
-              />
-              <span className="font-mono text-xs uppercase text-navy-2">{color}</span>
-            </div>
-          </div>
+  return (
+    <div className="space-y-5">
+      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+        {uploader("logo", logo, false)}
+        {uploader("stamp", stamp, true)}
+      </div>
+
+      <div className="rounded-xl border border-border bg-surface p-5">
+        <div className="font-display text-base font-medium text-navy">Brand colour</div>
+        <p className="mb-3 mt-0.5 text-[12px] text-navy-3">
+          An accent for your branded documents. App theming stays navy/gold.
+        </p>
+        <div className="flex items-center gap-3">
+          <input
+            type="color"
+            value={swatch}
+            onChange={(e) => setColor(e.target.value)}
+            className="h-10 w-12 shrink-0 cursor-pointer rounded-md border border-border-2 bg-bg"
+            aria-label="Brand colour picker"
+          />
+          <input
+            className={`${fieldClass} max-w-[160px] font-mono uppercase`}
+            value={color}
+            placeholder="#1A2B47"
+            maxLength={7}
+            onChange={(e) => setColor(e.target.value)}
+          />
+          <button
+            onClick={saveColor}
+            disabled={busy === "color" || color === initial.brandColor}
+            className="rounded-md bg-navy px-4 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-50"
+          >
+            {busy === "color" ? "Saving…" : "Save colour"}
+          </button>
         </div>
       </div>
+
+      {msg && (
+        <p
+          className={`text-sm ${msg.ok ? "text-green" : "text-terra"}`}
+          role={msg.ok ? undefined : "alert"}
+        >
+          {msg.text}
+        </p>
+      )}
     </div>
   );
 }

--- a/omnischools/lib/actions/settings.ts
+++ b/omnischools/lib/actions/settings.ts
@@ -5,6 +5,7 @@ import { withSchool } from "@/lib/db/rls";
 import { recordAudit } from "@/lib/db/audit";
 import { requireSchool, resolveActor } from "@/lib/auth/server";
 import { safeRevalidate } from "@/lib/revalidate";
+import { createAdminClient, BRANDING_BUCKET } from "@/lib/supabase/admin";
 import { schools, gradebookConfig } from "@/db/schema";
 
 // --------------------------------------------------------------- school profile
@@ -94,17 +95,17 @@ export async function updateSchoolBranding(
   }
   const d = parsed.data;
   const nz = (v?: string) => (v && v.trim() ? v.trim() : null);
+  // Partial update — only touch fields the caller actually sent (undefined = leave,
+  // "" = clear). Lets the colour Save and the per-image Remove run independently.
+  const set: Record<string, string | null> = {};
+  if (d.logoUrl !== undefined) set.logoUrl = nz(d.logoUrl);
+  if (d.stampUrl !== undefined) set.stampUrl = nz(d.stampUrl);
+  if (d.brandColor !== undefined) set.brandColor = nz(d.brandColor);
+  if (Object.keys(set).length === 0) return { ok: true };
   const actor = await resolveActor(school.id);
   try {
     await withSchool(school.id, async (tx) => {
-      await tx
-        .update(schools)
-        .set({
-          logoUrl: nz(d.logoUrl),
-          stampUrl: nz(d.stampUrl),
-          brandColor: nz(d.brandColor),
-        })
-        .where(eq(schools.id, school.id));
+      await tx.update(schools).set(set).where(eq(schools.id, school.id));
       await recordAudit(tx, {
         schoolId: school.id,
         actorUserId: actor.id ?? undefined,
@@ -112,7 +113,7 @@ export async function updateSchoolBranding(
         actionType: "updated",
         entityType: "school",
         entityId: school.id,
-        after: { logo: !!nz(d.logoUrl), stamp: !!nz(d.stampUrl) },
+        after: set,
         reason: "Branding updated",
       });
     });
@@ -121,6 +122,73 @@ export async function updateSchoolBranding(
     return { ok: true };
   } catch {
     return { ok: false, error: "Could not save branding. Please try again." };
+  }
+}
+
+// --------------------------------------------------------------- branding upload
+const MAX_BRAND_BYTES = 2 * 1024 * 1024; // 2 MB
+const MIME_EXT: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/webp": "webp",
+  "image/svg+xml": "svg",
+};
+
+/** Upload a logo/stamp to Supabase Storage (service role) and store its public URL. */
+export async function uploadBrandingImage(
+  formData: FormData,
+): Promise<{ ok: boolean; url?: string; error?: string }> {
+  const { school } = await requireSchool();
+  const kind = String(formData.get("kind") ?? "");
+  const file = formData.get("file");
+  if (kind !== "logo" && kind !== "stamp") {
+    return { ok: false, error: "Invalid image type." };
+  }
+  if (!(file instanceof File) || file.size === 0) {
+    return { ok: false, error: "No file selected." };
+  }
+  if (file.size > MAX_BRAND_BYTES) {
+    return { ok: false, error: "Image must be 2 MB or smaller." };
+  }
+  const ext = MIME_EXT[file.type];
+  if (!ext) return { ok: false, error: "Use a PNG, JPG, WebP or SVG image." };
+
+  const admin = createAdminClient();
+  if (!admin) {
+    return { ok: false, error: "Image upload isn't configured on this deployment." };
+  }
+
+  const path = `${school.id}/${kind}-${Date.now()}.${ext}`;
+  const buffer = Buffer.from(await file.arrayBuffer());
+  const up = await admin.storage
+    .from(BRANDING_BUCKET)
+    .upload(path, buffer, { contentType: file.type, upsert: true });
+  if (up.error) return { ok: false, error: "Upload failed. Please try again." };
+  const url = admin.storage.from(BRANDING_BUCKET).getPublicUrl(path).data.publicUrl;
+
+  const actor = await resolveActor(school.id);
+  try {
+    await withSchool(school.id, async (tx) => {
+      await tx
+        .update(schools)
+        .set(kind === "logo" ? { logoUrl: url } : { stampUrl: url })
+        .where(eq(schools.id, school.id));
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "updated",
+        entityType: "school",
+        entityId: school.id,
+        after: { [kind]: true },
+        reason: `Branding ${kind} uploaded`,
+      });
+    });
+    safeRevalidate("/settings");
+    safeRevalidate("/settings/branding");
+    return { ok: true, url };
+  } catch {
+    return { ok: false, error: "Saved the file but couldn't update the record." };
   }
 }
 

--- a/omnischools/lib/supabase/admin.ts
+++ b/omnischools/lib/supabase/admin.ts
@@ -1,0 +1,18 @@
+import "server-only";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { env } from "@/lib/env";
+
+/**
+ * Service-role Supabase client for privileged storage operations (server only).
+ * Returns null when Supabase isn't configured (local dev / build) so callers can
+ * fail gracefully rather than crash. NEVER expose the service key to the client.
+ */
+export function createAdminClient(): SupabaseClient | null {
+  if (!env.NEXT_PUBLIC_SUPABASE_URL || !env.SUPABASE_SERVICE_ROLE_KEY) return null;
+  return createClient(env.NEXT_PUBLIC_SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+/** Public bucket for school branding assets (logo, stamp). Created via SQL on deploy. */
+export const BRANDING_BUCKET = "branding";


### PR DESCRIPTION
Replaces the pasted-URL branding inputs with actual file upload (per review):
- lib/supabase/admin.ts — service-role Supabase client for privileged storage (server-only; returns null when unconfigured so dev/build never crash).
- uploadBrandingImage server action — validates type (PNG/JPG/WebP/SVG) + size (≤2 MB), uploads to the public `branding` bucket at <schoolId>/<kind>-<ts>.<ext>, stores the public URL on ref_school, audited. Tenant path is server-derived.
- updateSchoolBranding is now a partial update (undefined = leave, "" = clear) so the colour Save and per-image Remove run independently.
- BrandingForm: Upload / Replace / Remove per image with live preview (logo or an initials-on-brand-colour tile; stamp or placeholder), plus the colour picker.

No new migration (branding columns already in 0016). Needs the `branding` storage bucket (SQL paste on deploy) + SUPABASE_SERVICE_ROLE_KEY; the action fails gracefully when unconfigured.

Verified: typecheck ✓ · lint ✓ · build ✓ (/settings/branding 2.2 kB).