### PR TITLE
feat(settings): academic structure sub-page — terms, grade scale, weights (redesign step 7c)

### DIFF
--- a/omnischools/app/(app)/settings/academic/page.tsx
+++ b/omnischools/app/(app)/settings/academic/page.tsx
@@ -1,0 +1,87 @@
+import Link from "next/link";
+import { asc, eq } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import {
+  academicPeriodConfig,
+  academicPeriod,
+  gradeScale,
+  gradebookConfig,
+} from "@/db/schema";
+import { TermDatesForm } from "@/components/settings/term-dates-form";
+import { GradeScaleEditor } from "@/components/settings/grade-scale-editor";
+import { WeightsForm } from "@/components/settings/weights-form";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Academic structure" };
+
+export default async function AcademicSettingsPage() {
+  const { school } = await requireSchool();
+
+  const data = await withSchool(school.id, async (tx) => {
+    const [cfg] = await tx
+      .select()
+      .from(academicPeriodConfig)
+      .where(eq(academicPeriodConfig.schoolId, school.id));
+    const periods = await tx
+      .select()
+      .from(academicPeriod)
+      .where(eq(academicPeriod.schoolId, school.id))
+      .orderBy(asc(academicPeriod.periodNumber));
+    const grades = await tx
+      .select()
+      .from(gradeScale)
+      .where(eq(gradeScale.schoolId, school.id))
+      .orderBy(asc(gradeScale.ordinal));
+    const [gb] = await tx
+      .select()
+      .from(gradebookConfig)
+      .where(eq(gradebookConfig.schoolId, school.id));
+    return { cfg, periods, grades, classWeight: gb?.classWeight ?? 50 };
+  });
+
+  return (
+    <div className="mx-auto max-w-page">
+      <Link href="/settings" className="text-sm text-navy-3 hover:text-gold">
+        ← Settings
+      </Link>
+      <div className="mb-6 mt-2">
+        <h1 className="font-display text-3xl font-semibold text-navy">
+          Academic <em className="not-italic text-gold [font-style:italic]">structure.</em>
+        </h1>
+        <p className="text-sm text-navy-3">
+          Term dates, the grade scale and how scores are weighted — used across attendance,
+          the gradebook and report cards.
+        </p>
+      </div>
+
+      <div className="space-y-5">
+        <TermDatesForm
+          academicYear={data.cfg?.academicYear ?? "—"}
+          initial={data.periods.map((p) => ({
+            periodId: p.periodId,
+            label: p.periodLabel,
+            startsOn: p.startsOn,
+            endsOn: p.endsOn,
+          }))}
+        />
+
+        <GradeScaleEditor
+          initial={data.grades.map((g) => ({
+            grade: g.grade,
+            label: g.label ?? "",
+            minScore: Number(g.minScore),
+          }))}
+        />
+
+        <div className="rounded-xl border border-border bg-surface p-6">
+          <h2 className="font-display text-lg font-semibold text-navy">Grading weights</h2>
+          <p className="mb-4 mt-0.5 text-sm text-navy-3">
+            How class (continuous assessment) and exam scores combine into the term total.
+          </p>
+          <WeightsForm initialClassWeight={data.classWeight} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/omnischools/components/settings/grade-scale-editor.tsx
+++ b/omnischools/components/settings/grade-scale-editor.tsx
@@ -1,0 +1,133 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { updateGradeScale } from "@/lib/actions/settings";
+import { GRADE_SCALE_PRESETS } from "@/lib/onboarding";
+
+type Row = { grade: string; label: string; minScore: number };
+const inputCls =
+  "w-full rounded-md border border-border-2 bg-bg px-3 py-2 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
+
+export function GradeScaleEditor({ initial }: { initial: Row[] }) {
+  const router = useRouter();
+  const [rows, setRows] = useState<Row[]>(initial);
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
+
+  const update = (i: number, k: keyof Row, v: string) => {
+    setRows((p) =>
+      p.map((r, idx) =>
+        idx === i ? { ...r, [k]: k === "minScore" ? Number(v) : v } : r,
+      ),
+    );
+    setMsg(null);
+  };
+  const add = () => setRows((p) => [...p, { grade: "", label: "", minScore: 0 }]);
+  const remove = (i: number) => setRows((p) => p.filter((_, idx) => idx !== i));
+  const applyPreset = (key: "BASIC" | "WASSCE") => {
+    setRows(GRADE_SCALE_PRESETS[key].map((r) => ({ ...r })));
+    setMsg(null);
+  };
+
+  async function save() {
+    setBusy(true);
+    setMsg(null);
+    const res = await updateGradeScale({ rows });
+    setBusy(false);
+    if (res.ok) {
+      setMsg({ ok: true, text: "Saved." });
+      router.refresh();
+    } else setMsg({ ok: false, text: res.error ?? "Could not save." });
+  }
+
+  return (
+    <div className="rounded-xl border border-border bg-surface p-6">
+      <div className="flex flex-wrap items-baseline justify-between gap-3">
+        <h2 className="font-display text-lg font-semibold text-navy">Grade scale</h2>
+        <div className="flex gap-2 text-[11px]">
+          <button
+            onClick={() => applyPreset("BASIC")}
+            className="font-semibold text-gold hover:underline"
+          >
+            Use A–F
+          </button>
+          <span className="text-navy-3">·</span>
+          <button
+            onClick={() => applyPreset("WASSCE")}
+            className="font-semibold text-gold hover:underline"
+          >
+            Use WASSCE A1–F9
+          </button>
+        </div>
+      </div>
+      <p className="mb-4 mt-0.5 text-sm text-navy-3">
+        How a final score maps to a grade. A grade applies from its threshold up to the next
+        grade; the lowest grade covers everything below.
+      </p>
+
+      <div className="space-y-2">
+        <div className="grid grid-cols-[80px_1fr_110px_36px] gap-2 px-1 text-[10px] font-semibold uppercase tracking-wide text-navy-3">
+          <div>Grade</div>
+          <div>Label</div>
+          <div>From (score)</div>
+          <div />
+        </div>
+        {rows.map((r, i) => (
+          <div key={i} className="grid grid-cols-[80px_1fr_110px_36px] items-center gap-2">
+            <input
+              className={`${inputCls} text-center font-mono font-semibold`}
+              value={r.grade}
+              maxLength={8}
+              onChange={(e) => update(i, "grade", e.target.value)}
+            />
+            <input
+              className={inputCls}
+              value={r.label}
+              placeholder="e.g. Credit"
+              onChange={(e) => update(i, "label", e.target.value)}
+            />
+            <input
+              type="number"
+              min={0}
+              max={100}
+              className={`${inputCls} text-right font-mono`}
+              value={r.minScore}
+              onChange={(e) => update(i, "minScore", e.target.value)}
+            />
+            <button
+              type="button"
+              onClick={() => remove(i)}
+              aria-label={`Remove ${r.grade || "row"}`}
+              className="flex h-8 w-8 items-center justify-center rounded-md text-navy-3 transition-colors hover:bg-terra-bg hover:text-terra"
+            >
+              ✕
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={add}
+        className="mt-3 text-[13px] font-semibold text-gold hover:underline"
+      >
+        + Add grade
+      </button>
+
+      <div className="mt-5 flex items-center gap-3 border-t border-border pt-5">
+        <button
+          onClick={save}
+          disabled={busy || rows.length === 0}
+          className="rounded-md bg-navy px-5 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-50"
+        >
+          {busy ? "Saving…" : "Save grade scale"}
+        </button>
+        {msg && (
+          <span className={`text-sm ${msg.ok ? "text-green" : "text-terra"}`}>
+            {msg.text}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/omnischools/components/settings/term-dates-form.tsx
+++ b/omnischools/components/settings/term-dates-form.tsx
@@ -1,0 +1,116 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { updateAcademicPeriods } from "@/lib/actions/settings";
+
+type Period = { periodId: string; label: string; startsOn: string; endsOn: string };
+const inputCls =
+  "w-full rounded-md border border-border-2 bg-bg px-3 py-2 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
+
+export function TermDatesForm({
+  initial,
+  academicYear,
+}: {
+  initial: Period[];
+  academicYear: string;
+}) {
+  const router = useRouter();
+  const [rows, setRows] = useState<Period[]>(initial);
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
+
+  const dirty = JSON.stringify(rows) !== JSON.stringify(initial);
+  const update = (i: number, k: keyof Period, v: string) => {
+    setRows((p) => p.map((r, idx) => (idx === i ? { ...r, [k]: v } : r)));
+    setMsg(null);
+  };
+
+  async function save() {
+    setBusy(true);
+    setMsg(null);
+    const res = await updateAcademicPeriods({ periods: rows });
+    setBusy(false);
+    if (res.ok) {
+      setMsg({ ok: true, text: "Saved." });
+      router.refresh();
+    } else setMsg({ ok: false, text: res.error ?? "Could not save." });
+  }
+
+  return (
+    <div className="rounded-xl border border-border bg-surface p-6">
+      <div className="flex items-baseline justify-between gap-3">
+        <h2 className="font-display text-lg font-semibold text-navy">School year &amp; terms</h2>
+        <span className="font-mono text-xs text-navy-3">{academicYear}</span>
+      </div>
+      <p className="mb-4 mt-0.5 text-sm text-navy-3">
+        Term boundaries for the current year. These drive attendance weeks, report cards and
+        fee cycles.
+      </p>
+
+      {rows.length === 0 ? (
+        <p className="text-sm text-navy-3">
+          No terms configured. They&apos;re seeded from GES defaults during onboarding.
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {rows.map((r, i) => (
+            <div
+              key={r.periodId}
+              className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_1fr_1fr]"
+            >
+              <div>
+                <label className="mb-1 block text-[11px] font-semibold text-navy-3">
+                  Term
+                </label>
+                <input
+                  className={inputCls}
+                  value={r.label}
+                  onChange={(e) => update(i, "label", e.target.value)}
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-[11px] font-semibold text-navy-3">
+                  Starts
+                </label>
+                <input
+                  type="date"
+                  className={inputCls}
+                  value={r.startsOn}
+                  onChange={(e) => update(i, "startsOn", e.target.value)}
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-[11px] font-semibold text-navy-3">
+                  Ends
+                </label>
+                <input
+                  type="date"
+                  className={inputCls}
+                  value={r.endsOn}
+                  onChange={(e) => update(i, "endsOn", e.target.value)}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {rows.length > 0 && (
+        <div className="mt-5 flex items-center gap-3">
+          <button
+            onClick={save}
+            disabled={busy || !dirty}
+            className="rounded-md bg-navy px-5 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-50"
+          >
+            {busy ? "Saving…" : "Save term dates"}
+          </button>
+          {msg && (
+            <span className={`text-sm ${msg.ok ? "text-green" : "text-terra"}`}>
+              {msg.text}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/omnischools/lib/actions/settings.ts
+++ b/omnischools/lib/actions/settings.ts
@@ -1,12 +1,12 @@
 "use server";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { withSchool } from "@/lib/db/rls";
 import { recordAudit } from "@/lib/db/audit";
 import { requireSchool, resolveActor } from "@/lib/auth/server";
 import { safeRevalidate } from "@/lib/revalidate";
 import { createAdminClient, BRANDING_BUCKET } from "@/lib/supabase/admin";
-import { schools, gradebookConfig } from "@/db/schema";
+import { schools, gradebookConfig, academicPeriod, gradeScale } from "@/db/schema";
 
 // --------------------------------------------------------------- school profile
 const OWNERSHIPS = ["PUBLIC", "PRIVATE", "MISSION", "INTERNATIONAL"] as const;
@@ -246,5 +246,134 @@ export async function updateGradingWeights(
     return { ok: true };
   } catch {
     return { ok: false, error: "Could not save weights. Please try again." };
+  }
+}
+
+// --------------------------------------------------------------- academic periods
+const isIsoDate = (s: string) =>
+  /^\d{4}-\d{2}-\d{2}$/.test(s) && !Number.isNaN(Date.parse(s));
+
+const PeriodsSchema = z.object({
+  periods: z
+    .array(
+      z.object({
+        periodId: z.string().uuid(),
+        label: z.string().min(1).max(40),
+        startsOn: z.string(),
+        endsOn: z.string(),
+      }),
+    )
+    .min(1)
+    .max(6),
+});
+
+export async function updateAcademicPeriods(
+  input: unknown,
+): Promise<{ ok: boolean; error?: string }> {
+  const { school } = await requireSchool();
+  const parsed = PeriodsSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };
+  }
+  for (const p of parsed.data.periods) {
+    if (!isIsoDate(p.startsOn) || !isIsoDate(p.endsOn)) {
+      return { ok: false, error: `Enter valid dates for ${p.label}.` };
+    }
+    if (p.startsOn > p.endsOn) {
+      return { ok: false, error: `${p.label}: the start date is after the end date.` };
+    }
+  }
+  const actor = await resolveActor(school.id);
+  try {
+    await withSchool(school.id, async (tx) => {
+      for (const p of parsed.data.periods) {
+        await tx
+          .update(academicPeriod)
+          .set({ periodLabel: p.label.trim(), startsOn: p.startsOn, endsOn: p.endsOn })
+          .where(
+            and(
+              eq(academicPeriod.periodId, p.periodId),
+              eq(academicPeriod.schoolId, school.id),
+            ),
+          );
+      }
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "updated",
+        entityType: "academic_period",
+        entityId: school.id,
+        after: { periods: parsed.data.periods.length },
+        reason: "Term dates updated",
+      });
+    });
+    safeRevalidate("/settings");
+    safeRevalidate("/settings/academic");
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Could not save term dates. Please try again." };
+  }
+}
+
+// --------------------------------------------------------------- grade scale
+const GradeScaleSchema = z.object({
+  rows: z
+    .array(
+      z.object({
+        grade: z.string().min(1, "Grade is required").max(8),
+        label: z.string().max(40).optional().or(z.literal("")),
+        minScore: z.coerce.number().min(0).max(100),
+      }),
+    )
+    .min(1, "Add at least one grade")
+    .max(15),
+});
+
+export async function updateGradeScale(
+  input: unknown,
+): Promise<{ ok: boolean; error?: string }> {
+  const { school } = await requireSchool();
+  const parsed = GradeScaleSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };
+  }
+  const nz = (v?: string) => (v && v.trim() ? v.trim() : null);
+  const rows = parsed.data.rows.map((r) => ({ ...r, grade: r.grade.trim() }));
+  const codes = rows.map((r) => r.grade.toUpperCase());
+  if (new Set(codes).size !== codes.length) {
+    return { ok: false, error: "Grade letters must be unique." };
+  }
+  const ordered = [...rows].sort((a, b) => b.minScore - a.minScore);
+  const actor = await resolveActor(school.id);
+  try {
+    await withSchool(school.id, async (tx) => {
+      await tx.delete(gradeScale).where(eq(gradeScale.schoolId, school.id));
+      await tx.insert(gradeScale).values(
+        ordered.map((g, i) => ({
+          schoolId: school.id,
+          grade: g.grade,
+          label: nz(g.label),
+          minScore: String(g.minScore),
+          ordinal: i,
+        })),
+      );
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "updated",
+        entityType: "grade_scale",
+        entityId: school.id,
+        after: { grades: ordered.length },
+        reason: "Grade scale updated",
+      });
+    });
+    safeRevalidate("/settings");
+    safeRevalidate("/settings/academic");
+    safeRevalidate("/gradebook");
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Could not save the grade scale. Please try again." };
   }
 }

--- a/omnischools/lib/settings-nav.ts
+++ b/omnischools/lib/settings-nav.ts
@@ -59,7 +59,6 @@ export const SETTINGS_GROUPS: SettingsGroup[] = [
         tone: "gold",
         desc: "Term dates, the school-year calendar, and the grade scale (BECE 1–9 / WASSCE A1–F9 / percentage bands).",
         href: "/settings/academic",
-        soon: true,
       },
     ],
   },


### PR DESCRIPTION
## Step 7c — Academic structure

New **`/settings/academic`** deep page. Edits the academic calendar, grade scale and grading weights — all reusing existing tables. **No migration.**

### Page
- **Term dates** — edit each `academic_period`'s label + start/end (validated: ISO dates, start ≤ end) via `updateAcademicPeriods`. Academic year shown read-only.
- **Grade scale** — full editor over `grade_scale` (grade · label · threshold), add/remove rows, one-click **A–F** / **WASSCE A1–F9** presets; saved highest-first via `updateGradeScale` (replaces the school's rows; rejects duplicate grade letters).
- **Grading weights** — reuses the existing `WeightsForm` (CA vs exam split).

Un-"soon"s the Academic structure card in the directory.

### Verification
- `pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm build` ✓ (`/settings/academic` 5.09 kB)
- Auth-gated page → verified via build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)