### PR TITLE
fix(settings): make term dates editable + addable when none are seeded

### DIFF
--- a/omnischools/app/(app)/settings/academic/page.tsx
+++ b/omnischools/app/(app)/settings/academic/page.tsx
@@ -8,12 +8,20 @@ import {
   gradeScale,
   gradebookConfig,
 } from "@/db/schema";
+import { currentAcademicYearLabel } from "@/lib/onboarding";
 import { TermDatesForm } from "@/components/settings/term-dates-form";
 import { GradeScaleEditor } from "@/components/settings/grade-scale-editor";
 import { WeightsForm } from "@/components/settings/weights-form";
 
 export const dynamic = "force-dynamic";
 export const metadata = { title: "Academic structure" };
+
+/** Coerce a DB date (string 'YYYY-MM-DD[…]' or a Date) to the strict YYYY-MM-DD that
+ *  <input type="date"> requires — otherwise the field renders empty and won't edit. */
+function ymd(v: unknown): string {
+  if (v instanceof Date) return v.toISOString().slice(0, 10);
+  return String(v ?? "").slice(0, 10);
+}
 
 export default async function AcademicSettingsPage() {
   const { school } = await requireSchool();
@@ -57,12 +65,12 @@ export default async function AcademicSettingsPage() {
 
       <div className="space-y-5">
         <TermDatesForm
-          academicYear={data.cfg?.academicYear ?? "—"}
+          academicYear={data.cfg?.academicYear ?? currentAcademicYearLabel()}
           initial={data.periods.map((p) => ({
             periodId: p.periodId,
             label: p.periodLabel,
-            startsOn: p.startsOn,
-            endsOn: p.endsOn,
+            startsOn: ymd(p.startsOn),
+            endsOn: ymd(p.endsOn),
           }))}
         />
 

--- a/omnischools/components/settings/term-dates-form.tsx
+++ b/omnischools/components/settings/term-dates-form.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { updateAcademicPeriods } from "@/lib/actions/settings";
 
-type Period = { periodId: string; label: string; startsOn: string; endsOn: string };
+type Period = { periodId?: string; label: string; startsOn: string; endsOn: string };
 const inputCls =
   "w-full rounded-md border border-border-2 bg-bg px-3 py-2 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
 
@@ -24,11 +24,19 @@ export function TermDatesForm({
     setRows((p) => p.map((r, idx) => (idx === i ? { ...r, [k]: v } : r)));
     setMsg(null);
   };
+  const addTerm = () => {
+    setRows((p) => [
+      ...p,
+      { label: `Term ${p.length + 1}`, startsOn: "", endsOn: "" },
+    ]);
+    setMsg(null);
+  };
+  const removeNew = (i: number) => setRows((p) => p.filter((_, idx) => idx !== i));
 
   async function save() {
     setBusy(true);
     setMsg(null);
-    const res = await updateAcademicPeriods({ periods: rows });
+    const res = await updateAcademicPeriods({ academicYear, periods: rows });
     setBusy(false);
     if (res.ok) {
       setMsg({ ok: true, text: "Saved." });
@@ -48,15 +56,16 @@ export function TermDatesForm({
       </p>
 
       {rows.length === 0 ? (
-        <p className="text-sm text-navy-3">
-          No terms configured. They&apos;re seeded from GES defaults during onboarding.
+        <p className="rounded-lg border border-dashed border-border-2 bg-bg px-4 py-5 text-sm text-navy-3">
+          No terms set up yet. Add your terms below — most Basic/JHS schools run 3, SHS runs
+          2 semesters.
         </p>
       ) : (
         <div className="space-y-3">
           {rows.map((r, i) => (
             <div
-              key={r.periodId}
-              className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_1fr_1fr]"
+              key={r.periodId ?? `new-${i}`}
+              className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_1fr_1fr_auto]"
             >
               <div>
                 <label className="mb-1 block text-[11px] font-semibold text-navy-3">
@@ -90,27 +99,46 @@ export function TermDatesForm({
                   onChange={(e) => update(i, "endsOn", e.target.value)}
                 />
               </div>
+              <div className="flex items-end">
+                {!r.periodId && (
+                  <button
+                    type="button"
+                    onClick={() => removeNew(i)}
+                    aria-label="Remove term"
+                    className="flex h-9 w-9 items-center justify-center rounded-md text-navy-3 transition-colors hover:bg-terra-bg hover:text-terra"
+                  >
+                    ✕
+                  </button>
+                )}
+              </div>
             </div>
           ))}
         </div>
       )}
 
-      {rows.length > 0 && (
-        <div className="mt-5 flex items-center gap-3">
-          <button
-            onClick={save}
-            disabled={busy || !dirty}
-            className="rounded-md bg-navy px-5 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-50"
-          >
-            {busy ? "Saving…" : "Save term dates"}
-          </button>
-          {msg && (
-            <span className={`text-sm ${msg.ok ? "text-green" : "text-terra"}`}>
-              {msg.text}
-            </span>
-          )}
-        </div>
-      )}
+      <button
+        type="button"
+        onClick={addTerm}
+        disabled={rows.length >= 8}
+        className="mt-3 text-[13px] font-semibold text-gold hover:underline disabled:opacity-50"
+      >
+        + Add term
+      </button>
+
+      <div className="mt-5 flex items-center gap-3 border-t border-border pt-5">
+        <button
+          onClick={save}
+          disabled={busy || !dirty || rows.length === 0}
+          className="rounded-md bg-navy px-5 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-50"
+        >
+          {busy ? "Saving…" : "Save term dates"}
+        </button>
+        {msg && (
+          <span className={`text-sm ${msg.ok ? "text-green" : "text-terra"}`}>
+            {msg.text}
+          </span>
+        )}
+      </div>
     </div>
   );
 }

--- a/omnischools/lib/actions/settings.ts
+++ b/omnischools/lib/actions/settings.ts
@@ -6,7 +6,13 @@ import { recordAudit } from "@/lib/db/audit";
 import { requireSchool, resolveActor } from "@/lib/auth/server";
 import { safeRevalidate } from "@/lib/revalidate";
 import { createAdminClient, BRANDING_BUCKET } from "@/lib/supabase/admin";
-import { schools, gradebookConfig, academicPeriod, gradeScale } from "@/db/schema";
+import {
+  schools,
+  gradebookConfig,
+  academicPeriod,
+  academicPeriodConfig,
+  gradeScale,
+} from "@/db/schema";
 
 // --------------------------------------------------------------- school profile
 const OWNERSHIPS = ["PUBLIC", "PRIVATE", "MISSION", "INTERNATIONAL"] as const;
@@ -254,19 +260,23 @@ const isIsoDate = (s: string) =>
   /^\d{4}-\d{2}-\d{2}$/.test(s) && !Number.isNaN(Date.parse(s));
 
 const PeriodsSchema = z.object({
+  academicYear: z.string().min(1).max(20),
+  periodType: z.enum(["TERM", "SEMESTER"]).optional(),
   periods: z
     .array(
       z.object({
-        periodId: z.string().uuid(),
-        label: z.string().min(1).max(40),
+        periodId: z.string().uuid().optional(), // absent = a new term to insert
+        label: z.string().min(1, "Each term needs a name").max(40),
         startsOn: z.string(),
         endsOn: z.string(),
       }),
     )
-    .min(1)
-    .max(6),
+    .min(1, "Add at least one term")
+    .max(8),
 });
 
+/** Save term dates — updates existing periods (by id) and inserts new ones. Ensures an
+ *  academic-period-config row exists so the FK holds; never deletes (would cascade scores). */
 export async function updateAcademicPeriods(
   input: unknown,
 ): Promise<{ ok: boolean; error?: string }> {
@@ -275,7 +285,8 @@ export async function updateAcademicPeriods(
   if (!parsed.success) {
     return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };
   }
-  for (const p of parsed.data.periods) {
+  const { academicYear, periods } = parsed.data;
+  for (const p of periods) {
     if (!isIsoDate(p.startsOn) || !isIsoDate(p.endsOn)) {
       return { ok: false, error: `Enter valid dates for ${p.label}.` };
     }
@@ -286,16 +297,52 @@ export async function updateAcademicPeriods(
   const actor = await resolveActor(school.id);
   try {
     await withSchool(school.id, async (tx) => {
-      for (const p of parsed.data.periods) {
-        await tx
-          .update(academicPeriod)
-          .set({ periodLabel: p.label.trim(), startsOn: p.startsOn, endsOn: p.endsOn })
-          .where(
-            and(
-              eq(academicPeriod.periodId, p.periodId),
-              eq(academicPeriod.schoolId, school.id),
-            ),
-          );
+      // ensure the config row exists (FK target for academic_period)
+      await tx
+        .insert(academicPeriodConfig)
+        .values({
+          schoolId: school.id,
+          academicYear,
+          periodType: parsed.data.periodType ?? "TERM",
+          periodCount: periods.length,
+          source: "SCHOOL_OVERRIDE",
+          configuredBy: actor.id ?? undefined,
+        })
+        .onConflictDoNothing();
+
+      const existing = await tx
+        .select({ n: academicPeriod.periodNumber })
+        .from(academicPeriod)
+        .where(
+          and(
+            eq(academicPeriod.schoolId, school.id),
+            eq(academicPeriod.academicYear, academicYear),
+          ),
+        );
+      let nextNum = existing.reduce((m, e) => Math.max(m, e.n), 0);
+
+      for (const p of periods) {
+        if (p.periodId) {
+          await tx
+            .update(academicPeriod)
+            .set({ periodLabel: p.label.trim(), startsOn: p.startsOn, endsOn: p.endsOn })
+            .where(
+              and(
+                eq(academicPeriod.periodId, p.periodId),
+                eq(academicPeriod.schoolId, school.id),
+              ),
+            );
+        } else {
+          nextNum += 1;
+          await tx.insert(academicPeriod).values({
+            schoolId: school.id,
+            academicYear,
+            periodNumber: nextNum,
+            periodLabel: p.label.trim(),
+            startsOn: p.startsOn,
+            endsOn: p.endsOn,
+          });
+        }
       }
       await recordAudit(tx, {
         schoolId: school.id,
@@ -304,7 +351,7 @@ export async function updateAcademicPeriods(
         actionType: "updated",
         entityType: "academic_period",
         entityId: school.id,
-        after: { periods: parsed.data.periods.length },
+        after: { periods: periods.length, academicYear },
         reason: "Term dates updated",
       });
     });


### PR DESCRIPTION
## Fix — Academic structure term dates "unable to edit"

**Symptom:** on Settings → Academic structure, the term dates couldn't be edited.

**Cause:** the editor only updated *existing* `academic_period` rows. Schools whose periods weren't seeded at onboarding (no GES default for that year/tier, or the onboarding term-dates were left blank) had **no period rows** — so the form showed the empty message and there was nothing to edit.

### Changes
- `updateAcademicPeriods` now **inserts new terms** (rows without an id) as well as updating existing ones, and **ensures the `academic_period_config` row exists** first (FK target). It **never deletes** — avoids cascading away gradebook scores / report cards.
- `TermDatesForm` gains **"+ Add term"** (works from an empty state), an empty-state prompt, and per-new-row remove; it submits the `academicYear` (config year, else the current GES year).
- Page coerces DB dates to strict `YYYY-MM-DD` before `<input type="date">` (defensive against a driver returning a time component / `Date`).

### Verification
- `pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm build` ✓ (`/settings/academic` 5.22 kB)
- Reproduced live on the dev server (dev-bypass auth): existing terms edit and enable Save; **"+ Add term"** inserts an editable row with a remove ✕; no console errors.

No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)