### PR TITLE
feat(settings): audit-log viewer + data export sub-pages (redesign step 7d)

### DIFF
--- a/omnischools/app/(app)/settings/audit/page.tsx
+++ b/omnischools/app/(app)/settings/audit/page.tsx
@@ -1,0 +1,158 @@
+import Link from "next/link";
+import { and, desc, eq, sql } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import { auditLog, users } from "@/db/schema";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Audit log" };
+
+const ACTION_TONE: Record<string, string> = {
+  created: "bg-green-bg text-green",
+  updated: "bg-gold-bg text-gold",
+  deleted: "bg-terra-bg text-terra",
+  voided: "bg-terra-bg text-terra",
+};
+
+const title = (s?: string | null) =>
+  s ? s.charAt(0) + s.slice(1).toLowerCase().replaceAll("_", " ") : "—";
+
+function when(d: Date | string): string {
+  const date = d instanceof Date ? d : new Date(d);
+  if (Number.isNaN(date.getTime())) return String(d);
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${date.getFullYear()}-${p(date.getMonth() + 1)}-${p(date.getDate())} ${p(
+    date.getHours(),
+  )}:${p(date.getMinutes())}`;
+}
+
+export default async function AuditLogPage({
+  searchParams,
+}: {
+  searchParams: { entity?: string };
+}) {
+  const { school } = await requireSchool();
+  const entity = searchParams.entity;
+
+  const data = await withSchool(school.id, async (tx) => {
+    const kinds = await tx
+      .select({ entityType: auditLog.entityType, n: sql<number>`count(*)` })
+      .from(auditLog)
+      .where(eq(auditLog.schoolId, school.id))
+      .groupBy(auditLog.entityType)
+      .orderBy(desc(sql`count(*)`));
+    const rows = await tx
+      .select({
+        auditId: auditLog.auditId,
+        occurredAt: auditLog.occurredAt,
+        actorRole: auditLog.actorRole,
+        actorName: users.fullName,
+        actionType: auditLog.actionType,
+        entityType: auditLog.entityType,
+        entityId: auditLog.entityId,
+        reason: auditLog.reason,
+      })
+      .from(auditLog)
+      .leftJoin(users, eq(auditLog.actorUserId, users.id))
+      .where(
+        entity
+          ? and(eq(auditLog.schoolId, school.id), eq(auditLog.entityType, entity))
+          : eq(auditLog.schoolId, school.id),
+      )
+      .orderBy(desc(auditLog.occurredAt))
+      .limit(200);
+    return { kinds, rows };
+  });
+
+  const chip = (label: string, value: string | null, count?: number) => {
+    const active = (value ?? undefined) === entity || (!value && !entity);
+    const href = value ? `/settings/audit?entity=${value}` : "/settings/audit";
+    return (
+      <Link
+        key={value ?? "all"}
+        href={href}
+        className={`rounded-pill px-3 py-1 text-xs font-semibold ${
+          active ? "bg-navy text-bg" : "bg-bg text-navy-3 hover:bg-gold-bg"
+        }`}
+      >
+        {label}
+        {count != null && <span className="ml-1 opacity-70">{count}</span>}
+      </Link>
+    );
+  };
+
+  return (
+    <div className="mx-auto max-w-page">
+      <Link href="/settings" className="text-sm text-navy-3 hover:text-gold">
+        ← Settings
+      </Link>
+      <div className="mb-5 mt-2">
+        <h1 className="font-display text-3xl font-semibold text-navy">
+          Audit <em className="not-italic text-gold [font-style:italic]">log.</em>
+        </h1>
+        <p className="text-sm text-navy-3">
+          An append-only record of who changed what. Showing the latest {data.rows.length}{" "}
+          {entity ? `${title(entity)} ` : ""}events.
+        </p>
+      </div>
+
+      <div className="mb-4 flex flex-wrap gap-1.5">
+        {chip("All", null)}
+        {data.kinds.map((k) => chip(title(k.entityType), k.entityType, Number(k.n)))}
+      </div>
+
+      {data.rows.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border-2 bg-surface p-10 text-center text-sm text-navy-3">
+          No audit events yet.
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-border bg-surface">
+          <table className="w-full text-sm">
+            <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
+              <tr>
+                <th className="px-4 py-2.5 font-semibold">When</th>
+                <th className="px-4 py-2.5 font-semibold">Who</th>
+                <th className="px-4 py-2.5 font-semibold">Action</th>
+                <th className="px-4 py-2.5 font-semibold">Entity</th>
+                <th className="px-4 py-2.5 font-semibold">Reason</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {data.rows.map((r) => (
+                <tr key={r.auditId} className="align-top hover:bg-bg">
+                  <td className="whitespace-nowrap px-4 py-2.5 font-mono text-xs text-navy-2">
+                    {when(r.occurredAt)}
+                  </td>
+                  <td className="px-4 py-2.5 text-navy-2">
+                    {r.actorName ?? title(r.actorRole) ?? "System"}
+                    {r.actorName && r.actorRole && (
+                      <span className="text-navy-3"> · {title(r.actorRole)}</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2.5">
+                    <span
+                      className={`rounded-pill px-2 py-0.5 text-xs font-medium ${
+                        ACTION_TONE[r.actionType] ?? "bg-bg text-navy-3"
+                      }`}
+                    >
+                      {title(r.actionType)}
+                    </span>
+                  </td>
+                  <td className="px-4 py-2.5 text-navy-2">
+                    {title(r.entityType)}
+                    {r.entityId && (
+                      <span className="ml-1 font-mono text-[10px] text-navy-3">
+                        {r.entityId.slice(0, 8)}
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2.5 text-navy-3">{r.reason ?? "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/omnischools/app/(app)/settings/export/page.tsx
+++ b/omnischools/app/(app)/settings/export/page.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+import { requireSchool } from "@/lib/auth/server";
+import { ExportPanel } from "@/components/settings/export-panel";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Data export" };
+
+export default async function DataExportPage() {
+  await requireSchool();
+  return (
+    <div className="mx-auto max-w-page">
+      <Link href="/settings" className="text-sm text-navy-3 hover:text-gold">
+        ← Settings
+      </Link>
+      <div className="mb-6 mt-2">
+        <h1 className="font-display text-3xl font-semibold text-navy">
+          Data <em className="not-italic text-gold [font-style:italic]">export.</em>
+        </h1>
+        <p className="text-sm text-navy-3">
+          Download your school&apos;s records as CSV — open them in Excel or Google Sheets.
+        </p>
+      </div>
+      <ExportPanel />
+    </div>
+  );
+}

--- a/omnischools/components/settings/export-panel.tsx
+++ b/omnischools/components/settings/export-panel.tsx
@@ -1,0 +1,74 @@
+"use client";
+import { useState } from "react";
+import {
+  exportStudentsCsv,
+  exportStaffCsv,
+  exportFeesCsv,
+} from "@/lib/actions/export";
+
+type Kind = "students" | "staff" | "fees";
+const RUNNERS: Record<Kind, () => Promise<unknown>> = {
+  students: exportStudentsCsv,
+  staff: exportStaffCsv,
+  fees: exportFeesCsv,
+};
+
+const CARDS: { kind: Kind; name: string; desc: string }[] = [
+  { kind: "students", name: "Students", desc: "Codes, names, sex, DOB, class and status." },
+  { kind: "staff", name: "Staff", desc: "Names, phone, email and roles." },
+  { kind: "fees", name: "Fee structures", desc: "Fee plans and their line items by year." },
+];
+
+function download(filename: string, csv: string) {
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export function ExportPanel() {
+  const [busy, setBusy] = useState<Kind | null>(null);
+  const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
+
+  async function run(kind: Kind) {
+    setBusy(kind);
+    setMsg(null);
+    const res = (await RUNNERS[kind]()) as
+      | { ok: true; filename: string; csv: string; rows: number }
+      | { ok: false; error: string };
+    setBusy(null);
+    if (res.ok) {
+      download(res.filename, res.csv);
+      setMsg({ ok: true, text: `Exported ${res.rows} row${res.rows === 1 ? "" : "s"}.` });
+    } else setMsg({ ok: false, text: res.error });
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-3">
+        {CARDS.map((c) => (
+          <div key={c.kind} className="rounded-xl border border-border bg-surface p-5">
+            <div className="font-display text-base font-medium text-navy">{c.name}</div>
+            <p className="mb-4 mt-1 text-[12px] leading-relaxed text-navy-3">{c.desc}</p>
+            <button
+              onClick={() => run(c.kind)}
+              disabled={busy !== null}
+              className="rounded-md bg-navy px-4 py-2 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-50"
+            >
+              {busy === c.kind ? "Preparing…" : "↓ Download CSV"}
+            </button>
+          </div>
+        ))}
+      </div>
+      {msg && (
+        <p className={`text-sm ${msg.ok ? "text-green" : "text-terra"}`}>{msg.text}</p>
+      )}
+      <p className="text-xs text-navy-3">
+        Files download to your device. Your records are yours to take anytime.
+      </p>
+    </div>
+  );
+}

--- a/omnischools/lib/actions/export.ts
+++ b/omnischools/lib/actions/export.ts
@@ -1,0 +1,156 @@
+"use server";
+import { and, asc, desc, eq, notInArray } from "drizzle-orm";
+import { withSchool } from "@/lib/db/rls";
+import { requireSchool } from "@/lib/auth/server";
+import { csvTemplate } from "@/lib/import/csv";
+import { NON_STAFF_ROLE_CODES } from "@/lib/staff-roles";
+import {
+  students,
+  users,
+  roles,
+  roleAssignments,
+  feeStructures,
+  feeStructureItems,
+} from "@/db/schema";
+
+type ExportResult =
+  | { ok: true; filename: string; csv: string; rows: number }
+  | { ok: false; error: string };
+
+const cap = (s: string) => s.charAt(0) + s.slice(1).toLowerCase();
+
+/** Students → CSV (code, name parts, sex, DOB, class, status). */
+export async function exportStudentsCsv(): Promise<ExportResult> {
+  const { school } = await requireSchool();
+  try {
+    const rows = await withSchool(school.id, (tx) =>
+      tx
+        .select()
+        .from(students)
+        .where(eq(students.schoolId, school.id))
+        .orderBy(asc(students.lastName)),
+    );
+    const headers = [
+      "Student code",
+      "Last name",
+      "First name",
+      "Other names",
+      "Sex",
+      "Date of birth",
+      "Class",
+      "Status",
+    ];
+    const body = rows.map((s) => [
+      s.studentCode,
+      s.lastName,
+      s.firstName,
+      s.otherNames ?? "",
+      cap(s.sex),
+      s.dateOfBirth ? String(s.dateOfBirth).slice(0, 10) : "",
+      s.currentClassLabel ?? "",
+      cap(s.status),
+    ]);
+    return {
+      ok: true,
+      filename: "omnischools-students.csv",
+      csv: csvTemplate(headers, body),
+      rows: body.length,
+    };
+  } catch {
+    return { ok: false, error: "Could not export students." };
+  }
+}
+
+/** Staff → CSV (name, phone, email, roles). Excludes student/parent accounts. */
+export async function exportStaffCsv(): Promise<ExportResult> {
+  const { school } = await requireSchool();
+  try {
+    const rows = await withSchool(school.id, (tx) =>
+      tx
+        .select({
+          userId: users.id,
+          name: users.fullName,
+          phone: users.phone,
+          email: users.email,
+          roleCode: roles.code,
+          roleLabel: roles.label,
+        })
+        .from(roleAssignments)
+        .innerJoin(users, eq(roleAssignments.userId, users.id))
+        .innerJoin(roles, eq(roleAssignments.roleId, roles.id))
+        .where(
+          and(
+            eq(roleAssignments.schoolId, school.id),
+            notInArray(roles.code, NON_STAFF_ROLE_CODES),
+          ),
+        ),
+    );
+    const byUser = new Map<
+      string,
+      { name: string; phone: string; email: string; roles: string[] }
+    >();
+    for (const r of rows) {
+      let g = byUser.get(r.userId);
+      if (!g) {
+        g = { name: r.name ?? "", phone: r.phone, email: r.email ?? "", roles: [] };
+        byUser.set(r.userId, g);
+      }
+      if (r.roleLabel) g.roles.push(r.roleLabel);
+    }
+    const headers = ["Full name", "Phone", "Email", "Roles"];
+    const body = Array.from(byUser.values()).map((m) => [
+      m.name,
+      m.phone,
+      m.email,
+      m.roles.join(" · "),
+    ]);
+    return {
+      ok: true,
+      filename: "omnischools-staff.csv",
+      csv: csvTemplate(headers, body),
+      rows: body.length,
+    };
+  } catch {
+    return { ok: false, error: "Could not export staff." };
+  }
+}
+
+/** Fee structures + line items → CSV. */
+export async function exportFeesCsv(): Promise<ExportResult> {
+  const { school } = await requireSchool();
+  try {
+    const rows = await withSchool(school.id, (tx) =>
+      tx
+        .select({
+          structure: feeStructures.name,
+          level: feeStructures.level,
+          academicYear: feeStructures.academicYear,
+          item: feeStructureItems.description,
+          amount: feeStructureItems.amount,
+        })
+        .from(feeStructureItems)
+        .innerJoin(
+          feeStructures,
+          eq(feeStructureItems.feeStructureId, feeStructures.id),
+        )
+        .where(eq(feeStructureItems.schoolId, school.id))
+        .orderBy(desc(feeStructures.academicYear), asc(feeStructures.name)),
+    );
+    const headers = ["Fee structure", "Level", "Academic year", "Item", "Amount (GHS)"];
+    const body = rows.map((r) => [
+      r.structure,
+      r.level ?? "",
+      r.academicYear,
+      r.item,
+      String(r.amount),
+    ]);
+    return {
+      ok: true,
+      filename: "omnischools-fees.csv",
+      csv: csvTemplate(headers, body),
+      rows: body.length,
+    };
+  } catch {
+    return { ok: false, error: "Could not export fees." };
+  }
+}

--- a/omnischools/lib/settings-nav.ts
+++ b/omnischools/lib/settings-nav.ts
@@ -180,7 +180,6 @@ export const SETTINGS_GROUPS: SettingsGroup[] = [
         tone: "navy",
         desc: "An immutable record of who changed what and when — payments, records, roles and settings.",
         href: "/settings/audit",
-        soon: true,
       },
       {
         key: "export",
@@ -190,7 +189,6 @@ export const SETTINGS_GROUPS: SettingsGroup[] = [
         tone: "green",
         desc: "Download your students, staff and fees as CSV. Your records are yours to take anytime.",
         href: "/settings/export",
-        soon: true,
       },
       {
         key: "retention",


### PR DESCRIPTION
## Step 7d — Audit log + Data export

Two more Settings deep pages. **No migration.**

### Audit log (`/settings/audit`)
Read-only viewer over `audit_log`, scoped to the school:
- Latest 200 events — **when · who** (actor name + role) **· action** (colour-tinted) **· entity** (+ short id) **· reason**. Append-only; nothing editable.
- **Entity-type filter chips** with counts (`?entity=…`).

### Data export (`/settings/export`)
- Download **Students / Staff / Fee structures** as CSV. Server actions build the CSV with the shared csv util; the client downloads a Blob. Staff excludes student/parent accounts.

Un-"soon"s both directory cards.

### Verification
- `pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm build` ✓ (`/settings/audit` 207 B · `/settings/export` 1.25 kB)
- Reproduced live (dev-bypass): audit shows 33 events + working filter chips; export returns real counts (staff → 5 rows) and downloads; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)