### PR TITLE
fix(downloads): prefix every CSV download with the school name

### DIFF
--- a/omnischools/app/(app)/reports/page.tsx
+++ b/omnischools/app/(app)/reports/page.tsx
@@ -3,6 +3,7 @@ import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import { invoices, payments, students, classes } from "@/db/schema";
 import { ExportCsv } from "@/components/reports/export-csv";
+import { schoolFile } from "@/lib/filename";
 
 export const dynamic = "force-dynamic";
 
@@ -125,7 +126,7 @@ export default async function ReportsPage() {
             Outstanding by class
           </h2>
           <ExportCsv
-            filename="outstanding-by-class.csv"
+            filename={schoolFile(school.name, "outstanding-by-class.csv")}
             headers={["Class", "Billed", "Collected", "Outstanding"]}
             rows={byClass.map((c) => [
               c.className,
@@ -179,7 +180,7 @@ export default async function ReportsPage() {
               Monthly collections
             </h2>
             <ExportCsv
-              filename="monthly-collections.csv"
+              filename={schoolFile(school.name, "monthly-collections.csv")}
               headers={["Month", "Collected"]}
               rows={monthly.map((m) => [m.month, num(m.amount).toFixed(2)])}
             />

--- a/omnischools/app/(app)/staff/import/page.tsx
+++ b/omnischools/app/(app)/staff/import/page.tsx
@@ -6,7 +6,7 @@ export const dynamic = "force-dynamic";
 export const metadata = { title: "Import staff" };
 
 export default async function ImportStaffPage() {
-  await requireSchool();
+  const { school } = await requireSchool();
 
   return (
     <div className="mx-auto max-w-page">
@@ -26,7 +26,7 @@ export default async function ImportStaffPage() {
           </p>
         </div>
       </div>
-      <StaffImport />
+      <StaffImport schoolName={school.name} />
     </div>
   );
 }

--- a/omnischools/app/(app)/students/import/page.tsx
+++ b/omnischools/app/(app)/students/import/page.tsx
@@ -39,7 +39,7 @@ export default async function ImportStudentsPage() {
           </p>
         </div>
       </div>
-      <StudentImport classByName={classByName} />
+      <StudentImport classByName={classByName} schoolName={school.name} />
     </div>
   );
 }

--- a/omnischools/components/staff/staff-import.tsx
+++ b/omnischools/components/staff/staff-import.tsx
@@ -10,10 +10,11 @@ import {
   type ImportSummary,
 } from "@/lib/import/staff-import";
 import { importStaff } from "@/lib/actions/staff";
+import { schoolFile } from "@/lib/filename";
 
 type Filter = "all" | "ready" | "warning" | "error";
 
-export function StaffImport() {
+export function StaffImport({ schoolName }: { schoolName?: string }) {
   const router = useRouter();
   const [rows, setRows] = useState<StaffImportRow[]>([]);
   const [summary, setSummary] = useState<ImportSummary | null>(null);
@@ -30,7 +31,7 @@ export function StaffImport() {
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "omnischools-staff-template.csv";
+    a.download = schoolFile(schoolName, "staff-template.csv");
     a.click();
     URL.revokeObjectURL(url);
   }

--- a/omnischools/components/students/student-import.tsx
+++ b/omnischools/components/students/student-import.tsx
@@ -10,10 +10,17 @@ import {
   type ImportSummary,
 } from "@/lib/import/student-import";
 import { importStudents } from "@/lib/actions/students";
+import { schoolFile } from "@/lib/filename";
 
 type Filter = "all" | "ready" | "warning" | "error";
 
-export function StudentImport({ classByName }: { classByName: Record<string, string> }) {
+export function StudentImport({
+  classByName,
+  schoolName,
+}: {
+  classByName: Record<string, string>;
+  schoolName?: string;
+}) {
   const router = useRouter();
   const [rows, setRows] = useState<StudentRow[]>([]);
   const [summary, setSummary] = useState<ImportSummary | null>(null);
@@ -29,7 +36,7 @@ export function StudentImport({ classByName }: { classByName: Record<string, str
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "omnischools-students-template.csv";
+    a.download = schoolFile(schoolName, "students-template.csv");
     a.click();
     URL.revokeObjectURL(url);
   }

--- a/omnischools/lib/actions/export.ts
+++ b/omnischools/lib/actions/export.ts
@@ -3,6 +3,7 @@ import { and, asc, desc, eq, notInArray } from "drizzle-orm";
 import { withSchool } from "@/lib/db/rls";
 import { requireSchool } from "@/lib/auth/server";
 import { csvTemplate } from "@/lib/import/csv";
+import { schoolFile } from "@/lib/filename";
 import { NON_STAFF_ROLE_CODES } from "@/lib/staff-roles";
 import {
   students,
@@ -18,18 +19,6 @@ type ExportResult =
   | { ok: false; error: string };
 
 const cap = (s: string) => s.charAt(0) + s.slice(1).toLowerCase();
-
-/** Filename prefix from the school's name (filename-safe), e.g. "Asankrangwa High". */
-function filePrefix(school: { name: string; shortName: string | null }): string {
-  const base = (school.name || school.shortName || "school").trim();
-  return (
-    base
-      .replace(/[\\/:*?"<>|]+/g, "") // strip illegal filename chars
-      .replace(/\s+/g, " ")
-      .trim()
-      .slice(0, 60) || "school"
-  );
-}
 
 /** Students → CSV (code, name parts, sex, DOB, class, status). */
 export async function exportStudentsCsv(): Promise<ExportResult> {
@@ -64,7 +53,7 @@ export async function exportStudentsCsv(): Promise<ExportResult> {
     ]);
     return {
       ok: true,
-      filename: `${filePrefix(school)}-students.csv`,
+      filename: schoolFile(school.name, "students.csv"),
       csv: csvTemplate(headers, body),
       rows: body.length,
     };
@@ -118,7 +107,7 @@ export async function exportStaffCsv(): Promise<ExportResult> {
     ]);
     return {
       ok: true,
-      filename: `${filePrefix(school)}-staff.csv`,
+      filename: schoolFile(school.name, "staff.csv"),
       csv: csvTemplate(headers, body),
       rows: body.length,
     };
@@ -158,7 +147,7 @@ export async function exportFeesCsv(): Promise<ExportResult> {
     ]);
     return {
       ok: true,
-      filename: `${filePrefix(school)}-fees.csv`,
+      filename: schoolFile(school.name, "fees.csv"),
       csv: csvTemplate(headers, body),
       rows: body.length,
     };

--- a/omnischools/lib/filename.ts
+++ b/omnischools/lib/filename.ts
@@ -1,0 +1,19 @@
+/**
+ * Build a download filename prefixed with the school's name, e.g.
+ * `schoolFile("Asankrangwa Senior High School", "students.csv")`
+ *   → "Asankrangwa Senior High School-students.csv".
+ * Pure + client/server safe. Strips characters illegal in filenames.
+ */
+export function schoolFilePrefix(name?: string | null): string {
+  return (
+    (name ?? "")
+      .replace(/[\\/:*?"<>|]+/g, "") // illegal filename chars
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, 60) || "school"
+  );
+}
+
+export function schoolFile(name: string | null | undefined, suffix: string): string {
+  return `${schoolFilePrefix(name)}-${suffix}`;
+}


### PR DESCRIPTION
## Fix — all CSV downloads carry the school name

PR #44 only covered the **Settings data-export** page. The **import templates** and the **Reports** exports were still hardcoded (`omnischools-staff-template.csv`, and the Reports CSVs had no school prefix at all). This makes **every** download lead with the school's own name.

### Changes
- New shared **`lib/filename.ts`** → `schoolFilePrefix` / `schoolFile(name, suffix)` (filename-safe, length-capped).
- `lib/actions/export.ts` (students/staff/fees export) → uses the shared helper.
- **Student & Staff import templates** → `<School>-students-template.csv` / `-staff-template.csv` (school name passed from the import pages).
- **Reports exports** → `<School>-outstanding-by-class.csv` / `-monthly-collections.csv`.

### Verification
- `pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm build` ✓
- Reproduced live (dev-bypass): staff template → **`Asankrangwa Senior High School-staff-template.csv`**; students template → **`…-students-template.csv`**; no console errors.

No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)