### PR TITLE
fix(fidelity): currency + dashboard KPIs + comms/inbox polish (redesign step 8a)

### DIFF
--- a/omnischools/app/(app)/communication/page.tsx
+++ b/omnischools/app/(app)/communication/page.tsx
@@ -1,7 +1,20 @@
 import { desc, eq } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
-import { classes, announcements, smsTemplates, notificationLog } from "@/db/schema";
+import {
+  classes,
+  announcements,
+  smsTemplates,
+  notificationLog,
+  students,
+} from "@/db/schema";
+
+const fmtWhen = (d: Date | string) => {
+  const date = d instanceof Date ? d : new Date(d);
+  if (Number.isNaN(date.getTime())) return "—";
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${p(date.getDate())}/${p(date.getMonth() + 1)} ${p(date.getHours())}:${p(date.getMinutes())}`;
+};
 import { AnnouncementComposer, TemplateForm } from "@/components/comms/composers";
 import { SmsComposer } from "@/components/comms/sms-composer";
 
@@ -23,8 +36,18 @@ export default async function CommunicationPage() {
       .where(eq(smsTemplates.schoolId, school.id))
       .orderBy(desc(smsTemplates.createdAt));
     const log = await tx
-      .select()
+      .select({
+        id: notificationLog.id,
+        phone: notificationLog.phone,
+        message: notificationLog.message,
+        status: notificationLog.status,
+        provider: notificationLog.provider,
+        createdAt: notificationLog.createdAt,
+        studentFirst: students.firstName,
+        studentLast: students.lastName,
+      })
       .from(notificationLog)
+      .leftJoin(students, eq(notificationLog.studentId, students.id))
       .where(eq(notificationLog.schoolId, school.id))
       .orderBy(desc(notificationLog.createdAt))
       .limit(15);
@@ -107,18 +130,36 @@ export default async function CommunicationPage() {
             ) : (
               <div className="bg-surface overflow-hidden rounded-xl border border-border">
                 <table className="w-full text-sm">
+                  <thead className="border-b border-border bg-bg text-left text-[10px] uppercase tracking-wide text-navy-3">
+                    <tr>
+                      <th className="px-3 py-2 font-semibold">Recipient</th>
+                      <th className="px-3 py-2 font-semibold">Message</th>
+                      <th className="px-3 py-2 font-semibold">Channel</th>
+                      <th className="px-3 py-2 font-semibold">When</th>
+                      <th className="px-3 py-2 text-right font-semibold">Status</th>
+                    </tr>
+                  </thead>
                   <tbody className="divide-y divide-border">
                     {data.log.map((l) => (
-                      <tr key={l.id}>
-                        <td className="px-3 py-2 font-mono text-xs text-navy-3">
-                          {l.phone}
+                      <tr key={l.id} className="align-top">
+                        <td className="px-3 py-2">
+                          <div className="text-navy">
+                            {l.studentFirst
+                              ? `${l.studentFirst} ${l.studentLast ?? ""}`.trim()
+                              : "—"}
+                          </div>
+                          <div className="font-mono text-[10px] text-navy-3">{l.phone}</div>
                         </td>
                         <td className="max-w-0 truncate px-3 py-2 text-navy-2">
                           {l.message}
                         </td>
+                        <td className="px-3 py-2 text-navy-3">{l.provider ?? "SMS"}</td>
+                        <td className="whitespace-nowrap px-3 py-2 font-mono text-[11px] text-navy-3">
+                          {fmtWhen(l.createdAt)}
+                        </td>
                         <td className="px-3 py-2 text-right">
                           <span
-                            className={`rounded-pill px-2 py-0.5 text-xs font-medium ${l.status === "SENT" ? "bg-green-bg text-green" : "bg-terra-bg text-terra"}`}
+                            className={`rounded-pill px-2 py-0.5 text-xs font-medium ${l.status === "SENT" ? "bg-green-bg text-green" : l.status === "FAILED" ? "bg-terra-bg text-terra" : "bg-bg text-navy-3"}`}
                           >
                             {l.status.charAt(0) + l.status.slice(1).toLowerCase()}
                           </span>

--- a/omnischools/app/(app)/dashboard/page.tsx
+++ b/omnischools/app/(app)/dashboard/page.tsx
@@ -1,13 +1,31 @@
 import Link from "next/link";
-import { eq, and, sql } from "drizzle-orm";
+import { eq, and, gte, lte, sql } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
-import { students, admissionApplications } from "@/db/schema";
+import {
+  students,
+  admissionApplications,
+  classes,
+  roles,
+  roleAssignments,
+  academicPeriodConfig,
+  academicPeriod,
+} from "@/db/schema";
 
 export const dynamic = "force-dynamic";
 
+const fmtDate = (d: Date) =>
+  d.toLocaleDateString("en-GB", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+
 export default async function DashboardPage() {
   const { school } = await requireSchool();
+  const today = new Date().toISOString().slice(0, 10);
+
   const stats = await withSchool(school.id, async (tx) => {
     const [{ activeStudents }] = await tx
       .select({ activeStudents: sql<number>`count(*)::int` })
@@ -22,33 +40,150 @@ export default async function DashboardPage() {
           eq(admissionApplications.status, "SUBMITTED"),
         ),
       );
-    return { activeStudents, pending };
+    const [{ classCount }] = await tx
+      .select({ classCount: sql<number>`count(*)::int` })
+      .from(classes)
+      .where(and(eq(classes.schoolId, school.id), eq(classes.active, true)));
+    const [{ teacherCount }] = await tx
+      .select({ teacherCount: sql<number>`count(distinct ${roleAssignments.userId})::int` })
+      .from(roleAssignments)
+      .innerJoin(roles, eq(roleAssignments.roleId, roles.id))
+      .where(and(eq(roleAssignments.schoolId, school.id), eq(roles.code, "TEACHER")));
+    const [cfg] = await tx
+      .select({ academicYear: academicPeriodConfig.academicYear })
+      .from(academicPeriodConfig)
+      .where(eq(academicPeriodConfig.schoolId, school.id));
+    const [term] = await tx
+      .select({ label: academicPeriod.periodLabel })
+      .from(academicPeriod)
+      .where(
+        and(
+          eq(academicPeriod.schoolId, school.id),
+          lte(academicPeriod.startsOn, today),
+          gte(academicPeriod.endsOn, today),
+        ),
+      )
+      .limit(1);
+    return {
+      activeStudents,
+      pending,
+      classCount,
+      teacherCount,
+      academicYear: cfg?.academicYear ?? null,
+      term: term?.label ?? null,
+    };
   });
 
-  const cards = [
-    { label: "Active students", value: stats.activeStudents, href: "/students" },
-    { label: "Pending applications", value: stats.pending, href: "/admissions" },
+  const ratio = stats.teacherCount > 0 ? Math.round(stats.activeStudents / stats.teacherCount) : 0;
+  const avgClass =
+    stats.classCount > 0 ? Math.round(stats.activeStudents / stats.classCount) : 0;
+
+  const kpis = [
+    {
+      label: "Teaching staff",
+      value: stats.teacherCount,
+      sub: ratio > 0 ? `student:teacher ratio ${ratio}:1` : "no teachers yet",
+      href: "/staff",
+    },
+    {
+      label: "Active classes",
+      value: stats.classCount,
+      sub: stats.classCount > 0 ? "across the school" : "set up under Classes",
+      href: "/classes",
+    },
+    {
+      label: "Avg class size",
+      value: avgClass,
+      sub: avgClass > 0 ? "students per class" : "—",
+      href: "/classes",
+    },
   ];
 
   return (
     <div className="mx-auto max-w-page">
-      <h1 className="mb-1 font-display text-3xl font-semibold text-navy">
-        Good day, {school.shortName ?? "team"}.
+      <div className="mb-1.5 text-[11px] font-bold uppercase tracking-[0.16em] text-gold">
+        Dashboard
+      </div>
+      <h1 className="font-display text-3xl font-semibold text-navy">
+        Good day,{" "}
+        <em className="not-italic text-gold [font-style:italic]">
+          {school.shortName ?? school.name}.
+        </em>
       </h1>
-      <p className="mb-8 text-sm text-navy-2">
-        Here&apos;s the shape of your school today.
-      </p>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        {cards.map((c) => (
+      <p className="mt-1.5 text-sm text-navy-2">Here&apos;s the shape of your school today.</p>
+
+      {/* Snapshot pill */}
+      <div className="mt-4 inline-flex flex-wrap items-center gap-x-2 rounded-pill border border-border-2 bg-bg px-3.5 py-1.5 text-[11px] text-navy-3">
+        <span>Snapshot as of</span>
+        <b className="text-navy">{fmtDate(new Date())}</b>
+        {stats.academicYear && (
+          <>
+            <span>·</span>
+            <span>
+              academic year <b className="text-navy">{stats.academicYear}</b>
+            </span>
+          </>
+        )}
+        {stats.term && (
+          <>
+            <span>·</span>
+            <b className="text-navy">{stats.term}</b>
+          </>
+        )}
+      </div>
+
+      {/* KPI strip — featured primary + 3 cards */}
+      <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <Link
+          href="/students"
+          className="rounded-xl border border-navy bg-navy p-5 text-bg transition-colors hover:bg-navy-deep"
+        >
+          <div className="font-display text-4xl font-semibold">{stats.activeStudents}</div>
+          <div className="mt-1 text-sm text-gold-soft">Total students</div>
+          <div className="mt-0.5 text-[11px] text-bg/60">active on roll</div>
+        </Link>
+        {kpis.map((k) => (
           <Link
-            key={c.label}
-            href={c.href}
-            className="bg-surface rounded-xl border border-border p-5 transition-colors hover:border-gold-soft"
+            key={k.label}
+            href={k.href}
+            className="rounded-xl border border-border bg-surface p-5 transition-colors hover:border-gold-soft"
           >
-            <div className="font-display text-4xl font-semibold text-navy">{c.value}</div>
-            <div className="mt-1 text-sm text-navy-3">{c.label}</div>
+            <div className="font-display text-4xl font-semibold text-navy">{k.value}</div>
+            <div className="mt-1 text-sm text-navy-3">{k.label}</div>
+            <div className="mt-0.5 text-[11px] text-navy-3">{k.sub}</div>
           </Link>
         ))}
+      </div>
+
+      {/* Needs attention */}
+      <div className="mt-4">
+        <Link
+          href="/admissions"
+          className={`flex items-center justify-between rounded-xl border p-4 transition-colors ${
+            stats.pending > 0
+              ? "border-warn/40 bg-warn-bg/40 hover:border-warn"
+              : "border-border bg-surface hover:border-gold-soft"
+          }`}
+        >
+          <div className="flex items-center gap-3">
+            <div
+              className={`flex h-9 w-9 items-center justify-center rounded-lg font-display text-lg font-semibold ${
+                stats.pending > 0 ? "bg-warn text-surface" : "bg-bg text-navy-3"
+              }`}
+            >
+              {stats.pending}
+            </div>
+            <div>
+              <div className="text-sm font-semibold text-navy">Pending applications</div>
+              <div className="text-[11px] text-navy-3">
+                {stats.pending > 0
+                  ? "Awaiting review in Admissions"
+                  : "Nothing waiting — you're all caught up"}
+              </div>
+            </div>
+          </div>
+          <span className="text-sm font-semibold text-gold">Open admissions →</span>
+        </Link>
       </div>
     </div>
   );

--- a/omnischools/app/(app)/gradebook/report/[studentId]/page.tsx
+++ b/omnischools/app/(app)/gradebook/report/[studentId]/page.tsx
@@ -128,13 +128,13 @@ export default async function ReportCardPage({
                 <tr key={i}>
                   <td className="py-2 text-navy">{l.subject}</td>
                   <td className="py-2 text-right text-navy-2">
-                    {l.classScore ? Number(l.classScore).toFixed(0) : "—"}
+                    {l.classScore != null ? Number(l.classScore).toFixed(0) : "—"}
                   </td>
                   <td className="py-2 text-right text-navy-2">
-                    {l.examScore ? Number(l.examScore).toFixed(0) : "—"}
+                    {l.examScore != null ? Number(l.examScore).toFixed(0) : "—"}
                   </td>
                   <td className="py-2 text-right font-medium text-navy">
-                    {l.total ? Number(l.total).toFixed(2) : "—"}
+                    {l.total != null ? Number(l.total).toFixed(2) : "—"}
                   </td>
                   <td className="py-2 text-right font-semibold text-navy">
                     {l.grade ?? "—"}
@@ -162,7 +162,7 @@ export default async function ReportCardPage({
           <div className="text-right">
             <div className="text-xs uppercase tracking-wide text-navy-3">Overall</div>
             <div className="font-display text-3xl font-semibold text-navy">
-              {card?.overallTotal ? Number(card.overallTotal).toFixed(2) : "—"}
+              {card?.overallTotal != null ? Number(card.overallTotal).toFixed(2) : "—"}
               {card?.overallGrade && (
                 <span className="ml-2 text-xl text-gold">{card.overallGrade}</span>
               )}

--- a/omnischools/app/(app)/inbox/[id]/page.tsx
+++ b/omnischools/app/(app)/inbox/[id]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import { and, asc, eq } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
-import { conversations, inboxMessages } from "@/db/schema";
+import { conversations, inboxMessages, students } from "@/db/schema";
 import { loadStaffOptions } from "@/lib/data/staff-options";
 import { ReplyBox } from "@/components/inbox/reply-box";
 import { ConversationControls } from "@/components/inbox/conversation-controls";
@@ -24,11 +24,25 @@ export default async function ConversationPage({ params }: { params: { id: strin
 
   const [conv] = await withSchool(school.id, (tx) =>
     tx
-      .select()
+      .select({
+        id: conversations.id,
+        contactName: conversations.contactName,
+        contactPhone: conversations.contactPhone,
+        subject: conversations.subject,
+        status: conversations.status,
+        assignedToUserId: conversations.assignedToUserId,
+        studentFirst: students.firstName,
+        studentLast: students.lastName,
+        studentClass: students.currentClassLabel,
+      })
       .from(conversations)
+      .leftJoin(students, eq(conversations.studentId, students.id))
       .where(and(eq(conversations.id, id), eq(conversations.schoolId, school.id))),
   );
   if (!conv) notFound();
+  const studentName = conv.studentFirst
+    ? `${conv.studentFirst} ${conv.studentLast ?? ""}`.trim()
+    : null;
 
   const [messages, staff] = await Promise.all([
     withSchool(school.id, (tx) =>
@@ -57,6 +71,12 @@ export default async function ConversationPage({ params }: { params: { id: strin
             <h1 className="font-display text-2xl font-semibold text-navy">
               {conv.contactName ?? conv.contactPhone}
             </h1>
+            {studentName && (
+              <p className="text-sm text-navy-2">
+                Guardian of <span className="font-medium text-navy">{studentName}</span>
+                {conv.studentClass ? ` · ${conv.studentClass}` : ""}
+              </p>
+            )}
             <p className="text-sm text-navy-3">
               {conv.contactPhone}
               {conv.subject ? ` · ${conv.subject}` : ""} ·{" "}

--- a/omnischools/app/(app)/reports/page.tsx
+++ b/omnischools/app/(app)/reports/page.tsx
@@ -8,7 +8,7 @@ import { schoolFile } from "@/lib/filename";
 export const dynamic = "force-dynamic";
 
 const ghs = (n: number) =>
-  `GH₵ ${n.toLocaleString("en-GH", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  `GHS ${n.toLocaleString("en-GH", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 const num = (v: unknown) => Number(v ?? 0);
 
 const METHOD_LABEL: Record<string, string> = {

--- a/omnischools/components/billing/discount-manager.tsx
+++ b/omnischools/components/billing/discount-manager.tsx
@@ -5,7 +5,7 @@ import { createDiscount, deleteDiscount } from "@/lib/actions/billing";
 import { DataList } from "@/components/ui/fields";
 import { DEFAULT_DISCOUNTS } from "@/lib/field-options";
 
-const ghs = (n: number) => `GH₵ ${n.toFixed(2)}`;
+const ghs = (n: number) => `GHS ${n.toFixed(2)}`;
 const fieldClass =
   "rounded-md border border-border-2 bg-bg px-3 py-2 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
 
@@ -55,7 +55,7 @@ export function DiscountManager({ discounts }: { discounts: DiscountOpt[] }) {
         <div>
           <label className="mb-1 block text-xs font-semibold text-navy-2">Type</label>
           <select name="kind" defaultValue="FIXED" className={fieldClass}>
-            <option value="FIXED">Fixed (GH₵)</option>
+            <option value="FIXED">Fixed (GHS)</option>
             <option value="PERCENT">Percent (%)</option>
           </select>
         </div>

--- a/omnischools/components/billing/fee-structure-card.tsx
+++ b/omnischools/components/billing/fee-structure-card.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { generateInvoicesForClass, deleteFeeStructure } from "@/lib/actions/billing";
 
-const ghs = (n: number) => `GH₵ ${n.toFixed(2)}`;
+const ghs = (n: number) => `GHS ${n.toFixed(2)}`;
 
 type Structure = {
   id: string;

--- a/omnischools/components/billing/reminders-card.tsx
+++ b/omnischools/components/billing/reminders-card.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/navigation";
 import { sendFeeReminders } from "@/lib/actions/billing";
 
 const ghs = (n: number) =>
-  `GH₵ ${n.toLocaleString("en-GH", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  `GHS ${n.toLocaleString("en-GH", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 
 export function RemindersCard({ families, total }: { families: number; total: number }) {
   const router = useRouter();

--- a/omnischools/components/comms/composers.tsx
+++ b/omnischools/components/comms/composers.tsx
@@ -132,7 +132,7 @@ export function TemplateForm() {
       <textarea
         name="body"
         required
-        placeholder="Message — use {student} and {school} as placeholders"
+        placeholder="Message — use {student_first} and {school_short} as placeholders"
         className={`${fieldClass} min-h-[70px] resize-y`}
       />
       <div className="flex items-center gap-2">

--- a/omnischools/components/comms/sms-composer.tsx
+++ b/omnischools/components/comms/sms-composer.tsx
@@ -106,7 +106,7 @@ export function SmsComposer({
           value={message}
           onChange={(e) => setMessage(e.target.value)}
           disabled={usingTemplate}
-          placeholder="Type a message — {student} and {school} are replaced per recipient"
+          placeholder="Type a message — {student_first} and {school_short} are replaced per recipient"
           className={`${fieldClass} min-h-[80px] resize-y disabled:opacity-70`}
         />
       </div>
@@ -114,8 +114,8 @@ export function SmsComposer({
       {error && <p className="text-sm text-terra">{error}</p>}
       {result && <p className="text-sm text-green">{result}</p>}
       <p className="text-xs text-navy-3">
-        Sends to each student&apos;s primary guardian. {"{student}"} and {"{school}"} are
-        personalised per recipient.
+        Sends to each student&apos;s primary guardian. {"{student_first}"} and{" "}
+        {"{school_short}"} are personalised per recipient.
       </p>
       <button
         onClick={send}

--- a/omnischools/components/staff/staff-row.tsx
+++ b/omnischools/components/staff/staff-row.tsx
@@ -105,7 +105,7 @@ export function StaffRow({
             className={`${inputClass} font-sans`}
           />
         ) : (
-          member.phone
+          member.phone || "—"
         )}
       </td>
       <td className="px-4 py-3 text-navy-2">

--- a/omnischools/db/schema/comms.ts
+++ b/omnischools/db/schema/comms.ts
@@ -18,7 +18,7 @@ export const announcements = pgTable("announcement", {
   postedAt: timestamp("posted_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
-/** Reusable SMS message templates (placeholders: {student}, {school}). */
+/** Reusable SMS message templates (placeholders: {student_first}, {school_short}). */
 export const smsTemplates = pgTable(
   "sms_template",
   {

--- a/omnischools/lib/actions/comms.ts
+++ b/omnischools/lib/actions/comms.ts
@@ -116,7 +116,13 @@ export type SendSmsResult =
   | { ok: false; error: string };
 
 function render(body: string, vars: { student: string; school: string }): string {
-  return body.replaceAll("{student}", vars.student).replaceAll("{school}", vars.school);
+  // Canonical tokens match the SMS-library vocabulary; the bare {student}/{school}
+  // forms are kept for backward-compatibility with templates saved before the rename.
+  return body
+    .replaceAll("{student_first}", vars.student)
+    .replaceAll("{student}", vars.student)
+    .replaceAll("{school_short}", vars.school)
+    .replaceAll("{school}", vars.school);
 }
 
 export async function sendSmsToAudience(input: unknown): Promise<SendSmsResult> {


### PR DESCRIPTION
## Step 8a — Per-section fidelity sweep

From a full audit of the 12 built sections against their surfaces. The big structural gaps (SHS-tier academics, Fees allocation/void-reason, discount tiers, Reports catalogue, attendance card-grid, inbox routing) are **intentionally deferred** to the Senior MVP / module-deepening backlog (recorded in the plan). This PR lands the basic-tier fidelity fixes. **No migration.**

### 8a-i — quick wins
- **Currency** → `GHS 340.00` (space, 2dp): `reports/page.tsx`, `billing/{reminders-card,fee-structure-card,discount-manager}` (formatter + "Fixed (GHS)" label). Fees pages were already correct.
- **Report card** — guard score cells with `!= null` so a genuine **0** renders "0", not "—" (falsy-zero bug on class/exam/total/overall).
- **Staff list** — Phone falls back to "—" when empty.

### 8a-ii — medium polish
- **Dashboard** — from a 2-card stub to the surface's "school at a glance": snapshot pill (date · academic year · current term) + **4-KPI strip** (Total students on a featured navy card, Teaching staff + student:teacher ratio, Active classes, Avg class size) + a Pending-applications attention strip.
- **Communication "Recent sends"** — labeled header row + Recipient (student name + phone) · Message · Channel · When · Status.
- **Inbox** conversation header — "Guardian of {student} · {class}" (links the thread to the pupil).
- **SMS tokens** — `{student_first}` / `{school_short}` in composer/template hints + schema; the merge still accepts legacy `{student}`/`{school}`.

### Verification
- `pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm build` ✓
- Dashboard verified live (dev-bypass): snapshot pill (today · 2025/26 · Semester 2), all 4 KPIs, pending strip; no console errors. Currency confirmed: no `GH₵`/`₵` left in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)