### PR TITLE
feat(books): income & expense entries (redesign step 8b-ii)

### DIFF
--- a/omnischools/app/(app)/books/expenses/page.tsx
+++ b/omnischools/app/(app)/books/expenses/page.tsx
@@ -1,0 +1,59 @@
+import { and, asc, desc, eq } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import { bookCategories, bookEntries } from "@/db/schema";
+import { BooksTabs } from "@/components/books/books-tabs";
+import { BookEntries } from "@/components/books/book-entries";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Books · Expenses" };
+
+export default async function BooksExpensesPage() {
+  const { school } = await requireSchool();
+  const data = await withSchool(school.id, async (tx) => {
+    const cats = await tx
+      .select({ id: bookCategories.id, name: bookCategories.name })
+      .from(bookCategories)
+      .where(
+        and(
+          eq(bookCategories.schoolId, school.id),
+          eq(bookCategories.kind, "EXPENSE"),
+          eq(bookCategories.active, true),
+        ),
+      )
+      .orderBy(asc(bookCategories.name));
+    const entries = await tx
+      .select({
+        id: bookEntries.id,
+        entryDate: bookEntries.entryDate,
+        category: bookCategories.name,
+        description: bookEntries.description,
+        party: bookEntries.party,
+        method: bookEntries.method,
+        reference: bookEntries.reference,
+        amount: bookEntries.amount,
+      })
+      .from(bookEntries)
+      .leftJoin(bookCategories, eq(bookEntries.categoryId, bookCategories.id))
+      .where(and(eq(bookEntries.schoolId, school.id), eq(bookEntries.kind, "EXPENSE")))
+      .orderBy(desc(bookEntries.entryDate))
+      .limit(200);
+    return { cats, entries };
+  });
+
+  return (
+    <div className="mx-auto max-w-page">
+      <div className="mb-1.5 text-[11px] font-bold uppercase tracking-[0.16em] text-gold">
+        Books
+      </div>
+      <h1 className="mb-1 font-display text-3xl font-semibold text-navy">
+        <em className="not-italic text-gold [font-style:italic]">Expenses.</em>
+      </h1>
+      <p className="mb-5 text-sm text-navy-3">
+        Money the school spends — salaries, utilities, feeding, maintenance.
+      </p>
+      <BooksTabs />
+      <BookEntries kind="EXPENSE" categories={data.cats} entries={data.entries} />
+    </div>
+  );
+}

--- a/omnischools/app/(app)/books/income/page.tsx
+++ b/omnischools/app/(app)/books/income/page.tsx
@@ -1,0 +1,59 @@
+import { and, asc, desc, eq } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import { bookCategories, bookEntries } from "@/db/schema";
+import { BooksTabs } from "@/components/books/books-tabs";
+import { BookEntries } from "@/components/books/book-entries";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Books · Income" };
+
+export default async function BooksIncomePage() {
+  const { school } = await requireSchool();
+  const data = await withSchool(school.id, async (tx) => {
+    const cats = await tx
+      .select({ id: bookCategories.id, name: bookCategories.name })
+      .from(bookCategories)
+      .where(
+        and(
+          eq(bookCategories.schoolId, school.id),
+          eq(bookCategories.kind, "INCOME"),
+          eq(bookCategories.active, true),
+        ),
+      )
+      .orderBy(asc(bookCategories.name));
+    const entries = await tx
+      .select({
+        id: bookEntries.id,
+        entryDate: bookEntries.entryDate,
+        category: bookCategories.name,
+        description: bookEntries.description,
+        party: bookEntries.party,
+        method: bookEntries.method,
+        reference: bookEntries.reference,
+        amount: bookEntries.amount,
+      })
+      .from(bookEntries)
+      .leftJoin(bookCategories, eq(bookEntries.categoryId, bookCategories.id))
+      .where(and(eq(bookEntries.schoolId, school.id), eq(bookEntries.kind, "INCOME")))
+      .orderBy(desc(bookEntries.entryDate))
+      .limit(200);
+    return { cats, entries };
+  });
+
+  return (
+    <div className="mx-auto max-w-page">
+      <div className="mb-1.5 text-[11px] font-bold uppercase tracking-[0.16em] text-gold">
+        Books
+      </div>
+      <h1 className="mb-1 font-display text-3xl font-semibold text-navy">
+        <em className="not-italic text-gold [font-style:italic]">Income.</em>
+      </h1>
+      <p className="mb-5 text-sm text-navy-3">
+        Money the school receives — fees, dues, donations, grants.
+      </p>
+      <BooksTabs />
+      <BookEntries kind="INCOME" categories={data.cats} entries={data.entries} />
+    </div>
+  );
+}

--- a/omnischools/components/books/book-entries.tsx
+++ b/omnischools/components/books/book-entries.tsx
@@ -1,0 +1,250 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { addBookEntry, deleteBookEntry } from "@/lib/actions/books";
+
+type Kind = "INCOME" | "EXPENSE";
+type Cat = { id: string; name: string };
+type Entry = {
+  id: string;
+  entryDate: string;
+  category: string | null;
+  description: string | null;
+  party: string | null;
+  method: string | null;
+  reference: string | null;
+  amount: string;
+};
+
+const fieldClass =
+  "w-full rounded-md border border-border-2 bg-bg px-3 py-2 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
+const labelClass = "mb-1 block text-[11px] font-semibold text-navy-2";
+const METHODS = ["Cash", "MTN MoMo", "Telecel Cash", "AirtelTigo Money", "Bank transfer", "Cheque"];
+
+const ghs = (n: number) =>
+  `GHS ${n.toLocaleString("en-GH", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const fmtDate = (d: string) => {
+  const dt = new Date(`${d}T00:00:00`);
+  return Number.isNaN(dt.getTime())
+    ? d
+    : dt.toLocaleDateString("en-GB", { day: "2-digit", month: "short", year: "numeric" });
+};
+
+export function BookEntries({
+  kind,
+  categories,
+  entries,
+}: {
+  kind: Kind;
+  categories: Cat[];
+  entries: Entry[];
+}) {
+  const router = useRouter();
+  const income = kind === "INCOME";
+  const partyLabel = income ? "Source" : "Payee";
+  const todayDefault = new Date().toISOString().slice(0, 10);
+
+  const [date, setDate] = useState(todayDefault);
+  const [categoryId, setCategoryId] = useState("");
+  const [party, setParty] = useState("");
+  const [method, setMethod] = useState("");
+  const [reference, setReference] = useState("");
+  const [amount, setAmount] = useState("");
+  const [description, setDescription] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmId, setConfirmId] = useState<string | null>(null);
+
+  const total = entries.reduce((s, e) => s + Number(e.amount), 0);
+
+  async function add() {
+    setBusy(true);
+    setError(null);
+    const res = await addBookEntry({
+      kind,
+      entryDate: date,
+      categoryId,
+      party,
+      method,
+      reference,
+      amount,
+      description,
+    });
+    setBusy(false);
+    if (res.ok) {
+      setParty("");
+      setReference("");
+      setAmount("");
+      setDescription("");
+      router.refresh();
+    } else setError(res.error ?? "Could not save.");
+  }
+
+  async function remove(id: string) {
+    setBusy(true);
+    await deleteBookEntry({ id });
+    setBusy(false);
+    setConfirmId(null);
+    router.refresh();
+  }
+
+  return (
+    <div className="space-y-5">
+      {/* Total */}
+      <div className="rounded-xl border border-border bg-surface p-5">
+        <div className={`font-display text-3xl font-semibold ${income ? "text-green" : "text-terra"}`}>
+          {ghs(total)}
+        </div>
+        <div className="mt-1 text-sm text-navy-3">
+          Total {income ? "income" : "expenses"} · {entries.length}{" "}
+          {entries.length === 1 ? "entry" : "entries"}
+        </div>
+      </div>
+
+      {/* Add form */}
+      <div className="rounded-xl border border-border bg-surface p-5">
+        <h2 className="mb-3 font-display text-base font-medium text-navy">
+          Record {income ? "income" : "an expense"}
+        </h2>
+        <datalist id="book-methods">
+          {METHODS.map((m) => (
+            <option key={m} value={m} />
+          ))}
+        </datalist>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          <div>
+            <label className={labelClass}>Date</label>
+            <input type="date" value={date} onChange={(e) => setDate(e.target.value)} className={fieldClass} />
+          </div>
+          <div>
+            <label className={labelClass}>Category</label>
+            <select value={categoryId} onChange={(e) => setCategoryId(e.target.value)} className={fieldClass}>
+              <option value="">— choose —</option>
+              {categories.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className={labelClass}>{partyLabel}</label>
+            <input
+              value={party}
+              onChange={(e) => setParty(e.target.value)}
+              placeholder={income ? "Who paid" : "Paid to"}
+              className={fieldClass}
+            />
+          </div>
+          <div>
+            <label className={labelClass}>Method</label>
+            <input list="book-methods" value={method} onChange={(e) => setMethod(e.target.value)} placeholder="Cash" className={fieldClass} />
+          </div>
+          <div>
+            <label className={labelClass}>{income ? "Reference" : "Receipt #"}</label>
+            <input value={reference} onChange={(e) => setReference(e.target.value)} className={fieldClass} />
+          </div>
+          <div>
+            <label className={labelClass}>Amount (GHS)</label>
+            <input
+              type="number"
+              min={0}
+              step="0.01"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+              placeholder="0.00"
+              className={`${fieldClass} text-right font-mono`}
+            />
+          </div>
+          <div className="sm:col-span-2 lg:col-span-3">
+            <label className={labelClass}>
+              Note <span className="font-medium text-navy-3">— optional</span>
+            </label>
+            <input value={description} onChange={(e) => setDescription(e.target.value)} className={fieldClass} />
+          </div>
+        </div>
+        <div className="mt-4 flex items-center gap-3">
+          <button
+            onClick={add}
+            disabled={busy || !amount}
+            className="rounded-md bg-navy px-5 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-50"
+          >
+            {busy ? "Saving…" : income ? "Add income" : "Add expense"}
+          </button>
+          {error && <span className="text-sm text-terra">{error}</span>}
+        </div>
+      </div>
+
+      {/* Entries table */}
+      <div className="overflow-x-auto rounded-xl border border-border bg-surface">
+        <table className="w-full text-sm">
+          <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
+            <tr>
+              <th className="px-4 py-2.5 font-semibold">Date</th>
+              <th className="px-4 py-2.5 font-semibold">Category</th>
+              <th className="px-4 py-2.5 font-semibold">{partyLabel} / note</th>
+              <th className="px-4 py-2.5 font-semibold">Method</th>
+              <th className="px-4 py-2.5 font-semibold">{income ? "Ref" : "Receipt"}</th>
+              <th className="px-4 py-2.5 text-right font-semibold">Amount</th>
+              <th className="px-4 py-2.5" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {entries.length === 0 ? (
+              <tr>
+                <td colSpan={7} className="px-4 py-8 text-center text-sm text-navy-3">
+                  No {income ? "income" : "expenses"} recorded yet.
+                </td>
+              </tr>
+            ) : (
+              entries.map((e) => (
+                <tr key={e.id} className="align-top hover:bg-bg">
+                  <td className="whitespace-nowrap px-4 py-2.5 font-mono text-xs text-navy-2">
+                    {fmtDate(e.entryDate)}
+                  </td>
+                  <td className="px-4 py-2.5 text-navy-2">{e.category ?? "—"}</td>
+                  <td className="px-4 py-2.5 text-navy-2">
+                    {e.party || e.description || "—"}
+                  </td>
+                  <td className="px-4 py-2.5 text-navy-3">{e.method ?? "—"}</td>
+                  <td className="px-4 py-2.5 font-mono text-xs text-navy-3">
+                    {e.reference ?? "—"}
+                  </td>
+                  <td className={`whitespace-nowrap px-4 py-2.5 text-right font-medium ${income ? "text-green" : "text-terra"}`}>
+                    {ghs(Number(e.amount))}
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-2.5 text-right">
+                    {confirmId === e.id ? (
+                      <>
+                        <button
+                          onClick={() => remove(e.id)}
+                          disabled={busy}
+                          className="mr-2 text-xs font-semibold text-terra disabled:opacity-50"
+                        >
+                          Confirm
+                        </button>
+                        <button
+                          onClick={() => setConfirmId(null)}
+                          className="text-xs font-semibold text-navy-3"
+                        >
+                          Cancel
+                        </button>
+                      </>
+                    ) : (
+                      <button
+                        onClick={() => setConfirmId(e.id)}
+                        className="text-xs font-semibold text-navy-3 transition-colors hover:text-terra"
+                      >
+                        Delete
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/omnischools/components/books/books-tabs.tsx
+++ b/omnischools/components/books/books-tabs.tsx
@@ -5,8 +5,8 @@ import { cn } from "@/lib/utils";
 
 const TABS: { href: string; label: string; soon?: boolean }[] = [
   { href: "/books", label: "Dashboard" },
-  { href: "/books/income", label: "Income", soon: true },
-  { href: "/books/expenses", label: "Expenses", soon: true },
+  { href: "/books/income", label: "Income" },
+  { href: "/books/expenses", label: "Expenses" },
   { href: "/books/reports", label: "Financial reports", soon: true },
   { href: "/books/assets", label: "Fixed assets", soon: true },
   { href: "/books/settings", label: "Settings" },

--- a/omnischools/lib/actions/books.ts
+++ b/omnischools/lib/actions/books.ts
@@ -6,7 +6,7 @@ import { recordAudit } from "@/lib/db/audit";
 import { requireSchool, resolveActor } from "@/lib/auth/server";
 import { safeRevalidate } from "@/lib/revalidate";
 import { INCOME_CATEGORIES, EXPENSE_CATEGORIES } from "@/lib/field-options";
-import { bookCategories } from "@/db/schema";
+import { bookCategories, bookEntries } from "@/db/schema";
 
 type Result = { ok: boolean; error?: string; id?: string };
 
@@ -133,5 +133,102 @@ export async function seedDefaultBookCategories(): Promise<Result & { added?: nu
     return { ok: true, added };
   } catch {
     return { ok: false, error: "Could not seed default categories." };
+  }
+}
+
+// ----------------------------------------------------------- income / expense entries
+const isIsoDate = (s: string) =>
+  /^\d{4}-\d{2}-\d{2}$/.test(s) && !Number.isNaN(Date.parse(s));
+
+const AddEntrySchema = z.object({
+  kind: KIND,
+  entryDate: z.string().refine(isIsoDate, "Enter a valid date"),
+  categoryId: z.string().uuid().optional().or(z.literal("")),
+  description: z.string().max(200).optional().or(z.literal("")),
+  party: z.string().max(120).optional().or(z.literal("")),
+  method: z.string().max(40).optional().or(z.literal("")),
+  reference: z.string().max(60).optional().or(z.literal("")),
+  amount: z.coerce.number().positive("Amount must be greater than 0").max(100000000),
+});
+
+export async function addBookEntry(input: unknown): Promise<Result> {
+  const { school } = await requireSchool();
+  const parsed = AddEntrySchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };
+  }
+  const d = parsed.data;
+  const nz = (v?: string) => (v && v.trim() ? v.trim() : null);
+  const actor = await resolveActor(school.id);
+  try {
+    const id = await withSchool(school.id, async (tx) => {
+      const [e] = await tx
+        .insert(bookEntries)
+        .values({
+          schoolId: school.id,
+          kind: d.kind,
+          entryDate: d.entryDate,
+          categoryId: d.categoryId || null,
+          description: nz(d.description),
+          party: nz(d.party),
+          method: nz(d.method),
+          reference: nz(d.reference),
+          amount: String(d.amount),
+          createdByUserId: actor.id ?? null,
+        })
+        .returning({ id: bookEntries.id });
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "created",
+        entityType: "book_entry",
+        entityId: e.id,
+        after: { kind: d.kind, amount: d.amount },
+        reason: `${d.kind === "INCOME" ? "Income" : "Expense"} recorded`,
+      });
+      return e.id;
+    });
+    safeRevalidate("/books");
+    safeRevalidate(d.kind === "INCOME" ? "/books/income" : "/books/expenses");
+    return { ok: true, id };
+  } catch {
+    return { ok: false, error: "Could not save the entry. Please try again." };
+  }
+}
+
+const DeleteEntrySchema = z.object({ id: z.string().uuid() });
+export async function deleteBookEntry(input: unknown): Promise<Result> {
+  const { school } = await requireSchool();
+  const parsed = DeleteEntrySchema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: "Invalid input" };
+  const actor = await resolveActor(school.id);
+  try {
+    const outcome = await withSchool(school.id, async (tx) => {
+      const [row] = await tx
+        .select({ kind: bookEntries.kind })
+        .from(bookEntries)
+        .where(and(eq(bookEntries.id, parsed.data.id), eq(bookEntries.schoolId, school.id)));
+      if (!row) return { error: "Entry not found." };
+      await tx
+        .delete(bookEntries)
+        .where(and(eq(bookEntries.id, parsed.data.id), eq(bookEntries.schoolId, school.id)));
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "deleted",
+        entityType: "book_entry",
+        entityId: parsed.data.id,
+        reason: "Book entry deleted",
+      });
+      return { ok: true as const, kind: row.kind };
+    });
+    if ("error" in outcome) return { ok: false, error: outcome.error };
+    safeRevalidate("/books");
+    safeRevalidate(outcome.kind === "INCOME" ? "/books/income" : "/books/expenses");
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Could not delete the entry." };
   }
 }


### PR DESCRIPTION
## Step 8b-ii — Income & Expenses

Record and list income & expense entries against the chart of accounts. **No schema change** (uses 8b-i's `book_entry` table).

### Pages
- **`/books/income`** & **`/books/expenses`** — one kind-aware `BookEntries` component:
  - Record form: date · category · source/payee · method (datalist) · reference/receipt · amount · note.
  - Running **total** tile (green income / terra expense) + entries table with two-step delete.
- Income/Expenses tabs un-"soon"d. Entries feed the dashboard's Income / Expenses / Net KPIs.

### Actions (`lib/actions/books.ts`)
- `addBookEntry` — validates ISO date + positive amount, sets `created_by`, audited.
- `deleteBookEntry` — tenant-scoped, audited.
- Both revalidate the dashboard + their tab.

### Verification
- `pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm build` ✓ (`/books/income` · `/books/expenses`)
- Live (dev-bypass): recorded an income entry (GHS 1,500, Admission fees) → income-page total **and** dashboard Income/Net updated; entry shows in the table; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)