### PR TITLE
feat(books): fixed assets + financial reports (redesign step 8b-iii)

### DIFF
--- a/omnischools/app/(app)/books/assets/page.tsx
+++ b/omnischools/app/(app)/books/assets/page.tsx
@@ -1,0 +1,44 @@
+import { desc, eq } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import { fixedAssets } from "@/db/schema";
+import { BooksTabs } from "@/components/books/books-tabs";
+import { FixedAssets } from "@/components/books/fixed-assets";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Books · Fixed assets" };
+
+export default async function BooksAssetsPage() {
+  const { school } = await requireSchool();
+  const assets = await withSchool(school.id, (tx) =>
+    tx
+      .select({
+        id: fixedAssets.id,
+        name: fixedAssets.name,
+        acquiredOn: fixedAssets.acquiredOn,
+        originalCost: fixedAssets.originalCost,
+        accumulatedDepreciation: fixedAssets.accumulatedDepreciation,
+        condition: fixedAssets.condition,
+      })
+      .from(fixedAssets)
+      .where(eq(fixedAssets.schoolId, school.id))
+      .orderBy(desc(fixedAssets.createdAt)),
+  );
+
+  return (
+    <div className="mx-auto max-w-page">
+      <div className="mb-1.5 text-[11px] font-bold uppercase tracking-[0.16em] text-gold">
+        Books
+      </div>
+      <h1 className="mb-1 font-display text-3xl font-semibold text-navy">
+        Fixed <em className="not-italic text-gold [font-style:italic]">assets.</em>
+      </h1>
+      <p className="mb-5 text-sm text-navy-3">
+        Capital items — buildings, vehicles, equipment — with cost, depreciation and book
+        value.
+      </p>
+      <BooksTabs />
+      <FixedAssets assets={assets} />
+    </div>
+  );
+}

--- a/omnischools/app/(app)/books/reports/page.tsx
+++ b/omnischools/app/(app)/books/reports/page.tsx
@@ -1,0 +1,167 @@
+import Link from "next/link";
+import { and, eq, sql, desc } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import { bookCategories, bookEntries } from "@/db/schema";
+import { BooksTabs } from "@/components/books/books-tabs";
+import { ExportCsv } from "@/components/reports/export-csv";
+import { schoolFile } from "@/lib/filename";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Books · Financial reports" };
+
+const ghs = (n: number) =>
+  `GHS ${n.toLocaleString("en-GH", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+export default async function BooksReportsPage({
+  searchParams,
+}: {
+  searchParams: { year?: string };
+}) {
+  const { school } = await requireSchool();
+  const thisYear = new Date().getFullYear();
+  const year = searchParams.year && /^\d{4}$/.test(searchParams.year)
+    ? Number(searchParams.year)
+    : null; // null = all time
+
+  const data = await withSchool(school.id, async (tx) => {
+    const yearFilter = year
+      ? sql`extract(year from ${bookEntries.entryDate}) = ${year}`
+      : undefined;
+    const byCat = async (kind: "INCOME" | "EXPENSE") =>
+      tx
+        .select({
+          name: sql<string>`coalesce(${bookCategories.name}, 'Uncategorised')`,
+          total: sql<string>`sum(${bookEntries.amount})`,
+        })
+        .from(bookEntries)
+        .leftJoin(bookCategories, eq(bookEntries.categoryId, bookCategories.id))
+        .where(
+          yearFilter
+            ? and(eq(bookEntries.schoolId, school.id), eq(bookEntries.kind, kind), yearFilter)
+            : and(eq(bookEntries.schoolId, school.id), eq(bookEntries.kind, kind)),
+        )
+        .groupBy(sql`coalesce(${bookCategories.name}, 'Uncategorised')`)
+        .orderBy(desc(sql`sum(${bookEntries.amount})`));
+    return { income: await byCat("INCOME"), expense: await byCat("EXPENSE") };
+  });
+
+  const incomeRows = data.income.map((r) => ({ name: r.name, total: Number(r.total) }));
+  const expenseRows = data.expense.map((r) => ({ name: r.name, total: Number(r.total) }));
+  const incomeTotal = incomeRows.reduce((s, r) => s + r.total, 0);
+  const expenseTotal = expenseRows.reduce((s, r) => s + r.total, 0);
+  const net = incomeTotal - expenseTotal;
+  const periodLabel = year ? String(year) : "All time";
+
+  const csvRows: (string | number)[][] = [
+    ["Income", "", ""],
+    ...incomeRows.map((r) => ["", r.name, r.total.toFixed(2)]),
+    ["", "Total income", incomeTotal.toFixed(2)],
+    ["Expenses", "", ""],
+    ...expenseRows.map((r) => ["", r.name, r.total.toFixed(2)]),
+    ["", "Total expenses", expenseTotal.toFixed(2)],
+    ["Net", "", net.toFixed(2)],
+  ];
+
+  const chip = (label: string, value: number | null) => {
+    const active = value === year;
+    const href = value ? `/books/reports?year=${value}` : "/books/reports";
+    return (
+      <Link
+        key={label}
+        href={href}
+        className={`rounded-pill px-3 py-1 text-xs font-semibold ${active ? "bg-navy text-bg" : "bg-bg text-navy-3 hover:bg-gold-bg"}`}
+      >
+        {label}
+      </Link>
+    );
+  };
+
+  const CatTable = ({
+    title,
+    rows,
+    total,
+    tone,
+  }: {
+    title: string;
+    rows: { name: string; total: number }[];
+    total: number;
+    tone: string;
+  }) => (
+    <div className="overflow-hidden rounded-xl border border-border bg-surface">
+      <div className="flex items-center justify-between border-b border-border bg-bg px-4 py-2.5">
+        <span className="font-display text-sm font-semibold text-navy">{title}</span>
+        <span className={`font-mono text-sm font-semibold ${tone}`}>{ghs(total)}</span>
+      </div>
+      <table className="w-full text-sm">
+        <tbody className="divide-y divide-border">
+          {rows.length === 0 ? (
+            <tr>
+              <td className="px-4 py-6 text-center text-sm text-navy-3">No entries.</td>
+            </tr>
+          ) : (
+            rows.map((r) => (
+              <tr key={r.name}>
+                <td className="px-4 py-2 text-navy-2">{r.name}</td>
+                <td className="px-4 py-2 text-right font-mono text-navy-2">{ghs(r.total)}</td>
+                <td className="px-4 py-2 text-right text-[11px] text-navy-3">
+                  {total > 0 ? `${Math.round((r.total / total) * 100)}%` : "—"}
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+
+  return (
+    <div className="mx-auto max-w-page">
+      <div className="mb-1.5 text-[11px] font-bold uppercase tracking-[0.16em] text-gold">
+        Books
+      </div>
+      <h1 className="mb-1 font-display text-3xl font-semibold text-navy">
+        Financial <em className="not-italic text-gold [font-style:italic]">reports.</em>
+      </h1>
+      <p className="mb-5 text-sm text-navy-3">
+        Income and expenses by category — {periodLabel}.
+      </p>
+      <BooksTabs />
+
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap gap-1.5">
+          {chip("All time", null)}
+          {chip(String(thisYear), thisYear)}
+          {chip(String(thisYear - 1), thisYear - 1)}
+        </div>
+        <ExportCsv
+          filename={schoolFile(school.name, `financial-summary-${year ?? "all"}.csv`)}
+          headers={["Section", "Category", "Amount (GHS)"]}
+          rows={csvRows}
+          label="↓ Export CSV"
+        />
+      </div>
+
+      {/* KPI strip */}
+      <div className="mb-5 grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div className="rounded-xl border border-border bg-surface p-5">
+          <div className="font-display text-2xl font-semibold text-green">{ghs(incomeTotal)}</div>
+          <div className="mt-1 text-sm text-navy-3">Income</div>
+        </div>
+        <div className="rounded-xl border border-border bg-surface p-5">
+          <div className="font-display text-2xl font-semibold text-terra">{ghs(expenseTotal)}</div>
+          <div className="mt-1 text-sm text-navy-3">Expenses</div>
+        </div>
+        <div className={`rounded-xl border p-5 ${net >= 0 ? "border-navy bg-navy text-bg" : "border-terra bg-terra-bg"}`}>
+          <div className="font-display text-2xl font-semibold">{ghs(net)}</div>
+          <div className={`mt-1 text-sm ${net >= 0 ? "text-gold-soft" : "text-terra"}`}>Net</div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <CatTable title="Income by category" rows={incomeRows} total={incomeTotal} tone="text-green" />
+        <CatTable title="Expenses by category" rows={expenseRows} total={expenseTotal} tone="text-terra" />
+      </div>
+    </div>
+  );
+}

--- a/omnischools/components/books/books-tabs.tsx
+++ b/omnischools/components/books/books-tabs.tsx
@@ -7,8 +7,8 @@ const TABS: { href: string; label: string; soon?: boolean }[] = [
   { href: "/books", label: "Dashboard" },
   { href: "/books/income", label: "Income" },
   { href: "/books/expenses", label: "Expenses" },
-  { href: "/books/reports", label: "Financial reports", soon: true },
-  { href: "/books/assets", label: "Fixed assets", soon: true },
+  { href: "/books/reports", label: "Financial reports" },
+  { href: "/books/assets", label: "Fixed assets" },
   { href: "/books/settings", label: "Settings" },
 ];
 

--- a/omnischools/components/books/fixed-assets.tsx
+++ b/omnischools/components/books/fixed-assets.tsx
@@ -1,0 +1,198 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { addFixedAsset, deleteFixedAsset } from "@/lib/actions/books";
+
+type Asset = {
+  id: string;
+  name: string;
+  acquiredOn: string | null;
+  originalCost: string;
+  accumulatedDepreciation: string;
+  condition: string | null;
+};
+
+const fieldClass =
+  "w-full rounded-md border border-border-2 bg-bg px-3 py-2 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
+const labelClass = "mb-1 block text-[11px] font-semibold text-navy-2";
+const CONDITIONS = ["New", "Good", "Fair", "Poor"];
+const ghs = (n: number) =>
+  `GHS ${n.toLocaleString("en-GH", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const fmtDate = (d: string | null) => {
+  if (!d) return "—";
+  const dt = new Date(`${d}T00:00:00`);
+  return Number.isNaN(dt.getTime())
+    ? d
+    : dt.toLocaleDateString("en-GB", { day: "2-digit", month: "short", year: "numeric" });
+};
+
+export function FixedAssets({ assets }: { assets: Asset[] }) {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [acquiredOn, setAcquiredOn] = useState("");
+  const [cost, setCost] = useState("");
+  const [dep, setDep] = useState("");
+  const [condition, setCondition] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmId, setConfirmId] = useState<string | null>(null);
+
+  const totalBookValue = assets.reduce(
+    (s, a) => s + (Number(a.originalCost) - Number(a.accumulatedDepreciation)),
+    0,
+  );
+
+  async function add() {
+    setBusy(true);
+    setError(null);
+    const res = await addFixedAsset({
+      name,
+      acquiredOn,
+      originalCost: cost,
+      accumulatedDepreciation: dep || 0,
+      condition,
+    });
+    setBusy(false);
+    if (res.ok) {
+      setName("");
+      setAcquiredOn("");
+      setCost("");
+      setDep("");
+      setCondition("");
+      router.refresh();
+    } else setError(res.error ?? "Could not add.");
+  }
+
+  async function remove(id: string) {
+    setBusy(true);
+    await deleteFixedAsset({ id });
+    setBusy(false);
+    setConfirmId(null);
+    router.refresh();
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="rounded-xl border border-border bg-surface p-5">
+        <div className="font-display text-3xl font-semibold text-navy">
+          {ghs(totalBookValue)}
+        </div>
+        <div className="mt-1 text-sm text-navy-3">
+          Total book value · {assets.length} {assets.length === 1 ? "asset" : "assets"}
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-border bg-surface p-5">
+        <h2 className="mb-3 font-display text-base font-medium text-navy">Add an asset</h2>
+        <datalist id="asset-conditions">
+          {CONDITIONS.map((c) => (
+            <option key={c} value={c} />
+          ))}
+        </datalist>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="lg:col-span-2">
+            <label className={labelClass}>Asset</label>
+            <input value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. School bus (Toyota Coaster)" className={fieldClass} />
+          </div>
+          <div>
+            <label className={labelClass}>Acquired</label>
+            <input type="date" value={acquiredOn} onChange={(e) => setAcquiredOn(e.target.value)} className={fieldClass} />
+          </div>
+          <div>
+            <label className={labelClass}>Original cost (GHS)</label>
+            <input type="number" min={0} step="0.01" value={cost} onChange={(e) => setCost(e.target.value)} placeholder="0.00" className={`${fieldClass} text-right font-mono`} />
+          </div>
+          <div>
+            <label className={labelClass}>Depreciation to date (GHS)</label>
+            <input type="number" min={0} step="0.01" value={dep} onChange={(e) => setDep(e.target.value)} placeholder="0.00" className={`${fieldClass} text-right font-mono`} />
+          </div>
+          <div>
+            <label className={labelClass}>Condition</label>
+            <input list="asset-conditions" value={condition} onChange={(e) => setCondition(e.target.value)} placeholder="Good" className={fieldClass} />
+          </div>
+        </div>
+        <div className="mt-4 flex items-center gap-3">
+          <button
+            onClick={add}
+            disabled={busy || !name || !cost}
+            className="rounded-md bg-navy px-5 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-50"
+          >
+            {busy ? "Saving…" : "Add asset"}
+          </button>
+          {error && <span className="text-sm text-terra">{error}</span>}
+        </div>
+      </div>
+
+      <div className="overflow-x-auto rounded-xl border border-border bg-surface">
+        <table className="w-full text-sm">
+          <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
+            <tr>
+              <th className="px-4 py-2.5 font-semibold">Asset</th>
+              <th className="px-4 py-2.5 font-semibold">Acquired</th>
+              <th className="px-4 py-2.5 text-right font-semibold">Original cost</th>
+              <th className="px-4 py-2.5 text-right font-semibold">Depreciation</th>
+              <th className="px-4 py-2.5 text-right font-semibold">Book value</th>
+              <th className="px-4 py-2.5 font-semibold">Condition</th>
+              <th className="px-4 py-2.5" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {assets.length === 0 ? (
+              <tr>
+                <td colSpan={7} className="px-4 py-8 text-center text-sm text-navy-3">
+                  No assets recorded yet.
+                </td>
+              </tr>
+            ) : (
+              assets.map((a) => {
+                const bv = Number(a.originalCost) - Number(a.accumulatedDepreciation);
+                return (
+                  <tr key={a.id} className="align-top hover:bg-bg">
+                    <td className="px-4 py-2.5 font-medium text-navy">{a.name}</td>
+                    <td className="whitespace-nowrap px-4 py-2.5 font-mono text-xs text-navy-2">
+                      {fmtDate(a.acquiredOn)}
+                    </td>
+                    <td className="px-4 py-2.5 text-right text-navy-2">
+                      {ghs(Number(a.originalCost))}
+                    </td>
+                    <td className="px-4 py-2.5 text-right text-navy-3">
+                      {ghs(Number(a.accumulatedDepreciation))}
+                    </td>
+                    <td className="px-4 py-2.5 text-right font-medium text-navy">{ghs(bv)}</td>
+                    <td className="px-4 py-2.5 text-navy-3">{a.condition ?? "—"}</td>
+                    <td className="whitespace-nowrap px-4 py-2.5 text-right">
+                      {confirmId === a.id ? (
+                        <>
+                          <button
+                            onClick={() => remove(a.id)}
+                            disabled={busy}
+                            className="mr-2 text-xs font-semibold text-terra disabled:opacity-50"
+                          >
+                            Confirm
+                          </button>
+                          <button
+                            onClick={() => setConfirmId(null)}
+                            className="text-xs font-semibold text-navy-3"
+                          >
+                            Cancel
+                          </button>
+                        </>
+                      ) : (
+                        <button
+                          onClick={() => setConfirmId(a.id)}
+                          className="text-xs font-semibold text-navy-3 transition-colors hover:text-terra"
+                        >
+                          Delete
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/omnischools/lib/actions/books.ts
+++ b/omnischools/lib/actions/books.ts
@@ -6,7 +6,7 @@ import { recordAudit } from "@/lib/db/audit";
 import { requireSchool, resolveActor } from "@/lib/auth/server";
 import { safeRevalidate } from "@/lib/revalidate";
 import { INCOME_CATEGORIES, EXPENSE_CATEGORIES } from "@/lib/field-options";
-import { bookCategories, bookEntries } from "@/db/schema";
+import { bookCategories, bookEntries, fixedAssets } from "@/db/schema";
 
 type Result = { ok: boolean; error?: string; id?: string };
 
@@ -230,5 +230,93 @@ export async function deleteBookEntry(input: unknown): Promise<Result> {
     return { ok: true };
   } catch {
     return { ok: false, error: "Could not delete the entry." };
+  }
+}
+
+// ----------------------------------------------------------- fixed assets
+const AddAssetSchema = z.object({
+  name: z.string().min(1, "Enter an asset name").max(120),
+  acquiredOn: z.string().optional().or(z.literal("")),
+  originalCost: z.coerce.number().min(0).max(100000000),
+  accumulatedDepreciation: z.coerce.number().min(0).max(100000000).optional(),
+  usefulLifeYears: z.coerce.number().int().min(0).max(100).optional(),
+  condition: z.string().max(40).optional().or(z.literal("")),
+  notes: z.string().max(200).optional().or(z.literal("")),
+});
+
+export async function addFixedAsset(input: unknown): Promise<Result> {
+  const { school } = await requireSchool();
+  const parsed = AddAssetSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };
+  }
+  const d = parsed.data;
+  const nz = (v?: string) => (v && v.trim() ? v.trim() : null);
+  const dep = d.accumulatedDepreciation ?? 0;
+  if (dep > d.originalCost) {
+    return { ok: false, error: "Depreciation can't exceed the original cost." };
+  }
+  const actor = await resolveActor(school.id);
+  try {
+    const id = await withSchool(school.id, async (tx) => {
+      const [a] = await tx
+        .insert(fixedAssets)
+        .values({
+          schoolId: school.id,
+          name: d.name.trim(),
+          acquiredOn: nz(d.acquiredOn),
+          originalCost: String(d.originalCost),
+          accumulatedDepreciation: String(dep),
+          usefulLifeYears: d.usefulLifeYears ?? null,
+          condition: nz(d.condition),
+          notes: nz(d.notes),
+        })
+        .returning({ id: fixedAssets.id });
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "created",
+        entityType: "fixed_asset",
+        entityId: a.id,
+        after: { name: d.name, cost: d.originalCost },
+        reason: "Fixed asset added",
+      });
+      return a.id;
+    });
+    safeRevalidate("/books");
+    safeRevalidate("/books/assets");
+    return { ok: true, id };
+  } catch {
+    return { ok: false, error: "Could not add the asset. Please try again." };
+  }
+}
+
+const DeleteAssetSchema = z.object({ id: z.string().uuid() });
+export async function deleteFixedAsset(input: unknown): Promise<Result> {
+  const { school } = await requireSchool();
+  const parsed = DeleteAssetSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: "Invalid input" };
+  const actor = await resolveActor(school.id);
+  try {
+    await withSchool(school.id, async (tx) => {
+      await tx
+        .delete(fixedAssets)
+        .where(and(eq(fixedAssets.id, parsed.data.id), eq(fixedAssets.schoolId, school.id)));
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "deleted",
+        entityType: "fixed_asset",
+        entityId: parsed.data.id,
+        reason: "Fixed asset removed",
+      });
+    });
+    safeRevalidate("/books");
+    safeRevalidate("/books/assets");
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Could not remove the asset." };
   }
 }


### PR DESCRIPTION
## Step 8b-iii — Fixed assets + Financial reports

Final Books slice — completes the 6-page module. **No schema change** (uses 8b-i's tables).

### Pages
- **`/books/assets`** — asset register: add (name · acquired · original cost · depreciation · condition) + table with **computed book value** (cost − depreciation) + total book-value tile + two-step delete.
- **`/books/reports`** — income & expense **by category** with a **period filter** (All time / this year / last year), Income/Expenses/Net KPIs, %-of-total per row, and a **school-named CSV export** of the P&L summary.
- Financial-reports + Fixed-assets tabs un-"soon"d — all six Books tabs now live.

### Actions (`lib/actions/books.ts`)
- `addFixedAsset` (audited, scoped; rejects depreciation > cost) · `deleteFixedAsset`.

### Verification
- `pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm build` ✓ (all 6 `/books` routes)
- Live (dev-bypass): asset book value computes (120k − 30k = **GHS 90,000**); reports show income-by-category + KPIs + period chips + Export CSV (picked up the GHS 1,500 income); no console errors.

**Closes Step 8 — and the full 8-step surface-fidelity redesign.** (No migration here; 8b-i's migration 0018 + RLS must be applied on prod.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)