### PR TITLE
feat(fees): invoice aging badges (track 2a-i)

### DIFF
--- a/omnischools/app/(app)/fees/[studentId]/page.tsx
+++ b/omnischools/app/(app)/fees/[studentId]/page.tsx
@@ -4,7 +4,7 @@ import { and, desc, eq } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import { students, invoices, payments, receipts } from "@/db/schema";
-import { num } from "@/lib/fees-helpers";
+import { num, daysOverdue } from "@/lib/fees-helpers";
 import { IssueInvoiceForm } from "@/components/fees/issue-invoice-form";
 import { RecordPaymentForm } from "@/components/fees/record-payment-form";
 import { VoidPaymentButton } from "@/components/fees/void-payment-button";
@@ -106,29 +106,44 @@ export default async function StudentFeesPage({
               </tr>
             </thead>
             <tbody className="divide-y divide-border">
-              {invs.map((i) => (
-                <tr key={i.id}>
-                  <td className="px-4 py-3 font-mono text-xs text-navy-2">
-                    {i.invoiceNumber}
-                  </td>
-                  <td className="px-4 py-3 text-right text-navy">
-                    {ghs(num(i.billedAmount))}
-                  </td>
-                  <td className="px-4 py-3 text-right text-navy-2">
-                    {ghs(num(i.paidAmount))}
-                  </td>
-                  <td className="px-4 py-3 text-right font-medium text-navy">
-                    {ghs(num(i.balanceAmount))}
-                  </td>
-                  <td className="px-4 py-3">
-                    <span
-                      className={`rounded-pill px-2 py-0.5 text-xs font-medium ${INV_STATUS[i.status]}`}
-                    >
-                      {i.status.charAt(0) + i.status.slice(1).toLowerCase()}
-                    </span>
-                  </td>
-                </tr>
-              ))}
+              {invs.map((i) => {
+                const overdue =
+                  i.status !== "VOIDED" &&
+                  i.status !== "PAID" &&
+                  num(i.balanceAmount) > 0
+                    ? daysOverdue(i.dueAt)
+                    : 0;
+                return (
+                  <tr key={i.id}>
+                    <td className="px-4 py-3 font-mono text-xs text-navy-2">
+                      {i.invoiceNumber}
+                    </td>
+                    <td className="px-4 py-3 text-right text-navy">
+                      {ghs(num(i.billedAmount))}
+                    </td>
+                    <td className="px-4 py-3 text-right text-navy-2">
+                      {ghs(num(i.paidAmount))}
+                    </td>
+                    <td className="px-4 py-3 text-right font-medium text-navy">
+                      {ghs(num(i.balanceAmount))}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex flex-wrap items-center gap-1.5">
+                        <span
+                          className={`rounded-pill px-2 py-0.5 text-xs font-medium ${INV_STATUS[i.status]}`}
+                        >
+                          {i.status.charAt(0) + i.status.slice(1).toLowerCase()}
+                        </span>
+                        {overdue > 0 && (
+                          <span className="rounded-pill bg-terra-bg px-2 py-0.5 text-xs font-medium text-terra">
+                            Overdue {overdue}d
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/omnischools/app/(app)/fees/page.tsx
+++ b/omnischools/app/(app)/fees/page.tsx
@@ -27,6 +27,7 @@ export default async function FeesPage() {
         lastName: students.lastName,
         code: students.studentCode,
         balance: sql<number>`sum(${invoices.balanceAmount})::float`,
+        maxOverdue: sql<number>`coalesce(max(case when ${invoices.dueAt} is not null and ${invoices.dueAt} < now() and ${invoices.balanceAmount} > 0 then floor(extract(epoch from (now() - ${invoices.dueAt})) / 86400) else 0 end), 0)::int`,
       })
       .from(invoices)
       .innerJoin(students, eq(invoices.studentId, students.id))
@@ -100,6 +101,11 @@ export default async function FeesPage() {
                     <Link href={`/fees/${d.studentId}`} className="hover:text-gold">
                       {d.lastName}, {d.firstName}
                     </Link>
+                    {d.maxOverdue > 0 && (
+                      <span className="ml-2 rounded-pill bg-terra-bg px-2 py-0.5 text-xs font-medium text-terra">
+                        Overdue {d.maxOverdue}d
+                      </span>
+                    )}
                   </td>
                   <td className="px-4 py-3 text-right font-semibold text-terra">
                     {ghs(d.balance)}

--- a/omnischools/lib/fees-helpers.ts
+++ b/omnischools/lib/fees-helpers.ts
@@ -37,6 +37,22 @@ export async function nextReceiptNumber(tx: Tx, schoolId: string): Promise<strin
   return `RCT${yy()}${String(count + 1).padStart(4, "0")}`;
 }
 
+/**
+ * Whole days a balance is past its due date. Returns 0 when there's no due date,
+ * the date is unparseable, or it isn't past due yet. Used for invoice aging badges.
+ */
+export function daysOverdue(
+  dueAt: Date | string | null | undefined,
+  asOf: Date = new Date(),
+): number {
+  if (!dueAt) return 0;
+  const due = typeof dueAt === "string" ? new Date(dueAt) : dueAt;
+  if (Number.isNaN(due.getTime())) return 0;
+  const ms = asOf.getTime() - due.getTime();
+  if (ms <= 0) return 0;
+  return Math.floor(ms / 86_400_000);
+}
+
 /** MVP1 settlement status by method (cash settles immediately; momo/bank confirmed). */
 export function settlementFor(method: string): "SETTLED" | "CONFIRMED" | "PENDING" {
   if (method === "CASH") return "SETTLED";


### PR DESCRIPTION
## Track ② Financial deepening — slice 2a-i

Surfaces overdue indicators across the Fees module, matching the `schoolup-*` surfaces that show "Overdue Nd" badges.

### Changes
- **`lib/fees-helpers.ts`** — new `daysOverdue(dueAt, asOf?)` helper: whole days a balance is past due (0 when no due date / unparseable / not yet due).
- **Student statement** (`/fees/[studentId]`) — per-invoice "Overdue Nd" pill on outstanding invoices (not PAID/VOIDED, balance > 0) past their `dueAt`.
- **Collections list** (`/fees`) — per-student "Overdue Nd" pill showing each debtor's worst (oldest) overdue invoice, computed in SQL.

### Notes
- **No migration** — uses the existing `invoices.dueAt` column. Nothing to paste on prod.
- Pure display change; badges only render when `overdue > 0`.

### Verification
- `pnpm typecheck` ✅
- `pnpm lint` ✅ (no warnings/errors)
- `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)