### PR TITLE
feat(fees): multi-invoice payment allocation (track 2b)

### DIFF
--- a/omnischools/app/(app)/fees/[studentId]/page.tsx
+++ b/omnischools/app/(app)/fees/[studentId]/page.tsx
@@ -62,6 +62,18 @@ export default async function StudentFeesPage({
   const balance = invs
     .filter((i) => i.status !== "VOIDED")
     .reduce((s, i) => s + num(i.balanceAmount), 0);
+  // Outstanding invoices, oldest first (invs come newest-first), for allocation.
+  const outstanding = invs
+    .filter(
+      (i) => i.status !== "VOIDED" && i.status !== "PAID" && num(i.balanceAmount) > 0,
+    )
+    .slice()
+    .reverse()
+    .map((i) => ({
+      id: i.id,
+      invoiceNumber: i.invoiceNumber,
+      balance: num(i.balanceAmount),
+    }));
 
   return (
     <div className="mx-auto max-w-page">
@@ -86,7 +98,7 @@ export default async function StudentFeesPage({
       </div>
 
       <div className="mb-8 flex flex-wrap items-start gap-3">
-        <RecordPaymentForm studentId={student.id} />
+        <RecordPaymentForm studentId={student.id} outstanding={outstanding} />
         <IssueInvoiceForm studentId={student.id} />
       </div>
 

--- a/omnischools/components/fees/record-payment-form.tsx
+++ b/omnischools/components/fees/record-payment-form.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { recordPayment } from "@/lib/actions/fees";
 
@@ -17,25 +17,111 @@ const METHODS = [
   ["OTHER", "Other"],
 ] as const;
 
-export function RecordPaymentForm({ studentId }: { studentId: string }) {
+type Outstanding = { id: string; invoiceNumber: string; balance: number };
+
+const round2 = (n: number) => Math.round((n + Number.EPSILON) * 100) / 100;
+const ghs = (n: number) => `GHS ${round2(n).toFixed(2)}`;
+const parse = (v: string | undefined) => {
+  const n = Number.parseFloat(v ?? "");
+  return Number.isFinite(n) ? n : 0;
+};
+
+/** Spread `amount` across outstanding invoices, oldest first, capped at each balance. */
+function autoFill(amount: number, outstanding: Outstanding[]): Record<string, string> {
+  let rem = round2(amount);
+  const next: Record<string, string> = {};
+  for (const inv of outstanding) {
+    const give = Math.max(0, Math.min(inv.balance, rem));
+    next[inv.id] = give > 0 ? round2(give).toFixed(2) : "";
+    rem = round2(rem - give);
+  }
+  return next;
+}
+
+export function RecordPaymentForm({
+  studentId,
+  outstanding,
+}: {
+  studentId: string;
+  outstanding: Outstanding[];
+}) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [done, setDone] = useState<string | null>(null);
 
-  async function action(formData: FormData) {
+  const [gross, setGross] = useState("");
+  const [method, setMethod] = useState("");
+  const [reference, setReference] = useState("");
+  const [alloc, setAlloc] = useState<Record<string, string>>({});
+  const [touched, setTouched] = useState(false);
+
+  const grossNum = round2(parse(gross));
+  const hasInvoices = outstanding.length > 0;
+
+  const { allocatedTotal, credit, overInvoice, overGross } = useMemo(() => {
+    let total = 0;
+    let over = false;
+    for (const inv of outstanding) {
+      const v = round2(parse(alloc[inv.id]));
+      total += v;
+      if (v > inv.balance + 0.001) over = true;
+    }
+    total = round2(total);
+    return {
+      allocatedTotal: total,
+      credit: round2(Math.max(0, grossNum - total)),
+      overInvoice: over,
+      overGross: total > grossNum + 0.001,
+    };
+  }, [alloc, outstanding, grossNum]);
+
+  function changeGross(v: string) {
+    setGross(v);
+    if (!touched && hasInvoices) setAlloc(autoFill(round2(parse(v)), outstanding));
+  }
+  function changeAlloc(id: string, v: string) {
+    setTouched(true);
+    setAlloc((prev) => ({ ...prev, [id]: v }));
+  }
+  function reAuto() {
+    setTouched(false);
+    setAlloc(autoFill(grossNum, outstanding));
+  }
+  function clearAlloc() {
+    setTouched(true);
+    setAlloc({});
+  }
+
+  function reset() {
+    setGross("");
+    setMethod("");
+    setReference("");
+    setAlloc({});
+    setTouched(false);
+    setError(null);
+  }
+
+  const blocked = grossNum <= 0 || !method || overInvoice || overGross;
+
+  async function submit() {
+    if (blocked) return;
     setSaving(true);
     setError(null);
     const res = await recordPayment({
       studentId,
-      method: formData.get("method"),
-      grossAmount: formData.get("grossAmount"),
-      methodReference: formData.get("methodReference"),
+      method,
+      grossAmount: grossNum,
+      methodReference: reference,
+      allocations: hasInvoices
+        ? outstanding.map((inv) => ({ invoiceId: inv.id, amount: parse(alloc[inv.id]) }))
+        : undefined,
     });
     setSaving(false);
     if (res.ok) {
       setDone(res.receiptNumber);
+      reset();
       router.refresh();
     } else {
       setError(res.error);
@@ -57,7 +143,7 @@ export function RecordPaymentForm({ studentId }: { studentId: string }) {
   }
 
   return (
-    <div className="bg-surface rounded-xl border border-border p-5">
+    <div className="bg-surface w-full max-w-xl rounded-xl border border-border p-5">
       {done ? (
         <div className="flex items-center justify-between gap-4">
           <p className="text-sm text-navy">
@@ -72,12 +158,13 @@ export function RecordPaymentForm({ studentId }: { studentId: string }) {
           </button>
         </div>
       ) : (
-        <form action={action} className="space-y-4">
+        <div className="space-y-4">
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
             <div>
               <label className={labelClass}>Amount (GHS)</label>
               <input
-                name="grossAmount"
+                value={gross}
+                onChange={(e) => changeGross(e.target.value)}
                 type="number"
                 step="0.01"
                 min="0"
@@ -87,7 +174,12 @@ export function RecordPaymentForm({ studentId }: { studentId: string }) {
             </div>
             <div>
               <label className={labelClass}>Method</label>
-              <select name="method" required defaultValue="" className={fieldClass}>
+              <select
+                value={method}
+                onChange={(e) => setMethod(e.target.value)}
+                required
+                className={fieldClass}
+              >
                 <option value="" disabled>
                   Choose
                 </option>
@@ -103,20 +195,93 @@ export function RecordPaymentForm({ studentId }: { studentId: string }) {
                 Reference <span className="font-medium text-navy-3">— optional</span>
               </label>
               <input
-                name="methodReference"
+                value={reference}
+                onChange={(e) => setReference(e.target.value)}
                 placeholder="MoMo txn id"
                 className={fieldClass}
               />
             </div>
           </div>
-          <p className="text-xs text-navy-3">
-            Auto-allocated oldest invoice first; any excess is held as credit.
-          </p>
+
+          {hasInvoices ? (
+            <div className="rounded-lg border border-border-2 bg-bg p-3">
+              <div className="mb-2 flex items-center justify-between">
+                <span className="text-xs font-semibold uppercase tracking-wide text-navy-3">
+                  Allocate across invoices
+                </span>
+                <div className="flex items-center gap-3 text-xs font-semibold">
+                  <button
+                    type="button"
+                    onClick={reAuto}
+                    className="text-gold hover:underline"
+                  >
+                    Auto (oldest first)
+                  </button>
+                  <button
+                    type="button"
+                    onClick={clearAlloc}
+                    className="text-navy-3 hover:text-navy"
+                  >
+                    Clear
+                  </button>
+                </div>
+              </div>
+              <div className="space-y-1.5">
+                {outstanding.map((inv) => {
+                  const v = round2(parse(alloc[inv.id]));
+                  const bad = v > inv.balance + 0.001;
+                  return (
+                    <div key={inv.id} className="flex items-center gap-3 text-sm">
+                      <span className="w-28 shrink-0 font-mono text-xs text-navy-2">
+                        {inv.invoiceNumber}
+                      </span>
+                      <span className="flex-1 text-xs text-navy-3">
+                        bal {ghs(inv.balance)}
+                        <button
+                          type="button"
+                          onClick={() => changeAlloc(inv.id, inv.balance.toFixed(2))}
+                          className="ml-2 text-gold hover:underline"
+                        >
+                          full
+                        </button>
+                      </span>
+                      <input
+                        value={alloc[inv.id] ?? ""}
+                        onChange={(e) => changeAlloc(inv.id, e.target.value)}
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        placeholder="0.00"
+                        className={`w-28 rounded-md border bg-surface px-2.5 py-1.5 text-right text-sm text-navy outline-none focus:border-gold ${
+                          bad ? "border-terra" : "border-border-2"
+                        }`}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+              <div className="mt-3 flex flex-wrap justify-between gap-x-6 gap-y-1 border-t border-border-2 pt-2 text-xs">
+                <span className={overGross ? "font-semibold text-terra" : "text-navy-3"}>
+                  Allocated <b className="text-navy">{ghs(allocatedTotal)}</b>
+                  {overGross && " — exceeds payment"}
+                </span>
+                <span className="text-navy-3">
+                  Held as credit <b className="text-navy">{ghs(credit)}</b>
+                </span>
+              </div>
+            </div>
+          ) : (
+            <p className="text-xs text-navy-3">
+              No outstanding invoices — the full amount is held as credit.
+            </p>
+          )}
+
           {error && <p className="text-sm text-terra">{error}</p>}
           <div className="flex items-center gap-3">
             <button
-              type="submit"
-              disabled={saving}
+              type="button"
+              onClick={submit}
+              disabled={saving || blocked}
               className="text-bg rounded-md bg-navy px-5 py-2.5 text-sm font-semibold transition-colors hover:bg-navy-deep disabled:opacity-60"
             >
               {saving ? "Recording…" : "Record & receipt"}
@@ -129,7 +294,7 @@ export function RecordPaymentForm({ studentId }: { studentId: string }) {
               Cancel
             </button>
           </div>
-        </form>
+        </div>
       )}
     </div>
   );

--- a/omnischools/lib/actions/fees.ts
+++ b/omnischools/lib/actions/fees.ts
@@ -134,6 +134,19 @@ const RecordPaymentSchema = z.object({
   ]),
   grossAmount: z.coerce.number().positive("Amount must be > 0"),
   methodReference: z.string().max(120).optional().or(z.literal("")),
+  /**
+   * Optional manual split across specific invoices. When omitted (or all zero),
+   * the payment auto-allocates oldest-invoice-first. Any amount beyond the
+   * allocations (or beyond outstanding balances) is held as credit.
+   */
+  allocations: z
+    .array(
+      z.object({
+        invoiceId: z.string().uuid(),
+        amount: z.coerce.number().min(0),
+      }),
+    )
+    .optional(),
 });
 
 export type RecordPaymentResult =
@@ -186,7 +199,6 @@ export async function recordPayment(input: unknown): Promise<RecordPaymentResult
         afterState: { gross: toMoney(gross), method: d.method },
       });
 
-      // auto-allocate oldest-first across outstanding invoices
       const outstanding = await tx
         .select()
         .from(invoices)
@@ -200,21 +212,66 @@ export async function recordPayment(input: unknown): Promise<RecordPaymentResult
         )
         .orderBy(asc(invoices.issuedAt));
 
+      // Build the allocation plan: a manual per-invoice split when one is given,
+      // else auto oldest-invoice-first. Manual entries are validated against the
+      // current outstanding balances before anything is written.
+      type PlanEntry = {
+        inv: (typeof outstanding)[number];
+        applied: number;
+        method: "MANUAL" | "AUTO_OLDEST_FIRST";
+      };
+      const byId = new Map(outstanding.map((inv) => [inv.id, inv] as const));
+      const manualByInvoice = new Map<string, number>();
+      for (const a of d.allocations ?? []) {
+        const amt = round2(a.amount);
+        if (amt <= 0) continue;
+        manualByInvoice.set(a.invoiceId, round2((manualByInvoice.get(a.invoiceId) ?? 0) + amt));
+      }
+
+      const plan: PlanEntry[] = [];
+      if (manualByInvoice.size > 0) {
+        let manualTotal = 0;
+        for (const [invoiceId, applied] of Array.from(manualByInvoice)) {
+          const inv = byId.get(invoiceId);
+          if (!inv) {
+            return {
+              ok: false as const,
+              error: "An allocation target is not an outstanding invoice.",
+            };
+          }
+          if (applied > num(inv.balanceAmount)) {
+            return {
+              ok: false as const,
+              error: `Allocation to ${inv.invoiceNumber} exceeds its balance.`,
+            };
+          }
+          manualTotal = round2(manualTotal + applied);
+          plan.push({ inv, applied, method: "MANUAL" });
+        }
+        if (manualTotal > gross) {
+          return { ok: false as const, error: "Allocations exceed the payment amount." };
+        }
+      } else {
+        let rem = gross;
+        for (const inv of outstanding) {
+          if (rem <= 0) break;
+          const applied = round2(Math.min(num(inv.balanceAmount), rem));
+          if (applied <= 0) continue;
+          plan.push({ inv, applied, method: "AUTO_OLDEST_FIRST" });
+          rem = round2(rem - applied);
+        }
+      }
+
       let remaining = gross;
       let allocated = 0;
-      for (const inv of outstanding) {
-        if (remaining <= 0) break;
-        const bal = num(inv.balanceAmount);
-        const applied = round2(Math.min(bal, remaining));
-        if (applied <= 0) continue;
-
+      for (const { inv, applied, method } of plan) {
         await tx.insert(paymentAllocations).values({
           schoolId: school.id,
           paymentId: payment.id,
           invoiceId: inv.id,
           allocationType: "INVOICE",
           amount: toMoney(applied),
-          allocationMethod: "AUTO_OLDEST_FIRST",
+          allocationMethod: method,
           allocatedByUserId: actor.id ?? undefined,
         });
 
@@ -236,7 +293,7 @@ export async function recordPayment(input: unknown): Promise<RecordPaymentResult
           invoiceId: inv.id,
           eventType: "ALLOCATION_ADDED",
           actorUserId: actor.id ?? undefined,
-          afterState: { applied: toMoney(applied), invoice: inv.invoiceNumber },
+          afterState: { applied: toMoney(applied), invoice: inv.invoiceNumber, method },
         });
 
         remaining = round2(remaining - applied);

--- a/omnischools/scripts/verify-payments.ts
+++ b/omnischools/scripts/verify-payments.ts
@@ -18,6 +18,11 @@ async function invoiceState(studentId: string) {
   return inv;
 }
 
+async function invoiceById(id: string) {
+  const [inv] = await db.select().from(invoices).where(eq(invoices.id, id));
+  return inv;
+}
+
 async function main() {
   // 1. create a throwaway student
   const cs = await createStudent({
@@ -92,10 +97,73 @@ async function main() {
     s.status === "PARTIAL" && num(s.balanceAmount) === 300,
   );
 
+  // 6. manual allocation: split a payment across two invoices, not oldest-first
+  const cs2 = await createStudent({
+    firstName: "Alloc",
+    lastName: "Tester",
+    sex: "FEMALE",
+    guardianName: "G. Alloc",
+    guardianPhone: "0240000099",
+  });
+  if (!cs2.ok) {
+    console.error("createStudent (alloc) failed", cs2);
+    process.exit(1);
+  }
+  const sid2 = cs2.studentId;
+
+  const invA = await issueInvoice({
+    studentId: sid2,
+    lineItems: [{ description: "Tuition", amount: 400 }],
+  });
+  const invB = await issueInvoice({
+    studentId: sid2,
+    lineItems: [{ description: "Books", amount: 300 }],
+  });
+  check("two invoices issued", invA.ok && invB.ok);
+
+  if (invA.ok && invB.ok) {
+    // Pay 500 split 100 → A (oldest) and 300 → B, leaving 100 as credit. Oldest-first
+    // would instead fill A to 400 then B to 100 — so this proves the manual split wins.
+    const pm = await recordPayment({
+      studentId: sid2,
+      method: "CASH",
+      grossAmount: 500,
+      allocations: [
+        { invoiceId: invA.invoiceId, amount: 100 },
+        { invoiceId: invB.invoiceId, amount: 300 },
+      ],
+    });
+    check("manual payment ok", pm.ok, pm.ok ? "" : (pm as { error: string }).error);
+    const a = await invoiceById(invA.invoiceId);
+    const b = await invoiceById(invB.invoiceId);
+    check(
+      "invoice A PARTIAL, balance 300 (manual split, not oldest-first)",
+      a.status === "PARTIAL" && num(a.balanceAmount) === 300,
+      `${a.status} ${num(a.balanceAmount)}`,
+    );
+    check(
+      "invoice B PAID, balance 0 (manual split)",
+      b.status === "PAID" && num(b.balanceAmount) === 0,
+      `${b.status} ${num(b.balanceAmount)}`,
+    );
+
+    // allocating more than an invoice's balance is rejected
+    const bad = await recordPayment({
+      studentId: sid2,
+      method: "CASH",
+      grossAmount: 500,
+      allocations: [{ invoiceId: invA.invoiceId, amount: 500 }],
+    });
+    check("over-balance allocation rejected", !bad.ok);
+  }
+
   // cleanup (payments first → cascades allocations + receipts, then invoices, then student)
   await db.delete(payments).where(eq(payments.studentId, sid));
   await db.delete(invoices).where(eq(invoices.studentId, sid));
   await db.delete(students).where(eq(students.id, sid));
+  await db.delete(payments).where(eq(payments.studentId, sid2));
+  await db.delete(invoices).where(eq(invoices.studentId, sid2));
+  await db.delete(students).where(eq(students.id, sid2));
 
   console.log(
     failures === 0 ? "\n✓ Fees flow verified." : `\n✗ ${failures} assertion(s) failed.`,


### PR DESCRIPTION
## Track ② Financial deepening — slice 2b

Recording a payment auto-applied oldest-invoice-first with no way to direct it. This adds the **manual allocation** the record-payment surface calls for — while keeping oldest-first as the default.

### Changes
- **`recordPayment` action** — optional `allocations: [{ invoiceId, amount }]`. When provided, each amount is validated against the invoice's current balance and the total against the payment; the split is applied with `allocationMethod = MANUAL`. When omitted (or all-zero), it falls back to the existing oldest-first auto-allocation. Any unallocated remainder is still held as credit.
- **`RecordPaymentForm`** — now an allocation editor: lists outstanding invoices seeded oldest-first, with a per-invoice amount field, a **full** quick-fill, **Auto (oldest first)** / **Clear** actions, and a live **Allocated / Held as credit** summary. Submit is blocked on over-allocation (per-invoice or total).
- **Student statement** — passes the oldest-first outstanding invoices to the form.
- **`scripts/verify-payments.ts`** — adds manual-split coverage.

### Notes
- **No schema change**, nothing to paste on prod.
- Branches off `main`; touches `recordPayment` (a different function than #55's `voidPayment`) and the record-payment form, so it merges cleanly alongside #54/#55.

### Verification
- `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm build` ✅
- `pnpm db:verify-payments` ✅ — new assertions pass: a 100→A / 300→B split leaves **A PARTIAL (bal 300)** and **B PAID (bal 0)** (oldest-first would have filled A first), and an over-balance allocation is **rejected**.
- Student route renders 200 with both invoices + the form; no console/hydration errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)