### PR TITLE
feat(billing): reminder cost/preview confirmation drawer (track 2c-i)

### DIFF
--- a/omnischools/components/billing/reminders-card.tsx
+++ b/omnischools/components/billing/reminders-card.tsx
@@ -1,24 +1,44 @@
 "use client";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { sendFeeReminders } from "@/lib/actions/billing";
+import {
+  sendFeeReminders,
+  previewFeeReminders,
+  type ReminderPreview,
+} from "@/lib/actions/billing";
+import { Modal } from "@/components/ui/modal";
 
 const ghs = (n: number) =>
   `GHS ${n.toLocaleString("en-GH", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 
 export function RemindersCard({ families, total }: { families: number; total: number }) {
   const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [preview, setPreview] = useState<ReminderPreview | null>(null);
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  async function send() {
-    setBusy(true);
+  async function openPreview() {
+    setOpen(true);
+    setPreview(null);
     setError(null);
     setMsg(null);
+    setLoading(true);
+    const res = await previewFeeReminders();
+    setLoading(false);
+    if (res.ok) setPreview(res.preview);
+    else setError(res.error ?? "Could not load the preview.");
+  }
+
+  async function confirmSend() {
+    setBusy(true);
+    setError(null);
     const res = await sendFeeReminders();
     setBusy(false);
     if (res.ok) {
+      setOpen(false);
       setMsg(
         `Sent ${res.sent} reminder${res.sent === 1 ? "" : "s"}${res.noPhone ? ` · ${res.noPhone} family/ies had no phone on file` : ""}.`,
       );
@@ -36,15 +56,93 @@ export function RemindersCard({ families, total }: { families: number; total: nu
           Send an SMS fee reminder to every family with an outstanding balance.
         </p>
         {msg && <p className="mt-1 text-sm font-medium text-green">{msg}</p>}
-        {error && <p className="mt-1 text-sm text-terra">{error}</p>}
+        {!open && error && <p className="mt-1 text-sm text-terra">{error}</p>}
       </div>
       <button
-        onClick={send}
-        disabled={busy || families === 0}
+        onClick={openPreview}
+        disabled={families === 0}
         className="rounded-md bg-navy px-5 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-50"
       >
-        {busy ? "Sending…" : "Send reminders"}
+        Send reminders
       </button>
+
+      <Modal
+        open={open}
+        onClose={busy ? () => {} : () => setOpen(false)}
+        title="Send fee reminders"
+      >
+        <div className="space-y-4">
+          {loading ? (
+            <p className="text-sm text-navy-3">Calculating recipients…</p>
+          ) : preview ? (
+            <>
+              <p className="text-sm leading-relaxed text-navy-2">
+                An SMS will be sent to each family with an outstanding balance and a phone
+                number on file.
+              </p>
+              <dl className="space-y-2 rounded-lg border border-border-2 bg-bg p-3 text-sm">
+                <div className="flex justify-between">
+                  <dt className="text-navy-3">Recipients</dt>
+                  <dd className="font-semibold text-navy">{preview.recipients}</dd>
+                </div>
+                <div className="flex justify-between">
+                  <dt className="text-navy-3">Outstanding total</dt>
+                  <dd className="font-medium text-navy">
+                    {ghs(preview.totalOutstanding)}
+                  </dd>
+                </div>
+                <div className="flex justify-between">
+                  <dt className="text-navy-3">SMS segments</dt>
+                  <dd className="font-medium text-navy">{preview.segments}</dd>
+                </div>
+                <div className="flex justify-between border-t border-border-2 pt-2">
+                  <dt className="font-semibold text-navy">Estimated cost</dt>
+                  <dd className="font-display text-base font-semibold text-navy">
+                    {ghs(preview.estCost)}
+                  </dd>
+                </div>
+                {preview.noPhone > 0 && (
+                  <p className="pt-1 text-xs text-warn">
+                    {preview.noPhone} family/ies have a balance but no phone on file — they
+                    will be skipped.
+                  </p>
+                )}
+              </dl>
+
+              {error && (
+                <p className="rounded-md bg-terra-bg px-3 py-2 text-sm text-terra">
+                  {error}
+                </p>
+              )}
+
+              <div className="flex items-center justify-end gap-3">
+                <button
+                  type="button"
+                  onClick={() => setOpen(false)}
+                  disabled={busy}
+                  className="text-sm font-semibold text-navy-2 transition-colors hover:text-navy disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={confirmSend}
+                  disabled={busy || preview.recipients === 0}
+                  className="rounded-md bg-navy px-4 py-2 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-60"
+                >
+                  {busy
+                    ? "Sending…"
+                    : `Send ${preview.recipients} reminder${preview.recipients === 1 ? "" : "s"}`}
+                </button>
+              </div>
+            </>
+          ) : (
+            <p className="rounded-md bg-terra-bg px-3 py-2 text-sm text-terra">
+              {error ?? "Could not load the preview."}
+            </p>
+          )}
+        </div>
+      </Modal>
     </div>
   );
 }

--- a/omnischools/lib/actions/billing.ts
+++ b/omnischools/lib/actions/billing.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { withSchool } from "@/lib/db/rls";
 import { recordAudit } from "@/lib/db/audit";
 import { requireSchool, resolveActor } from "@/lib/auth/server";
-import { sendSms } from "@/lib/sms";
+import { sendSms, smsSegments, SMS_SEGMENT_RATE_GHS } from "@/lib/sms";
 import { safeRevalidate } from "@/lib/revalidate";
 import { round2, toMoney, num, nextInvoiceNumber } from "@/lib/fees-helpers";
 import {
@@ -309,6 +309,86 @@ export async function generateInvoicesForClass(input: unknown): Promise<Generate
 }
 
 // ---------------------------------------------------------------- reminders
+/** The SMS body sent to a guardian about an outstanding balance. */
+function feeReminderMessage(sender: string, firstName: string, amount: number): string {
+  return `${sender}: Dear parent, ${firstName} has an outstanding fee balance of GHS ${toMoney(amount)}. Kindly settle at your earliest convenience. Thank you.`;
+}
+
+/** Outstanding-balance rows (one per student) with the primary guardian phone. */
+function reminderRows(schoolId: string) {
+  return withSchool(schoolId, (tx) =>
+    tx
+      .select({
+        studentId: invoices.studentId,
+        firstName: students.firstName,
+        outstanding: sql<string>`sum(${invoices.balanceAmount})`,
+        phone: studentGuardians.phone,
+      })
+      .from(invoices)
+      .innerJoin(students, eq(invoices.studentId, students.id))
+      .leftJoin(
+        studentGuardians,
+        and(
+          eq(studentGuardians.studentId, students.id),
+          eq(studentGuardians.isPrimary, true),
+        ),
+      )
+      .where(
+        and(
+          eq(invoices.schoolId, schoolId),
+          inArray(invoices.status, ["ISSUED", "PARTIAL", "OVERDUE"]),
+          sql`${invoices.balanceAmount} > 0`,
+        ),
+      )
+      .groupBy(invoices.studentId, students.firstName, studentGuardians.phone)
+      .limit(1000),
+  );
+}
+
+export type ReminderPreview = {
+  recipients: number; // families with a phone on file (will receive an SMS)
+  noPhone: number; // families with a balance but no phone (skipped)
+  totalOutstanding: number;
+  segments: number; // total SMS segments across all recipients
+  estCost: number; // segments × per-segment rate, in GHS
+};
+
+export async function previewFeeReminders(): Promise<
+  { ok: true; preview: ReminderPreview } | { ok: false; error: string }
+> {
+  const { school } = await requireSchool();
+  try {
+    const rows = await reminderRows(school.id);
+    const sender = school.shortName ?? "Omnischools";
+    let recipients = 0;
+    let noPhone = 0;
+    let segments = 0;
+    let totalOutstanding = 0;
+    for (const r of rows) {
+      const amount = num(r.outstanding);
+      totalOutstanding = round2(totalOutstanding + amount);
+      if (!r.phone) {
+        noPhone++;
+        continue;
+      }
+      recipients++;
+      segments += smsSegments(feeReminderMessage(sender, r.firstName, amount));
+    }
+    return {
+      ok: true,
+      preview: {
+        recipients,
+        noPhone,
+        totalOutstanding,
+        segments,
+        estCost: round2(segments * SMS_SEGMENT_RATE_GHS),
+      },
+    };
+  } catch {
+    return { ok: false, error: "Could not load the reminder preview." };
+  }
+}
+
 export type RemindersResult =
   | { ok: true; sent: number; noPhone: number }
   | { ok: false; error: string };
@@ -317,34 +397,7 @@ export async function sendFeeReminders(): Promise<RemindersResult> {
   const { school } = await requireSchool();
   const actor = await resolveActor(school.id);
   try {
-    const rows = await withSchool(school.id, (tx) =>
-      tx
-        .select({
-          studentId: invoices.studentId,
-          firstName: students.firstName,
-          outstanding: sql<string>`sum(${invoices.balanceAmount})`,
-          phone: studentGuardians.phone,
-        })
-        .from(invoices)
-        .innerJoin(students, eq(invoices.studentId, students.id))
-        .leftJoin(
-          studentGuardians,
-          and(
-            eq(studentGuardians.studentId, students.id),
-            eq(studentGuardians.isPrimary, true),
-          ),
-        )
-        .where(
-          and(
-            eq(invoices.schoolId, school.id),
-            inArray(invoices.status, ["ISSUED", "PARTIAL", "OVERDUE"]),
-            sql`${invoices.balanceAmount} > 0`,
-          ),
-        )
-        .groupBy(invoices.studentId, students.firstName, studentGuardians.phone)
-        .limit(1000),
-    );
-
+    const rows = await reminderRows(school.id);
     let sent = 0;
     let noPhone = 0;
     const sender = school.shortName ?? "Omnischools";
@@ -353,7 +406,7 @@ export async function sendFeeReminders(): Promise<RemindersResult> {
         noPhone++;
         continue;
       }
-      const msg = `${sender}: Dear parent, ${r.firstName} has an outstanding fee balance of GHS ${toMoney(num(r.outstanding))}. Kindly settle at your earliest convenience. Thank you.`;
+      const msg = feeReminderMessage(sender, r.firstName, num(r.outstanding));
       await sendSms(r.phone, msg);
       await withSchool(school.id, (tx) =>
         tx.insert(notificationLog).values({

--- a/omnischools/lib/sms/index.ts
+++ b/omnischools/lib/sms/index.ts
@@ -71,3 +71,17 @@ export function getSmsProvider(): SmsProvider {
 export async function sendSms(to: string, body: string): Promise<SmsResult> {
   return getSmsProvider().send({ to, body });
 }
+
+/** Estimated cost per SMS segment in GHS (Hubtel-style bulk rate). */
+export const SMS_SEGMENT_RATE_GHS = 0.035;
+
+/**
+ * Number of SMS segments a GSM-7 message occupies: one segment up to 160 chars,
+ * then 153 chars per segment once it concatenates. Used to estimate send cost
+ * before a bulk reminder run. Names are ASCII so GSM-7 is a fair assumption.
+ */
+export function smsSegments(body: string): number {
+  const len = body.length;
+  if (len === 0) return 0;
+  return len <= 160 ? 1 : Math.ceil(len / 153);
+}


### PR DESCRIPTION
## Track ② Financial deepening — slice 2c-i

Sending fee reminders fired immediately at every debtor with no sense of reach or cost. It now **previews the run and asks for confirmation** first, per the billing reminder surface.

### Changes
- **`previewFeeReminders`** — new dry-run action returning **recipients** (families with a phone), **no-phone** count (skipped), **total outstanding**, **SMS segments**, and an **estimated GHS cost** — without sending anything.
- **`lib/sms`** — `smsSegments()` (GSM-7 segmenting: 160 chars, then 153/segment) + `SMS_SEGMENT_RATE_GHS` (0.035). A shared `feeReminderMessage()` / `reminderRows()` is now used by both preview and send so the two can't drift.
- **`RemindersCard`** — "Send reminders" opens a `Modal` showing recipients / outstanding / segments / **estimated cost**, with a **Send N reminders** confirm. No-phone families are flagged as skipped.

### Notes
- **No schema change**, nothing to paste on prod.
- Billing-module only — independent of the Fees slices.

### Verification
- `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm build` ✅
- Seeded check: 1 phoned family + 1 no-phone family → preview reports **recipients 1, noPhone 1, total GHS 400, 1 segment, est GHS 0.04** ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)