### PR TITLE
feat(reports): aging buckets + per-class collection rate (track 2d-i)

### DIFF
--- a/omnischools/app/(app)/reports/page.tsx
+++ b/omnischools/app/(app)/reports/page.tsx
@@ -24,7 +24,7 @@ const METHOD_LABEL: Record<string, string> = {
 export default async function ReportsPage() {
   const { school } = await requireSchool();
 
-  const [[totals], byClass, monthly, byMethod] = await Promise.all([
+  const [[totals], byClass, monthly, byMethod, agingRows] = await Promise.all([
     withSchool(school.id, (tx) =>
       tx
         .select({
@@ -73,6 +73,30 @@ export default async function ReportsPage() {
         .where(and(eq(payments.schoolId, school.id), isNull(payments.voidedAt)))
         .groupBy(payments.method),
     ),
+    // Outstanding balance bucketed by how far past due it is.
+    withSchool(school.id, (tx) =>
+      tx
+        .select({
+          bucket: sql<string>`case
+            when ${invoices.dueAt} is null or ${invoices.dueAt} >= now() then 'current'
+            when now() - ${invoices.dueAt} <= interval '30 days' then 'd30'
+            when now() - ${invoices.dueAt} <= interval '60 days' then 'd60'
+            when now() - ${invoices.dueAt} <= interval '90 days' then 'd90'
+            else 'd90plus'
+          end`,
+          amount: sql<string>`coalesce(sum(${invoices.balanceAmount}), 0)`,
+          count: sql<number>`count(*)`,
+        })
+        .from(invoices)
+        .where(
+          and(
+            eq(invoices.schoolId, school.id),
+            ne(invoices.status, "VOIDED"),
+            sql`${invoices.balanceAmount} > 0`,
+          ),
+        )
+        .groupBy(sql`1`),
+    ),
   ]);
 
   const billed = num(totals?.billed);
@@ -80,6 +104,24 @@ export default async function ReportsPage() {
   const outstanding = num(totals?.outstanding);
   const rate = billed > 0 ? Math.round((collected / billed) * 100) : 0;
   const maxMonth = Math.max(1, ...monthly.map((m) => num(m.amount)));
+  const classRate = (b: unknown, c: unknown) =>
+    num(b) > 0 ? Math.round((num(c) / num(b)) * 100) : 0;
+
+  const AGING = [
+    { key: "current", label: "Not yet due", tone: "bg-navy" },
+    { key: "d30", label: "1–30 days overdue", tone: "bg-gold" },
+    { key: "d60", label: "31–60 days overdue", tone: "bg-warn" },
+    { key: "d90", label: "61–90 days overdue", tone: "bg-terra" },
+    { key: "d90plus", label: "90+ days overdue", tone: "bg-terra" },
+  ];
+  const agingMap = new Map(
+    agingRows.map((r) => [r.bucket, { amount: num(r.amount), count: num(r.count) }]),
+  );
+  const agingMax = Math.max(1, ...AGING.map((b) => agingMap.get(b.key)?.amount ?? 0));
+  const overdueTotal = AGING.filter((b) => b.key !== "current").reduce(
+    (s, b) => s + (agingMap.get(b.key)?.amount ?? 0),
+    0,
+  );
 
   const kpis = [
     {
@@ -127,12 +169,13 @@ export default async function ReportsPage() {
           </h2>
           <ExportCsv
             filename={schoolFile(school.name, "outstanding-by-class.csv")}
-            headers={["Class", "Billed", "Collected", "Outstanding"]}
+            headers={["Class", "Billed", "Collected", "Outstanding", "Rate %"]}
             rows={byClass.map((c) => [
               c.className,
               num(c.billed).toFixed(2),
               num(c.collected).toFixed(2),
               num(c.outstanding).toFixed(2),
+              String(classRate(c.billed, c.collected)),
             ])}
           />
         </div>
@@ -149,25 +192,86 @@ export default async function ReportsPage() {
                   <th className="px-4 py-3 text-right font-semibold">Billed</th>
                   <th className="px-4 py-3 text-right font-semibold">Collected</th>
                   <th className="px-4 py-3 text-right font-semibold">Outstanding</th>
+                  <th className="px-4 py-3 text-right font-semibold">Rate</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-border">
-                {byClass.map((c) => (
-                  <tr key={c.className} className="hover:bg-bg">
-                    <td className="px-4 py-3 font-medium text-navy">{c.className}</td>
-                    <td className="px-4 py-3 text-right text-navy-2">
-                      {ghs(num(c.billed))}
-                    </td>
-                    <td className="px-4 py-3 text-right text-green">
-                      {ghs(num(c.collected))}
-                    </td>
-                    <td className="px-4 py-3 text-right font-medium text-terra">
-                      {ghs(num(c.outstanding))}
-                    </td>
-                  </tr>
-                ))}
+                {byClass.map((c) => {
+                  const r = classRate(c.billed, c.collected);
+                  return (
+                    <tr key={c.className} className="hover:bg-bg">
+                      <td className="px-4 py-3 font-medium text-navy">{c.className}</td>
+                      <td className="px-4 py-3 text-right text-navy-2">
+                        {ghs(num(c.billed))}
+                      </td>
+                      <td className="px-4 py-3 text-right text-green">
+                        {ghs(num(c.collected))}
+                      </td>
+                      <td className="px-4 py-3 text-right font-medium text-terra">
+                        {ghs(num(c.outstanding))}
+                      </td>
+                      <td
+                        className={`px-4 py-3 text-right font-medium ${r >= 80 ? "text-green" : r >= 50 ? "text-navy-2" : "text-terra"}`}
+                      >
+                        {r}%
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
+          </div>
+        )}
+      </section>
+
+      {/* Aging of receivables */}
+      <section>
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="font-display text-lg font-semibold text-navy">
+            Aging of receivables
+          </h2>
+          <ExportCsv
+            filename={schoolFile(school.name, "aging.csv")}
+            headers={["Bucket", "Outstanding", "Invoices"]}
+            rows={AGING.map((b) => {
+              const a = agingMap.get(b.key);
+              return [b.label, num(a?.amount).toFixed(2), String(a?.count ?? 0)];
+            })}
+          />
+        </div>
+        {outstanding <= 0 ? (
+          <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
+            Nothing outstanding — every invoice is settled.
+          </p>
+        ) : (
+          <div className="rounded-xl border border-border bg-surface p-5">
+            <p className="mb-3 text-sm text-navy-3">
+              <b className="text-terra">{ghs(overdueTotal)}</b> overdue of{" "}
+              <b className="text-navy">{ghs(outstanding)}</b> outstanding
+            </p>
+            <div className="space-y-2">
+              {AGING.map((b) => {
+                const a = agingMap.get(b.key);
+                const amt = a?.amount ?? 0;
+                return (
+                  <div key={b.key} className="flex items-center gap-3">
+                    <span className="w-40 shrink-0 text-xs text-navy-2">{b.label}</span>
+                    <div className="h-5 flex-1 overflow-hidden rounded-full bg-bg">
+                      <div
+                        className={`h-full rounded-full ${b.tone}`}
+                        style={{ width: `${(amt / agingMax) * 100}%` }}
+                      />
+                    </div>
+                    <span className="w-14 shrink-0 text-right text-[11px] text-navy-3">
+                      {a?.count ?? 0} inv
+                    </span>
+                    <span className="w-28 shrink-0 text-right text-xs font-medium text-navy-2">
+                      {ghs(amt)}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
           </div>
         )}
       </section>


### PR DESCRIPTION
## Track ② — slice 2d-i (Reports catalogue, part 1)

First slice of the Reports deepening — two finance views off existing data, **no migration**.

### Changes
- **Aging of receivables** — outstanding balance bucketed by how far past due it is (not-yet-due / 1–30 / 31–60 / 61–90 / 90+ days), each with a bar, invoice count and amount, plus an "**X overdue of Y outstanding**" headline and CSV export. Buckets come from `invoices.due_at` (a `CASE`/`interval` group-by).
- **Per-class collection rate** — the outstanding-by-class table gains a **Rate** column (collected ÷ billed), colour-coded (green ≥80%, terra <50%), also added to its CSV.

### Verification
- `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm build` ✅
- `/reports` renders 200 with all five aging buckets and the rate column; the aging SQL executes cleanly.

### Next in 2d
2d-ii Voids/refunds + Discounts report views · 2d-iii period selector + per-class drill-through · 2d-iv print/PDF export + per-row send-reminder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)