### PR TITLE
feat(reports): per-class drill-through, per-row reminder & print (track 2d-iv)

### DIFF
--- a/omnischools/app/(app)/layout.tsx
+++ b/omnischools/app/(app)/layout.tsx
@@ -16,7 +16,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
         user={{ name: user.name ?? null, role: user.roles[0] ?? null }}
       />
       <div className="flex min-w-0 flex-1 flex-col">
-        <header className="flex items-center justify-between gap-4 border-b border-border bg-surface px-6 py-3">
+        <header className="flex items-center justify-between gap-4 border-b border-border bg-surface px-6 py-3 print:hidden">
           {/* School name shows on mobile (sidebar hidden < md); on desktop it lives in the sidebar. */}
           <div className="truncate font-display text-base font-semibold text-navy md:hidden">
             {school.name}

--- a/omnischools/app/(app)/reports/class/[classId]/page.tsx
+++ b/omnischools/app/(app)/reports/class/[classId]/page.tsx
@@ -1,0 +1,133 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { and, eq, sql, desc } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import { invoices, students, classes } from "@/db/schema";
+import { SendReminderButton } from "@/components/reports/send-reminder-button";
+import { PrintButton } from "@/components/reports/print-button";
+import { ExportCsv } from "@/components/reports/export-csv";
+import { schoolFile } from "@/lib/filename";
+
+export const dynamic = "force-dynamic";
+
+const ghs = (n: number) =>
+  `GHS ${n.toLocaleString("en-GH", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const num = (v: unknown) => Number(v ?? 0);
+
+export default async function ClassReportPage({
+  params,
+}: {
+  params: { classId: string };
+}) {
+  const { school } = await requireSchool();
+  const data = await withSchool(school.id, async (tx) => {
+    const [cls] = await tx
+      .select({ id: classes.id, name: classes.name })
+      .from(classes)
+      .where(and(eq(classes.id, params.classId), eq(classes.schoolId, school.id)));
+    if (!cls) return null;
+    const debtors = await tx
+      .select({
+        studentId: students.id,
+        firstName: students.firstName,
+        lastName: students.lastName,
+        code: students.studentCode,
+        balance: sql<string>`sum(${invoices.balanceAmount})`,
+        maxOverdue: sql<number>`coalesce(max(case when ${invoices.dueAt} is not null and ${invoices.dueAt} < now() and ${invoices.balanceAmount} > 0 then floor(extract(epoch from (now() - ${invoices.dueAt})) / 86400) else 0 end), 0)::int`,
+      })
+      .from(invoices)
+      .innerJoin(students, eq(invoices.studentId, students.id))
+      .where(
+        and(
+          eq(invoices.schoolId, school.id),
+          eq(students.classId, params.classId),
+          sql`${invoices.status} <> 'VOIDED'`,
+          sql`${invoices.balanceAmount} > 0`,
+        ),
+      )
+      .groupBy(students.id, students.firstName, students.lastName, students.studentCode)
+      .orderBy(desc(sql`sum(${invoices.balanceAmount})`));
+    return { cls, debtors };
+  });
+
+  if (!data) notFound();
+  const { cls, debtors } = data;
+  const total = debtors.reduce((s, d) => s + num(d.balance), 0);
+
+  return (
+    <div className="mx-auto max-w-page">
+      <Link href="/reports" className="text-sm text-navy-3 hover:text-gold print:hidden">
+        ← Reports
+      </Link>
+      <div className="mb-6 mt-2 flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h1 className="font-display text-3xl font-semibold text-navy">{cls.name}</h1>
+          <p className="text-sm text-navy-3">
+            {debtors.length} student{debtors.length === 1 ? "" : "s"} owe{" "}
+            <b className="text-terra">{ghs(total)}</b>
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <PrintButton />
+          {debtors.length > 0 && (
+            <ExportCsv
+              filename={schoolFile(school.name, `${cls.name}-debtors.csv`)}
+              headers={["Code", "Student", "Days overdue", "Balance"]}
+              rows={debtors.map((d) => [
+                d.code,
+                `${d.lastName}, ${d.firstName}`,
+                String(d.maxOverdue),
+                num(d.balance).toFixed(2),
+              ])}
+            />
+          )}
+        </div>
+      </div>
+
+      {debtors.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border-2 bg-surface p-12 text-center">
+          <p className="font-display text-lg text-navy">Nothing outstanding in this class.</p>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-xl border border-border bg-surface">
+          <table className="w-full text-sm">
+            <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
+              <tr>
+                <th className="px-4 py-3 font-semibold">Code</th>
+                <th className="px-4 py-3 font-semibold">Student</th>
+                <th className="px-4 py-3 text-right font-semibold">Balance</th>
+                <th className="px-4 py-3 text-right font-semibold print:hidden"></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {debtors.map((d) => (
+                <tr key={d.studentId} className="hover:bg-bg">
+                  <td className="px-4 py-3 font-mono text-xs text-navy-2">
+                    <Link href={`/fees/${d.studentId}`} className="hover:text-gold">
+                      {d.code}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 font-medium text-navy">
+                    {d.lastName}, {d.firstName}
+                    {d.maxOverdue > 0 && (
+                      <span className="ml-2 rounded-pill bg-terra-bg px-2 py-0.5 text-xs font-medium text-terra">
+                        Overdue {d.maxOverdue}d
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-right font-semibold text-terra">
+                    {ghs(num(d.balance))}
+                  </td>
+                  <td className="px-4 py-3 text-right print:hidden">
+                    <SendReminderButton studentId={d.studentId} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/omnischools/app/(app)/reports/page.tsx
+++ b/omnischools/app/(app)/reports/page.tsx
@@ -14,6 +14,7 @@ import {
   feeCategories,
 } from "@/db/schema";
 import { ExportCsv } from "@/components/reports/export-csv";
+import { PrintButton } from "@/components/reports/print-button";
 import { schoolFile } from "@/lib/filename";
 
 const ordinal = (n: number) =>
@@ -94,6 +95,7 @@ export default async function ReportsPage({
     withSchool(school.id, (tx) =>
       tx
         .select({
+          classId: classes.id,
           className: sql<string>`coalesce(${classes.name}, '— Unassigned —')`,
           billed: sql<string>`coalesce(sum(${invoices.billedAmount}), 0)`,
           collected: sql<string>`coalesce(sum(${invoices.paidAmount}), 0)`,
@@ -105,7 +107,7 @@ export default async function ReportsPage({
         .where(
           and(eq(invoices.schoolId, school.id), ne(invoices.status, "VOIDED"), yearInv),
         )
-        .groupBy(classes.name)
+        .groupBy(classes.id, classes.name)
         .orderBy(desc(sql`sum(${invoices.balanceAmount})`)),
     ),
     withSchool(school.id, (tx) =>
@@ -285,17 +287,20 @@ export default async function ReportsPage({
 
   return (
     <div className="mx-auto max-w-page space-y-8">
-      <div>
-        <h1 className="font-display text-3xl font-semibold text-navy">Reports</h1>
-        <p className="text-sm text-navy-3">
-          Fees collected, outstanding by class, and collection trends — for the bursar.
-          {selectedYear && (
-            <>
-              {" "}
-              Showing <b className="text-navy">{selectedYear}</b>.
-            </>
-          )}
-        </p>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="font-display text-3xl font-semibold text-navy">Reports</h1>
+          <p className="text-sm text-navy-3">
+            Fees collected, outstanding by class, and collection trends — for the bursar.
+            {selectedYear && (
+              <>
+                {" "}
+                Showing <b className="text-navy">{selectedYear}</b>.
+              </>
+            )}
+          </p>
+        </div>
+        <PrintButton />
       </div>
 
       {yearRows.length > 0 && (
@@ -371,7 +376,18 @@ export default async function ReportsPage({
                   const r = classRate(c.billed, c.collected);
                   return (
                     <tr key={c.className} className="hover:bg-bg">
-                      <td className="px-4 py-3 font-medium text-navy">{c.className}</td>
+                      <td className="px-4 py-3 font-medium text-navy">
+                        {c.classId ? (
+                          <Link
+                            href={`/reports/class/${c.classId}`}
+                            className="hover:text-gold"
+                          >
+                            {c.className}
+                          </Link>
+                        ) : (
+                          c.className
+                        )}
+                      </td>
                       <td className="px-4 py-3 text-right text-navy-2">
                         {ghs(num(c.billed))}
                       </td>

--- a/omnischools/components/app/sidebar.tsx
+++ b/omnischools/components/app/sidebar.tsx
@@ -75,7 +75,7 @@ export function AppSidebar({
     .join(" · ");
 
   return (
-    <aside className="hidden w-60 shrink-0 flex-col bg-navy text-bg md:flex">
+    <aside className="hidden w-60 shrink-0 flex-col bg-navy text-bg md:flex print:hidden">
       {/* School block */}
       <div className="flex items-center gap-3 border-b border-white/10 px-5 py-4">
         <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-gold font-display text-sm font-semibold text-navy">

--- a/omnischools/components/reports/print-button.tsx
+++ b/omnischools/components/reports/print-button.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+/** Triggers the browser print dialog — users "Save as PDF" from there. */
+export function PrintButton() {
+  return (
+    <button
+      onClick={() => window.print()}
+      className="rounded-md border border-border-2 bg-surface px-3 py-1.5 text-xs font-semibold text-navy-2 transition-colors hover:border-gold print:hidden"
+    >
+      Print / Save as PDF
+    </button>
+  );
+}

--- a/omnischools/components/reports/send-reminder-button.tsx
+++ b/omnischools/components/reports/send-reminder-button.tsx
@@ -1,0 +1,39 @@
+"use client";
+import { useState, useTransition } from "react";
+import { sendReminderToStudent } from "@/lib/actions/billing";
+
+/** Sends the fee-balance SMS to one debtor's primary guardian (Reports drill-down). */
+export function SendReminderButton({ studentId }: { studentId: string }) {
+  const [pending, start] = useTransition();
+  const [state, setState] = useState<"idle" | "sent" | "error">("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  function go() {
+    setError(null);
+    start(async () => {
+      const res = await sendReminderToStudent({ studentId });
+      if (res.ok) {
+        setState("sent");
+      } else {
+        setState("error");
+        setError(res.error ?? "Could not send.");
+      }
+    });
+  }
+
+  if (state === "sent") {
+    return <span className="text-xs font-medium text-green">Reminder sent ✓</span>;
+  }
+  return (
+    <span className="inline-flex items-center gap-2">
+      <button
+        onClick={go}
+        disabled={pending}
+        className="text-xs font-semibold text-gold transition-colors hover:underline disabled:opacity-50 print:hidden"
+      >
+        {pending ? "Sending…" : state === "error" ? "Retry" : "Remind"}
+      </button>
+      {error && <span className="text-xs text-terra">{error}</span>}
+    </span>
+  );
+}

--- a/omnischools/lib/actions/billing.ts
+++ b/omnischools/lib/actions/billing.ts
@@ -633,3 +633,73 @@ export async function sendFeeReminders(): Promise<RemindersResult> {
     return { ok: false, error: "Could not send reminders. Please try again." };
   }
 }
+
+export type SingleReminderResult =
+  | { ok: true; sent: boolean }
+  | { ok: false; error: string };
+
+/** Send the fee reminder to one student's primary guardian (used from Reports). */
+export async function sendReminderToStudent(input: unknown): Promise<SingleReminderResult> {
+  const { school } = await requireSchool();
+  const sid = z
+    .string()
+    .uuid()
+    .safeParse((input as { studentId?: string })?.studentId);
+  if (!sid.success) return { ok: false, error: "Invalid student." };
+  const actor = await resolveActor(school.id);
+  try {
+    const data = await withSchool(school.id, async (tx) => {
+      const [stu] = await tx
+        .select({ firstName: students.firstName })
+        .from(students)
+        .where(and(eq(students.id, sid.data), eq(students.schoolId, school.id)));
+      if (!stu) return null;
+      const [bal] = await tx
+        .select({
+          outstanding: sql<string>`coalesce(sum(${invoices.balanceAmount}), 0)`,
+        })
+        .from(invoices)
+        .where(
+          and(
+            eq(invoices.studentId, sid.data),
+            inArray(invoices.status, ["ISSUED", "PARTIAL", "OVERDUE"]),
+          ),
+        );
+      const [g] = await tx
+        .select({ phone: studentGuardians.phone })
+        .from(studentGuardians)
+        .where(
+          and(
+            eq(studentGuardians.studentId, sid.data),
+            eq(studentGuardians.isPrimary, true),
+          ),
+        )
+        .limit(1);
+      return { firstName: stu.firstName, outstanding: num(bal?.outstanding), phone: g?.phone ?? null };
+    });
+
+    if (!data) return { ok: false, error: "Student not found." };
+    if (data.outstanding <= 0) return { ok: true, sent: false };
+    if (!data.phone) return { ok: false, error: "No guardian phone on file." };
+
+    const msg = feeReminderMessage(
+      school.shortName ?? "Omnischools",
+      data.firstName,
+      data.outstanding,
+    );
+    await sendSms(data.phone, msg);
+    await withSchool(school.id, (tx) =>
+      tx.insert(notificationLog).values({
+        schoolId: school.id,
+        studentId: sid.data,
+        phone: data.phone as string,
+        message: msg,
+        status: "SENT",
+        sentByUserId: actor.id ?? undefined,
+      }),
+    );
+    return { ok: true, sent: true };
+  } catch {
+    return { ok: false, error: "Could not send the reminder." };
+  }
+}


### PR DESCRIPTION
## Track ② — slice 2d-iv (final Reports slice — closes Track ②)

Makes the bursar's report **actionable and printable**. No migration.

### Changes
- **Per-class drill-through** — each class in "Outstanding by class" links to a new **`/reports/class/[classId]`** view listing that class's debtors (balance, days-overdue badge, link to each statement) with its own CSV.
- **Per-row send-reminder** — a `sendReminderToStudent` action (one debtor's primary guardian, reusing the shared reminder message + notification log) behind a **Remind** button on each drill-down row.
- **Print / Save as PDF** — a print button on `/reports` and the drill-down; the sidebar, header, and interactive controls are `print:hidden` so the printout is clean (browser handles Save-as-PDF).

### Verification
- `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm build` ✅
- Seeded check: the per-student reminder **sends** for a phoned debtor, **errors** with no phone, and **no-ops** at zero balance.
- `/reports` renders the Print button + class drill-through links; `/reports/class/<missing>` returns **404** gracefully (route + query execute, not a crash).

### 🏁 Track ② Financial deepening complete
2a (void+aging) · 2b (allocation) · 2c (reminder preview + discount tiers/stacking) · 2d (aging buckets, voids/discounts views, period selector, drill-through/reminder/print) — all shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)