### PR TITLE
feat(attendance): admin card-grid dashboard (A2)

### DIFF
--- a/omnischools/app/(app)/attendance/page.tsx
+++ b/omnischools/app/(app)/attendance/page.tsx
@@ -1,18 +1,47 @@
 import Link from "next/link";
-import { and, eq } from "drizzle-orm";
+import { and, eq, asc, sql } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
-import { classes, students, attendanceRecords, attendanceCorrections } from "@/db/schema";
+import {
+  classes,
+  students,
+  attendanceRecords,
+  attendanceCorrections,
+  users,
+} from "@/db/schema";
 import { NewClassForm, AssignStudent } from "@/components/attendance/class-controls";
 
 export const dynamic = "force-dynamic";
 
+const fmtTime = (d: Date) =>
+  d.toLocaleTimeString("en-GB", { hour: "numeric", minute: "2-digit", hour12: true });
+
+// today's segments, in display order
+const SEG: { key: string; label: string; tone: string }[] = [
+  { key: "PRESENT", label: "Present", tone: "bg-green" },
+  { key: "LATE", label: "Late", tone: "bg-warn" },
+  { key: "EXCUSED", label: "Excused", tone: "bg-navy-2" },
+  { key: "MEDICAL", label: "Medical", tone: "bg-gold" },
+  { key: "ABSENT", label: "Absent", tone: "bg-terra" },
+];
+
 export default async function AttendancePage() {
   const { school } = await requireSchool();
   const today = new Date().toISOString().slice(0, 10);
+  const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
 
   const data = await withSchool(school.id, async (tx) => {
-    const cls = await tx.select().from(classes).where(eq(classes.schoolId, school.id));
+    const cls = await tx
+      .select({
+        id: classes.id,
+        name: classes.name,
+        level: classes.level,
+        teacher: users.fullName,
+      })
+      .from(classes)
+      .leftJoin(users, eq(classes.classTeacherUserId, users.id))
+      .where(eq(classes.schoolId, school.id))
+      .orderBy(asc(classes.name));
     const studs = await tx
       .select({
         id: students.id,
@@ -24,10 +53,26 @@ export default async function AttendancePage() {
       .from(students)
       .where(and(eq(students.schoolId, school.id), eq(students.status, "ACTIVE")));
     const todayRecs = await tx
-      .select({ classId: attendanceRecords.classId, status: attendanceRecords.status })
+      .select({
+        classId: attendanceRecords.classId,
+        status: attendanceRecords.status,
+        markedAt: attendanceRecords.markedAt,
+      })
       .from(attendanceRecords)
       .where(
         and(eq(attendanceRecords.schoolId, school.id), eq(attendanceRecords.date, today)),
+      );
+    const [yAgg] = await tx
+      .select({
+        attended: sql<number>`sum(case when ${attendanceRecords.status} in ('PRESENT','LATE') then 1 else 0 end)::int`,
+        total: sql<number>`count(*)::int`,
+      })
+      .from(attendanceRecords)
+      .where(
+        and(
+          eq(attendanceRecords.schoolId, school.id),
+          eq(attendanceRecords.date, yesterday),
+        ),
       );
     const pendingCorrections = (
       await tx
@@ -40,11 +85,59 @@ export default async function AttendancePage() {
           ),
         )
     ).length;
-    return { cls, studs, todayRecs, pendingCorrections };
+    return { cls, studs, todayRecs, yAgg, pendingCorrections };
   });
 
   const unassigned = data.studs.filter((s) => !s.classId);
   const classOptions = data.cls.map((c) => ({ id: c.id, name: c.name }));
+
+  // Per-class roll-up of today.
+  type ClassView = {
+    id: string;
+    name: string;
+    level: string | null;
+    teacher: string | null;
+    count: number;
+    counts: Record<string, number>;
+    total: number;
+    markedAt: Date | null;
+    marked: boolean;
+  };
+  const classViews: ClassView[] = data.cls.map((c) => {
+    const recs = data.todayRecs.filter((r) => r.classId === c.id);
+    const counts: Record<string, number> = {};
+    let latest: Date | null = null;
+    for (const r of recs) {
+      counts[r.status] = (counts[r.status] ?? 0) + 1;
+      const at = r.markedAt instanceof Date ? r.markedAt : new Date(r.markedAt as string);
+      if (!latest || at > latest) latest = at;
+    }
+    return {
+      id: c.id,
+      name: c.name,
+      level: c.level,
+      teacher: c.teacher,
+      count: data.studs.filter((s) => s.classId === c.id).length,
+      counts,
+      total: recs.length,
+      markedAt: latest,
+      marked: recs.length > 0,
+    };
+  });
+
+  // School-wide pulse (over students marked so far today).
+  const totalMarked = data.todayRecs.length;
+  const presentish = data.todayRecs.filter(
+    (r) => r.status === "PRESENT" || r.status === "LATE",
+  ).length;
+  const schoolRate = totalMarked > 0 ? Math.round((presentish / totalMarked) * 100) : null;
+  const tally = (st: string) => data.todayRecs.filter((r) => r.status === st).length;
+  const registersMarked = classViews.filter((c) => c.marked).length;
+  const yRate =
+    data.yAgg && data.yAgg.total > 0
+      ? Math.round((data.yAgg.attended / data.yAgg.total) * 100)
+      : null;
+  const delta = schoolRate !== null && yRate !== null ? schoolRate - yRate : null;
 
   return (
     <div className="mx-auto max-w-page">
@@ -73,59 +166,124 @@ export default async function AttendancePage() {
           </p>
         </div>
       ) : (
-        <div className="bg-surface overflow-hidden rounded-xl border border-border">
-          <table className="w-full text-sm">
-            <thead className="bg-bg border-b border-border text-left text-xs uppercase tracking-wide text-navy-3">
-              <tr>
-                <th className="px-4 py-3 font-semibold">Class</th>
-                <th className="px-4 py-3 text-right font-semibold">Students</th>
-                <th className="px-4 py-3 text-right font-semibold">Present today</th>
-                <th className="px-4 py-3 text-right font-semibold">Absent</th>
-                <th className="px-4 py-3 text-right font-semibold">Rate</th>
-                <th className="px-4 py-3"></th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              {data.cls.map((c) => {
-                const count = data.studs.filter((s) => s.classId === c.id).length;
-                const recs = data.todayRecs.filter((r) => r.classId === c.id);
-                const present = recs.filter(
-                  (r) => r.status === "PRESENT" || r.status === "LATE",
-                ).length;
-                const absent = recs.filter((r) => r.status === "ABSENT").length;
-                const rate = recs.length
-                  ? Math.round((present / recs.length) * 100)
-                  : null;
-                return (
-                  <tr key={c.id} className="hover:bg-bg">
-                    <td className="px-4 py-3 font-medium text-navy">
-                      <Link href={`/attendance/${c.id}`} className="hover:text-gold">
-                        {c.name}
-                      </Link>
+        <>
+          {/* Today's pulse */}
+          <div className="mb-6 grid grid-cols-2 gap-4 lg:grid-cols-4">
+            <div className="rounded-xl border border-navy bg-navy p-5 text-bg">
+              <div className="font-display text-4xl font-semibold">
+                {schoolRate === null ? "—" : `${schoolRate}%`}
+              </div>
+              <div className="mt-1 text-sm text-gold-soft">School attendance · today</div>
+              <div className="mt-0.5 text-[11px] text-bg/60">
+                {presentish} of {totalMarked} marked present
+              </div>
+            </div>
+            <div className="rounded-xl border border-border bg-surface p-5">
+              <div className="font-display text-4xl font-semibold text-navy">
+                {registersMarked}
+                <span className="text-xl text-navy-3">/{data.cls.length}</span>
+              </div>
+              <div className="mt-1 text-sm text-navy-3">Registers marked</div>
+              <div className="mt-0.5 text-[11px] text-navy-3">
+                {data.cls.length - registersMarked} pending
+              </div>
+            </div>
+            <div className="rounded-xl border border-border bg-surface p-5">
+              <div className="font-display text-4xl font-semibold text-navy">
+                {tally("ABSENT")}
+              </div>
+              <div className="mt-1 text-sm text-navy-3">Absent today</div>
+              <div className="mt-0.5 text-[11px] text-navy-3">
+                {tally("LATE")} late · {tally("EXCUSED") + tally("MEDICAL")} excused
+              </div>
+            </div>
+            <div className="rounded-xl border border-border bg-surface p-5">
+              <div
+                className={`font-display text-4xl font-semibold ${
+                  delta === null ? "text-navy-3" : delta >= 0 ? "text-green" : "text-terra"
+                }`}
+              >
+                {delta === null ? "—" : `${delta >= 0 ? "+" : ""}${delta}%`}
+              </div>
+              <div className="mt-1 text-sm text-navy-3">vs yesterday</div>
+              <div className="mt-0.5 text-[11px] text-navy-3">
+                {yRate === null ? "no data" : `yesterday ${yRate}%`}
+              </div>
+            </div>
+          </div>
+
+          {/* By class */}
+          <h2 className="mb-3 font-display text-lg font-semibold text-navy">By class</h2>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {classViews.map((c) => (
+              <Link
+                key={c.id}
+                href={`/attendance/${c.id}`}
+                className={`rounded-xl border bg-surface p-4 transition-colors hover:border-gold-soft ${
+                  c.marked ? "border-border" : "border-terra/40 bg-terra-bg/30"
+                }`}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <div className="font-display text-base font-semibold text-navy">
+                      {c.name}
                       {c.level && (
-                        <span className="ml-2 text-xs text-navy-3">{c.level}</span>
+                        <span className="ml-1.5 text-xs font-normal text-navy-3">
+                          {c.level}
+                        </span>
                       )}
-                    </td>
-                    <td className="px-4 py-3 text-right text-navy-2">{count}</td>
-                    <td className="px-4 py-3 text-right text-green">{present || "—"}</td>
-                    <td className="px-4 py-3 text-right text-terra">{absent || "—"}</td>
-                    <td className="px-4 py-3 text-right font-medium text-navy">
-                      {rate === null ? "—" : `${rate}%`}
-                    </td>
-                    <td className="px-4 py-3 text-right">
-                      <Link
-                        href={`/attendance/${c.id}`}
-                        className="text-bg rounded-md bg-navy px-3 py-1.5 text-xs font-semibold hover:bg-navy-deep"
-                      >
-                        Take attendance
-                      </Link>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+                    </div>
+                    <div className="truncate text-xs text-navy-3">
+                      {c.count} student{c.count === 1 ? "" : "s"}
+                      {c.teacher ? ` · ${c.teacher}` : " · no class teacher"}
+                    </div>
+                  </div>
+                  <span
+                    className={`shrink-0 rounded-pill px-2 py-0.5 text-[11px] font-medium ${
+                      c.marked ? "bg-green-bg text-green" : "bg-terra-bg text-terra"
+                    }`}
+                  >
+                    {c.marked ? "Done" : "Pending"}
+                  </span>
+                </div>
+
+                {c.marked ? (
+                  <>
+                    <div className="mt-3 flex h-2.5 overflow-hidden rounded-pill bg-bg">
+                      {SEG.map((s) => {
+                        const n = c.counts[s.key] ?? 0;
+                        if (n === 0) return null;
+                        return (
+                          <div
+                            key={s.key}
+                            className={s.tone}
+                            style={{ width: `${(n / c.total) * 100}%` }}
+                          />
+                        );
+                      })}
+                    </div>
+                    <div className="mt-2 flex items-center justify-between text-[11px] text-navy-3">
+                      <span>
+                        {(c.counts.PRESENT ?? 0) + (c.counts.LATE ?? 0)} present ·{" "}
+                        {c.counts.ABSENT ?? 0} absent
+                      </span>
+                      {c.markedAt && <span>marked {fmtTime(c.markedAt)}</span>}
+                    </div>
+                  </>
+                ) : (
+                  <div className="mt-3 flex h-2.5 overflow-hidden rounded-pill bg-bg">
+                    <div className="h-full w-full bg-border-2" />
+                  </div>
+                )}
+                {!c.marked && (
+                  <div className="mt-2 text-[11px] font-medium text-terra">
+                    Register not yet marked — take attendance →
+                  </div>
+                )}
+              </Link>
+            ))}
+          </div>
+        </>
       )}
 
       {unassigned.length > 0 && (


### PR DESCRIPTION
## Attendance surface fidelity — slice A2 (admin oversight)

Replaces the plain attendance table with the **admin oversight** surface (`schoolup-attendance-admin`) — the head's once-a-day pulse + per-class status grid. **No migration.**

### Changes
- **Today's pulse KPIs** — school attendance rate (present+late ÷ marked), **registers marked X of N** classes, **absent today** (+ late/excused), and a **vs-yesterday** delta.
- **By-class cards** — each class shows student count, class teacher, a stacked **P/L/E/M/A** bar, the latest **marked-at** time, and a **Done / Pending** pill. Unmarked registers are terra-tinted and flagged "not yet marked".
- Cards link straight into the class register; the corrections link, new-class form, and unassigned-students section are retained.

### Notes
- Independent of A1 (different file) — branches cleanly off `main`.
- Excursion status, the term-trend chart, and the needs-attention table are later slices (A4) / MVP2.

### Verification
- `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm build` ✅
- A seeded class with a mixed register (present/late/absent) renders the KPI strip and a **Done** card with marked-at time at `/attendance` (HTTP 200).

Next: **A3** per-student attendance drill-down (term register + at-a-glance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)