### PR TITLE
feat(attendance): needs-attention list + threshold flags (A4)

### DIFF
--- a/omnischools/app/(app)/attendance/page.tsx
+++ b/omnischools/app/(app)/attendance/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { and, eq, asc, sql } from "drizzle-orm";
+import { and, eq, asc, gte, lte, sql } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import {
@@ -7,9 +7,11 @@ import {
   students,
   attendanceRecords,
   attendanceCorrections,
+  academicPeriod,
   users,
 } from "@/db/schema";
 import { NewClassForm, AssignStudent } from "@/components/attendance/class-controls";
+import { computeAttendanceFlags } from "@/lib/attendance-flags";
 
 export const dynamic = "force-dynamic";
 
@@ -85,11 +87,60 @@ export default async function AttendancePage() {
           ),
         )
     ).length;
-    return { cls, studs, todayRecs, yAgg, pendingCorrections };
+    // Current term's records, to compute who needs attention.
+    const [term] = await tx
+      .select({ startsOn: academicPeriod.startsOn, endsOn: academicPeriod.endsOn })
+      .from(academicPeriod)
+      .where(
+        and(
+          eq(academicPeriod.schoolId, school.id),
+          lte(academicPeriod.startsOn, today),
+          gte(academicPeriod.endsOn, today),
+        ),
+      )
+      .limit(1);
+    const termRecs = term
+      ? await tx
+          .select({
+            studentId: attendanceRecords.studentId,
+            date: attendanceRecords.date,
+            status: attendanceRecords.status,
+          })
+          .from(attendanceRecords)
+          .where(
+            and(
+              eq(attendanceRecords.schoolId, school.id),
+              gte(attendanceRecords.date, term.startsOn),
+              lte(attendanceRecords.date, term.endsOn),
+            ),
+          )
+      : [];
+    return { cls, studs, todayRecs, yAgg, pendingCorrections, termRecs };
   });
 
   const unassigned = data.studs.filter((s) => !s.classId);
   const classOptions = data.cls.map((c) => ({ id: c.id, name: c.name }));
+
+  // Threshold-based "needs attention" list over the current term.
+  const flagMap = computeAttendanceFlags(data.termRecs);
+  const classNameById = new Map(data.cls.map((c) => [c.id, c.name]));
+  const sevRank = (w: string | null) =>
+    w === "CRITICAL" ? 0 : w === "WATCHING" ? 1 : 2;
+  const needsAttention = data.studs
+    .map((s) => ({ s, f: flagMap.get(s.id) }))
+    .filter((x) => x.f && x.f.flags.length > 0)
+    .map((x) => ({
+      id: x.s.id,
+      name: `${x.s.lastName}, ${x.s.firstName}`,
+      code: x.s.code,
+      className: x.s.classId ? (classNameById.get(x.s.classId) ?? null) : null,
+      ...x.f!,
+    }))
+    .sort(
+      (a, b) =>
+        sevRank(a.worst) - sevRank(b.worst) || (a.termPct ?? 100) - (b.termPct ?? 100),
+    )
+    .slice(0, 50);
 
   // Per-class roll-up of today.
   type ClassView = {
@@ -283,6 +334,86 @@ export default async function AttendancePage() {
               </Link>
             ))}
           </div>
+
+          {/* Students needing attention */}
+          {needsAttention.length > 0 && (
+            <section className="mt-8">
+              <h2 className="mb-3 font-display text-lg font-semibold text-navy">
+                Students needing attention{" "}
+                <span className="text-sm font-normal text-navy-3">
+                  ({needsAttention.length})
+                </span>
+              </h2>
+              <div className="overflow-hidden rounded-xl border border-border bg-surface">
+                <table className="w-full text-sm">
+                  <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
+                    <tr>
+                      <th className="px-4 py-3 font-semibold">Student</th>
+                      <th className="px-4 py-3 font-semibold">Flag</th>
+                      <th className="px-4 py-3 text-right font-semibold">Term</th>
+                      <th className="px-4 py-3"></th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    {needsAttention.map((s) => (
+                      <tr key={s.id} className="hover:bg-bg">
+                        <td className="px-4 py-3">
+                          <div className="font-medium text-navy">{s.name}</div>
+                          <div className="font-mono text-xs text-navy-3">
+                            {s.code}
+                            {s.className ? ` · ${s.className}` : ""}
+                          </div>
+                        </td>
+                        <td className="px-4 py-3">
+                          <div className="flex flex-wrap gap-1.5">
+                            {s.flags.map((f) => (
+                              <span
+                                key={f.type}
+                                title={f.detail}
+                                className={`rounded-pill px-2 py-0.5 text-xs font-medium ${
+                                  f.severity === "CRITICAL"
+                                    ? "bg-terra-bg text-terra"
+                                    : "bg-warn-bg text-warn"
+                                }`}
+                              >
+                                {f.label}
+                              </span>
+                            ))}
+                          </div>
+                        </td>
+                        <td className="px-4 py-3 text-right">
+                          <span
+                            className={`text-sm font-semibold ${
+                              s.termPct === null
+                                ? "text-navy-3"
+                                : s.termPct < 60
+                                  ? "text-terra"
+                                  : s.termPct < 70
+                                    ? "text-warn"
+                                    : "text-navy-2"
+                            }`}
+                          >
+                            {s.termPct === null ? "—" : `${s.termPct}%`}
+                          </span>
+                          <span className="ml-1 text-[11px] text-navy-3">
+                            {s.attended}/{s.total}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 text-right">
+                          <Link
+                            href={`/students/${s.id}`}
+                            className="text-xs font-semibold text-gold hover:underline"
+                          >
+                            View →
+                          </Link>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          )}
         </>
       )}
 

--- a/omnischools/lib/attendance-flags.ts
+++ b/omnischools/lib/attendance-flags.ts
@@ -1,0 +1,103 @@
+/**
+ * Threshold-based attendance flags, computed from a term's records. Two rules
+ * (matching the alerts surface): long absence (consecutive absent days) and
+ * below-threshold (term attendance %). Each escalates Watching → Critical.
+ * Pattern-shift / anomaly detection is deferred to MVP2.
+ */
+export type FlagSeverity = "WATCHING" | "CRITICAL";
+export type FlagType = "LONG_ABSENCE" | "BELOW_THRESHOLD";
+
+export type AttendanceFlag = {
+  type: FlagType;
+  severity: FlagSeverity;
+  label: string;
+  detail: string;
+};
+
+export type StudentFlags = {
+  studentId: string;
+  termPct: number | null;
+  attended: number;
+  total: number;
+  consecutiveAbsent: number;
+  flags: AttendanceFlag[];
+  worst: FlagSeverity | null; // most severe across this student's flags
+};
+
+export const FLAG_THRESHOLDS = {
+  absWatch: 3,
+  absCritical: 5,
+  pctWatch: 70,
+  pctCritical: 60,
+};
+
+type Rec = { studentId: string; date: string; status: string };
+
+/**
+ * Group records by student and derive flags. `records` should cover the term of
+ * interest; order doesn't matter (sorted internally by date).
+ */
+export function computeAttendanceFlags(
+  records: Rec[],
+  thresholds = FLAG_THRESHOLDS,
+): Map<string, StudentFlags> {
+  const byStudent = new Map<string, Rec[]>();
+  for (const r of records) {
+    const arr = byStudent.get(r.studentId) ?? [];
+    arr.push(r);
+    byStudent.set(r.studentId, arr);
+  }
+
+  const out = new Map<string, StudentFlags>();
+  for (const [studentId, recs] of Array.from(byStudent)) {
+    recs.sort((a, b) => a.date.localeCompare(b.date));
+    const total = recs.length;
+    const attended = recs.filter(
+      (r) => r.status === "PRESENT" || r.status === "LATE",
+    ).length;
+    const termPct = total > 0 ? Math.round((attended / total) * 100) : null;
+
+    let consecutiveAbsent = 0;
+    for (let i = recs.length - 1; i >= 0; i--) {
+      if (recs[i].status === "ABSENT") consecutiveAbsent++;
+      else break;
+    }
+
+    const flags: AttendanceFlag[] = [];
+    if (consecutiveAbsent >= thresholds.absWatch) {
+      const critical = consecutiveAbsent >= thresholds.absCritical;
+      flags.push({
+        type: "LONG_ABSENCE",
+        severity: critical ? "CRITICAL" : "WATCHING",
+        label: "Long absence",
+        detail: `${consecutiveAbsent} consecutive absent day${consecutiveAbsent === 1 ? "" : "s"}`,
+      });
+    }
+    if (termPct !== null && termPct < thresholds.pctWatch) {
+      const critical = termPct < thresholds.pctCritical;
+      flags.push({
+        type: "BELOW_THRESHOLD",
+        severity: critical ? "CRITICAL" : "WATCHING",
+        label: critical ? "Below 60%" : "Below 70%",
+        detail: `term attendance ${termPct}%`,
+      });
+    }
+
+    const worst: FlagSeverity | null = flags.some((f) => f.severity === "CRITICAL")
+      ? "CRITICAL"
+      : flags.length > 0
+        ? "WATCHING"
+        : null;
+
+    out.set(studentId, {
+      studentId,
+      termPct,
+      attended,
+      total,
+      consecutiveAbsent,
+      flags,
+      worst,
+    });
+  }
+  return out;
+}


### PR DESCRIPTION
## Attendance surface fidelity — slice A4 (needs-attention)

Surfaces students who need follow-up on the admin dashboard (admin Region 4 + the alerts threshold rules), computed from the current term's records. **No migration.**

### Changes
- **`lib/attendance-flags.ts`** — a pure helper deriving two threshold rules per student:
  - **Long absence** — ≥3 consecutive absent days (Watching), ≥5 (Critical)
  - **Below threshold** — term attendance <70% (Watching), <60% (Critical)
  - (Pattern-shift / anomaly detection stays MVP2.)
- **Dashboard "Students needing attention" section** — flagged students sorted by severity then term %, each row showing flag chips (**Watching** amber / **Critical** terra with the detail on hover), term % + days fraction, and a link to the student. Capped at 50.

### Verification
- `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm build` ✅
- **Unit check** of the rule boundaries: healthy→none, 3-absent→Watching, 5-absent→Critical, 65%→Below-70, all pass.
- A seeded student with 3 trailing absences renders in the needs-attention list (flagged **Long absence** + **Below 60**) at `/attendance` (HTTP 200).

### Next
**A5** attendance settings (migration — wires these thresholds + day times + edit-window), then **A6** edit-window enforcement + correction diff drawer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)