### PR TITLE
feat(attendance): edit-window lock + correction diff (A6)

### DIFF
--- a/omnischools/app/(app)/attendance/[classId]/page.tsx
+++ b/omnischools/app/(app)/attendance/[classId]/page.tsx
@@ -3,7 +3,13 @@ import { notFound } from "next/navigation";
 import { and, asc, eq, inArray, gte, lte, sql } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
-import { classes, students, attendanceRecords, academicPeriod } from "@/db/schema";
+import {
+  classes,
+  students,
+  attendanceRecords,
+  academicPeriod,
+  attendanceSettings,
+} from "@/db/schema";
 import { TakeRegister } from "@/components/attendance/take-register";
 
 export const dynamic = "force-dynamic";
@@ -50,11 +56,17 @@ export default async function TakeAttendancePage({
         status: attendanceRecords.status,
         reasonCode: attendanceRecords.reasonCode,
         note: attendanceRecords.note,
+        markedAt: attendanceRecords.markedAt,
       })
       .from(attendanceRecords)
       .where(
         and(eq(attendanceRecords.classId, cls.id), eq(attendanceRecords.date, date)),
       );
+    const [cfg] = await tx
+      .select({ editWindowHours: attendanceSettings.editWindowHours })
+      .from(attendanceSettings)
+      .where(eq(attendanceSettings.schoolId, school.id))
+      .limit(1);
 
     // Per-student term attendance %, scoped to the current term when one is active.
     const ids = roster.map((s) => s.id);
@@ -88,10 +100,22 @@ export default async function TakeAttendancePage({
               ),
             )
             .groupBy(attendanceRecords.studentId);
-    return { cls, roster, recs, termAgg };
+    return { cls, roster, recs, termAgg, editWindowHours: cfg?.editWindowHours ?? 24 };
   });
 
   if (!data) notFound();
+  // The register locks once its earliest mark is older than the edit window.
+  const windowH = data.editWindowHours;
+  const oldestMark = data.recs.reduce<number>((min, r) => {
+    const t = (
+      r.markedAt instanceof Date ? r.markedAt : new Date(r.markedAt as string)
+    ).getTime();
+    return t < min ? t : min;
+  }, Infinity);
+  const locked =
+    data.recs.length > 0 &&
+    windowH > 0 &&
+    Date.now() - oldestMark > windowH * 3_600_000;
   const recByStudent = new Map(data.recs.map((r) => [r.studentId, r]));
   const aggByStudent = new Map(data.termAgg.map((a) => [a.studentId, a]));
   const roster = data.roster.map((s) => {
@@ -136,7 +160,12 @@ export default async function TakeAttendancePage({
           </p>
         </div>
       ) : (
-        <TakeRegister classId={data.cls.id} date={date} roster={roster} />
+        <TakeRegister
+          classId={data.cls.id}
+          date={date}
+          roster={roster}
+          locked={locked}
+        />
       )}
     </div>
   );

--- a/omnischools/app/(app)/attendance/corrections/page.tsx
+++ b/omnischools/app/(app)/attendance/corrections/page.tsx
@@ -8,6 +8,23 @@ import { CorrectionActions } from "@/components/attendance/correction-actions";
 export const dynamic = "force-dynamic";
 
 const fmt = (s: string) => s.charAt(0) + s.slice(1).toLowerCase();
+
+const STATUS_PILL: Record<string, string> = {
+  PRESENT: "bg-green-bg text-green",
+  LATE: "bg-warn-bg text-warn",
+  EXCUSED: "bg-bg text-navy-2",
+  MEDICAL: "bg-gold-bg text-navy",
+  ABSENT: "bg-terra-bg text-terra",
+};
+function StatusPill({ status }: { status: string }) {
+  return (
+    <span
+      className={`rounded-pill px-2 py-0.5 text-xs font-semibold ${STATUS_PILL[status] ?? "bg-bg text-navy-3"}`}
+    >
+      {fmt(status)}
+    </span>
+  );
+}
 const fmtWhen = (d: Date | string) => {
   const dt = d instanceof Date ? d : new Date(d);
   return Number.isNaN(dt.getTime())
@@ -78,13 +95,14 @@ export default async function CorrectionsPage() {
                   {r.lastName}, {r.firstName}{" "}
                   <span className="text-xs text-navy-3">· {r.date}</span>
                 </div>
-                <div className="text-xs text-navy-3">
-                  {fmt(r.currentStatus)} →{" "}
-                  <span className="font-semibold text-navy-2">
-                    {fmt(r.requestedStatus)}
-                  </span>{" "}
-                  · {r.reason}
+                <div className="mt-1 flex items-center gap-2">
+                  <StatusPill status={r.currentStatus} />
+                  <span className="text-navy-3">→</span>
+                  <StatusPill status={r.requestedStatus} />
                 </div>
+                <p className="mt-1.5 border-l-2 border-gold-soft pl-2 text-xs italic text-navy-2">
+                  “{r.reason}”
+                </p>
                 <div className="mt-0.5 text-[11px] text-navy-3">
                   Requested by{" "}
                   <span className="font-medium text-navy-2">

--- a/omnischools/components/attendance/take-register.tsx
+++ b/omnischools/components/attendance/take-register.tsx
@@ -41,10 +41,12 @@ export function TakeRegister({
   classId,
   date,
   roster,
+  locked = false,
 }: {
   classId: string;
   date: string;
   roster: Row[];
+  locked?: boolean;
 }) {
   const router = useRouter();
   const [statuses, setStatuses] = useState<Record<string, Status>>(
@@ -95,6 +97,15 @@ export function TakeRegister({
 
   return (
     <div>
+      {locked && (
+        <div className="mb-4 flex flex-wrap items-center gap-x-2 gap-y-1 rounded-lg border border-warn/40 bg-warn-bg/40 px-4 py-3 text-sm">
+          <span className="font-semibold text-warn">Register locked.</span>
+          <span className="text-navy-2">
+            The edit window has closed — use <b>Request correction</b> on a student to
+            change a mark (it needs an admin co-sign).
+          </span>
+        </div>
+      )}
       {/* Stat strip */}
       <div className="mb-4 grid grid-cols-2 gap-2 sm:grid-cols-5">
         {STAT.map((s, i) => (
@@ -128,16 +139,17 @@ export function TakeRegister({
         <div className="flex items-center gap-2">
           <button
             onClick={allPresent}
-            className="border-border-2 bg-surface rounded-md border px-3 py-2 text-sm font-semibold text-navy hover:bg-gold-bg"
+            disabled={locked}
+            className="border-border-2 bg-surface rounded-md border px-3 py-2 text-sm font-semibold text-navy hover:bg-gold-bg disabled:opacity-50"
           >
             Mark all present
           </button>
           <button
             onClick={save}
-            disabled={saving}
+            disabled={saving || locked}
             className="text-bg rounded-md bg-navy px-5 py-2 text-sm font-semibold transition-colors hover:bg-navy-deep disabled:opacity-60"
           >
-            {saving ? "Saving…" : "Save register"}
+            {locked ? "Locked" : saving ? "Saving…" : "Save register"}
           </button>
         </div>
       </div>
@@ -187,9 +199,10 @@ export function TakeRegister({
                         <button
                           key={o.v}
                           onClick={() => set(r.id, o.v)}
+                          disabled={locked}
                           title={o.v}
                           className={cn(
-                            "h-8 w-8 rounded-md text-xs font-bold transition-colors",
+                            "h-8 w-8 rounded-md text-xs font-bold transition-colors disabled:opacity-60",
                             statuses[r.id] === o.v
                               ? o.on
                               : "bg-bg text-navy-3 hover:bg-gold-bg",

--- a/omnischools/lib/actions/attendance.ts
+++ b/omnischools/lib/actions/attendance.ts
@@ -119,7 +119,37 @@ export async function saveAttendance(input: unknown): Promise<SaveAttendanceResu
   const actor = await resolveActor(school.id);
 
   try {
-    const absentStudentIds = await withSchool(school.id, async (tx) => {
+    const out = await withSchool(school.id, async (tx) => {
+      // Edit-window lock — a register marked longer ago than the window can only
+      // be changed through the correction flow, not re-saved directly.
+      const existing = await tx
+        .select({ markedAt: attendanceRecords.markedAt })
+        .from(attendanceRecords)
+        .where(
+          and(
+            eq(attendanceRecords.schoolId, school.id),
+            eq(attendanceRecords.classId, d.classId),
+            eq(attendanceRecords.date, d.date),
+          ),
+        );
+      if (existing.length > 0) {
+        const [cfg] = await tx
+          .select({ editWindowHours: attendanceSettings.editWindowHours })
+          .from(attendanceSettings)
+          .where(eq(attendanceSettings.schoolId, school.id))
+          .limit(1);
+        const windowH = cfg?.editWindowHours ?? 24;
+        const oldest = existing.reduce<number>((min, r) => {
+          const t = (
+            r.markedAt instanceof Date ? r.markedAt : new Date(r.markedAt as string)
+          ).getTime();
+          return t < min ? t : min;
+        }, Infinity);
+        if (windowH > 0 && Date.now() - oldest > windowH * 3_600_000) {
+          return { locked: true as const };
+        }
+      }
+
       for (const e of d.entries) {
         // Reason/note only make sense for non-present marks; clear them otherwise.
         const reasonCode = e.status === "PRESENT" ? null : (e.reasonCode ?? null);
@@ -165,8 +195,17 @@ export async function saveAttendance(input: unknown): Promise<SaveAttendanceResu
         after: { date: d.date, marked: d.entries.length, absent: absent.length },
         reason: "Attendance taken",
       });
-      return absent;
+      return { locked: false as const, absent };
     });
+
+    if (out.locked) {
+      return {
+        ok: false,
+        error:
+          "This register is locked — the edit window has closed. Submit a correction request to change it.",
+      };
+    }
+    const absentStudentIds = out.absent;
 
     // absence alerts to primary guardians — only when the school keeps them on
     let alertsSent = 0;


### PR DESCRIPTION
## Attendance surface fidelity — slice A6 (edit-window + corrections) · final slice

Enforces the configurable edit window and sharpens the correction review (the edit-request surface idiom). **No migration** — consumes A5's `edit_window_hours`.

### Changes
- **`saveAttendance`** — a register whose earliest mark is older than the school's edit window can no longer be re-saved directly; it returns a "**locked — submit a correction**" error. A window of `0` disables locking.
- **Take-register** — shows a **"Register locked"** banner and disables the status controls + Save once the window has closed, steering to **Request correction** (still available per-row).
- **Corrections page** — the before→after change now renders as **coloured status pills** (the P/L/E/M/A vocabulary) with the reason quoted, alongside the existing requester attribution and co-sign actions.

### Verification
- `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm build` ✅
- Seeded check: a fresh register **saves**, within-window re-saves **allowed**, a back-dated (48h) register is **rejected as locked**, and **window=0 disables** the lock.

### ✅ Basic-tier Attendance complete (A1–A6)
A1 register reason+term% · A2 admin card-grid · A3 per-student drill-down · A4 needs-attention flags · A5 settings · A6 edit-window + correction diff. The 8 `schoolup-attendance-*` surfaces are covered for Basic tier; parent app, offline/sync, WhatsApp/digest, and pattern-shift detection remain MVP2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)