### PR TITLE
feat(attendance): pattern-shift flags + section-04 tabs (I2)

### DIFF
--- a/omnischools/app/(app)/attendance/page.tsx
+++ b/omnischools/app/(app)/attendance/page.tsx
@@ -12,8 +12,8 @@ import {
   users,
 } from "@/db/schema";
 import { NewClassForm, AssignStudent } from "@/components/attendance/class-controls";
-import { computeAttendanceFlags } from "@/lib/attendance-flags";
-import { ATTENDANCE_SETTINGS_DEFAULTS } from "@/lib/attendance-settings";
+import { computeAttendanceFlags, FLAG_THRESHOLDS } from "@/lib/attendance-flags";
+import { NeedsAttention } from "@/components/attendance/needs-attention";
 
 export const dynamic = "force-dynamic";
 
@@ -135,12 +135,24 @@ export default async function AttendancePage() {
 
   // Threshold-based "needs attention" list over the current term (configurable).
   const flagMap = computeAttendanceFlags(data.termRecs, {
-    absWatch: data.cfg?.absWatchDays ?? ATTENDANCE_SETTINGS_DEFAULTS.absWatchDays,
-    absCritical: data.cfg?.absCriticalDays ?? ATTENDANCE_SETTINGS_DEFAULTS.absCriticalDays,
-    pctWatch: data.cfg?.pctWatch ?? ATTENDANCE_SETTINGS_DEFAULTS.pctWatch,
-    pctCritical: data.cfg?.pctCritical ?? ATTENDANCE_SETTINGS_DEFAULTS.pctCritical,
+    ...FLAG_THRESHOLDS,
+    absWatch: data.cfg?.absWatchDays ?? FLAG_THRESHOLDS.absWatch,
+    absCritical: data.cfg?.absCriticalDays ?? FLAG_THRESHOLDS.absCritical,
+    pctWatch: data.cfg?.pctWatch ?? FLAG_THRESHOLDS.pctWatch,
+    pctCritical: data.cfg?.pctCritical ?? FLAG_THRESHOLDS.pctCritical,
   });
   const classNameById = new Map(data.cls.map((c) => [c.id, c.name]));
+  // Last-14-school-days status series per student, for the attention sparkline.
+  const last14ByStudent = new Map<string, { date: string; status: string }[]>();
+  for (const r of data.termRecs) {
+    const arr = last14ByStudent.get(r.studentId) ?? [];
+    arr.push({ date: r.date, status: r.status });
+    last14ByStudent.set(r.studentId, arr);
+  }
+  for (const [id, arr] of Array.from(last14ByStudent)) {
+    arr.sort((a, b) => a.date.localeCompare(b.date));
+    last14ByStudent.set(id, arr.slice(-14));
+  }
   const sevRank = (w: string | null) =>
     w === "CRITICAL" ? 0 : w === "WATCHING" ? 1 : 2;
   const needsAttention = data.studs
@@ -151,6 +163,7 @@ export default async function AttendancePage() {
       name: `${x.s.lastName}, ${x.s.firstName}`,
       code: x.s.code,
       className: x.s.classId ? (classNameById.get(x.s.classId) ?? null) : null,
+      last14: last14ByStudent.get(x.s.id) ?? [],
       ...x.f!,
     }))
     .sort(
@@ -352,85 +365,8 @@ export default async function AttendancePage() {
             ))}
           </div>
 
-          {/* Students needing attention */}
-          {needsAttention.length > 0 && (
-            <section className="mt-8">
-              <h2 className="mb-3 font-display text-lg font-semibold text-navy">
-                Students needing attention{" "}
-                <span className="text-sm font-normal text-navy-3">
-                  ({needsAttention.length})
-                </span>
-              </h2>
-              <div className="overflow-hidden rounded-xl border border-border bg-surface">
-                <table className="w-full text-sm">
-                  <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
-                    <tr>
-                      <th className="px-4 py-3 font-semibold">Student</th>
-                      <th className="px-4 py-3 font-semibold">Flag</th>
-                      <th className="px-4 py-3 text-right font-semibold">Term</th>
-                      <th className="px-4 py-3"></th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-border">
-                    {needsAttention.map((s) => (
-                      <tr key={s.id} className="hover:bg-bg">
-                        <td className="px-4 py-3">
-                          <div className="font-medium text-navy">{s.name}</div>
-                          <div className="font-mono text-xs text-navy-3">
-                            {s.code}
-                            {s.className ? ` · ${s.className}` : ""}
-                          </div>
-                        </td>
-                        <td className="px-4 py-3">
-                          <div className="flex flex-wrap gap-1.5">
-                            {s.flags.map((f) => (
-                              <span
-                                key={f.type}
-                                title={f.detail}
-                                className={`rounded-pill px-2 py-0.5 text-xs font-medium ${
-                                  f.severity === "CRITICAL"
-                                    ? "bg-terra-bg text-terra"
-                                    : "bg-warn-bg text-warn"
-                                }`}
-                              >
-                                {f.label}
-                              </span>
-                            ))}
-                          </div>
-                        </td>
-                        <td className="px-4 py-3 text-right">
-                          <span
-                            className={`text-sm font-semibold ${
-                              s.termPct === null
-                                ? "text-navy-3"
-                                : s.termPct < 60
-                                  ? "text-terra"
-                                  : s.termPct < 70
-                                    ? "text-warn"
-                                    : "text-navy-2"
-                            }`}
-                          >
-                            {s.termPct === null ? "—" : `${s.termPct}%`}
-                          </span>
-                          <span className="ml-1 text-[11px] text-navy-3">
-                            {s.attended}/{s.total}
-                          </span>
-                        </td>
-                        <td className="px-4 py-3 text-right">
-                          <Link
-                            href={`/students/${s.id}`}
-                            className="text-xs font-semibold text-gold hover:underline"
-                          >
-                            View →
-                          </Link>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </section>
-          )}
+          {/* 04 · Students needing attention */}
+          {needsAttention.length > 0 && <NeedsAttention students={needsAttention} />}
         </>
       )}
 

--- a/omnischools/components/attendance/needs-attention.tsx
+++ b/omnischools/components/attendance/needs-attention.tsx
@@ -1,0 +1,158 @@
+"use client";
+import { useState } from "react";
+import Link from "next/link";
+
+type Flag = { type: string; severity: string; label: string; detail: string };
+export type FlaggedRow = {
+  id: string;
+  name: string;
+  code: string;
+  className: string | null;
+  termPct: number | null;
+  attended: number;
+  total: number;
+  flags: Flag[];
+  worst: string | null;
+  last14: { date: string; status: string }[];
+};
+
+const TABS: { key: string; label: string }[] = [
+  { key: "all", label: "All flagged" },
+  { key: "BELOW_THRESHOLD", label: "Below 70%" },
+  { key: "LONG_ABSENCE", label: "Long absence" },
+  { key: "PATTERN_SHIFT", label: "Pattern shift" },
+];
+
+const CELL: Record<string, string> = {
+  PRESENT: "bg-green",
+  LATE: "bg-warn",
+  EXCUSED: "bg-navy-2",
+  MEDICAL: "bg-gold",
+  ABSENT: "bg-terra",
+};
+
+const pctTone = (p: number | null) =>
+  p === null ? "text-navy-3" : p < 60 ? "text-terra" : p < 70 ? "text-warn" : "text-navy-2";
+
+export function NeedsAttention({ students }: { students: FlaggedRow[] }) {
+  const [tab, setTab] = useState("all");
+  const count = (key: string) =>
+    key === "all"
+      ? students.length
+      : students.filter((s) => s.flags.some((f) => f.type === key)).length;
+  const rows =
+    tab === "all"
+      ? students
+      : students.filter((s) => s.flags.some((f) => f.type === tab));
+
+  return (
+    <section className="mt-8">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <h2 className="font-display text-lg font-semibold text-navy">
+          Students needing attention
+        </h2>
+        <div className="flex flex-wrap gap-1.5">
+          {TABS.map((t) => {
+            const n = count(t.key);
+            const active = tab === t.key;
+            return (
+              <button
+                key={t.key}
+                onClick={() => setTab(t.key)}
+                className={`rounded-pill px-2.5 py-1 text-xs font-semibold transition-colors ${
+                  active
+                    ? "bg-navy text-bg"
+                    : "border border-border-2 bg-surface text-navy-2 hover:border-gold"
+                }`}
+              >
+                {t.label} <span className={active ? "text-bg/70" : "text-navy-3"}>{n}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="overflow-x-auto rounded-xl border border-border bg-surface">
+        <table className="w-full text-sm">
+          <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
+            <tr>
+              <th className="px-4 py-3 font-semibold">Student</th>
+              <th className="px-4 py-3 font-semibold">Flag</th>
+              <th className="px-4 py-3 font-semibold">Term attendance</th>
+              <th className="px-4 py-3 font-semibold">Last 14 days</th>
+              <th className="px-4 py-3 font-semibold"></th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {rows.map((s) => (
+              <tr key={s.id} className="hover:bg-bg">
+                <td className="px-4 py-3">
+                  <div className="font-medium text-navy">{s.name}</div>
+                  <div className="font-mono text-xs text-navy-3">
+                    {s.code}
+                    {s.className ? ` · ${s.className}` : ""}
+                  </div>
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex flex-col gap-1">
+                    {s.flags.map((f) => (
+                      <span key={f.type} className="flex items-center gap-1.5">
+                        <span
+                          className={`rounded-pill px-2 py-0.5 text-xs font-medium ${
+                            f.severity === "CRITICAL"
+                              ? "bg-terra-bg text-terra"
+                              : "bg-warn-bg text-warn"
+                          }`}
+                        >
+                          {f.label}
+                        </span>
+                        <span className="text-[11px] text-navy-3">{f.detail}</span>
+                      </span>
+                    ))}
+                  </div>
+                </td>
+                <td className="px-4 py-3 whitespace-nowrap">
+                  <span className={`text-sm font-semibold ${pctTone(s.termPct)}`}>
+                    {s.termPct === null ? "—" : `${s.termPct}%`}
+                  </span>
+                  <span className="ml-1 text-[11px] text-navy-3">
+                    {s.attended}/{s.total}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex gap-0.5">
+                    {s.last14.map((d, i) => (
+                      <span
+                        key={i}
+                        title={`${d.date} · ${d.status.charAt(0) + d.status.slice(1).toLowerCase()}`}
+                        className={`h-4 w-1.5 rounded-sm ${CELL[d.status] ?? "bg-border-2"}`}
+                      />
+                    ))}
+                    {s.last14.length === 0 && (
+                      <span className="text-[11px] text-navy-3">—</span>
+                    )}
+                  </div>
+                </td>
+                <td className="px-4 py-3 text-right">
+                  <Link
+                    href={`/attendance/student/${s.id}`}
+                    className="text-xs font-semibold text-gold hover:underline"
+                  >
+                    Follow up →
+                  </Link>
+                </td>
+              </tr>
+            ))}
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={5} className="px-4 py-6 text-center text-sm text-navy-3">
+                  No students under this flag.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/omnischools/lib/attendance-flags.ts
+++ b/omnischools/lib/attendance-flags.ts
@@ -1,11 +1,22 @@
 /**
- * Threshold-based attendance flags, computed from a term's records. Two rules
- * (matching the alerts surface): long absence (consecutive absent days) and
- * below-threshold (term attendance %). Each escalates Watching → Critical.
- * Pattern-shift / anomaly detection is deferred to MVP2.
+ * Attendance flags computed from a term's records, matching the alerts surface:
+ * long absence (consecutive absent days), below-threshold (term attendance %),
+ * and pattern shift (same-day-of-week absences, or a rolling-14-day drop).
+ * Long-absence / below-threshold escalate Watching → Critical; pattern shift is
+ * Watching only (per the surface).
  */
 export type FlagSeverity = "WATCHING" | "CRITICAL";
-export type FlagType = "LONG_ABSENCE" | "BELOW_THRESHOLD";
+export type FlagType = "LONG_ABSENCE" | "BELOW_THRESHOLD" | "PATTERN_SHIFT";
+
+const WEEKDAYS = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
 
 export type AttendanceFlag = {
   type: FlagType;
@@ -29,6 +40,10 @@ export const FLAG_THRESHOLDS = {
   absCritical: 5,
   pctWatch: 70,
   pctCritical: 60,
+  // pattern shift
+  dropPct: 30, // ≥30-point fall, recent 14 days vs the prior 14
+  dowWindow: 6, // look at the last 6 occurrences of a weekday…
+  dowMiss: 4, // …and flag if ≥4 were absent
 };
 
 type Rec = { studentId: string; date: string; status: string };
@@ -81,6 +96,58 @@ export function computeAttendanceFlags(
         label: critical ? "Below 60%" : "Below 70%",
         detail: `term attendance ${termPct}%`,
       });
+    }
+
+    // Pattern shift — only worth checking with a few weeks of history.
+    if (total >= 8) {
+      // (a) same day-of-week: the last `dowWindow` occurrences of a weekday,
+      // flagged when ≥`dowMiss` were absent (e.g. "Pattern · Fridays").
+      const byDow = new Map<number, Rec[]>();
+      for (const r of recs) {
+        const dow = new Date(`${r.date}T00:00:00Z`).getUTCDay();
+        const arr = byDow.get(dow) ?? [];
+        arr.push(r);
+        byDow.set(dow, arr);
+      }
+      let dowFlag: { day: number; missed: number } | null = null;
+      for (const [day, list] of Array.from(byDow)) {
+        const recent = list.slice(-thresholds.dowWindow);
+        if (recent.length < thresholds.dowWindow) continue;
+        const missed = recent.filter((r) => r.status === "ABSENT").length;
+        if (missed >= thresholds.dowMiss && (!dowFlag || missed > dowFlag.missed)) {
+          dowFlag = { day, missed };
+        }
+      }
+      if (dowFlag) {
+        flags.push({
+          type: "PATTERN_SHIFT",
+          severity: "WATCHING",
+          label: `Pattern · ${WEEKDAYS[dowFlag.day]}s`,
+          detail: `absent ${dowFlag.missed} of the last ${thresholds.dowWindow} ${WEEKDAYS[dowFlag.day]}s`,
+        });
+      } else {
+        // (b) rolling drop: recent 14 days vs the prior 14.
+        const recent = recs.slice(-14);
+        const prior = recs.slice(-28, -14);
+        if (prior.length >= 5 && recent.length >= 5) {
+          const pct = (arr: Rec[]) =>
+            Math.round(
+              (arr.filter((r) => r.status === "PRESENT" || r.status === "LATE").length /
+                arr.length) *
+                100,
+            );
+          const recentPct = pct(recent);
+          const priorPct = pct(prior);
+          if (priorPct - recentPct >= thresholds.dropPct) {
+            flags.push({
+              type: "PATTERN_SHIFT",
+              severity: "WATCHING",
+              label: "Pattern shift",
+              detail: `${priorPct}% → ${recentPct}% over 2 weeks`,
+            });
+          }
+        }
+      }
     }
 
     const worst: FlagSeverity | null = flags.some((f) => f.severity === "CRITICAL")


### PR DESCRIPTION
## Attendance exact-replication — slice I2 (dashboard §04)

Brings the admin **"Students needing attention"** section to the surface (`schoolup-attendance-admin` Region 04). **No migration.**

### Changes
- **`lib/attendance-flags.ts`** — third flag type **PATTERN_SHIFT**:
  - same-day-of-week — **"Pattern · Fridays"** when ≥4 of the last 6 occurrences of a weekday were absent
  - rolling drop — **"Pattern shift"** when attendance fell ≥30 points (recent 14 days vs the prior 14)
  - Watching severity (the surface shows no critical tier for pattern).
- **`NeedsAttention`** component — the section now matches the surface: tabs **All flagged / Below 70% / Long absence / Pattern shift** with live counts, the exact columns **Student · Flag · Term attendance · Last 14 days · Follow up**, a 14-day status **sparkline**, and **Follow up →** to the student's attendance view.
- Dashboard wires the configured thresholds + per-student last-14 series.

### Verification
- `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm build` ✅
- **Unit check**: no false-positive on steady attendance; **Pattern · Fridays** and the rolling-drop both fire correctly.
- **Live render** (term temporarily extended to cover today, then reverted): the four tabs, the Last-14-days sparkline, and the flagged student all render at `/attendance`.

### Note
This is part of the exhaustive surface-replication pass now in the plan. Remaining dashboard §gaps for full admin fidelity: header meta ("Attendance · today · {full date} · Term 1 · Day X of Y"), **§03 This term's trend** chart, **§05 Register edit requests** on the dashboard, and the **View term grid** / **Export term report** actions — queued as the next slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)