### PR TITLE
feat(attendance): §03 this term's trend (I4)

### DIFF
--- a/omnischools/app/(app)/attendance/page.tsx
+++ b/omnischools/app/(app)/attendance/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { and, eq, asc, gte, lte, sql } from "drizzle-orm";
+import { and, eq, asc, desc, gte, lte, sql } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import {
@@ -15,12 +15,19 @@ import {
 import { NewClassForm, AssignStudent } from "@/components/attendance/class-controls";
 import { computeAttendanceFlags, FLAG_THRESHOLDS } from "@/lib/attendance-flags";
 import { NeedsAttention } from "@/components/attendance/needs-attention";
+import { TermTrend } from "@/components/attendance/term-trend";
 import { termDayProgress } from "@/lib/school-calendar";
 
 export const dynamic = "force-dynamic";
 
 const fmtTime = (d: Date) =>
   d.toLocaleTimeString("en-GB", { hour: "numeric", minute: "2-digit", hour12: true });
+const fmtShort = (iso: string) =>
+  new Date(`${iso}T00:00:00Z`).toLocaleDateString("en-GB", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+  });
 
 // today's segments, in display order
 const SEG: { key: string; label: string; tone: string }[] = [
@@ -55,6 +62,7 @@ export default async function AttendancePage() {
         firstName: students.firstName,
         lastName: students.lastName,
         code: students.studentCode,
+        sex: students.sex,
       })
       .from(students)
       .where(and(eq(students.schoolId, school.id), eq(students.status, "ACTIVE")));
@@ -142,7 +150,49 @@ export default async function AttendancePage() {
       .from(attendanceSettings)
       .where(eq(attendanceSettings.schoolId, school.id))
       .limit(1);
-    return { cls, studs, todayRecs, yAgg, pendingCorrections, termRecs, cfg, term, holidays };
+    // Previous term's average, for the trend headline's "vs previous term".
+    let prevAvg: number | null = null;
+    if (term) {
+      const [prev] = await tx
+        .select({ startsOn: academicPeriod.startsOn, endsOn: academicPeriod.endsOn })
+        .from(academicPeriod)
+        .where(
+          and(
+            eq(academicPeriod.schoolId, school.id),
+            lte(academicPeriod.endsOn, term.startsOn),
+          ),
+        )
+        .orderBy(desc(academicPeriod.endsOn))
+        .limit(1);
+      if (prev) {
+        const [agg] = await tx
+          .select({
+            attended: sql<number>`sum(case when ${attendanceRecords.status} in ('PRESENT','LATE') then 1 else 0 end)::int`,
+            total: sql<number>`count(*)::int`,
+          })
+          .from(attendanceRecords)
+          .where(
+            and(
+              eq(attendanceRecords.schoolId, school.id),
+              gte(attendanceRecords.date, prev.startsOn),
+              lte(attendanceRecords.date, prev.endsOn),
+            ),
+          );
+        prevAvg = agg && agg.total > 0 ? Math.round((agg.attended / agg.total) * 100) : null;
+      }
+    }
+    return {
+      cls,
+      studs,
+      todayRecs,
+      yAgg,
+      pendingCorrections,
+      termRecs,
+      cfg,
+      term,
+      holidays,
+      prevAvg,
+    };
   });
 
   const unassigned = data.studs.filter((s) => !s.classId);
@@ -157,6 +207,77 @@ export default async function AttendancePage() {
   const progress = data.term
     ? termDayProgress(data.term.startsOn, data.term.endsOn, today, data.holidays)
     : null;
+
+  // §03 trend — daily attendance % over the term: school / by-gender / by-class.
+  type Bucket = { att: number; tot: number };
+  const bump = (m: Map<string, Bucket>, k: string, present: boolean) => {
+    const b = m.get(k) ?? { att: 0, tot: 0 };
+    b.tot++;
+    if (present) b.att++;
+    m.set(k, b);
+  };
+  const trendMeta = new Map(data.studs.map((s) => [s.id, s]));
+  const dayAll = new Map<string, Bucket>();
+  const dayMale = new Map<string, Bucket>();
+  const dayFemale = new Map<string, Bucket>();
+  const dayByClass = new Map<string, Map<string, Bucket>>();
+  for (const r of data.termRecs) {
+    const present = r.status === "PRESENT" || r.status === "LATE";
+    bump(dayAll, r.date, present);
+    const m = trendMeta.get(r.studentId);
+    if (m?.sex === "MALE") bump(dayMale, r.date, present);
+    else if (m?.sex === "FEMALE") bump(dayFemale, r.date, present);
+    if (m?.classId) {
+      const cm = dayByClass.get(m.classId) ?? new Map<string, Bucket>();
+      bump(cm, r.date, present);
+      dayByClass.set(m.classId, cm);
+    }
+  }
+  const toPoints = (m: Map<string, Bucket>) =>
+    Array.from(m.entries())
+      .filter(([, b]) => b.tot > 0)
+      .map(([date, b]) => ({ date, pct: Math.round((b.att / b.tot) * 100) }))
+      .sort((a, b) => a.date.localeCompare(b.date));
+  const schoolPts = toPoints(dayAll);
+  const trend =
+    data.term && schoolPts.length > 0
+      ? {
+          school: schoolPts,
+          male: toPoints(dayMale),
+          female: toPoints(dayFemale),
+          byClass: data.cls
+            .map((c) => ({ name: c.name, points: toPoints(dayByClass.get(c.id) ?? new Map()) }))
+            .filter((c) => c.points.length > 0),
+          holidays: data.holidays,
+          termStart: data.term.startsOn,
+          termEnd: data.term.endsOn,
+          today,
+        }
+      : null;
+  const termAvg =
+    data.termRecs.length > 0
+      ? Math.round(
+          (data.termRecs.filter((r) => r.status === "PRESENT" || r.status === "LATE")
+            .length /
+            data.termRecs.length) *
+            100,
+        )
+      : null;
+  const trendDelta =
+    termAvg !== null && data.prevAvg !== null ? termAvg - data.prevAvg : null;
+  const dowOf = (d: string) => new Date(`${d}T00:00:00Z`).getUTCDay();
+  const avgOf = (pts: { pct: number }[]) =>
+    pts.length ? Math.round(pts.reduce((s, p) => s + p.pct, 0) / pts.length) : null;
+  const bestDay = schoolPts.reduce<{ date: string; pct: number } | null>(
+    (m, p) => (!m || p.pct > m.pct ? p : m),
+    null,
+  );
+  const lowestDay = schoolPts.reduce<{ date: string; pct: number } | null>(
+    (m, p) => (!m || p.pct < m.pct ? p : m),
+    null,
+  );
+  const monAvg = avgOf(schoolPts.filter((p) => dowOf(p.date) === 1));
+  const friAvg = avgOf(schoolPts.filter((p) => dowOf(p.date) === 5));
 
   // Threshold-based "needs attention" list over the current term (configurable).
   const flagMap = computeAttendanceFlags(data.termRecs, {
@@ -401,6 +522,54 @@ export default async function AttendancePage() {
               </Link>
             ))}
           </div>
+
+          {/* 03 · This term's trend */}
+          {trend && (
+            <section className="mt-8">
+              <div className="mb-3 flex flex-wrap items-end justify-between gap-2">
+                <h2 className="font-display text-lg font-semibold text-navy">
+                  This term&apos;s trend
+                </h2>
+                <div className="text-sm text-navy-3">
+                  <b className="text-navy">{termAvg}%</b> term average
+                  {trendDelta !== null && (
+                    <span
+                      className={
+                        trendDelta >= 0 ? "text-green" : "text-terra"
+                      }
+                    >
+                      {" · "}
+                      {trendDelta >= 0 ? "↑" : "↓"} {Math.abs(trendDelta)}% vs previous term
+                    </span>
+                  )}
+                </div>
+              </div>
+              <TermTrend data={trend} />
+              <div className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-4">
+                {(
+                  [
+                    ["Best day", bestDay ? `${bestDay.pct}%` : "—", bestDay ? fmtShort(bestDay.date) : ""],
+                    ["Lowest day", lowestDay ? `${lowestDay.pct}%` : "—", lowestDay ? fmtShort(lowestDay.date) : ""],
+                    ["Mondays avg", monAvg !== null ? `${monAvg}%` : "—", ""],
+                    ["Fridays avg", friAvg !== null ? `${friAvg}%` : "—", ""],
+                  ] as const
+                ).map(([label, val, sub]) => (
+                  <div
+                    key={label}
+                    className="rounded-lg border border-border bg-surface px-3 py-2"
+                  >
+                    <div className="text-[11px] uppercase tracking-wide text-navy-3">
+                      {label}
+                    </div>
+                    <div className="font-display text-lg font-semibold text-navy">
+                      {val}
+                    </div>
+                    {sub && <div className="text-[11px] text-navy-3">{sub}</div>}
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
 
           {/* 04 · Students needing attention */}
           {needsAttention.length > 0 && <NeedsAttention students={needsAttention} />}

--- a/omnischools/components/attendance/term-trend.tsx
+++ b/omnischools/components/attendance/term-trend.tsx
@@ -1,0 +1,157 @@
+"use client";
+import { useState } from "react";
+
+export type TrendPoint = { date: string; pct: number };
+export type TermTrendData = {
+  school: TrendPoint[];
+  male: TrendPoint[];
+  female: TrendPoint[];
+  byClass: { name: string; points: TrendPoint[] }[];
+  holidays: { name: string; startsOn: string; endsOn: string }[];
+  termStart: string;
+  termEnd: string;
+  today: string;
+};
+
+const W = 720;
+const H = 220;
+const PAD = { t: 12, r: 12, b: 22, l: 30 };
+const Y_MIN = 50;
+const Y_MAX = 100;
+const days = (a: string, b: string) =>
+  (Date.parse(`${b}T00:00:00Z`) - Date.parse(`${a}T00:00:00Z`)) / 86_400_000;
+
+const CLASS_COLORS = [
+  "#1A2B47",
+  "#C8975B",
+  "#3E7C5A",
+  "#B5552E",
+  "#7B6CA8",
+  "#2F7D8C",
+  "#9C6B3F",
+];
+
+export function TermTrend({ data }: { data: TermTrendData }) {
+  const [view, setView] = useState<"school" | "gender" | "class">("school");
+  const span = Math.max(1, days(data.termStart, data.termEnd));
+  const x = (d: string) =>
+    PAD.l + (days(data.termStart, d) / span) * (W - PAD.l - PAD.r);
+  const y = (p: number) =>
+    PAD.t +
+    (1 - (Math.min(Y_MAX, Math.max(Y_MIN, p)) - Y_MIN) / (Y_MAX - Y_MIN)) *
+      (H - PAD.t - PAD.b);
+  const path = (pts: TrendPoint[]) =>
+    pts.map((p, i) => `${i === 0 ? "M" : "L"} ${x(p.date).toFixed(1)} ${y(p.pct).toFixed(1)}`).join(" ");
+
+  const lines =
+    view === "school"
+      ? [{ name: "School", points: data.school, color: "#1A2B47" }]
+      : view === "gender"
+        ? [
+            { name: "Boys", points: data.male, color: "#1A2B47" },
+            { name: "Girls", points: data.female, color: "#C8975B" },
+          ]
+        : data.byClass.map((c, i) => ({
+            name: c.name,
+            points: c.points,
+            color: CLASS_COLORS[i % CLASS_COLORS.length],
+          }));
+
+  return (
+    <div className="rounded-xl border border-border bg-surface p-5">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <div className="flex flex-wrap gap-3 text-xs">
+          {lines.map((l) => (
+            <span key={l.name} className="flex items-center gap-1.5 text-navy-2">
+              <span className="h-2 w-3 rounded-sm" style={{ background: l.color }} />
+              {l.name}
+            </span>
+          ))}
+        </div>
+        <div className="flex gap-1.5">
+          {(
+            [
+              ["school", "School"],
+              ["class", "By class"],
+              ["gender", "By gender"],
+            ] as const
+          ).map(([k, label]) => (
+            <button
+              key={k}
+              onClick={() => setView(k)}
+              className={`rounded-pill px-2.5 py-1 text-xs font-semibold transition-colors ${
+                view === k
+                  ? "bg-navy text-bg"
+                  : "border border-border-2 bg-surface text-navy-2 hover:border-gold"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <svg viewBox={`0 0 ${W} ${H}`} className="w-full" role="img" aria-label="Daily attendance trend">
+        {/* y gridlines + labels */}
+        {[60, 70, 80, 90, 100].map((g) => (
+          <g key={g}>
+            <line
+              x1={PAD.l}
+              x2={W - PAD.r}
+              y1={y(g)}
+              y2={y(g)}
+              stroke={g === 90 ? "#C8975B" : "#E7E3DC"}
+              strokeWidth={g === 90 ? 1 : 0.5}
+              strokeDasharray={g === 90 ? "4 3" : undefined}
+            />
+            <text x={4} y={y(g) + 3} className="fill-navy-3" fontSize="9">
+              {g}
+            </text>
+          </g>
+        ))}
+        {/* holiday bands */}
+        {data.holidays
+          .filter((h) => h.endsOn >= data.termStart && h.startsOn <= data.termEnd)
+          .map((h, i) => {
+            const x1 = x(h.startsOn < data.termStart ? data.termStart : h.startsOn);
+            const x2 = x(h.endsOn > data.termEnd ? data.termEnd : h.endsOn);
+            return (
+              <rect
+                key={i}
+                x={Math.min(x1, x2)}
+                y={PAD.t}
+                width={Math.max(2, Math.abs(x2 - x1))}
+                height={H - PAD.t - PAD.b}
+                fill="#C8975B"
+                opacity={0.1}
+              >
+                <title>{h.name}</title>
+              </rect>
+            );
+          })}
+        {/* today marker */}
+        {data.today >= data.termStart && data.today <= data.termEnd && (
+          <line
+            x1={x(data.today)}
+            x2={x(data.today)}
+            y1={PAD.t}
+            y2={H - PAD.b}
+            stroke="#C8975B"
+            strokeWidth={1}
+          />
+        )}
+        {/* series */}
+        {lines.map((l) => (
+          <path
+            key={l.name}
+            d={path(l.points)}
+            fill="none"
+            stroke={l.color}
+            strokeWidth={1.75}
+            strokeLinejoin="round"
+          />
+        ))}
+      </svg>
+    </div>
+  );
+}


### PR DESCRIPTION
## Attendance exact-replication — slice I4 (dashboard §03)

Adds the admin surface's **§03 "This term's trend"** section. **No migration** (uses I1 holidays + the term records already loaded).

### Changes
- **`TermTrend`** chart — daily attendance % over the term as an SVG line, with a **90% gold reference line**, 60–100 gridlines, shaded **holiday bands**, and a **today marker**. A **School / By class / By gender** toggle switches the plotted series.
- **Headline** — "{X}% term average · ↑/↓ {Y}% vs previous term" (prior term's average from its records; the delta hides when there's no prior data).
- **Mini-stats** — best day · lowest day · Mondays avg · Fridays avg.
- Series + stats are computed from the term records, split by student **sex** and **class**.

### Verification
- `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm build` ✅
- Live render (term temporarily covering today + 10 days of seeded records, then reverted): the section header, term-average headline, all four mini-stats, the School/By-class/By-gender toggle, and the SVG line all render.

### Dashboard fidelity now
§01 pulse ✅ · §02 by class ✅ · **§03 trend ✅** · §04 needs-attention ✅ · header meta ✅. Remaining: **§05 Register edit requests** (I5), then **View term grid** (I6) + **Export term report** (I7) header actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)