### PR TITLE
feat(attendance): register surface replication — desktop fidelity (R1)

### DIFF
--- a/omnischools/app/(app)/attendance/[classId]/page.tsx
+++ b/omnischools/app/(app)/attendance/[classId]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { and, asc, eq, inArray, gte, lte, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, gte, lt, lte } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import {
@@ -9,10 +9,31 @@ import {
   attendanceRecords,
   academicPeriod,
   attendanceSettings,
+  schoolHolidays,
+  users,
 } from "@/db/schema";
-import { TakeRegister } from "@/components/attendance/take-register";
+import { computeAttendanceFlags } from "@/lib/attendance-flags";
+import { termDayProgress } from "@/lib/school-calendar";
+import { TakeRegister, type RegisterRow } from "@/components/attendance/take-register";
+import type { AttendanceStatus } from "@/lib/attendance-status";
 
 export const dynamic = "force-dynamic";
+
+const fmtLongDate = (iso: string) =>
+  new Date(`${iso}T00:00:00Z`).toLocaleDateString("en-GB", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+  });
+
+const fmtCloseAt = (ms: number) =>
+  new Date(ms).toLocaleString("en-GB", {
+    day: "numeric",
+    month: "short",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  });
 
 export default async function TakeAttendancePage({
   params,
@@ -29,10 +50,16 @@ export default async function TakeAttendancePage({
 
   const data = await withSchool(school.id, async (tx) => {
     const [cls] = await tx
-      .select()
+      .select({
+        id: classes.id,
+        name: classes.name,
+        teacher: users.fullName,
+      })
       .from(classes)
+      .leftJoin(users, eq(classes.classTeacherUserId, users.id))
       .where(and(eq(classes.id, params.classId), eq(classes.schoolId, school.id)));
     if (!cls) return null;
+
     const roster = await tx
       .select({
         id: students.id,
@@ -48,7 +75,8 @@ export default async function TakeAttendancePage({
           eq(students.status, "ACTIVE"),
         ),
       )
-      .orderBy(asc(students.lastName));
+      .orderBy(asc(students.firstName), asc(students.lastName));
+
     const recs = await tx
       .select({
         id: attendanceRecords.id,
@@ -62,16 +90,19 @@ export default async function TakeAttendancePage({
       .where(
         and(eq(attendanceRecords.classId, cls.id), eq(attendanceRecords.date, date)),
       );
+
     const [cfg] = await tx
       .select({ editWindowHours: attendanceSettings.editWindowHours })
       .from(attendanceSettings)
       .where(eq(attendanceSettings.schoolId, school.id))
       .limit(1);
 
-    // Per-student term attendance %, scoped to the current term when one is active.
-    const ids = roster.map((s) => s.id);
     const [term] = await tx
-      .select({ startsOn: academicPeriod.startsOn, endsOn: academicPeriod.endsOn })
+      .select({
+        label: academicPeriod.periodLabel,
+        startsOn: academicPeriod.startsOn,
+        endsOn: academicPeriod.endsOn,
+      })
       .from(academicPeriod)
       .where(
         and(
@@ -81,30 +112,73 @@ export default async function TakeAttendancePage({
         ),
       )
       .limit(1);
-    const termAgg =
-      ids.length === 0
-        ? []
-        : await tx
+
+    const holidays = await tx
+      .select({
+        name: schoolHolidays.name,
+        startsOn: schoolHolidays.startsOn,
+        endsOn: schoolHolidays.endsOn,
+        kind: schoolHolidays.kind,
+      })
+      .from(schoolHolidays)
+      .where(eq(schoolHolidays.schoolId, school.id));
+
+    // Whole-term records for this class's roster → term %, flags, patterns.
+    const ids = roster.map((s) => s.id);
+    const termRecs =
+      term && ids.length
+        ? await tx
             .select({
               studentId: attendanceRecords.studentId,
-              attended: sql<number>`sum(case when ${attendanceRecords.status} in ('PRESENT','LATE') then 1 else 0 end)::int`,
-              total: sql<number>`count(*)::int`,
+              date: attendanceRecords.date,
+              status: attendanceRecords.status,
             })
             .from(attendanceRecords)
             .where(
               and(
                 eq(attendanceRecords.schoolId, school.id),
                 inArray(attendanceRecords.studentId, ids),
-                term ? gte(attendanceRecords.date, term.startsOn) : undefined,
-                term ? lte(attendanceRecords.date, term.endsOn) : undefined,
+                gte(attendanceRecords.date, term.startsOn),
+                lte(attendanceRecords.date, term.endsOn),
               ),
             )
-            .groupBy(attendanceRecords.studentId);
-    return { cls, roster, recs, termAgg, editWindowHours: cfg?.editWindowHours ?? 24 };
+        : [];
+
+    // The most recent earlier register for this class → "Copy from yesterday".
+    const [prev] = await tx
+      .select({ date: attendanceRecords.date })
+      .from(attendanceRecords)
+      .where(and(eq(attendanceRecords.classId, cls.id), lt(attendanceRecords.date, date)))
+      .orderBy(desc(attendanceRecords.date))
+      .limit(1);
+    const prevRecs = prev
+      ? await tx
+          .select({
+            studentId: attendanceRecords.studentId,
+            status: attendanceRecords.status,
+            reasonCode: attendanceRecords.reasonCode,
+            note: attendanceRecords.note,
+          })
+          .from(attendanceRecords)
+          .where(
+            and(eq(attendanceRecords.classId, cls.id), eq(attendanceRecords.date, prev.date)),
+          )
+      : [];
+
+    return {
+      cls,
+      roster,
+      recs,
+      termRecs,
+      term,
+      holidays,
+      prev: prev ? { date: prev.date, recs: prevRecs } : null,
+      editWindowHours: cfg?.editWindowHours ?? 24,
+    };
   });
 
   if (!data) notFound();
-  // The register locks once its earliest mark is older than the edit window.
+
   const windowH = data.editWindowHours;
   const oldestMark = data.recs.reduce<number>((min, r) => {
     const t = (
@@ -113,43 +187,70 @@ export default async function TakeAttendancePage({
     return t < min ? t : min;
   }, Infinity);
   const locked =
-    data.recs.length > 0 &&
-    windowH > 0 &&
-    Date.now() - oldestMark > windowH * 3_600_000;
+    data.recs.length > 0 && windowH > 0 && Date.now() - oldestMark > windowH * 3_600_000;
+  const windowCloseLabel =
+    data.recs.length > 0 && windowH > 0 ? fmtCloseAt(oldestMark + windowH * 3_600_000) : null;
+
+  const flags = computeAttendanceFlags(data.termRecs);
   const recByStudent = new Map(data.recs.map((r) => [r.studentId, r]));
-  const aggByStudent = new Map(data.termAgg.map((a) => [a.studentId, a]));
-  const roster = data.roster.map((s) => {
+
+  const roster: RegisterRow[] = data.roster.map((s) => {
     const rec = recByStudent.get(s.id);
-    const agg = aggByStudent.get(s.id);
-    const termPct =
-      agg && agg.total > 0 ? Math.round((agg.attended / agg.total) * 100) : null;
+    const f = flags.get(s.id);
+    const tags = (f?.flags ?? [])
+      .filter((fl) => fl.type === "BELOW_THRESHOLD" || fl.type === "PATTERN_SHIFT")
+      .map((fl) => ({
+        label: fl.label,
+        tone: (fl.type === "BELOW_THRESHOLD" ? "terra" : "warn") as "terra" | "warn",
+      }));
     return {
       id: s.id,
-      name: `${s.lastName}, ${s.firstName}`,
+      first: s.firstName,
+      last: s.lastName,
+      initials: `${s.firstName[0] ?? ""}${s.lastName[0] ?? ""}`.toUpperCase(),
       code: s.code,
-      status: rec?.status ?? null,
+      status: (rec?.status as AttendanceStatus | undefined) ?? null,
       recordId: rec?.id ?? null,
       reasonCode: rec?.reasonCode ?? null,
       note: rec?.note ?? null,
-      termPct,
-      termDays: agg ? `${agg.attended}/${agg.total}` : null,
+      termPct: f?.termPct ?? null,
+      termDays: f ? `${f.attended}/${f.total} days` : null,
+      consecutiveAbsent: f?.consecutiveAbsent ?? 0,
+      tags,
     };
   });
 
-  return (
-    <div className="mx-auto max-w-3xl">
-      <Link href="/attendance" className="text-sm text-navy-3 hover:text-gold">
-        ← Attendance
-      </Link>
-      <h1 className="mb-1 mt-2 font-display text-3xl font-semibold text-navy">
-        {data.cls.name}
-      </h1>
-      <p className="mb-6 text-sm text-navy-3">
-        {roster.length} student{roster.length === 1 ? "" : "s"}
-      </p>
+  const progress = data.term
+    ? termDayProgress(data.term.startsOn, data.term.endsOn, date, data.holidays)
+    : null;
 
-      {roster.length === 0 ? (
-        <div className="border-border-2 bg-surface rounded-xl border border-dashed p-12 text-center">
+  const yesterday = data.prev
+    ? {
+        date: fmtLongDate(data.prev.date),
+        entries: Object.fromEntries(
+          data.prev.recs.map((r) => [
+            r.studentId,
+            {
+              status: r.status as AttendanceStatus,
+              reasonCode: r.reasonCode,
+              note: r.note,
+            },
+          ]),
+        ),
+      }
+    : null;
+
+  if (roster.length === 0) {
+    return (
+      <div className="mx-auto max-w-3xl">
+        <Link href="/attendance" className="text-sm text-navy-3 hover:text-gold">
+          ← Attendance
+        </Link>
+        <h1 className="mb-1 mt-2 font-display text-3xl font-semibold text-navy">
+          {data.cls.name}
+        </h1>
+        <p className="mb-6 text-sm text-navy-3">0 students</p>
+        <div className="rounded-xl border border-dashed border-border-2 bg-surface p-12 text-center">
           <p className="font-display text-lg text-navy">No students in this class.</p>
           <p className="mt-1 text-sm text-navy-3">
             Assign students from the{" "}
@@ -159,14 +260,26 @@ export default async function TakeAttendancePage({
             dashboard.
           </p>
         </div>
-      ) : (
-        <TakeRegister
-          classId={data.cls.id}
-          date={date}
-          roster={roster}
-          locked={locked}
-        />
-      )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl">
+      <TakeRegister
+        classId={data.cls.id}
+        date={date}
+        roster={roster}
+        locked={locked}
+        className={data.cls.name}
+        dateLabel={fmtLongDate(date)}
+        teacher={data.cls.teacher ?? null}
+        termLabel={data.term?.label ?? null}
+        dayOf={progress?.dayOf ?? null}
+        editWindowHours={windowH}
+        windowCloseLabel={windowCloseLabel}
+        yesterday={yesterday}
+      />
     </div>
   );
 }

--- a/omnischools/components/attendance/take-register.tsx
+++ b/omnischools/components/attendance/take-register.tsx
@@ -1,56 +1,104 @@
 "use client";
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { saveAttendance, requestCorrection } from "@/lib/actions/attendance";
-import { ATTENDANCE_REASONS } from "@/lib/attendance-reasons";
+import { ATTENDANCE_REASONS, reasonLabel } from "@/lib/attendance-reasons";
+import {
+  ATTENDANCE_STATUS_META,
+  ATTENDANCE_STATUS_ORDER,
+  STATUS_HOTKEYS,
+  type AttendanceStatus,
+} from "@/lib/attendance-status";
 
-type Status = "PRESENT" | "ABSENT" | "LATE" | "EXCUSED" | "MEDICAL";
-type Row = {
+type Tag = { label: string; tone: "warn" | "terra" };
+
+export type RegisterRow = {
   id: string;
-  name: string;
+  first: string;
+  last: string;
+  initials: string;
   code: string;
-  status: Status | null;
+  status: AttendanceStatus | null;
   recordId: string | null;
   reasonCode: string | null;
   note: string | null;
   termPct: number | null;
   termDays: string | null;
+  consecutiveAbsent: number;
+  tags: Tag[];
 };
 
-const OPTS: { v: Status; label: string; on: string }[] = [
-  { v: "PRESENT", label: "P", on: "bg-green text-white" },
-  { v: "LATE", label: "L", on: "bg-warn text-white" },
-  { v: "EXCUSED", label: "E", on: "bg-navy-2 text-white" },
-  { v: "MEDICAL", label: "M", on: "bg-gold text-navy" },
-  { v: "ABSENT", label: "A", on: "bg-terra text-white" },
-];
+export type YesterdayPrefill = {
+  date: string;
+  entries: Record<
+    string,
+    { status: AttendanceStatus; reasonCode: string | null; note: string | null }
+  >;
+};
 
-const STAT: { v: Status; label: string; dot: string }[] = [
-  { v: "PRESENT", label: "Present", dot: "bg-green" },
-  { v: "LATE", label: "Late", dot: "bg-warn" },
-  { v: "EXCUSED", label: "Excused", dot: "bg-navy-2" },
-  { v: "MEDICAL", label: "Medical", dot: "bg-gold" },
-  { v: "ABSENT", label: "Absent", dot: "bg-terra" },
-];
+const ordinal = (n: number) => {
+  const s = ["th", "st", "nd", "rd"];
+  const v = n % 100;
+  return n + (s[(v - 20) % 10] ?? s[v] ?? s[0]);
+};
 
 const pctTone = (p: number) =>
-  p >= 90 ? "text-green" : p >= 70 ? "text-navy-2" : "text-terra";
+  p >= 90 ? "text-green" : p >= 70 ? "text-gold" : "text-terra";
+
+/** "JHS 2A" → JHS <em>2A</em> (italic-gold form suffix, per the surface H1). */
+function ClassTitle({ name }: { name: string }) {
+  const parts = name.trim().split(/\s+/);
+  const last = parts[parts.length - 1];
+  if (parts.length > 1 && /^[A-Za-z]?\d+[A-Za-z]?$/.test(last)) {
+    return (
+      <>
+        {parts.slice(0, -1).join(" ")} <em className="not-italic text-gold">{last}</em>
+      </>
+    );
+  }
+  return <>{name}</>;
+}
+
+function Kbd({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="inline-flex h-[18px] min-w-[18px] items-center justify-center rounded border border-b-2 border-border-2 bg-bg px-[5px] font-mono text-[10px] font-bold text-navy-2">
+      {children}
+    </span>
+  );
+}
 
 export function TakeRegister({
   classId,
   date,
   roster,
   locked = false,
+  className,
+  dateLabel,
+  teacher,
+  termLabel,
+  dayOf,
+  editWindowHours = 24,
+  windowCloseLabel = null,
+  yesterday = null,
 }: {
   classId: string;
   date: string;
-  roster: Row[];
+  roster: RegisterRow[];
   locked?: boolean;
+  className: string;
+  dateLabel: string;
+  teacher: string | null;
+  termLabel: string | null;
+  dayOf: number | null;
+  editWindowHours?: number;
+  windowCloseLabel?: string | null;
+  yesterday?: YesterdayPrefill | null;
 }) {
   const router = useRouter();
-  const [statuses, setStatuses] = useState<Record<string, Status>>(
-    Object.fromEntries(roster.map((r) => [r.id, r.status ?? "PRESENT"])),
+  const [statuses, setStatuses] = useState<Record<string, AttendanceStatus | null>>(
+    Object.fromEntries(roster.map((r) => [r.id, r.status])),
   );
   const [reasons, setReasons] = useState<Record<string, string>>(
     Object.fromEntries(roster.map((r) => [r.id, r.reasonCode ?? ""])),
@@ -58,32 +106,77 @@ export function TakeRegister({
   const [notes, setNotes] = useState<Record<string, string>>(
     Object.fromEntries(roster.map((r) => [r.id, r.note ?? ""])),
   );
+  const [focused, setFocused] = useState<number | null>(null);
   const [saving, setSaving] = useState(false);
   const [result, setResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const set = (id: string, v: Status) => setStatuses((s) => ({ ...s, [id]: v }));
+  const total = roster.length;
+  const byStatus = (st: AttendanceStatus) => roster.filter((r) => statuses[r.id] === st);
+  const present = byStatus("PRESENT");
+  const late = byStatus("LATE");
+  const excused = byStatus("EXCUSED");
+  const medical = byStatus("MEDICAL");
+  const absent = byStatus("ABSENT");
+  const marked = roster.filter((r) => statuses[r.id] != null).length;
+  const unmarked = total - marked;
+  const pctOfClass = total ? Math.round((present.length / total) * 1000) / 10 : 0;
+  const fullName = (r: RegisterRow) => `${r.first} ${r.last}`;
+  const overflow = (arr: RegisterRow[]) => (arr.length > 1 ? ` +${arr.length - 1}` : "");
+
+  const markStatus = useCallback((id: string, v: AttendanceStatus) => {
+    setStatuses((s) => ({ ...s, [id]: v }));
+  }, []);
+
   const allPresent = () =>
-    setStatuses(Object.fromEntries(roster.map((r) => [r.id, "PRESENT" as Status])));
+    setStatuses(Object.fromEntries(roster.map((r) => [r.id, "PRESENT" as AttendanceStatus])));
+  const reset = () =>
+    setStatuses(Object.fromEntries(roster.map((r) => [r.id, null])));
+  const copyYesterday = () => {
+    if (!yesterday) return;
+    setStatuses((s) => {
+      const next = { ...s };
+      for (const r of roster) {
+        const y = yesterday.entries[r.id];
+        if (y) next[r.id] = y.status;
+      }
+      return next;
+    });
+    setReasons((s) => {
+      const next = { ...s };
+      for (const r of roster) {
+        const y = yesterday.entries[r.id];
+        if (y) next[r.id] = y.reasonCode ?? "";
+      }
+      return next;
+    });
+    setNotes((s) => {
+      const next = { ...s };
+      for (const r of roster) {
+        const y = yesterday.entries[r.id];
+        if (y) next[r.id] = y.note ?? "";
+      }
+      return next;
+    });
+  };
 
-  const counts = STAT.map(
-    (s) => roster.filter((r) => statuses[r.id] === s.v).length,
-  );
-
-  async function save() {
+  const doSave = useCallback(async () => {
+    const entries = roster
+      .filter((r) => statuses[r.id] != null)
+      .map((r) => ({
+        studentId: r.id,
+        status: statuses[r.id] as AttendanceStatus,
+        reasonCode: statuses[r.id] === "PRESENT" ? null : reasons[r.id] || null,
+        note: statuses[r.id] === "PRESENT" ? null : notes[r.id] || null,
+      }));
+    if (entries.length === 0) {
+      setError("Mark at least one student before saving.");
+      return;
+    }
     setSaving(true);
     setError(null);
     setResult(null);
-    const res = await saveAttendance({
-      classId,
-      date,
-      entries: roster.map((r) => ({
-        studentId: r.id,
-        status: statuses[r.id],
-        reasonCode: statuses[r.id] === "PRESENT" ? null : reasons[r.id] || null,
-        note: statuses[r.id] === "PRESENT" ? null : notes[r.id] || null,
-      })),
-    });
+    const res = await saveAttendance({ classId, date, entries });
     setSaving(false);
     if (res.ok) {
       setResult(
@@ -93,137 +186,382 @@ export function TakeRegister({
     } else {
       setError(res.error);
     }
-  }
+  }, [roster, statuses, reasons, notes, classId, date, router]);
+
+  // Keyboard workflow (surface legend: P L E M A · ↑ ↓ · ⏎ · ⌘⏎).
+  useEffect(() => {
+    if (locked) return;
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+        e.preventDefault();
+        if (marked === total && total > 0) void doSave();
+        return;
+      }
+      const el = e.target as HTMLElement;
+      if (["INPUT", "SELECT", "TEXTAREA"].includes(el.tagName)) return;
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setFocused((f) => Math.min((f ?? -1) + 1, total - 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setFocused((f) => Math.max((f ?? total) - 1, 0));
+      } else if (focused != null) {
+        const hot = STATUS_HOTKEYS[e.key.toLowerCase()];
+        if (hot) {
+          e.preventDefault();
+          markStatus(roster[focused].id, hot);
+        } else if (e.key === "Enter") {
+          e.preventDefault();
+          document
+            .querySelector<HTMLSelectElement>(`[data-reason="${roster[focused].id}"]`)
+            ?.focus();
+        }
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [locked, focused, marked, total, roster, markStatus, doSave]);
+
+  const absentSms = absent.length;
+  const footerMeta = (
+    <>
+      {absentSms === 0
+        ? "No absence SMS to send"
+        : `${absentSms} absence SMS will be sent on submit`}{" "}
+      ·{" "}
+      {windowCloseLabel ? (
+        <>
+          edit window closes <b className="font-semibold text-navy-2">{windowCloseLabel}</b>
+        </>
+      ) : (
+        <>
+          edit window: <b className="font-semibold text-navy-2">{editWindowHours}h</b> after
+          you submit
+        </>
+      )}
+    </>
+  );
+
+  type Tile = { label: string; count: number; num: string; accent: string; sub: React.ReactNode };
+  const tiles: Tile[] = [
+    {
+      label: "Present",
+      count: present.length,
+      num: ATTENDANCE_STATUS_META.PRESENT.num,
+      accent: "#2F6B47",
+      sub: (
+        <>
+          <b className="font-semibold text-navy-2">{pctOfClass}%</b> of class
+        </>
+      ),
+    },
+    {
+      label: "Late",
+      count: late.length,
+      num: ATTENDANCE_STATUS_META.LATE.num,
+      accent: "#C8975B",
+      sub: late.length ? `${fullName(late[0])}${overflow(late)}` : "—",
+    },
+    {
+      label: "Excused",
+      count: excused.length,
+      num: ATTENDANCE_STATUS_META.EXCUSED.num,
+      accent: "#C58A2E",
+      sub: excused.length
+        ? `${fullName(excused[0])} · ${reasonLabel(reasons[excused[0].id]) ?? "excused"}`
+        : "—",
+    },
+    {
+      label: "Medical",
+      count: medical.length,
+      num: ATTENDANCE_STATUS_META.MEDICAL.num,
+      accent: "#2D3F5C",
+      sub: medical.length ? `${fullName(medical[0])} · medical` : "—",
+    },
+    {
+      label: "Absent",
+      count: absent.length,
+      num: ATTENDANCE_STATUS_META.ABSENT.num,
+      accent: "#B84A39",
+      sub: absent.length
+        ? `${fullName(absent[0])}${
+            absent[0].consecutiveAbsent >= 2
+              ? ` · ${ordinal(absent[0].consecutiveAbsent)} day`
+              : ""
+          }${overflow(absent)}`
+        : "—",
+    },
+    {
+      label: "Unmarked",
+      count: unmarked,
+      num: "text-navy-3",
+      accent: "#D4CCBA",
+      sub: unmarked === 0 ? "All accounted for" : `${unmarked} to mark`,
+    },
+  ];
+
+  const ledeParts: React.ReactNode[] = [
+    `${total} student${total === 1 ? "" : "s"}`,
+  ];
+  if (teacher)
+    ledeParts.push(
+      <>
+        class teacher <b className="font-semibold text-navy-2">{teacher}</b>
+      </>,
+    );
+  if (termLabel) ledeParts.push(termLabel);
+  if (dayOf != null) ledeParts.push(`Day ${dayOf}`);
 
   return (
     <div>
-      {locked && (
-        <div className="mb-4 flex flex-wrap items-center gap-x-2 gap-y-1 rounded-lg border border-warn/40 bg-warn-bg/40 px-4 py-3 text-sm">
-          <span className="font-semibold text-warn">Register locked.</span>
-          <span className="text-navy-2">
-            The edit window has closed — use <b>Request correction</b> on a student to
-            change a mark (it needs an admin co-sign).
-          </span>
-        </div>
-      )}
-      {/* Stat strip */}
-      <div className="mb-4 grid grid-cols-2 gap-2 sm:grid-cols-5">
-        {STAT.map((s, i) => (
-          <div
-            key={s.v}
-            className="rounded-lg border border-border bg-surface px-3 py-2"
-          >
-            <div className="flex items-center gap-1.5">
-              <span className={cn("h-2 w-2 shrink-0 rounded-full", s.dot)} />
-              <span className="text-[11px] uppercase tracking-wide text-navy-3">
-                {s.label}
+      {/* ── Active-register head ───────────────────────────────── */}
+      <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-xs text-navy-3">
+            <Link href="/attendance" className="text-gold hover:underline">
+              Attendance
+            </Link>{" "}
+            / Today / {className}
+          </div>
+          <h1 className="mt-1 font-display text-3xl font-semibold text-navy">
+            <ClassTitle name={className} /> · {dateLabel}
+          </h1>
+          <p className="mt-1 text-sm text-navy-3">
+            {ledeParts.map((p, i) => (
+              <span key={i}>
+                {i > 0 ? " · " : ""}
+                {p}
               </span>
+            ))}
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            onClick={copyYesterday}
+            disabled={locked || !yesterday}
+            title={yesterday ? `Copy marks from ${yesterday.date}` : "No earlier register"}
+            className="rounded-md border border-border-2 bg-surface px-3 py-2 text-sm font-semibold text-navy hover:bg-gold-bg disabled:opacity-50"
+          >
+            Copy from yesterday
+          </button>
+          <Link
+            href={`/attendance/term-grid?classId=${classId}`}
+            className="rounded-md bg-navy px-3 py-2 text-sm font-semibold text-bg hover:bg-navy-deep"
+          >
+            View term grid
+          </Link>
+        </div>
+      </div>
+
+      {/* Stat strip */}
+      <div className="mb-4 grid grid-cols-2 gap-2.5 sm:grid-cols-3 lg:grid-cols-6">
+        {tiles.map((t) => (
+          <div
+            key={t.label}
+            className="grid grid-cols-[auto_1fr] items-center gap-3 rounded-[10px] border border-border bg-surface px-4 py-3"
+            style={{ borderLeftWidth: 3, borderLeftColor: t.accent }}
+          >
+            <div className={cn("font-display text-[26px] font-semibold leading-none", t.num)}>
+              {t.count}
             </div>
-            <div className="mt-0.5 font-display text-xl font-semibold text-navy">
-              {counts[i]}
+            <div>
+              <div className="text-[10px] font-bold uppercase tracking-[0.1em] text-navy-3">
+                {t.label}
+              </div>
+              <div className="mt-0.5 text-[11px] text-navy-3">{t.sub}</div>
             </div>
           </div>
         ))}
       </div>
 
-      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
-        <label className="flex items-center gap-2 text-sm text-navy-2">
-          Date
-          <input
-            type="date"
-            value={date}
-            onChange={(e) => router.push(`/attendance/${classId}?date=${e.target.value}`)}
-            className="border-border-2 bg-bg rounded-md border px-3 py-2 text-sm text-navy outline-none focus:border-gold"
-          />
-        </label>
+      {locked && (
+        <div className="mb-4 flex flex-wrap items-center gap-x-2 gap-y-1 rounded-lg border border-warn/40 bg-warn-bg/40 px-4 py-3 text-sm">
+          <span className="font-semibold text-warn">Register locked.</span>
+          <span className="text-navy-2">
+            The edit window has closed — use <b>Request correction</b> on a student to change a
+            mark (it needs an admin co-sign).
+          </span>
+        </div>
+      )}
+
+      {/* ── Action bar ─────────────────────────────────────────── */}
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2">
           <button
             onClick={allPresent}
             disabled={locked}
-            className="border-border-2 bg-surface rounded-md border px-3 py-2 text-sm font-semibold text-navy hover:bg-gold-bg disabled:opacity-50"
+            className="rounded-md bg-navy px-4 py-2 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-60"
           >
-            Mark all present
+            All present
           </button>
           <button
-            onClick={save}
-            disabled={saving || locked}
-            className="text-bg rounded-md bg-navy px-5 py-2 text-sm font-semibold transition-colors hover:bg-navy-deep disabled:opacity-60"
+            onClick={reset}
+            disabled={locked || marked === 0}
+            className="rounded-md border border-border-2 bg-surface px-3 py-2 text-sm font-semibold text-navy hover:bg-gold-bg disabled:opacity-50"
           >
-            {locked ? "Locked" : saving ? "Saving…" : "Save register"}
+            Reset
           </button>
+          <label className="ml-1 flex items-center gap-2 text-sm text-navy-2">
+            Date
+            <input
+              type="date"
+              value={date}
+              onChange={(e) =>
+                router.push(`/attendance/${classId}?date=${e.target.value}`)
+              }
+              className="rounded-md border border-border-2 bg-bg px-3 py-2 text-sm text-navy outline-none focus:border-gold"
+            />
+          </label>
+        </div>
+        <div className="hidden gap-3.5 text-[10px] font-semibold text-navy-3 lg:flex">
+          <span className="inline-flex items-center gap-1.5">
+            <Kbd>P</Kbd>
+            <Kbd>L</Kbd>
+            <Kbd>E</Kbd>
+            <Kbd>M</Kbd>
+            <Kbd>A</Kbd>
+            <span className="tracking-wide">mark status</span>
+          </span>
+          <span className="inline-flex items-center gap-1.5">
+            <Kbd>↑</Kbd>
+            <Kbd>↓</Kbd>
+            <span className="tracking-wide">navigate</span>
+          </span>
+          <span className="inline-flex items-center gap-1.5">
+            <Kbd>⏎</Kbd>
+            <span className="tracking-wide">add reason</span>
+          </span>
         </div>
       </div>
 
       {result && (
-        <p className="mb-3 rounded-md bg-green-bg px-3 py-2 text-sm text-green">
-          {result}
-        </p>
+        <p className="mb-3 rounded-md bg-green-bg px-3 py-2 text-sm text-green">{result}</p>
       )}
       {error && <p className="mb-3 text-sm text-terra">{error}</p>}
 
-      <div className="bg-surface overflow-hidden rounded-xl border border-border">
+      {/* ── Roster table ───────────────────────────────────────── */}
+      <div className="overflow-hidden rounded-[10px] border border-border bg-surface">
         <table className="w-full text-sm">
-          <thead className="bg-bg border-b border-border text-left text-xs uppercase tracking-wide text-navy-3">
+          <thead className="border-b border-border bg-bg text-left text-[9px] uppercase tracking-[0.14em] text-navy-3">
             <tr>
-              <th className="px-4 py-3 font-semibold">Student</th>
-              <th className="px-4 py-3 font-semibold">Term</th>
-              <th className="px-4 py-3 font-semibold">Mark</th>
-              <th className="px-4 py-3 font-semibold">Reason / note</th>
-              <th className="px-4 py-3 font-semibold"></th>
+              <th className="w-8 px-4 py-2.5 font-bold">#</th>
+              <th className="px-4 py-2.5 font-bold">Student</th>
+              <th className="px-4 py-2.5 font-bold">Term attendance</th>
+              <th className="px-4 py-2.5 text-center font-bold">Status</th>
+              <th className="px-4 py-2.5 font-bold">Reason / note</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-border">
-            {roster.map((r) => {
-              const present = statuses[r.id] === "PRESENT";
+            {roster.map((r, idx) => {
+              const st = statuses[r.id];
+              const isFocused = focused === idx;
+              const tint = st ? ATTENDANCE_STATUS_META[st].rowTint : "";
+              const editable = !locked && st != null && st !== "PRESENT";
               return (
-                <tr key={r.id}>
+                <tr
+                  key={r.id}
+                  onClick={() => setFocused(idx)}
+                  className={cn(
+                    isFocused && "bg-gold-bg outline outline-2 -outline-offset-2 outline-gold",
+                  )}
+                  style={!isFocused && tint ? { backgroundColor: tint } : undefined}
+                >
+                  <td className="px-4 py-2.5 font-mono text-[11px] font-semibold text-navy-3">
+                    {String(idx + 1).padStart(2, "0")}
+                  </td>
                   <td className="px-4 py-2.5">
-                    <div className="font-medium text-navy">{r.name}</div>
-                    <div className="font-mono text-xs text-navy-3">{r.code}</div>
+                    <div className="flex items-center gap-2.5">
+                      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gold-bg font-display text-[11px] font-semibold text-navy">
+                        {r.initials}
+                      </span>
+                      <div>
+                        <div className="text-[13px] font-semibold text-navy">
+                          {fullName(r)}
+                        </div>
+                        <div className="font-mono text-[10px] text-navy-3">{r.code}</div>
+                      </div>
+                    </div>
                   </td>
                   <td className="px-4 py-2.5 whitespace-nowrap">
                     {r.termPct === null ? (
-                      <span className="text-xs text-navy-3">—</span>
+                      <span className="text-[10px] text-navy-3">—</span>
                     ) : (
-                      <span className={cn("text-xs font-semibold", pctTone(r.termPct))}>
-                        {r.termPct}%
-                        <span className="ml-1 font-normal text-navy-3">
-                          {r.termDays}
+                      <span className="flex items-baseline gap-2">
+                        <span
+                          className={cn(
+                            "font-display text-sm font-semibold",
+                            pctTone(r.termPct),
+                          )}
+                        >
+                          {r.termPct}%
                         </span>
+                        <span className="text-[10px] text-navy-3">{r.termDays}</span>
+                        {r.tags.map((tag) => (
+                          <span
+                            key={tag.label}
+                            className={cn(
+                              "rounded-pill px-[7px] py-0.5 text-[9px] font-bold uppercase tracking-[0.04em]",
+                              tag.tone === "terra"
+                                ? "bg-terra-bg text-terra"
+                                : "bg-warn-bg text-warn",
+                            )}
+                          >
+                            {tag.label}
+                          </span>
+                        ))}
                       </span>
                     )}
                   </td>
                   <td className="px-4 py-2.5">
-                    <div className="flex gap-1">
-                      {OPTS.map((o) => (
-                        <button
-                          key={o.v}
-                          onClick={() => set(r.id, o.v)}
-                          disabled={locked}
-                          title={o.v}
-                          className={cn(
-                            "h-8 w-8 rounded-md text-xs font-bold transition-colors disabled:opacity-60",
-                            statuses[r.id] === o.v
-                              ? o.on
-                              : "bg-bg text-navy-3 hover:bg-gold-bg",
-                          )}
-                        >
-                          {o.label}
-                        </button>
-                      ))}
+                    <div className="flex justify-center">
+                      <div className="inline-flex gap-0 rounded-lg border border-border bg-bg p-[3px]">
+                        {ATTENDANCE_STATUS_ORDER.map((s) => {
+                          const m = ATTENDANCE_STATUS_META[s];
+                          const sel = st === s;
+                          return (
+                            <button
+                              key={s}
+                              onClick={() => markStatus(r.id, s)}
+                              disabled={locked}
+                              title={m.label}
+                              className={cn(
+                                "flex h-[30px] w-9 items-center justify-center rounded-[5px] font-display text-[13px] font-bold transition-colors disabled:opacity-60",
+                                sel ? m.seg : "text-navy-3 hover:bg-surface hover:text-navy",
+                              )}
+                            >
+                              {m.letter}
+                            </button>
+                          );
+                        })}
+                      </div>
                     </div>
                   </td>
                   <td className="px-4 py-2.5">
-                    {present ? (
-                      <span className="text-xs text-navy-3">—</span>
-                    ) : (
+                    {locked && r.recordId ? (
+                      <div className="text-xs italic leading-snug text-navy-2">
+                        {r.reasonCode || r.note ? (
+                          <>
+                            <b className="font-semibold not-italic text-navy">
+                              {reasonLabel(r.reasonCode) ?? "Marked"}
+                            </b>
+                            {r.note ? ` · ${r.note}` : ""}
+                          </>
+                        ) : (
+                          <span className="opacity-50">—</span>
+                        )}
+                        <span className="ml-2 not-italic">
+                          <RequestCorrection recordId={r.recordId} />
+                        </span>
+                      </div>
+                    ) : editable ? (
                       <div className="flex flex-wrap items-center gap-1.5">
                         <select
+                          data-reason={r.id}
                           value={reasons[r.id] ?? ""}
                           onChange={(e) =>
                             setReasons((s) => ({ ...s, [r.id]: e.target.value }))
                           }
-                          className="border-border-2 bg-bg rounded border px-1.5 py-1 text-xs text-navy outline-none focus:border-gold"
+                          className="rounded border border-border-2 bg-bg px-1.5 py-1 text-xs text-navy outline-none focus:border-gold"
                         >
                           <option value="">Reason…</option>
                           {ATTENDANCE_REASONS.map((o) => (
@@ -239,13 +577,12 @@ export function TakeRegister({
                           }
                           placeholder="note (optional)"
                           maxLength={300}
-                          className="border-border-2 bg-bg w-36 rounded border px-1.5 py-1 text-xs text-navy outline-none focus:border-gold"
+                          className="w-36 rounded border border-border-2 bg-bg px-1.5 py-1 text-xs text-navy outline-none focus:border-gold"
                         />
                       </div>
+                    ) : (
+                      <span className="text-[11px] italic text-navy-3 opacity-50">—</span>
                     )}
-                  </td>
-                  <td className="px-4 py-2.5 text-right">
-                    {r.recordId && <RequestCorrection recordId={r.recordId} />}
                   </td>
                 </tr>
               );
@@ -253,9 +590,37 @@ export function TakeRegister({
           </tbody>
         </table>
       </div>
+
+      {/* ── Sticky submit footer ───────────────────────────────── */}
+      <div className="sticky bottom-0 z-10 mt-4 flex flex-wrap items-center justify-between gap-3 rounded-[10px] border border-border bg-surface px-5 py-4 shadow-sm">
+        <div>
+          <div className="font-display text-sm font-semibold text-navy">
+            {marked} of {total} marked
+          </div>
+          <div className="text-[11px] text-navy-3">{footerMeta}</div>
+        </div>
+        <div className="flex items-center gap-2.5">
+          <button
+            onClick={doSave}
+            disabled={saving || locked || marked === 0 || marked === total}
+            className="rounded-md border border-border-2 bg-surface px-4 py-2.5 text-sm font-semibold text-navy hover:bg-gold-bg disabled:opacity-50"
+          >
+            Save draft
+          </button>
+          <button
+            onClick={doSave}
+            disabled={saving || locked || total === 0 || marked !== total}
+            className="inline-flex items-center gap-1.5 rounded-md bg-navy px-5 py-2.5 text-sm font-bold text-bg transition-colors hover:bg-navy-deep disabled:opacity-60"
+          >
+            {locked ? "Locked" : saving ? "Saving…" : "Submit register"}
+            {!locked && !saving && <Kbd>⌘ ⏎</Kbd>}
+          </button>
+        </div>
+      </div>
+
       <p className="mt-3 text-xs text-navy-3">
-        P present · L late · E excused · M medical · A absent. Add a reason for any
-        non-present mark. Absences notify the primary guardian by SMS on save.
+        P present · L late · E excused · M medical · A absent. Add a reason for any non-present
+        mark. Absences notify the primary guardian by SMS on submit.
       </p>
     </div>
   );
@@ -264,7 +629,7 @@ export function TakeRegister({
 function RequestCorrection({ recordId }: { recordId: string }) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
-  const [status, setStatus] = useState<Status>("PRESENT");
+  const [status, setStatus] = useState<AttendanceStatus>("PRESENT");
   const [reason, setReason] = useState("");
   const [busy, setBusy] = useState(false);
 
@@ -279,15 +644,15 @@ function RequestCorrection({ recordId }: { recordId: string }) {
     );
   }
   return (
-    <div className="flex items-center justify-end gap-1.5">
+    <span className="inline-flex items-center gap-1.5">
       <select
         value={status}
-        onChange={(e) => setStatus(e.target.value as Status)}
-        className="border-border-2 bg-bg rounded border px-1.5 py-1 text-xs"
+        onChange={(e) => setStatus(e.target.value as AttendanceStatus)}
+        className="rounded border border-border-2 bg-bg px-1.5 py-1 text-xs"
       >
-        {OPTS.map((o) => (
-          <option key={o.v} value={o.v}>
-            {o.v.charAt(0) + o.v.slice(1).toLowerCase()}
+        {ATTENDANCE_STATUS_ORDER.map((s) => (
+          <option key={s} value={s}>
+            {ATTENDANCE_STATUS_META[s].label}
           </option>
         ))}
       </select>
@@ -295,7 +660,7 @@ function RequestCorrection({ recordId }: { recordId: string }) {
         value={reason}
         onChange={(e) => setReason(e.target.value)}
         placeholder="reason"
-        className="border-border-2 bg-bg w-28 rounded border px-1.5 py-1 text-xs"
+        className="w-28 rounded border border-border-2 bg-bg px-1.5 py-1 text-xs"
       />
       <button
         disabled={busy || reason.length < 3}
@@ -317,6 +682,6 @@ function RequestCorrection({ recordId }: { recordId: string }) {
       <button onClick={() => setOpen(false)} className="text-xs text-navy-3">
         ×
       </button>
-    </div>
+    </span>
   );
 }

--- a/omnischools/lib/attendance-status.ts
+++ b/omnischools/lib/attendance-status.ts
@@ -1,0 +1,87 @@
+/**
+ * Canonical attendance-status presentation, mapped to the register surface's
+ * design tokens (`Surfaces/schoolup-attendance-desktop.html`). The surface uses
+ * four statuses — Present (green) / Late (gold) / Excused (warn) / Absent (terra)
+ * — and treats "medical" as an Excused *reason*. This build keeps a fifth
+ * first-class status, MEDICAL, by deliberate product choice; it is rendered in
+ * navy-2 so it never collides with Late (gold) or Excused (warn).
+ *
+ * `rowTint` matches the surface's barely-there row backgrounds (rgba …,0.04–0.05);
+ * the tokens are raw `var(--…)` hexes with no alpha channel, so the tint is an
+ * inline-style rgba rather than a Tailwind opacity utility.
+ */
+export type AttendanceStatus = "PRESENT" | "LATE" | "EXCUSED" | "MEDICAL" | "ABSENT";
+
+export type StatusMeta = {
+  letter: string;
+  label: string;
+  /** Selected segmented-control fill (surface `.status-tile-desk.selected.*`). */
+  seg: string;
+  /** Stat-tile number colour (surface `.stat-tile.* .num`). */
+  num: string;
+  /** Stat-tile coloured left border (surface `.stat-tile.*`). */
+  borderL: string;
+  /** Subtle row tint, exact rgba from the surface (`""` = no tint). */
+  rowTint: string;
+};
+
+export const ATTENDANCE_STATUS_META: Record<AttendanceStatus, StatusMeta> = {
+  PRESENT: {
+    letter: "P",
+    label: "Present",
+    seg: "bg-green text-white",
+    num: "text-green",
+    borderL: "border-l-green",
+    rowTint: "",
+  },
+  LATE: {
+    letter: "L",
+    label: "Late",
+    seg: "bg-gold text-navy",
+    num: "text-gold",
+    borderL: "border-l-gold",
+    rowTint: "rgba(200,151,91,0.05)",
+  },
+  EXCUSED: {
+    letter: "E",
+    label: "Excused",
+    seg: "bg-warn text-white",
+    num: "text-warn",
+    borderL: "border-l-warn",
+    rowTint: "rgba(197,138,46,0.05)",
+  },
+  MEDICAL: {
+    letter: "M",
+    label: "Medical",
+    seg: "bg-navy-2 text-white",
+    num: "text-navy-2",
+    borderL: "border-l-navy-2",
+    rowTint: "rgba(45,63,92,0.04)",
+  },
+  ABSENT: {
+    letter: "A",
+    label: "Absent",
+    seg: "bg-terra text-white",
+    num: "text-terra",
+    borderL: "border-l-terra",
+    rowTint: "rgba(184,74,57,0.05)",
+  },
+};
+
+/** The five statuses in the order the segmented control / stat strip show them. */
+export const ATTENDANCE_STATUS_ORDER: AttendanceStatus[] = [
+  "PRESENT",
+  "LATE",
+  "EXCUSED",
+  "MEDICAL",
+  "ABSENT",
+];
+
+/** Map a single keypress to a status (keyboard marking workflow). */
+export const STATUS_HOTKEYS: Record<string, AttendanceStatus> = {
+  p: "PRESENT",
+  l: "LATE",
+  e: "EXCUSED",
+  m: "MEDICAL",
+  a: "ABSENT",
+};


### PR DESCRIPTION
Rebuilds the **take-register** page + component to **1:1** with `Surfaces/schoolup-attendance-desktop.html`, per the Surface Replication Protocol (mapped exhaustively → diffed vs build → replicated → verified live).

## What changed
- **Active-register head** — breadcrumb `Attendance / Today / {class}`; Fraunces H1 `{class} · {weekday D Month}` with the italic-gold form suffix; lede `{n} students · class teacher {name} · {term} · Day {n}`; header buttons **Copy from yesterday** + **View term grid**.
- **Stat strip** — coloured-left-border tiles, Fraunces coloured numbers, personalised sub-lines, plus an **Unmarked** tile. The register now opens *unmarked*; **All present** fast-fills and **Submit** gates on all-marked.
- **Roster row anatomy** — mono row #, gold-initials avatar, `First Last`, mono student code, tinted term % + days fraction, per-row flag tags (**Below 70%** terra / **Pattern · {weekday}s** warn), **P/L/E/M/A** segmented control on surface tokens, inline reason editor, status row-tints, focused-row gold outline.
- **Keyboard workflow** — ↑/↓ navigate · P/L/E/M/A mark · ⏎ focus reason · ⌘/Ctrl+⏎ submit, with the legend in the action bar.
- **Sticky submit footer** — `{marked} of {total} marked` + consequence meta (absence SMS + edit window) + **Save draft** / **Submit register**.
- New `lib/attendance-status.ts` centralises status → surface tokens (Present green, Late gold, Excused warn, Absent terra).

## Decision
The surface uses 4 statuses (medical = an Excused reason); this build **keeps the 5th MEDICAL status** (your call), rendered **navy-2** so it never collides with Late (gold) / Excused (warn).

## Deferred (named, infra-blocked — not dropped)
Multi-class register switcher pane · Excursion mode (needs trip model) · offline / pending-sync / conflict (MVP2) · scheduled 3 PM SMS batch (build sends on submit). The mobile bottom-sheet editor is a responsive follow-up.

## Verification
`typecheck` + `lint` + `build` clean. Live render against a seeded JHS 2A scenario confirmed element-by-element: header/lede, 6-tile strip, **Below 70%** (terra #B84A39) + **Pattern · Fridays** (warn #C58A2E) tags, pct tints (green/gold/terra), solid segmented fills, `rgba(184,74,57,0.05)` absent row tint, focused gold outline, All-present → counts flip + Submit enables, mark-absent → reason editor + footer SMS copy. Zero console errors. Seed + temp scripts removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)