### PR TITLE
feat(attendance): register switcher pane — desktop §01 pane 2 (R2)

### DIFF
--- a/omnischools/app/(app)/attendance/[classId]/page.tsx
+++ b/omnischools/app/(app)/attendance/[classId]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { and, asc, desc, eq, inArray, gte, lt, lte } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, gte, lt, lte, sql } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import {
@@ -15,6 +15,12 @@ import {
 import { computeAttendanceFlags } from "@/lib/attendance-flags";
 import { termDayProgress } from "@/lib/school-calendar";
 import { TakeRegister, type RegisterRow } from "@/components/attendance/take-register";
+import {
+  RegisterSwitcher,
+  type SwitcherClass,
+  type SwitcherSeg,
+  type EarlierReg,
+} from "@/components/attendance/register-switcher";
 import type { AttendanceStatus } from "@/lib/attendance-status";
 
 export const dynamic = "force-dynamic";
@@ -26,14 +32,51 @@ const fmtLongDate = (iso: string) =>
     month: "long",
   });
 
-const fmtCloseAt = (ms: number) =>
-  new Date(ms).toLocaleString("en-GB", {
+const fmtShortDate = (iso: string) =>
+  new Date(`${iso}T00:00:00Z`).toLocaleDateString("en-GB", {
+    weekday: "short",
     day: "numeric",
     month: "short",
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: true,
   });
+
+const fmtTime = (d: Date) =>
+  upperMeridiem(
+    d.toLocaleTimeString("en-GB", { hour: "numeric", minute: "2-digit", hour12: true }),
+  );
+
+const STATUS_KINDS = ["PRESENT", "LATE", "EXCUSED", "MEDICAL", "ABSENT"] as const;
+
+/** Sparkline segments + marked total from a status→count tally. */
+function buildSegs(
+  counts: Record<string, number>,
+  studentCount: number,
+): { segs: SwitcherSeg[]; marked: number } {
+  const segs: SwitcherSeg[] = STATUS_KINDS.filter((k) => (counts[k] ?? 0) > 0).map((k) => ({
+    kind: k,
+    n: counts[k],
+  }));
+  const marked = STATUS_KINDS.reduce((s, k) => s + (counts[k] ?? 0), 0);
+  const unmarked = Math.max(studentCount - marked, 0);
+  if (unmarked > 0 || segs.length === 0)
+    segs.push({ kind: "UNMARKED", n: unmarked || studentCount || 1 });
+  return { segs, marked };
+}
+
+const toMs = (d: unknown) =>
+  (d instanceof Date ? d : new Date(d as string)).getTime();
+
+const upperMeridiem = (s: string) => s.replace(/\b(am|pm)\b/i, (m) => m.toUpperCase());
+
+const fmtCloseAt = (ms: number) =>
+  upperMeridiem(
+    new Date(ms).toLocaleString("en-GB", {
+      day: "numeric",
+      month: "short",
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+    }),
+  );
 
 export default async function TakeAttendancePage({
   params,
@@ -144,26 +187,39 @@ export default async function TakeAttendancePage({
             )
         : [];
 
-    // The most recent earlier register for this class → "Copy from yesterday".
-    const [prev] = await tx
-      .select({ date: attendanceRecords.date })
+    // Switcher rail: every active class + its register state today.
+    const allClasses = await tx
+      .select({ id: classes.id, name: classes.name })
+      .from(classes)
+      .where(and(eq(classes.schoolId, school.id), eq(classes.active, true)))
+      .orderBy(asc(classes.name));
+    const studentCounts = await tx
+      .select({ classId: students.classId, n: sql<number>`count(*)::int` })
+      .from(students)
+      .where(and(eq(students.schoolId, school.id), eq(students.status, "ACTIVE")))
+      .groupBy(students.classId);
+    const todayRecs = await tx
+      .select({
+        classId: attendanceRecords.classId,
+        status: attendanceRecords.status,
+        markedAt: attendanceRecords.markedAt,
+      })
+      .from(attendanceRecords)
+      .where(and(eq(attendanceRecords.schoolId, school.id), eq(attendanceRecords.date, date)));
+
+    // The active class's earlier registers → "Earlier this week" + Copy from yesterday.
+    const earlierRecs = await tx
+      .select({
+        date: attendanceRecords.date,
+        studentId: attendanceRecords.studentId,
+        status: attendanceRecords.status,
+        reasonCode: attendanceRecords.reasonCode,
+        note: attendanceRecords.note,
+        markedAt: attendanceRecords.markedAt,
+      })
       .from(attendanceRecords)
       .where(and(eq(attendanceRecords.classId, cls.id), lt(attendanceRecords.date, date)))
-      .orderBy(desc(attendanceRecords.date))
-      .limit(1);
-    const prevRecs = prev
-      ? await tx
-          .select({
-            studentId: attendanceRecords.studentId,
-            status: attendanceRecords.status,
-            reasonCode: attendanceRecords.reasonCode,
-            note: attendanceRecords.note,
-          })
-          .from(attendanceRecords)
-          .where(
-            and(eq(attendanceRecords.classId, cls.id), eq(attendanceRecords.date, prev.date)),
-          )
-      : [];
+      .orderBy(desc(attendanceRecords.date));
 
     return {
       cls,
@@ -172,7 +228,10 @@ export default async function TakeAttendancePage({
       termRecs,
       term,
       holidays,
-      prev: prev ? { date: prev.date, recs: prevRecs } : null,
+      allClasses,
+      studentCounts,
+      todayRecs,
+      earlierRecs,
       editWindowHours: cfg?.editWindowHours ?? 24,
     };
   });
@@ -224,11 +283,76 @@ export default async function TakeAttendancePage({
     ? termDayProgress(data.term.startsOn, data.term.endsOn, date, data.holidays)
     : null;
 
-  const yesterday = data.prev
+  // ── Switcher rail: today's register state per class ──────────────────
+  const countMap = new Map(data.studentCounts.map((s) => [s.classId, s.n]));
+  type Today = { counts: Record<string, number>; oldest: number };
+  const todayByClass = new Map<string, Today>();
+  for (const r of data.todayRecs) {
+    const t = todayByClass.get(r.classId) ?? { counts: {}, oldest: Infinity };
+    t.counts[r.status] = (t.counts[r.status] ?? 0) + 1;
+    t.oldest = Math.min(t.oldest, toMs(r.markedAt));
+    todayByClass.set(r.classId, t);
+  }
+  const switcherClasses: SwitcherClass[] = data.allClasses.map((c) => {
+    const studentCount = countMap.get(c.id) ?? 0;
+    const t = todayByClass.get(c.id);
+    const { segs, marked } = buildSegs(t?.counts ?? {}, studentCount);
+    let state: SwitcherClass["state"];
+    let metaLine: string;
+    if (marked === 0) {
+      state = "PENDING";
+      metaLine = "Not yet marked";
+    } else {
+      const isLocked =
+        windowH > 0 && t!.oldest !== Infinity && Date.now() - t!.oldest > windowH * 3_600_000;
+      const markedAtLabel = t!.oldest !== Infinity ? fmtTime(new Date(t!.oldest)) : null;
+      if (isLocked) {
+        state = "LOCKED";
+        metaLine = `marked ${markedAtLabel}`;
+      } else if (marked < studentCount) {
+        state = "PARTIAL";
+        metaLine = `${marked}/${studentCount} marked`;
+      } else {
+        state = "DONE";
+        metaLine = `marked ${markedAtLabel}`;
+      }
+    }
+    return { id: c.id, name: c.name, studentCount, state, metaLine, segs };
+  });
+
+  // ── Earlier registers for the active class (grouped by date, newest first) ──
+  const earlierByDate = new Map<
+    string,
+    { studentId: string; status: string; reasonCode: string | null; note: string | null; markedAt: unknown }[]
+  >();
+  for (const r of data.earlierRecs) {
+    const arr = earlierByDate.get(r.date) ?? [];
+    arr.push(r);
+    earlierByDate.set(r.date, arr);
+  }
+  const earlierDates = Array.from(earlierByDate.keys()); // already desc from the query
+  const earlier: EarlierReg[] = earlierDates.slice(0, 3).map((iso) => {
+    const recs = earlierByDate.get(iso)!;
+    const counts: Record<string, number> = {};
+    let oldest = Infinity;
+    for (const r of recs) {
+      counts[r.status] = (counts[r.status] ?? 0) + 1;
+      oldest = Math.min(oldest, toMs(r.markedAt));
+    }
+    const { segs } = buildSegs(counts, roster.length);
+    return {
+      iso,
+      dateLabel: fmtShortDate(iso),
+      markedAtLabel: oldest !== Infinity ? fmtTime(new Date(oldest)) : null,
+      segs,
+    };
+  });
+
+  const yesterday = earlierDates.length
     ? {
-        date: fmtLongDate(data.prev.date),
+        date: fmtLongDate(earlierDates[0]),
         entries: Object.fromEntries(
-          data.prev.recs.map((r) => [
+          earlierByDate.get(earlierDates[0])!.map((r) => [
             r.studentId,
             {
               status: r.status as AttendanceStatus,
@@ -265,21 +389,29 @@ export default async function TakeAttendancePage({
   }
 
   return (
-    <div className="mx-auto max-w-5xl">
-      <TakeRegister
-        classId={data.cls.id}
-        date={date}
-        roster={roster}
-        locked={locked}
-        className={data.cls.name}
-        dateLabel={fmtLongDate(date)}
-        teacher={data.cls.teacher ?? null}
-        termLabel={data.term?.label ?? null}
-        dayOf={progress?.dayOf ?? null}
-        editWindowHours={windowH}
-        windowCloseLabel={windowCloseLabel}
-        yesterday={yesterday}
+    <div className="flex gap-6">
+      <RegisterSwitcher
+        dateLabel={fmtShortDate(date)}
+        classes={switcherClasses}
+        earlier={earlier}
+        activeId={data.cls.id}
       />
+      <div className="min-w-0 flex-1">
+        <TakeRegister
+          classId={data.cls.id}
+          date={date}
+          roster={roster}
+          locked={locked}
+          className={data.cls.name}
+          dateLabel={fmtLongDate(date)}
+          teacher={data.cls.teacher ?? null}
+          termLabel={data.term?.label ?? null}
+          dayOf={progress?.dayOf ?? null}
+          editWindowHours={windowH}
+          windowCloseLabel={windowCloseLabel}
+          yesterday={yesterday}
+        />
+      </div>
     </div>
   );
 }

--- a/omnischools/components/attendance/register-switcher.tsx
+++ b/omnischools/components/attendance/register-switcher.tsx
@@ -1,0 +1,233 @@
+"use client";
+import { useState } from "react";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+
+/** Sparkline segment colours, keyed to the attendance statuses + unmarked. */
+const SEG_BG: Record<string, string> = {
+  PRESENT: "bg-green",
+  LATE: "bg-gold",
+  EXCUSED: "bg-warn",
+  MEDICAL: "bg-navy-2",
+  ABSENT: "bg-terra",
+  UNMARKED: "bg-border-2",
+};
+
+export type SwitcherSeg = { kind: string; n: number };
+export type SwitcherClass = {
+  id: string;
+  name: string;
+  studentCount: number;
+  state: "PENDING" | "PARTIAL" | "DONE" | "LOCKED";
+  metaLine: string;
+  segs: SwitcherSeg[];
+};
+export type EarlierReg = {
+  iso: string;
+  dateLabel: string;
+  markedAtLabel: string | null;
+  segs: SwitcherSeg[];
+};
+
+const PILL: Record<SwitcherClass["state"], { label: string; cls: string }> = {
+  PENDING: { label: "Pending", cls: "bg-terra-bg text-terra" },
+  PARTIAL: { label: "Partial", cls: "bg-warn-bg text-warn" },
+  DONE: { label: "Done", cls: "bg-green-bg text-green" },
+  LOCKED: { label: "Locked", cls: "border border-border bg-bg text-navy-3" },
+};
+
+/** "JHS 2A register" → JHS <em>2A</em> register (italic-gold form token). */
+function ClassName({ name }: { name: string }) {
+  const parts = name.trim().split(/\s+/);
+  const last = parts[parts.length - 1];
+  if (parts.length > 1 && /^[A-Za-z]?\d+[A-Za-z]?$/.test(last)) {
+    return (
+      <>
+        {parts.slice(0, -1).join(" ")} <em className="not-italic text-gold">{last}</em>{" "}
+        register
+      </>
+    );
+  }
+  return <>{name} register</>;
+}
+
+function Sparkline({ segs }: { segs: SwitcherSeg[] }) {
+  return (
+    <div className="mt-1.5 flex h-1.5 overflow-hidden rounded-sm bg-bg">
+      {segs.map((s, i) => (
+        <div
+          key={i}
+          className={SEG_BG[s.kind] ?? "bg-border-2"}
+          style={{ flexGrow: s.n, flexBasis: 0 }}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function RegisterSwitcher({
+  dateLabel,
+  classes,
+  earlier,
+  activeId,
+}: {
+  dateLabel: string;
+  classes: SwitcherClass[];
+  earlier: EarlierReg[];
+  activeId: string;
+}) {
+  const [filter, setFilter] = useState<"all" | "pending" | "done">("all");
+
+  const isPending = (c: SwitcherClass) => c.state === "PENDING" || c.state === "PARTIAL";
+  const isDone = (c: SwitcherClass) => c.state === "DONE" || c.state === "LOCKED";
+  const pendingN = classes.filter(isPending).length;
+  const doneN = classes.filter(isDone).length;
+  const total = classes.length;
+  const shown =
+    filter === "all"
+      ? classes
+      : filter === "pending"
+        ? classes.filter(isPending)
+        : classes.filter(isDone);
+  const pct = total ? Math.round((doneN / total) * 100) : 0;
+
+  const pills: { key: "all" | "pending" | "done"; label: string; n: number }[] = [
+    { key: "all", label: "All", n: total },
+    { key: "pending", label: "Pending", n: pendingN },
+    { key: "done", label: "Done", n: doneN },
+  ];
+
+  return (
+    <aside className="hidden w-72 shrink-0 flex-col self-start overflow-hidden rounded-[10px] border border-border bg-surface lg:sticky lg:top-6 lg:flex lg:max-h-[calc(100vh-3rem)]">
+      {/* Head */}
+      <div className="border-b border-border px-[18px] pb-3.5 pt-[18px]">
+        <div className="mb-2.5 flex items-center justify-between">
+          <span className="text-[10px] font-bold uppercase tracking-[0.16em] text-gold">
+            Today&apos;s registers
+          </span>
+          <span className="font-mono text-[10px] font-semibold text-navy-3">{dateLabel}</span>
+        </div>
+        <h2 className="font-display text-xl font-semibold text-navy">
+          My <em className="text-gold">classes</em> today
+        </h2>
+      </div>
+
+      {/* Progress strip */}
+      <div className="border-b border-gold-soft bg-gold-bg px-[18px] py-3">
+        <div className="mb-1.5 flex items-baseline justify-between">
+          <span className="font-display text-base font-semibold text-navy">
+            {doneN} of <em className="not-italic text-gold">{total}</em> done
+          </span>
+          <span className="text-[11px] text-navy-3">{total - doneN} left to mark</span>
+        </div>
+        <div className="h-1.5 overflow-hidden rounded-pill bg-white/70">
+          <div className="h-full rounded-pill bg-gold" style={{ width: `${pct}%` }} />
+        </div>
+      </div>
+
+      {/* Filter pills */}
+      <div className="flex gap-1 border-b border-border px-3.5 py-2.5">
+        {pills.map((p) => {
+          const active = filter === p.key;
+          return (
+            <button
+              key={p.key}
+              onClick={() => setFilter(p.key)}
+              className={cn(
+                "rounded-pill px-2.5 py-1.5 text-[11px] font-semibold",
+                active
+                  ? "border border-border bg-bg text-navy"
+                  : "border border-transparent text-navy-3 hover:text-navy",
+              )}
+            >
+              {p.label}
+              <span
+                className={cn(
+                  "ml-1 rounded-pill px-1.5 py-px text-[9px] font-bold",
+                  active ? "bg-gold text-navy" : "bg-bg text-navy-3",
+                )}
+              >
+                {p.n}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Rows */}
+      <div className="flex-1 overflow-y-auto">
+        {shown.map((c) => {
+          const active = c.id === activeId;
+          const pill = PILL[c.state];
+          return (
+            <Link
+              key={c.id}
+              href={`/attendance/${c.id}`}
+              className={cn(
+                "grid grid-cols-[1fr_auto] gap-2 border-b border-border px-[18px] py-3.5 hover:bg-bg",
+                active && "border-l-[3px] border-l-gold bg-gold-bg pl-[15px]",
+              )}
+            >
+              <div className="min-w-0">
+                <div className="mb-1 flex items-baseline gap-2">
+                  <span className="font-display text-sm font-semibold text-navy">
+                    <ClassName name={c.name} />
+                  </span>
+                  <span className="font-mono text-[10px] font-semibold text-navy-3">
+                    {c.studentCount}
+                  </span>
+                </div>
+                <div className="text-[11px] text-navy-3">{c.metaLine}</div>
+                <Sparkline segs={c.segs} />
+              </div>
+              <span
+                className={cn(
+                  "self-center rounded-pill px-2 py-[3px] text-[9px] font-bold uppercase tracking-[0.06em]",
+                  pill.cls,
+                )}
+              >
+                {pill.label}
+              </span>
+            </Link>
+          );
+        })}
+
+        {earlier.length > 0 && (
+          <>
+            <div className="border-t-[6px] border-bg bg-bg px-[18px] pb-1.5 pt-3.5 text-[9px] font-bold uppercase tracking-[0.14em] text-navy-3">
+              Earlier this week
+            </div>
+            {earlier.map((e) => (
+              <Link
+                key={e.iso}
+                href={`/attendance/${activeId}?date=${e.iso}`}
+                className="grid grid-cols-[1fr_auto] gap-2 border-b border-border px-[18px] py-3.5 hover:bg-bg"
+              >
+                <div className="min-w-0">
+                  <div className="mb-1 flex items-baseline gap-2">
+                    <span className="font-display text-sm font-semibold text-navy">
+                      <ClassName name={classes.find((c) => c.id === activeId)?.name ?? ""} />
+                    </span>
+                  </div>
+                  <div className="text-[11px] text-navy-3">
+                    {e.dateLabel}
+                    {e.markedAtLabel ? (
+                      <>
+                        {" · marked "}
+                        <b className="font-semibold text-navy-2">{e.markedAtLabel}</b>
+                      </>
+                    ) : null}
+                  </div>
+                  <Sparkline segs={e.segs} />
+                </div>
+                <span className="self-center rounded-pill border border-border bg-bg px-2 py-[3px] text-[9px] font-bold uppercase tracking-[0.06em] text-navy-3">
+                  Locked
+                </span>
+              </Link>
+            ))}
+          </>
+        )}
+      </div>
+    </aside>
+  );
+}


### PR DESCRIPTION
Adds the multi-class **"Today's registers"** rail beside the take-register, completing the desktop register surface (`Surfaces/schoolup-attendance-desktop.html` §01). This was the headline deferral from R1 ([#76](https://github.com/Omnischools/omnischools/pull/76)).

## What changed
- **`RegisterSwitcher`** (new client component) renders the surface's left pane 1:1:
  - "Today's registers" eyebrow + mono date + Fraunces `My classes today`
  - Gold **progress strip** — `{done} of {total} done` + `{n} left to mark` + bar
  - **All / Pending / Done** filter pills (with counts)
  - One **row per active class** — Fraunces class name (italic-gold form suffix), student count, meta line, status **sparkline**, status **pill**; active class highlighted (gold-bg + gold left border)
  - **Earlier this week** — the active class's recent **Locked** registers, deep-linked with `?date=`
- Per-class **today state** derived server-side: **Pending** (0 marked) / **Partial** / **Done** / **Locked** (past edit window); sparkline + earliest mark time from the day's records.
- Register page is now **two-column** (rail + active register). Rail is **lg-only**; mobile keeps the single-column register (dashboard already serves class nav).
- Replaced the single "previous register" probe with one earlier-records query (still powers **Copy from yesterday**).
- Marked-time labels now render **AM/PM uppercase** to match the surface.

## Adaptation (named, not dropped)
The surface meta line is timetable-aware (`Class teacher · Period 1 · Maths`). We don't have per-period timetable data, so the row meta shows **register state** instead (`Not yet marked` / `{m}/{n} marked` / `marked {time}`). Period/subject labelling → **MVP2 (timetable)**.

## Verification
`typecheck` + `lint` + `build` clean. Live render against a seeded 4-class scenario (1A Done · 2A active/Pending · 2C Pending · 3B 5/9 Partial): progress **"1 of 4 done"**, pills **4 / 3 / 1**, Pending filter narrows to pending+partial, **Earlier this week** shows Fri/Thu/Wed Locked rows with `?date=` links, active row highlighted, times render **2:30 PM**. Zero console errors. Seed + temp scripts removed; term reverted.

No schema/RLS changes — **nothing to paste on prod.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)