### PR TITLE
feat(attendance): term grid — desktop §02 fidelity (R3)

### DIFF
--- a/omnischools/app/(app)/attendance/term-grid/page.tsx
+++ b/omnischools/app/(app)/attendance/term-grid/page.tsx
@@ -8,54 +8,60 @@ import {
   attendanceRecords,
   academicPeriod,
   schoolHolidays,
+  users,
 } from "@/db/schema";
-import { isHoliday, type HolidayRange } from "@/lib/school-calendar";
+import { isHoliday, schoolDaysInRange, type HolidayRange } from "@/lib/school-calendar";
 import { PrintButton } from "@/components/reports/print-button";
+import { ATTENDANCE_STATUS_META, type AttendanceStatus } from "@/lib/attendance-status";
 
 export const dynamic = "force-dynamic";
 
-const CELL: Record<string, string> = {
-  PRESENT: "bg-green text-white",
-  LATE: "bg-warn text-white",
-  EXCUSED: "bg-navy-2 text-white",
-  MEDICAL: "bg-gold text-navy",
-  ABSENT: "bg-terra text-white",
-};
-const LETTER: Record<string, string> = {
-  PRESENT: "P",
-  LATE: "L",
-  EXCUSED: "E",
-  MEDICAL: "M",
-  ABSENT: "A",
-};
+const WINDOW = 21; // calendar days shown at once (≈ 3 weeks)
+const DOW_LETTER = ["S", "M", "T", "W", "T", "F", "S"];
+const HATCH =
+  "repeating-linear-gradient(45deg,#FAF7F2,#FAF7F2 3px,#D4CCBA 3px,#D4CCBA 4px)";
 
-/** Weekday (Mon–Fri) ISO dates in [start, end], excluding holidays. */
-function schoolDayList(start: string, end: string, holidays: HolidayRange[]) {
-  const out: string[] = [];
-  if (!start || !end || start > end) return out;
-  const last = new Date(`${end}T00:00:00Z`);
-  for (const d = new Date(`${start}T00:00:00Z`); d <= last; d.setUTCDate(d.getUTCDate() + 1)) {
-    const dow = d.getUTCDay();
-    if (dow === 0 || dow === 6) continue;
-    const iso = d.toISOString().slice(0, 10);
-    if (isHoliday(iso, holidays)) continue;
-    out.push(iso);
-  }
-  return out;
-}
+const isoOf = (d: Date) => d.toISOString().slice(0, 10);
+const addDays = (iso: string, n: number) => {
+  const d = new Date(`${iso}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + n);
+  return isoOf(d);
+};
+const dowOf = (iso: string) => new Date(`${iso}T00:00:00Z`).getUTCDay();
+const dayNum = (iso: string) => Number(iso.slice(8, 10));
+const monthShort = (iso: string) =>
+  new Date(`${iso}T00:00:00Z`).toLocaleDateString("en-GB", { month: "short" });
+const longDay = (iso: string) =>
+  new Date(`${iso}T00:00:00Z`).toLocaleDateString("en-GB", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+  });
+
+const pctClass = (p: number | null) =>
+  p === null ? "text-navy-3" : p >= 90 ? "text-green" : p >= 70 ? "text-gold" : "text-terra";
+
+const BREAKDOWN: { k: AttendanceStatus; letter: string; tone: string }[] = [
+  { k: "PRESENT", letter: "P", tone: "text-green" },
+  { k: "LATE", letter: "L", tone: "text-gold" },
+  { k: "EXCUSED", letter: "E", tone: "text-warn" },
+  { k: "MEDICAL", letter: "M", tone: "text-navy-2" },
+  { k: "ABSENT", letter: "A", tone: "text-terra" },
+];
 
 export default async function TermGridPage({
   searchParams,
 }: {
-  searchParams: { classId?: string };
+  searchParams: { classId?: string; end?: string };
 }) {
   const { school } = await requireSchool();
   const today = new Date().toISOString().slice(0, 10);
 
   const data = await withSchool(school.id, async (tx) => {
     const cls = await tx
-      .select({ id: classes.id, name: classes.name })
+      .select({ id: classes.id, name: classes.name, teacher: users.fullName })
       .from(classes)
+      .leftJoin(users, eq(classes.classTeacherUserId, users.id))
       .where(and(eq(classes.schoolId, school.id), eq(classes.active, true)))
       .orderBy(asc(classes.name));
     const selectedId =
@@ -92,7 +98,6 @@ export default async function TermGridPage({
             id: students.id,
             firstName: students.firstName,
             lastName: students.lastName,
-            code: students.studentCode,
           })
           .from(students)
           .where(
@@ -102,10 +107,10 @@ export default async function TermGridPage({
               eq(students.status, "ACTIVE"),
             ),
           )
-          .orderBy(asc(students.lastName))
+          .orderBy(asc(students.firstName), asc(students.lastName))
       : [];
     const recs =
-      selectedId && roster.length > 0
+      selectedId && roster.length > 0 && term
         ? await tx
             .select({
               studentId: attendanceRecords.studentId,
@@ -117,6 +122,8 @@ export default async function TermGridPage({
               and(
                 eq(attendanceRecords.schoolId, school.id),
                 eq(attendanceRecords.classId, selectedId),
+                gte(attendanceRecords.date, term.startsOn),
+                lte(attendanceRecords.date, term.endsOn),
                 inArray(
                   attendanceRecords.studentId,
                   roster.map((r) => r.id),
@@ -128,36 +135,108 @@ export default async function TermGridPage({
   });
 
   const cls = data.cls.find((c) => c.id === data.selectedId) ?? null;
-  // Columns: school days from term start to today (elapsed), bounded to the last 40.
-  const allDays = data.term
-    ? schoolDayList(
-        data.term.startsOn,
-        data.term.endsOn < today ? data.term.endsOn : today,
-        data.holidays,
-      )
-    : [];
-  const days = allDays.slice(-40);
+  const holidays: HolidayRange[] = data.holidays;
+  const term = data.term;
+
+  // ── Visible window (clamped to the term) ────────────────────────────
+  const reqEnd =
+    searchParams.end && /^\d{4}-\d{2}-\d{2}$/.test(searchParams.end)
+      ? searchParams.end
+      : today;
+  let end = term ? (reqEnd < term.endsOn ? reqEnd : term.endsOn) : reqEnd;
+  if (term && end < term.startsOn) end = term.startsOn;
+  let start = addDays(end, -(WINDOW - 1));
+  if (term && start < term.startsOn) {
+    start = term.startsOn;
+    end = addDays(start, WINDOW - 1);
+    if (term && end > term.endsOn) end = term.endsOn;
+  }
+  const columns: string[] = [];
+  if (term) for (let d = start; d <= end; d = addDays(d, 1)) columns.push(d);
+
+  const hasPrev = !!term && start > term.startsOn;
+  const hasNext = !!term && end < term.endsOn;
+  const prevHref = `/attendance/term-grid?classId=${data.selectedId}&end=${addDays(start, -1)}`;
+  const nextHref = `/attendance/term-grid?classId=${data.selectedId}&end=${addDays(end, WINDOW)}`;
+  const monthLabel = term
+    ? monthShort(start) === monthShort(end)
+      ? `${monthShort(start)} ${end.slice(0, 4)}`
+      : `${monthShort(start)} – ${monthShort(end)} ${end.slice(0, 4)}`
+    : "";
+
+  const kindOf = (iso: string): "weekend" | "holiday" | "future" | "school" => {
+    const w = dowOf(iso);
+    if (w === 0 || w === 6) return "weekend";
+    if (isHoliday(iso, holidays)) return "holiday";
+    if (iso > today) return "future";
+    return "school";
+  };
+
+  // ── Per-student term aggregates ─────────────────────────────────────
   const byKey = new Map(data.recs.map((r) => [`${r.studentId}|${r.date}`, r.status]));
+  type Agg = { counts: Record<string, number>; attended: number; marked: number };
+  const aggOf = (id: string): Agg => {
+    const counts: Record<string, number> = {};
+    let attended = 0;
+    let marked = 0;
+    for (const r of data.recs) {
+      if (r.studentId !== id) continue;
+      counts[r.status] = (counts[r.status] ?? 0) + 1;
+      marked++;
+      if (r.status === "PRESENT" || r.status === "LATE") attended++;
+    }
+    return { counts, attended, marked };
+  };
+  const rows = data.roster.map((s) => {
+    const agg = aggOf(s.id);
+    const pct = agg.marked > 0 ? Math.round((agg.attended / agg.marked) * 100) : null;
+    return { s, agg, pct };
+  });
+
+  const termMarkedDays = term
+    ? new Set(data.recs.map((r) => r.date)).size
+    : 0;
+  const termTotalDays = term
+    ? schoolDaysInRange(term.startsOn, term.endsOn, holidays)
+    : 0;
+  const totalAttended = rows.reduce((a, r) => a + r.agg.attended, 0);
+  const totalMarked = rows.reduce((a, r) => a + r.agg.marked, 0);
+  const termAvg = totalMarked > 0 ? (totalAttended / totalMarked) * 100 : null;
 
   return (
     <div className="mx-auto max-w-page">
-      <Link href="/attendance" className="text-sm text-navy-3 hover:text-gold print:hidden">
-        ← Attendance
-      </Link>
-      <div className="mb-5 mt-2 flex flex-wrap items-end justify-between gap-3">
+      {/* ── Head ─────────────────────────────────────────────── */}
+      <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h1 className="font-display text-3xl font-semibold text-navy">
-            Term <em className="not-italic text-gold [font-style:italic]">grid.</em>
+          <div className="text-xs text-navy-3 print:hidden">
+            <Link href="/attendance" className="text-gold hover:underline">
+              Attendance
+            </Link>{" "}
+            / {cls?.name ?? "—"} / Term grid
+          </div>
+          <h1 className="mt-1 font-display text-3xl font-semibold text-navy">
+            {cls ? <ClassTitle name={cls.name} /> : "Term grid"}
+            {term ? <> · {term.label} register</> : ""}
           </h1>
-          <p className="text-sm text-navy-3">
-            {cls ? cls.name : "No class"}
-            {data.term ? ` · ${data.term.label}` : ""}
-            {days.length ? ` · last ${days.length} school days` : ""}
-          </p>
+          {cls && term && (
+            <p className="mt-1 text-sm text-navy-3">
+              {data.roster.length} student{data.roster.length === 1 ? "" : "s"}
+              {cls.teacher ? (
+                <>
+                  {" · "}class teacher{" "}
+                  <b className="font-semibold text-navy-2">{cls.teacher}</b>
+                </>
+              ) : null}
+              {" · "}
+              <b className="font-semibold text-navy-2">{termMarkedDays}</b> school days marked
+              of <b className="font-semibold text-navy-2">{termTotalDays} in term</b>
+            </p>
+          )}
         </div>
-        <div className="flex items-center gap-2 print:hidden">
+        <div className="flex flex-wrap items-center gap-2 print:hidden">
           {data.cls.length > 1 && (
             <form>
+              <input type="hidden" name="end" value={end} />
               <select
                 name="classId"
                 defaultValue={data.selectedId ?? ""}
@@ -174,96 +253,289 @@ export default async function TermGridPage({
               </button>
             </form>
           )}
-          <PrintButton />
+          <PrintButton label="Export PDF" />
+          {cls && (
+            <Link
+              href={`/attendance/${cls.id}`}
+              className="rounded-md bg-navy px-3 py-1.5 text-sm font-semibold text-bg hover:bg-navy-deep"
+            >
+              Today&apos;s register →
+            </Link>
+          )}
         </div>
       </div>
 
       {!cls ? (
-        <p className="rounded-xl border border-dashed border-border-2 bg-surface p-10 text-center text-sm text-navy-3">
-          No classes yet.
-        </p>
-      ) : !data.term ? (
-        <p className="rounded-xl border border-dashed border-border-2 bg-surface p-10 text-center text-sm text-navy-3">
-          No active term — set term dates in Settings to see the grid.
-        </p>
+        <Empty>No classes yet.</Empty>
+      ) : !term ? (
+        <Empty>No active term — set term dates in Settings to see the grid.</Empty>
       ) : data.roster.length === 0 ? (
-        <p className="rounded-xl border border-dashed border-border-2 bg-surface p-10 text-center text-sm text-navy-3">
-          No students in this class.
-        </p>
+        <Empty>No students in this class.</Empty>
       ) : (
         <>
-          <div className="overflow-x-auto rounded-xl border border-border bg-surface">
-            <table className="text-xs">
-              <thead className="border-b border-border bg-bg text-navy-3">
+          {/* ── Controls: month nav + legend ─────────────────── */}
+          <div className="mb-3.5 flex flex-wrap items-center justify-between gap-4 rounded-[10px] border border-border bg-surface px-4 py-3 print:hidden">
+            <div className="flex items-center gap-3">
+              <NavBtn href={prevHref} disabled={!hasPrev}>
+                ‹
+              </NavBtn>
+              <span className="min-w-[140px] text-center font-display text-base font-semibold text-navy">
+                {monthLabel.split(" ").slice(0, -1).join(" ")}{" "}
+                <em className="not-italic text-gold">{end.slice(0, 4)}</em>
+              </span>
+              <NavBtn href={nextHref} disabled={!hasNext}>
+                ›
+              </NavBtn>
+            </div>
+            <div className="flex flex-wrap gap-3 text-[11px] text-navy-3">
+              <Legend swatch="bg-green border-green">Present</Legend>
+              <Legend swatch="bg-gold border-gold">Late</Legend>
+              <Legend swatch="bg-warn border-warn">Excused</Legend>
+              <Legend swatch="bg-navy-2 border-navy-2">Medical</Legend>
+              <Legend swatch="bg-terra border-terra">Absent</Legend>
+              <Legend swatchStyle={{ backgroundImage: HATCH }}>Holiday</Legend>
+              <Legend swatch="bg-bg border-border-2">Weekend</Legend>
+              <Legend swatch="bg-surface border-dashed border-border-2">Future</Legend>
+            </div>
+          </div>
+
+          {/* ── Grid ─────────────────────────────────────────── */}
+          <div className="overflow-auto rounded-[10px] border border-border bg-surface">
+            <table className="border-separate border-spacing-0">
+              <thead>
                 <tr>
-                  <th className="sticky left-0 z-10 bg-bg px-3 py-2 text-left font-semibold">
-                    Student
+                  <th
+                    rowSpan={2}
+                    style={{ borderRight: "1.5px solid var(--navy-3)" }}
+                    className="sticky left-0 z-30 w-[220px] min-w-[220px] border-b border-border bg-bg px-4 text-left text-[9px] font-bold uppercase tracking-[0.14em] text-navy-3"
+                  >
+                    Student · {data.roster.length} in roster
                   </th>
-                  <th className="px-2 py-2 text-right font-semibold">%</th>
-                  {days.map((d) => (
-                    <th key={d} className="px-1 py-2 text-center font-medium" title={d}>
-                      {Number(d.slice(8, 10))}
-                    </th>
-                  ))}
+                  {columns.map((d) => {
+                    const k = kindOf(d);
+                    const isToday = d === today;
+                    return (
+                      <th
+                        key={d}
+                        className={cellHeadCls(
+                          "h-[18px] border-b-0 px-0 pt-0.5 text-[9px] font-bold uppercase tracking-[0.06em]",
+                          k,
+                          isToday,
+                        )}
+                      >
+                        {DOW_LETTER[dowOf(d)]}
+                      </th>
+                    );
+                  })}
+                  <th
+                    rowSpan={2}
+                    style={{ borderLeft: "1.5px solid var(--navy-3)" }}
+                    className="sticky right-0 z-30 w-[100px] min-w-[100px] border-b border-border bg-bg px-3 text-[9px] font-bold uppercase tracking-[0.14em] text-navy-3"
+                  >
+                    Summary
+                  </th>
+                </tr>
+                <tr>
+                  {columns.map((d) => {
+                    const k = kindOf(d);
+                    const isToday = d === today;
+                    return (
+                      <th
+                        key={d}
+                        className={cellHeadCls(
+                          "h-[18px] w-[30px] border-b border-border px-0 font-mono text-[11px] font-semibold",
+                          k,
+                          isToday,
+                        )}
+                      >
+                        {dayNum(d)}
+                      </th>
+                    );
+                  })}
                 </tr>
               </thead>
-              <tbody className="divide-y divide-border">
-                {data.roster.map((s) => {
-                  let att = 0;
-                  let tot = 0;
-                  const cells = days.map((d) => {
-                    const st = byKey.get(`${s.id}|${d}`);
-                    if (st) {
-                      tot++;
-                      if (st === "PRESENT" || st === "LATE") att++;
-                    }
-                    return { d, st };
-                  });
-                  const pct = tot > 0 ? Math.round((att / tot) * 100) : null;
-                  return (
-                    <tr key={s.id}>
-                      <td className="sticky left-0 z-10 bg-surface px-3 py-1.5 font-medium text-navy">
-                        {s.lastName}, {s.firstName}
-                      </td>
-                      <td
-                        className={`px-2 py-1.5 text-right font-semibold ${
-                          pct === null
-                            ? "text-navy-3"
-                            : pct >= 90
-                              ? "text-green"
-                              : pct >= 70
-                                ? "text-navy-2"
-                                : "text-terra"
-                        }`}
-                      >
-                        {pct === null ? "—" : `${pct}%`}
-                      </td>
-                      {cells.map(({ d, st }) => (
-                        <td key={d} className="px-1 py-1.5 text-center">
-                          {st ? (
-                            <span
-                              title={`${d} · ${st.charAt(0) + st.slice(1).toLowerCase()}`}
-                              className={`inline-flex h-5 w-5 items-center justify-center rounded text-[10px] font-bold ${CELL[st]}`}
-                            >
-                              {LETTER[st]}
-                            </span>
-                          ) : (
-                            <span className="text-border-2">·</span>
-                          )}
+              <tbody>
+                {rows.map(({ s, agg, pct }) => (
+                  <tr key={s.id} className="group">
+                    <td
+                      style={{ borderRight: "1.5px solid var(--navy-3)" }}
+                      className="sticky left-0 z-10 flex w-[220px] items-center gap-2.5 border-b border-border bg-surface px-4 py-2 group-hover:bg-bg"
+                    >
+                      <span className="flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-full bg-gold-bg font-display text-[10px] font-semibold text-navy">
+                        {(s.firstName[0] ?? "") + (s.lastName[0] ?? "")}
+                      </span>
+                      <span className="min-w-0">
+                        <span className="block truncate text-xs font-semibold text-navy">
+                          {s.firstName} {s.lastName}
+                        </span>
+                        <span className={`block font-mono text-[10px] font-semibold ${pctClass(pct)}`}>
+                          {pct === null ? "— · 0/0" : `${pct}% · ${agg.attended}/${agg.marked}`}
+                        </span>
+                      </span>
+                    </td>
+                    {columns.map((d) => {
+                      const k = kindOf(d);
+                      const isToday = d === today;
+                      const st = byKey.get(`${s.id}|${d}`) as AttendanceStatus | undefined;
+                      const base =
+                        "h-[32px] w-[30px] border-b border-r border-border text-center font-display text-xs font-bold";
+                      const ring = isToday ? "outline outline-2 -outline-offset-2 outline-gold" : "";
+                      if (k === "weekend")
+                        return <td key={d} className={`${base} bg-bg ${ring}`} />;
+                      if (k === "holiday")
+                        return (
+                          <td key={d} className={`${base} ${ring}`} style={{ backgroundImage: HATCH }} />
+                        );
+                      if (k === "future")
+                        return (
+                          <td key={d} className={`${base} bg-surface text-border-2 ${ring}`}>
+                            ·
+                          </td>
+                        );
+                      // school day
+                      if (!st)
+                        return <td key={d} className={`${base} bg-surface ${ring}`} />;
+                      const m = ATTENDANCE_STATUS_META[st];
+                      return (
+                        <td key={d} className={`${base} ${m.seg} ${ring} relative`}>
+                          {m.letter}
+                          <span className="pointer-events-none absolute bottom-full left-1/2 z-20 -translate-x-1/2 -translate-y-1 whitespace-nowrap rounded-md bg-navy px-2.5 py-1.5 text-[10px] font-medium text-white opacity-0 group-hover:opacity-100">
+                            {longDay(d)} · {m.label}
+                          </span>
                         </td>
-                      ))}
-                    </tr>
-                  );
-                })}
+                      );
+                    })}
+                    <td
+                      style={{ borderLeft: "1.5px solid var(--navy-3)" }}
+                      className="sticky right-0 z-10 w-[100px] border-b border-border bg-bg px-3 py-2 text-center font-mono text-[11px] font-semibold group-hover:bg-gold-bg"
+                    >
+                      <span className="flex justify-center gap-1.5">
+                        {BREAKDOWN.filter((b) => (agg.counts[b.k] ?? 0) > 0).map((b) => (
+                          <span key={b.k} className={`text-[10px] font-bold ${b.tone}`}>
+                            {b.letter} {agg.counts[b.k]}
+                          </span>
+                        ))}
+                        {agg.marked === 0 && <span className="text-navy-3">—</span>}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
               </tbody>
+              <tfoot>
+                <tr>
+                  <td className="sticky left-0 z-10 border-t-[1.5px] border-navy bg-bg px-4 py-1.5 text-left font-display text-[11px] font-bold uppercase tracking-[0.06em] text-navy">
+                    Class total
+                  </td>
+                  {columns.map((d) => {
+                    const k = kindOf(d);
+                    let label = "";
+                    if (k === "school") {
+                      const present = data.roster.filter((s) => {
+                        const st = byKey.get(`${s.id}|${d}`);
+                        return st && st !== "ABSENT";
+                      }).length;
+                      label = `${present}/${data.roster.length}`;
+                    } else if (k === "future") {
+                      label = "—";
+                    }
+                    return (
+                      <td
+                        key={d}
+                        className="border-t-[1.5px] border-navy bg-bg px-0 py-1.5 text-center font-mono text-[10px] font-bold text-navy"
+                      >
+                        {label}
+                      </td>
+                    );
+                  })}
+                  <td className="sticky right-0 z-10 border-t-[1.5px] border-navy bg-navy px-3 py-1.5 text-center font-mono text-[10px] font-bold text-white">
+                    {termAvg === null ? "—" : `${termAvg.toFixed(1)}% avg`}
+                  </td>
+                </tr>
+              </tfoot>
             </table>
           </div>
-          <p className="mt-3 text-xs text-navy-3">
-            P present · L late · E excused · M medical · A absent · · not marked. Weekends
-            and holidays are omitted.
+
+          <p className="mt-3 text-[11px] italic leading-relaxed text-navy-3">
+            Showing {data.roster.length} student{data.roster.length === 1 ? "" : "s"} · scroll the
+            table or use ‹ › to change the date range · weekends are tinted, holidays hatched,
+            future days dashed.
           </p>
         </>
       )}
     </div>
   );
+}
+
+/** Italic-gold form suffix, e.g. JHS <em>2A</em>. */
+function ClassTitle({ name }: { name: string }) {
+  const parts = name.trim().split(/\s+/);
+  const last = parts[parts.length - 1];
+  if (parts.length > 1 && /^[A-Za-z]?\d+[A-Za-z]?$/.test(last))
+    return (
+      <>
+        {parts.slice(0, -1).join(" ")} <em className="not-italic text-gold">{last}</em>
+      </>
+    );
+  return <>{name}</>;
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="rounded-xl border border-dashed border-border-2 bg-surface p-10 text-center text-sm text-navy-3">
+      {children}
+    </p>
+  );
+}
+
+function NavBtn({
+  href,
+  disabled,
+  children,
+}: {
+  href: string;
+  disabled: boolean;
+  children: React.ReactNode;
+}) {
+  const cls =
+    "flex h-7 w-7 items-center justify-center rounded-md border border-border bg-bg text-sm font-bold text-navy-2";
+  if (disabled)
+    return <span className={`${cls} cursor-default opacity-40`}>{children}</span>;
+  return (
+    <Link href={href} className={`${cls} hover:border-gold`}>
+      {children}
+    </Link>
+  );
+}
+
+function Legend({
+  swatch,
+  swatchStyle,
+  children,
+}: {
+  swatch?: string;
+  swatchStyle?: React.CSSProperties;
+  children: React.ReactNode;
+}) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span
+        className={`h-3.5 w-3.5 rounded-[3px] border ${swatch ?? "border-border"}`}
+        style={swatchStyle}
+      />
+      {children}
+    </span>
+  );
+}
+
+/** Shared header-cell classes for weekend/holiday/future/today tinting. */
+function cellHeadCls(
+  base: string,
+  kind: "weekend" | "holiday" | "future" | "school",
+  isToday: boolean,
+): string {
+  let bg = "bg-bg text-navy";
+  if (isToday) bg = "bg-gold-bg text-gold";
+  else if (kind === "weekend" || kind === "holiday") bg = "bg-bg text-navy-3";
+  const underline = isToday ? "border-b-2 border-gold" : "";
+  return `${base} border-r border-border ${bg} ${underline}`;
 }

--- a/omnischools/components/reports/print-button.tsx
+++ b/omnischools/components/reports/print-button.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 /** Triggers the browser print dialog — users "Save as PDF" from there. */
-export function PrintButton() {
+export function PrintButton({ label = "Print / Save as PDF" }: { label?: string }) {
   return (
     <button
       onClick={() => window.print()}
       className="rounded-md border border-border-2 bg-surface px-3 py-1.5 text-xs font-semibold text-navy-2 transition-colors hover:border-gold print:hidden"
     >
-      Print / Save as PDF
+      {label}
     </button>
   );
 }


### PR DESCRIPTION
Rebuilds the **term-grid** screen to **1:1** with `Surfaces/schoolup-attendance-desktop.html` §02 — completing the desktop register surface (R1 register [#76](https://github.com/Omnischools/omnischools/pull/76) + R2 switcher [#77](https://github.com/Omnischools/omnischools/pull/77) + R3 term grid).

## What changed
- **Full-calendar windowed columns** (≈3-week window, `‹ ›` month-nav via `?end=`) replacing the old "last 40 school days". Every day renders by kind:
  - **school day** → saturated P/L/E/M/A block + Fraunces letter
  - **weekend** → tinted blank · **holiday** → diagonal hatch · **future** → border-2 "·"
  - **today** → gold-tinted + gold-underlined header, gold ring on cells
- **Two-row header**: day-of-week letter over mono day number.
- **Sticky student column** — gold-initials avatar + `First Last` + colour-coded `pct · attended/marked` (green ≥90 / gold 70–89 / terra <70), 1.5px navy divider.
- **Sticky Summary column** — mono colour-coded breakdown (`P 31 · M 1 · A 8`).
- **tfoot "Class total"** — per-day marked-not-absent / roster (blank on weekends/holidays, `—` on future) + navy **term-average** cell (`91.9% avg`).
- **Head** — breadcrumb, Fraunces H1 `{class} · {term} register` (italic-gold form), lede `{n} students · class teacher {name} · {marked} school days marked of {total} in term`, **Export PDF** + **Today's register →**. Controls bar with month-nav + **8-item legend**. Hover **tooltip** on marked cells (`Fri 19 Jun · Absent`).
- `PrintButton` gains an optional `label` (default unchanged) → renders "Export PDF".

## Deferred (named)
Surface cells open the exception drawer on click; that shared edit drawer is **MVP2**. Cells are read-only here.

## Verification
`typecheck` + `lint` + `build` clean. Live render against a seeded JHS 2A scenario with a mid-window holiday (2026-06-18) and future days: **today** header `#F5EBDC` + gold text + gold underline, **hatched** holiday column, **tinted** weekends, **future "·"** cells, summary breakdowns (`P 31 M 1 A 8`, `P 24 A 16`), class-total footer with navy **"91.9% avg"**, colour-coded pct (100% green / 78% gold / 60% terra) — all element-exact. Zero console errors. Seed + holiday + temp scripts removed; term reverted.

No schema/RLS changes — **nothing to paste on prod.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)