### PR TITLE
feat(attendance): reason bottom-sheet — mobile State D (R4)

### DIFF
--- a/omnischools/components/attendance/reason-sheet.tsx
+++ b/omnischools/components/attendance/reason-sheet.tsx
@@ -1,0 +1,222 @@
+"use client";
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import { ATTENDANCE_REASONS } from "@/lib/attendance-reasons";
+import {
+  ATTENDANCE_STATUS_META,
+  ATTENDANCE_STATUS_ORDER,
+  type AttendanceStatus,
+} from "@/lib/attendance-status";
+
+export type SheetStudent = {
+  id: string;
+  name: string;
+  initials: string;
+  className: string;
+  termPct: number | null;
+};
+
+/** Selected-tile tint per status (surface `.sheet-status-tile.selected.*`). */
+const TILE_SELECTED: Record<AttendanceStatus, string> = {
+  PRESENT: "border-green bg-green-bg text-green",
+  LATE: "border-gold bg-gold-bg text-gold",
+  EXCUSED: "border-warn bg-warn-bg text-warn",
+  MEDICAL: "border-navy-2 bg-bg text-navy-2",
+  ABSENT: "border-terra bg-terra-bg text-terra",
+};
+
+function smsNotice(status: AttendanceStatus, hasReason: boolean) {
+  if (status === "ABSENT")
+    return (
+      <>
+        <b className="font-semibold text-navy">An absence SMS will be sent</b> to the guardian
+        when you submit the register.
+      </>
+    );
+  if (status === "EXCUSED" || status === "MEDICAL")
+    return (
+      <>
+        <b className="font-semibold text-navy">No SMS will go out</b> for this student today —
+        excused absences {hasReason ? "with a noted reason " : ""}are not flagged to the parent.
+      </>
+    );
+  return (
+    <>
+      <b className="font-semibold text-navy">No SMS will go out</b> for a late arrival.
+    </>
+  );
+}
+
+export function ReasonSheet({
+  student,
+  initialStatus,
+  initialReason,
+  initialNote,
+  onSave,
+  onClose,
+}: {
+  student: SheetStudent;
+  initialStatus: AttendanceStatus;
+  initialReason: string;
+  initialNote: string;
+  onSave: (status: AttendanceStatus, reasonCode: string | null, note: string | null) => void;
+  onClose: () => void;
+}) {
+  const [status, setStatus] = useState<AttendanceStatus>(initialStatus);
+  const [reason, setReason] = useState(initialReason);
+  const [note, setNote] = useState(initialNote);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const isPresent = status === "PRESENT";
+
+  return (
+    <div
+      onClick={onClose}
+      className="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+      style={{ backgroundColor: "rgba(26,43,71,0.45)", backdropFilter: "blur(2px)" }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="max-h-[80vh] w-full overflow-y-auto rounded-t-3xl bg-surface px-[18px] pb-6 pt-2 sm:max-h-[88vh] sm:max-w-md sm:rounded-2xl sm:p-5"
+      >
+        <div className="mx-auto mb-3.5 h-1 w-9 rounded-full bg-border-2 sm:hidden" />
+
+        {/* Head */}
+        <div className="mb-3.5 flex items-center gap-3 border-b border-border pb-3.5">
+          <span className="flex h-[42px] w-[42px] shrink-0 items-center justify-center rounded-full bg-gold-bg font-display text-sm font-semibold text-navy">
+            {student.initials}
+          </span>
+          <div className="flex-1">
+            <div className="font-display text-base font-semibold text-navy">{student.name}</div>
+            <div className="mt-px text-[11px] text-navy-3">
+              {student.className}
+              {student.termPct !== null ? ` · ${student.termPct}% term attendance` : ""}
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="flex h-[30px] w-[30px] items-center justify-center rounded-full border border-border bg-bg text-sm font-semibold text-navy-3"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Status tiles */}
+        <div className="mb-4 grid grid-cols-5 gap-2">
+          {ATTENDANCE_STATUS_ORDER.map((s) => {
+            const m = ATTENDANCE_STATUS_META[s];
+            const sel = status === s;
+            return (
+              <button
+                key={s}
+                onClick={() => setStatus(s)}
+                className={cn(
+                  "rounded-xl border-[1.5px] px-1.5 py-2.5 text-center transition-colors",
+                  sel ? TILE_SELECTED[s] : "border-border-2 bg-surface text-navy",
+                )}
+              >
+                <div className="font-display text-base font-bold leading-none">{m.letter}</div>
+                <div className="mt-1 text-[10px] font-bold text-navy-2">{m.label}</div>
+              </button>
+            );
+          })}
+        </div>
+
+        {!isPresent && (
+          <>
+            {/* Reason radio list */}
+            <div className="mb-3.5">
+              <div className="mb-2 text-[9px] font-bold uppercase tracking-[0.14em] text-navy-3">
+                Reason
+              </div>
+              <div className="flex flex-col gap-1.5">
+                {ATTENDANCE_REASONS.map((r) => {
+                  const sel = reason === r.code;
+                  return (
+                    <button
+                      key={r.code}
+                      onClick={() => setReason(r.code)}
+                      className={cn(
+                        "grid grid-cols-[18px_1fr] items-center gap-3 rounded-[10px] border px-3.5 py-2.5 text-left",
+                        sel ? "border-warn bg-warn-bg" : "border-border bg-bg",
+                      )}
+                    >
+                      <span
+                        className={cn(
+                          "relative h-[18px] w-[18px] rounded-full border-[1.5px]",
+                          sel ? "border-warn bg-warn" : "border-border-2 bg-surface",
+                        )}
+                      >
+                        {sel && (
+                          <span className="absolute inset-1 rounded-full bg-white" />
+                        )}
+                      </span>
+                      <span>
+                        <span className="block text-xs font-semibold text-navy">{r.label}</span>
+                        <span className="mt-px block text-[10px] text-navy-3">{r.detail}</span>
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Note */}
+            <div className="mb-3.5">
+              <div className="mb-2 text-[9px] font-bold uppercase tracking-[0.14em] text-navy-3">
+                Note (optional)
+              </div>
+              <textarea
+                value={note}
+                onChange={(e) => setNote(e.target.value)}
+                maxLength={300}
+                placeholder="e.g. mother called this morning, will return tomorrow"
+                className="min-h-[60px] w-full resize-none rounded-lg border border-border-2 bg-surface px-3 py-2.5 text-xs text-navy outline-none placeholder:italic placeholder:text-navy-3 focus:border-gold"
+              />
+            </div>
+
+            {/* SMS notice */}
+            <div className="mb-3 grid grid-cols-[22px_1fr] items-start gap-2.5 rounded-[10px] border border-gold-soft bg-gold-bg px-3.5 py-2.5">
+              <span className="flex h-5 w-5 items-center justify-center rounded-full bg-gold font-display text-[11px] font-bold text-navy">
+                i
+              </span>
+              <span className="text-[11px] leading-relaxed text-navy-2">
+                {smsNotice(status, reason !== "")}
+              </span>
+            </div>
+          </>
+        )}
+
+        {/* Footer */}
+        <div className="mt-2 grid grid-cols-[1fr_2fr] gap-2">
+          <button
+            onClick={onClose}
+            className="rounded-pill border border-border bg-bg py-3 text-sm font-semibold text-navy"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() =>
+              onSave(
+                status,
+                isPresent ? null : reason || null,
+                isPresent ? null : note || null,
+              )
+            }
+            className="rounded-pill bg-navy py-3 text-sm font-bold text-bg hover:bg-navy-deep"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/omnischools/components/attendance/take-register.tsx
+++ b/omnischools/components/attendance/take-register.tsx
@@ -4,13 +4,14 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { saveAttendance, requestCorrection } from "@/lib/actions/attendance";
-import { ATTENDANCE_REASONS, reasonLabel } from "@/lib/attendance-reasons";
+import { reasonLabel } from "@/lib/attendance-reasons";
 import {
   ATTENDANCE_STATUS_META,
   ATTENDANCE_STATUS_ORDER,
   STATUS_HOTKEYS,
   type AttendanceStatus,
 } from "@/lib/attendance-status";
+import { ReasonSheet } from "@/components/attendance/reason-sheet";
 
 type Tag = { label: string; tone: "warn" | "terra" };
 
@@ -107,6 +108,7 @@ export function TakeRegister({
     Object.fromEntries(roster.map((r) => [r.id, r.note ?? ""])),
   );
   const [focused, setFocused] = useState<number | null>(null);
+  const [sheetFor, setSheetFor] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [result, setResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -212,15 +214,14 @@ export function TakeRegister({
           markStatus(roster[focused].id, hot);
         } else if (e.key === "Enter") {
           e.preventDefault();
-          document
-            .querySelector<HTMLSelectElement>(`[data-reason="${roster[focused].id}"]`)
-            ?.focus();
+          const fr = roster[focused];
+          if (statuses[fr.id] && statuses[fr.id] !== "PRESENT") setSheetFor(fr.id);
         }
       }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [locked, focused, marked, total, roster, markStatus, doSave]);
+  }, [locked, focused, marked, total, roster, statuses, markStatus, doSave]);
 
   const absentSms = absent.length;
   const footerMeta = (
@@ -554,31 +555,30 @@ export function TakeRegister({
                         </span>
                       </div>
                     ) : editable ? (
-                      <div className="flex flex-wrap items-center gap-1.5">
-                        <select
-                          data-reason={r.id}
-                          value={reasons[r.id] ?? ""}
-                          onChange={(e) =>
-                            setReasons((s) => ({ ...s, [r.id]: e.target.value }))
-                          }
-                          className="rounded border border-border-2 bg-bg px-1.5 py-1 text-xs text-navy outline-none focus:border-gold"
-                        >
-                          <option value="">Reason…</option>
-                          {ATTENDANCE_REASONS.map((o) => (
-                            <option key={o.code} value={o.code}>
-                              {o.label}
-                            </option>
-                          ))}
-                        </select>
-                        <input
-                          value={notes[r.id] ?? ""}
-                          onChange={(e) =>
-                            setNotes((s) => ({ ...s, [r.id]: e.target.value }))
-                          }
-                          placeholder="note (optional)"
-                          maxLength={300}
-                          className="w-36 rounded border border-border-2 bg-bg px-1.5 py-1 text-xs text-navy outline-none focus:border-gold"
-                        />
+                      <div className="flex flex-wrap items-center gap-2 text-xs italic leading-snug text-navy-2">
+                        {reasons[r.id] || notes[r.id] ? (
+                          <>
+                            <span>
+                              <b className="font-semibold not-italic text-navy">
+                                {reasonLabel(reasons[r.id]) ?? "Reason"}
+                              </b>
+                              {notes[r.id] ? ` · ${notes[r.id]}` : ""}
+                            </span>
+                            <button
+                              onClick={() => setSheetFor(r.id)}
+                              className="font-semibold not-italic text-gold hover:underline"
+                            >
+                              Edit
+                            </button>
+                          </>
+                        ) : (
+                          <button
+                            onClick={() => setSheetFor(r.id)}
+                            className="font-semibold not-italic text-gold hover:underline"
+                          >
+                            + Add reason
+                          </button>
+                        )}
                       </div>
                     ) : (
                       <span className="text-[11px] italic text-navy-3 opacity-50">—</span>
@@ -622,6 +622,33 @@ export function TakeRegister({
         P present · L late · E excused · M medical · A absent. Add a reason for any non-present
         mark. Absences notify the primary guardian by SMS on submit.
       </p>
+
+      {sheetFor &&
+        (() => {
+          const r = roster.find((x) => x.id === sheetFor);
+          if (!r) return null;
+          return (
+            <ReasonSheet
+              student={{
+                id: r.id,
+                name: fullName(r),
+                initials: r.initials,
+                className,
+                termPct: r.termPct,
+              }}
+              initialStatus={(statuses[r.id] ?? "ABSENT") as AttendanceStatus}
+              initialReason={reasons[r.id] ?? ""}
+              initialNote={notes[r.id] ?? ""}
+              onSave={(st, rc, nt) => {
+                setStatuses((s) => ({ ...s, [r.id]: st }));
+                setReasons((s) => ({ ...s, [r.id]: rc ?? "" }));
+                setNotes((s) => ({ ...s, [r.id]: nt ?? "" }));
+                setSheetFor(null);
+              }}
+              onClose={() => setSheetFor(null)}
+            />
+          );
+        })()}
     </div>
   );
 }

--- a/omnischools/lib/attendance-reasons.ts
+++ b/omnischools/lib/attendance-reasons.ts
@@ -4,11 +4,15 @@
  * Shared by the take-register UI and the per-student attendance view.
  */
 export const ATTENDANCE_REASONS = [
-  { code: "SICK", label: "Sick" },
-  { code: "MEDICAL", label: "Medical appointment" },
-  { code: "FAMILY", label: "Family event" },
-  { code: "TRAVEL", label: "Travel" },
-  { code: "OTHER", label: "Other" },
+  { code: "SICK", label: "Sick", detail: "Medical illness, doctor's note may follow" },
+  {
+    code: "MEDICAL",
+    label: "Medical appointment",
+    detail: "Hospital, dental, optometrist visit",
+  },
+  { code: "FAMILY", label: "Family event", detail: "Funeral, wedding, religious observance" },
+  { code: "TRAVEL", label: "Travel", detail: "Out of town with family" },
+  { code: "OTHER", label: "Other", detail: "Anything not listed above" },
 ] as const;
 
 export type AttendanceReasonCode = (typeof ATTENDANCE_REASONS)[number]["code"];


### PR DESCRIPTION
Brings the mobile register surface's signature interaction — the **exception bottom-sheet** (`schoolup-attendance-mobile.html` State D) — into the register, and in doing so improves fidelity to the **desktop** surface too (its reason cell is a read-back + "add reason" link, not an inline editor).

## What changed
- **`ReasonSheet`** (new) — one responsive component, two presentations:
  - **mobile**: bottom-sheet (slides up, drag handle, dimmed + blurred backdrop)
  - **desktop (≥sm)**: centered modal (448px, handle hidden)
  - Contents 1:1 with State D: avatar + name + `{class} · {pct}% term attendance` + close; **5 status tiles** (P/L/E/M/A — Medical kept, surface selected-tints); **reason radio list** with the five one-line details; note textarea; **contextual gold SMS notice** — "No SMS will go out" (Excused/Medical), "An absence SMS will be sent" (Absent); Cancel / Save; Escape + backdrop close.
- **take-register**: reason column is now a **read-back** (`Medical appointment · note`) + **Add reason / Edit** link that opens the sheet (matches the desktop surface). Status seg still marks directly; `⏎` on a focused non-present row opens the sheet; **Save** writes status + reason + note back to the row. Inline select/input removed.
- **attendance-reasons**: each reason gains a one-line `detail` (shared by the sheet) — no code/label changes.

Saving in the sheet can also change the student's status, so it doubles as the full exception editor.

## Deferred (named)
Excursion mode (State E — trip model) and offline / pending-sync / conflict (States G–I) remain **MVP2**.

## Verification
`typecheck` + `lint` + `build` clean. Live on a seeded JHS 2A:
- **Mobile** (375px): bottom-sheet with handle, State-D layout, Absent → "An absence SMS will be sent" notice
- **Desktop** (1320px): centered modal (align/justify center, 448px, handle `display:none`), Excused → "No SMS will go out", **Medical appointment** reason highlighted (warn + filled radio)
- **Save** flips row 1 to **Excused** (seg `bg-warn`) and writes the `Medical appointment · …` read-back
- Zero console errors. Seed + temp scripts removed; term reverted.

No schema/RLS changes — **nothing to paste on prod.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)