### PR TITLE
feat(attendance): settings — school calendar region (R6)

### DIFF
--- a/omnischools/app/(app)/settings/attendance/page.tsx
+++ b/omnischools/app/(app)/settings/attendance/page.tsx
@@ -1,29 +1,73 @@
 import Link from "next/link";
-import { asc, eq } from "drizzle-orm";
+import { and, asc, eq, gte, lte } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
-import { attendanceSettings, schoolHolidays } from "@/db/schema";
+import { attendanceSettings, schoolHolidays, academicPeriod } from "@/db/schema";
 import {
   ATTENDANCE_SETTINGS_DEFAULTS,
   type AttendanceSettings,
 } from "@/lib/attendance-settings";
 import { AttendanceSettingsForm } from "@/components/settings/attendance-settings-form";
 import { HolidaysManager } from "@/components/settings/holidays-manager";
+import { TermCalendar } from "@/components/settings/term-calendar";
 
 export const dynamic = "force-dynamic";
 export const metadata = { title: "Attendance settings" };
 
+const fmtFull = (iso: string) =>
+  new Date(iso + "T00:00:00Z").toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+
+function lastEdited(updatedAt: Date | string | null | undefined): string | null {
+  if (!updatedAt) return null;
+  const ms = Date.now() - (updatedAt instanceof Date ? updatedAt : new Date(updatedAt)).getTime();
+  const days = Math.floor(ms / 86_400_000);
+  if (days <= 0) return "today";
+  if (days === 1) return "yesterday";
+  if (days < 14) return `${days} days ago`;
+  if (days < 60) return `${Math.floor(days / 7)} weeks ago`;
+  return `${Math.floor(days / 30)} months ago`;
+}
+
+function SectionHead({ num, title, meta }: { num: string; title: string; meta?: string }) {
+  return (
+    <div className="mb-3 mt-8 flex flex-wrap items-baseline gap-3 first:mt-0">
+      <span className="font-display text-xl font-semibold italic text-gold">{num}</span>
+      <h2 className="font-display text-lg font-semibold text-navy">{title}</h2>
+      {meta && <span className="text-[11px] uppercase tracking-wide text-navy-3">{meta}</span>}
+    </div>
+  );
+}
+
 export default async function AttendanceSettingsPage() {
   const { school } = await requireSchool();
-  const [row] = await withSchool(school.id, (tx) =>
-    tx
+  const today = new Date().toISOString().slice(0, 10);
+
+  const data = await withSchool(school.id, async (tx) => {
+    const [row] = await tx
       .select()
       .from(attendanceSettings)
       .where(eq(attendanceSettings.schoolId, school.id))
-      .limit(1),
-  );
-  const holidays = await withSchool(school.id, (tx) =>
-    tx
+      .limit(1);
+    const [term] = await tx
+      .select({
+        label: academicPeriod.periodLabel,
+        startsOn: academicPeriod.startsOn,
+        endsOn: academicPeriod.endsOn,
+      })
+      .from(academicPeriod)
+      .where(
+        and(
+          eq(academicPeriod.schoolId, school.id),
+          lte(academicPeriod.startsOn, today),
+          gte(academicPeriod.endsOn, today),
+        ),
+      )
+      .limit(1);
+    const holidays = await tx
       .select({
         id: schoolHolidays.id,
         name: schoolHolidays.name,
@@ -33,9 +77,11 @@ export default async function AttendanceSettingsPage() {
       })
       .from(schoolHolidays)
       .where(eq(schoolHolidays.schoolId, school.id))
-      .orderBy(asc(schoolHolidays.startsOn)),
-  );
+      .orderBy(asc(schoolHolidays.startsOn));
+    return { row, term, holidays };
+  });
 
+  const { row, term, holidays } = data;
   const initial: AttendanceSettings = row
     ? {
         dayStart: row.dayStart,
@@ -49,25 +95,69 @@ export default async function AttendanceSettingsPage() {
         pctCritical: row.pctCritical,
       }
     : ATTENDANCE_SETTINGS_DEFAULTS;
+  const edited = lastEdited(row?.updatedAt);
 
   return (
     <div className="mx-auto max-w-page">
-      <Link href="/settings" className="text-sm text-navy-3 hover:text-gold">
-        ← Settings
-      </Link>
-      <div className="mb-6 mt-2">
+      <div className="text-xs uppercase tracking-wide text-navy-3">
+        <Link href="/settings" className="font-semibold text-gold hover:underline">
+          Settings
+        </Link>{" "}
+        / Attendance
+      </div>
+      <div className="mb-5 mt-2">
         <h1 className="font-display text-3xl font-semibold text-navy">
-          Attendance <em className="not-italic text-gold [font-style:italic]">rules.</em>
+          Attendance <em className="text-gold">settings</em>
         </h1>
         <p className="text-sm text-navy-3">
-          The daily schedule, the absence SMS, and when students get flagged. These drive
-          the attendance module.
+          School calendar, daily schedule, and the rules that drive flags &amp; SMS
+          {edited ? (
+            <>
+              {" · "}last edited <b className="font-semibold text-navy-2">{edited}</b>
+            </>
+          ) : null}
         </p>
       </div>
-      <div className="space-y-6">
-        <AttendanceSettingsForm initial={initial} />
-        <HolidaysManager holidays={holidays} />
+
+      {/* Default notice */}
+      <div className="mb-6 grid grid-cols-[24px_1fr] gap-3 rounded-xl border border-gold-soft bg-gold-bg p-4">
+        <span className="flex h-6 w-6 items-center justify-center rounded-full bg-gold font-display text-xs font-bold text-navy">
+          i
+        </span>
+        <p className="text-xs leading-relaxed text-navy-2">
+          <b className="font-semibold text-navy">
+            These are the Omnischools recommended defaults.
+          </b>{" "}
+          We&apos;ve calibrated them for typical Ghanaian basic schools — change them only if
+          you have a reason. Defaults are auditable; admins reviewing later can see what&apos;s
+          been changed.
+        </p>
       </div>
+
+      {/* Region 01 — School calendar */}
+      <SectionHead
+        num="01"
+        title="School calendar"
+        meta={term ? `${term.label} · ${fmtFull(term.startsOn)} — ${fmtFull(term.endsOn)}` : undefined}
+      />
+      {term ? (
+        <div className="space-y-4">
+          <TermCalendar term={term} holidays={holidays} today={today} />
+          <HolidaysManager holidays={holidays} termLabel={term.label} />
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
+            No active term — set term dates in onboarding or the term &amp; calendar settings to
+            see the calendar visual.
+          </p>
+          <HolidaysManager holidays={holidays} />
+        </div>
+      )}
+
+      {/* Region 02 — Daily schedule, marking & alert rules */}
+      <SectionHead num="02" title="Daily schedule, marking & alert rules" />
+      <AttendanceSettingsForm initial={initial} />
     </div>
   );
 }

--- a/omnischools/components/settings/holidays-manager.tsx
+++ b/omnischools/components/settings/holidays-manager.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { addSchoolHoliday, deleteSchoolHoliday } from "@/lib/actions/calendar";
 
@@ -7,33 +7,43 @@ const fieldClass =
   "rounded-md border border-border-2 bg-bg px-3 py-2 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
 const labelClass = "mb-1 block text-xs font-semibold text-navy-2";
 
-type Holiday = {
-  id: string;
-  name: string;
-  startsOn: string;
-  endsOn: string;
-  kind: string;
-};
+type Holiday = { id: string; name: string; startsOn: string; endsOn: string; kind: string };
 
 const KINDS = [
   { v: "PUBLIC", l: "Public holiday" },
-  { v: "BREAK", l: "Break" },
+  { v: "BREAK", l: "School-set" },
   { v: "EVENT", l: "School event" },
   { v: "EXAM", l: "Exam week" },
 ];
 const KIND_TONE: Record<string, string> = {
-  PUBLIC: "bg-terra-bg text-terra",
-  BREAK: "bg-warn-bg text-warn",
-  EVENT: "bg-gold-bg text-navy",
-  EXAM: "bg-navy text-bg",
+  PUBLIC: "border border-border-2 bg-bg text-navy-2",
+  BREAK: "bg-gold-bg text-gold",
+  EVENT: "bg-gold-bg text-gold",
+  EXAM: "bg-gold text-navy",
 };
-const fmt = (iso: string) =>
-  new Date(iso + "T00:00:00Z").toLocaleDateString("en-GB", {
-    day: "numeric",
-    month: "short",
-  });
+const kindLabel = (k: string) => KINDS.find((x) => x.v === k)?.l ?? k;
 
-export function HolidaysManager({ holidays }: { holidays: Holiday[] }) {
+const MON = (iso: string) =>
+  new Date(iso + "T00:00:00Z").toLocaleDateString("en-GB", { month: "short" }).toUpperCase();
+const D = (iso: string) => Number(iso.slice(8, 10));
+function dateCol(s: string, e: string) {
+  if (s === e) return `${D(s)} ${MON(s)}`;
+  if (MON(s) === MON(e)) return `${D(s)}—${D(e)} ${MON(s)}`;
+  return `${D(s)} ${MON(s)} — ${D(e)} ${MON(e)}`;
+}
+
+/** Display name with the last word in italic gold (surface `.h-name em`). */
+function HolidayName({ name }: { name: string }) {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length < 2) return <>{name}</>;
+  return (
+    <>
+      {parts.slice(0, -1).join(" ")} <em className="text-gold">{parts.at(-1)}</em>
+    </>
+  );
+}
+
+export function HolidaysManager({ holidays, termLabel }: { holidays: Holiday[]; termLabel?: string }) {
   const router = useRouter();
   const [name, setName] = useState("");
   const [startsOn, setStartsOn] = useState("");
@@ -41,6 +51,14 @@ export function HolidaysManager({ holidays }: { holidays: Holiday[] }) {
   const [kind, setKind] = useState("PUBLIC");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const formRef = useRef<HTMLDivElement>(null);
+
+  const startAdd = (k: string) => {
+    setKind(k);
+    setError(null);
+    formRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+    formRef.current?.querySelector("input")?.focus();
+  };
 
   async function add() {
     setBusy(true);
@@ -62,16 +80,25 @@ export function HolidaysManager({ holidays }: { holidays: Holiday[] }) {
   }
 
   return (
-    <section className="rounded-xl border border-border bg-surface p-6">
-      <h2 className="mb-1 font-display text-base font-semibold text-navy">
-        Holidays &amp; closures
-      </h2>
-      <p className="mb-4 text-xs text-navy-3">
-        Weekends are already excluded. Add public holidays, breaks, events and exam
-        weeks so the school-day counter and trends are accurate.
-      </p>
+    <div className="space-y-3">
+      {/* Calendar actions */}
+      <div className="flex flex-wrap items-center gap-2">
+        <CalBtn onClick={() => startAdd("PUBLIC")}>+ Add holiday</CalBtn>
+        <CalBtn onClick={() => startAdd("EVENT")}>+ Add school event</CalBtn>
+        <CalBtn onClick={() => startAdd("EXAM")}>+ Add exam week</CalBtn>
+        <span
+          title="Coming soon — GES public-holiday import"
+          className="ml-auto cursor-default rounded-md border border-border-2 bg-bg px-2.5 py-1.5 text-[11px] font-semibold text-navy-3 opacity-60"
+        >
+          ↓ Import GES public holidays
+        </span>
+      </div>
 
-      <div className="mb-4 grid grid-cols-1 gap-3 sm:grid-cols-[1.5fr_1fr_1fr_1fr_auto] sm:items-end">
+      {/* Add form */}
+      <div
+        ref={formRef}
+        className="grid grid-cols-1 gap-3 rounded-xl border border-border bg-surface p-4 sm:grid-cols-[1.5fr_1fr_1fr_1fr_auto] sm:items-end"
+      >
         <div>
           <label className={labelClass}>Name</label>
           <input
@@ -101,11 +128,7 @@ export function HolidaysManager({ holidays }: { holidays: Holiday[] }) {
         </div>
         <div>
           <label className={labelClass}>Type</label>
-          <select
-            value={kind}
-            onChange={(e) => setKind(e.target.value)}
-            className={`${fieldClass} w-full`}
-          >
+          <select value={kind} onChange={(e) => setKind(e.target.value)} className={`${fieldClass} w-full`}>
             {KINDS.map((k) => (
               <option key={k.v} value={k.v}>
                 {k.l}
@@ -121,40 +144,64 @@ export function HolidaysManager({ holidays }: { holidays: Holiday[] }) {
           Add
         </button>
       </div>
-      {error && <p className="mb-3 text-sm text-terra">{error}</p>}
+      {error && <p className="text-sm text-terra">{error}</p>}
 
-      {holidays.length === 0 ? (
-        <p className="rounded-lg border border-dashed border-border-2 bg-bg p-4 text-center text-sm text-navy-3">
-          No holidays added yet.
-        </p>
-      ) : (
-        <ul className="divide-y divide-border border-t border-border">
-          {holidays.map((h) => (
-            <li key={h.id} className="flex items-center justify-between gap-3 py-2.5">
-              <div className="min-w-0">
-                <span className="text-sm font-medium text-navy">{h.name}</span>
-                <span className="ml-2 text-xs text-navy-3">
-                  {fmt(h.startsOn)}
-                  {h.endsOn !== h.startsOn ? ` – ${fmt(h.endsOn)}` : ""}
+      {/* List */}
+      <div className="rounded-xl border border-border bg-surface p-4">
+        <div className="mb-2 flex items-center justify-between">
+          <span className="text-xs text-navy-2">
+            <b className="font-semibold text-navy">
+              {holidays.length} holiday{holidays.length === 1 ? "" : "s"} &amp; events
+            </b>
+            {termLabel ? ` in ${termLabel}` : ""}
+          </span>
+          <span className="text-[10px] italic text-navy-3">Sorted by date</span>
+        </div>
+        {holidays.length === 0 ? (
+          <p className="rounded-lg border border-dashed border-border-2 bg-bg p-4 text-center text-sm text-navy-3">
+            No holidays added yet.
+          </p>
+        ) : (
+          <ul className="divide-y divide-border border-t border-border">
+            {holidays.map((h) => (
+              <li
+                key={h.id}
+                className="grid grid-cols-[88px_1fr_auto_auto] items-center gap-3 py-2.5"
+              >
+                <span className="font-mono text-[11px] font-bold uppercase text-navy-2">
+                  {dateCol(h.startsOn, h.endsOn)}
                 </span>
-              </div>
-              <div className="flex shrink-0 items-center gap-3">
+                <span className="font-display text-[13px] font-semibold text-navy">
+                  <HolidayName name={h.name} />
+                </span>
                 <span
-                  className={`rounded-pill px-2 py-0.5 text-[11px] font-medium ${KIND_TONE[h.kind] ?? "bg-bg text-navy-3"}`}
+                  className={`rounded-pill px-2 py-0.5 text-[10px] font-bold uppercase ${KIND_TONE[h.kind] ?? "bg-bg text-navy-3"}`}
                 >
-                  {KINDS.find((k) => k.v === h.kind)?.l ?? h.kind}
+                  {kindLabel(h.kind)}
                 </span>
                 <button
                   onClick={() => remove(h.id)}
-                  className="text-xs font-semibold text-navy-3 transition-colors hover:text-terra"
+                  aria-label={`Delete ${h.name}`}
+                  className="flex h-6 w-6 items-center justify-center rounded-md bg-bg text-navy-3 transition-colors hover:text-terra"
                 >
-                  Remove
+                  ×
                 </button>
-              </div>
-            </li>
-          ))}
-        </ul>
-      )}
-    </section>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CalBtn({ onClick, children }: { onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      onClick={onClick}
+      className="rounded-md border border-border-2 bg-surface px-2.5 py-1.5 text-[11px] font-semibold text-navy hover:border-gold"
+    >
+      {children}
+    </button>
   );
 }

--- a/omnischools/components/settings/term-calendar.tsx
+++ b/omnischools/components/settings/term-calendar.tsx
@@ -1,0 +1,220 @@
+import { isHoliday, schoolDaysInRange, termDayProgress, type HolidayRange } from "@/lib/school-calendar";
+
+/**
+ * Region 01 "School calendar" visual for the attendance settings surface
+ * (Surfaces/schoolup-attendance-settings.html): a term boundary strip, a
+ * week-strip "term at a glance" grid with a 6-item legend, and inline
+ * full-width banners for multi-day holidays / exam weeks. Pure server render.
+ */
+
+const HATCH =
+  "repeating-linear-gradient(45deg,#FAF7F2,#FAF7F2 3px,#D4CCBA 3px,#D4CCBA 4px)";
+const DOW_LETTER = ["S", "M", "T", "W", "T", "F", "S"];
+
+const isoOf = (d: Date) => d.toISOString().slice(0, 10);
+const addDays = (iso: string, n: number) => {
+  const d = new Date(`${iso}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + n);
+  return isoOf(d);
+};
+const dowOf = (iso: string) => new Date(`${iso}T00:00:00Z`).getUTCDay();
+const dayNum = (iso: string) => Number(iso.slice(8, 10));
+const fmtShort = (iso: string) =>
+  new Date(`${iso}T00:00:00Z`).toLocaleDateString("en-GB", { day: "numeric", month: "short" });
+const fmtFull = (iso: string) =>
+  new Date(`${iso}T00:00:00Z`).toLocaleDateString("en-GB", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+
+type Kind = "school" | "weekend" | "holiday" | "exam" | "future" | "today";
+
+function kindOf(iso: string, today: string, holidays: HolidayRange[]): Kind {
+  if (iso === today) return "today";
+  const w = dowOf(iso);
+  if (w === 0 || w === 6) return "weekend";
+  const h = isHoliday(iso, holidays);
+  if (h) return h.kind === "EXAM" ? "exam" : "holiday";
+  if (iso > today) return "future";
+  return "school";
+}
+
+const BANNER: Record<string, (range: HolidayRange, days: number) => string> = {
+  PUBLIC: () => "public holiday · school closed",
+  BREAK: (_r, d) => `${d} school day${d === 1 ? "" : "s"} · whole week off`,
+  EVENT: () => "school event · attendance auto-marked",
+  EXAM: (_r, d) => `${d} day${d === 1 ? "" : "s"} · attendance still tracked`,
+};
+
+export function TermCalendar({
+  term,
+  holidays,
+  today,
+}: {
+  term: { label: string; startsOn: string; endsOn: string };
+  holidays: HolidayRange[];
+  today: string;
+}) {
+  const totalDays = schoolDaysInRange(term.startsOn, term.endsOn, holidays);
+  const progress = termDayProgress(term.startsOn, term.endsOn, today, holidays);
+  const counts = holidays.reduce<Record<string, number>>((m, h) => {
+    m[h.kind] = (m[h.kind] ?? 0) + 1;
+    return m;
+  }, {});
+  const holidayBlurb = (["PUBLIC", "BREAK", "EVENT", "EXAM"] as const)
+    .filter((k) => counts[k])
+    .map(
+      (k) =>
+        `${counts[k]} ${
+          { PUBLIC: "public", BREAK: "mid-term", EVENT: "event", EXAM: "exam" }[k]
+        }`,
+    )
+    .join(" · ");
+
+  // Build Monday-anchored weeks across the term.
+  const firstMonday = addDays(term.startsOn, -((dowOf(term.startsOn) + 6) % 7));
+  const weeks: { wk: number; start: string; days: string[] }[] = [];
+  let wk = 1;
+  for (let ws = firstMonday; ws <= term.endsOn; ws = addDays(ws, 7)) {
+    weeks.push({ wk, start: ws, days: Array.from({ length: 7 }, (_, i) => addDays(ws, i)) });
+    wk++;
+  }
+  const holidayFor = (weekStart: string) =>
+    holidays.filter((h) => h.startsOn >= weekStart && h.startsOn <= addDays(weekStart, 6));
+
+  const boundary = [
+    { lbl: "Term begins", val: fmtFull(term.startsOn).split(", ")[0], sub: "school days started" },
+    {
+      lbl: "Term ends",
+      val: fmtFull(term.endsOn).split(", ")[0],
+      sub: `${weeks.length} weeks · ${totalDays} school days`,
+    },
+    {
+      lbl: "Days marked so far",
+      val: `${progress.dayOf} of ${progress.total}`,
+      sub: progress.total ? `${Math.round((progress.dayOf / progress.total) * 100)}% through term` : "—",
+    },
+    {
+      lbl: "Holidays & closures",
+      val: `${holidays.length} noted`,
+      sub: holidayBlurb || "none yet",
+    },
+  ];
+
+  return (
+    <div className="space-y-4">
+      {/* Term boundary strip */}
+      <div className="grid grid-cols-2 gap-px overflow-hidden rounded-xl border border-border bg-border lg:grid-cols-4">
+        {boundary.map((c) => (
+          <div key={c.lbl} className="bg-surface p-4">
+            <div className="text-[9px] font-bold uppercase tracking-[0.16em] text-navy-3">
+              {c.lbl}
+            </div>
+            <div className="mt-1 font-display text-base font-semibold text-navy">{c.val}</div>
+            <div className="mt-0.5 font-mono text-[10px] font-semibold text-navy-3">{c.sub}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* Calendar strip */}
+      <div className="rounded-xl border border-border bg-surface p-4">
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+          <span className="text-[9px] font-bold uppercase tracking-[0.14em] text-navy-3">
+            Term at a glance
+          </span>
+          <div className="flex flex-wrap gap-2.5 text-[10px] text-navy-3">
+            <Legend swatch="bg-green border-green">School day</Legend>
+            <Legend swatch="bg-bg border-border-2">Weekend</Legend>
+            <Legend swatchStyle={{ backgroundImage: HATCH }}>Holiday</Legend>
+            <Legend swatch="bg-gold border-gold">Exam</Legend>
+            <Legend swatch="bg-surface border-dashed border-border-2">Future</Legend>
+          </div>
+        </div>
+        <div className="space-y-1.5">
+          {weeks.map((w) => {
+            const banners = holidayFor(w.start);
+            return (
+              <div key={w.start}>
+                <div className="grid grid-cols-[64px_1fr] items-center gap-2">
+                  <div className="leading-tight">
+                    <div className="font-display text-xs font-semibold text-navy">Wk {w.wk}</div>
+                    <div className="font-mono text-[9px] text-navy-3">{fmtShort(w.start)}</div>
+                  </div>
+                  <div className="grid grid-cols-7 gap-1">
+                    {w.days.map((d) => {
+                      const k = kindOf(d, today, holidays);
+                      const content =
+                        k === "holiday" || k === "exam" || k === "future"
+                          ? dayNum(d)
+                          : DOW_LETTER[dowOf(d)];
+                      const base =
+                        "flex h-7 items-center justify-center rounded font-display text-[11px] font-bold";
+                      const cls =
+                        k === "school"
+                          ? "bg-green text-white"
+                          : k === "exam"
+                            ? "bg-gold text-navy"
+                            : k === "weekend"
+                              ? "bg-bg text-navy-3"
+                              : k === "future"
+                                ? "border border-dashed border-border-2 bg-surface text-border-2"
+                                : k === "today"
+                                  ? "bg-green text-white outline outline-2 -outline-offset-2 outline-gold"
+                                  : "text-navy-3"; // holiday (hatch via style)
+                      return (
+                        <div
+                          key={d}
+                          title={fmtFull(d)}
+                          className={`${base} ${cls}`}
+                          style={k === "holiday" ? { backgroundImage: HATCH } : undefined}
+                        >
+                          {content}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+                {banners.map((h) => {
+                  const days = schoolDaysInRange(h.startsOn, h.endsOn, []);
+                  const exam = h.kind === "EXAM";
+                  return (
+                    <div
+                      key={h.startsOn + h.name}
+                      className={`mt-1.5 rounded-md border px-3 py-1.5 text-[10px] font-bold uppercase tracking-wide ${
+                        exam
+                          ? "border-gold-soft bg-gold-bg text-gold"
+                          : "border-dashed border-border-2 bg-bg text-navy-2"
+                      }`}
+                    >
+                      <span className="font-display normal-case italic text-gold">{h.name}</span>{" "}
+                      · {(BANNER[h.kind] ?? BANNER.PUBLIC)(h, days)}
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Legend({
+  swatch,
+  swatchStyle,
+  children,
+}: {
+  swatch?: string;
+  swatchStyle?: React.CSSProperties;
+  children: React.ReactNode;
+}) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span className={`h-3 w-3 rounded-[3px] border ${swatch ?? "border-border"}`} style={swatchStyle} />
+      {children}
+    </span>
+  );
+}


### PR DESCRIPTION
Rebuilds the attendance settings page toward `Surfaces/schoolup-attendance-settings.html`. This slice lands the **page structure + Region 01 "School calendar"** (the surface centerpiece). Regions 02/03 keep the existing functional form under a numbered head and get their full re-skin in the next slice.

## What changed
- **Page head** — "Settings / Attendance" crumb, Fraunces H1 "Attendance **settings**", lede with **"last edited {relative}"** (from `attendanceSettings.updatedAt`), and the gold **"recommended defaults"** notice card.
- **Numbered region heads** (01 / 02, Fraunces italic-gold) with meta.
- **Region 01 — `TermCalendar`** (new server component):
  - **Term boundary strip** — Term begins / ends (weeks + school days) / **days marked so far** (X of Y · % through term via `termDayProgress`) / holidays & closures (count + public/break/event/exam blurb)
  - **"Term at a glance" week-strip calendar** — Monday-anchored week rows × 7 day tiles (school green / weekend / **holiday hatch** / **exam gold** / future dashed / **today gold ring**), 5-item legend, and **inline full-width banners** for each holiday/exam with per-kind copy
  - **Re-skinned holidays manager** — mono date column (`13—17 APR`), Fraunces italic-gold names, surface-aligned type tags (Public neutral / School-set + School event gold-bg / Exam solid gold), "N holidays & events in {term} · Sorted by date" head, and calendar-action buttons (Add holiday / school event / exam week that prefill the form)

## Deferred (named)
- **Region 02/03 full re-skin** (schedule time-bar + per-field help, edit-window stepper, absence-SMS toggle + cost preview, flag-threshold steppers, sticky save bar) — **next slice**
- Term-selector pills, settings sub-tabs, holiday inline-edit + term-date edit (need new actions)
- GES holiday import (no data source); late/reassurance/auto-correction SMS toggles + daily-digest card + pattern-shift config (need new schema/infra) — **MVP2**

## Verification
`typecheck` + `lint` + `build` clean. Live against a seeded Semester 2 with 5 holidays (public/break/event/exam): boundary strip (**102 of 131 · 78%**), **29 week strips** with correct day-kind tiles, **all 5 inline banners** with per-kind copy, holidays list with mono date ranges + aligned tags. Zero console errors. Seeded holidays + temp scripts removed; term reverted. (Full-page screenshot timed out on the 29-week render; verified element-by-element via DOM instead.)

No schema/RLS changes — **nothing to paste on prod.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)