### PR TITLE
feat(attendance): settings — daily-schedule & alert-rules re-skin (R7)

### DIFF
--- a/omnischools/app/(app)/settings/attendance/page.tsx
+++ b/omnischools/app/(app)/settings/attendance/page.tsx
@@ -155,9 +155,8 @@ export default async function AttendanceSettingsPage() {
         </div>
       )}
 
-      {/* Region 02 — Daily schedule, marking & alert rules */}
-      <SectionHead num="02" title="Daily schedule, marking & alert rules" />
-      <AttendanceSettingsForm initial={initial} />
+      {/* Regions 02 & 03 — daily schedule + notifications (owned by the form) */}
+      <AttendanceSettingsForm initial={initial} schoolName={school.name} />
     </div>
   );
 }

--- a/omnischools/components/settings/attendance-settings-form.tsx
+++ b/omnischools/components/settings/attendance-settings-form.tsx
@@ -1,25 +1,134 @@
 "use client";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { cn } from "@/lib/utils";
 import { updateAttendanceSettings } from "@/lib/actions/attendance";
-import type { AttendanceSettings } from "@/lib/attendance-settings";
+import { ATTENDANCE_SETTINGS_DEFAULTS, type AttendanceSettings } from "@/lib/attendance-settings";
+import { FLAG_THRESHOLDS } from "@/lib/attendance-flags";
 
-const fieldClass =
-  "rounded-md border border-border-2 bg-bg px-3 py-2 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
-const labelClass = "mb-1 block text-xs font-semibold text-navy-2";
+/** Mirrors SMS_SEGMENT_RATE_GHS in lib/sms (server-only module — not imported here). */
+const SMS_SEGMENT_RATE_GHS = 0.035;
 
-export function AttendanceSettingsForm({ initial }: { initial: AttendanceSettings }) {
+const time12 = (hhmm: string) => {
+  const [h, m] = hhmm.split(":").map(Number);
+  const ap = h < 12 ? "AM" : "PM";
+  return `${h % 12 || 12}:${String(m).padStart(2, "0")} ${ap}`;
+};
+/** Position of a HH:MM time across the 6 AM–6 PM axis, as a 0–100 %. */
+const timePos = (hhmm: string) => {
+  const [h, m] = hhmm.split(":").map(Number);
+  return Math.max(0, Math.min(100, ((h * 60 + m - 360) / 720) * 100));
+};
+
+function SectionHead({ num, title, meta }: { num: string; title: string; meta?: string }) {
+  return (
+    <div className="mb-3 mt-8 flex flex-wrap items-baseline gap-3">
+      <span className="font-display text-xl font-semibold italic text-gold">{num}</span>
+      <h2 className="font-display text-lg font-semibold text-navy">{title}</h2>
+      {meta && <span className="text-[11px] uppercase tracking-wide text-navy-3">{meta}</span>}
+    </div>
+  );
+}
+
+function Stepper({
+  value,
+  onChange,
+  min,
+  max,
+  suffix,
+}: {
+  value: number;
+  onChange: (v: number) => void;
+  min: number;
+  max: number;
+  suffix?: string;
+}) {
+  const clamp = (v: number) => Math.max(min, Math.min(max, v));
+  return (
+    <span className="inline-flex items-center gap-1 rounded-pill border border-border-2 bg-bg px-1 py-0.5">
+      <button
+        type="button"
+        onClick={() => onChange(clamp(value - 1))}
+        className="flex h-6 w-6 items-center justify-center rounded-full text-navy-2 hover:bg-surface"
+      >
+        −
+      </button>
+      <span className="min-w-[3.5rem] text-center font-display text-[13px] font-semibold text-navy">
+        {value}
+        {suffix ? <em className="not-italic text-gold"> {suffix}</em> : null}
+      </span>
+      <button
+        type="button"
+        onClick={() => onChange(clamp(value + 1))}
+        className="flex h-6 w-6 items-center justify-center rounded-full text-navy-2 hover:bg-surface"
+      >
+        +
+      </button>
+    </span>
+  );
+}
+
+function Toggle({ on, onChange }: { on: boolean; onChange: (v: boolean) => void }) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={on}
+      onClick={() => onChange(!on)}
+      className={cn(
+        "relative h-6 w-11 shrink-0 rounded-full transition-colors",
+        on ? "bg-green" : "bg-border-2",
+      )}
+    >
+      <span
+        className={cn(
+          "absolute top-0.5 h-5 w-5 rounded-full bg-white shadow-sm transition-all",
+          on ? "left-[22px]" : "left-0.5",
+        )}
+      />
+    </button>
+  );
+}
+
+const FIELD_LABEL: Record<keyof AttendanceSettings, string> = {
+  dayStart: "Day starts",
+  lateThreshold: "Late after",
+  dayEnd: "Day ends",
+  editWindowHours: "Edit window",
+  absenceSms: "Absence SMS",
+  absWatchDays: "Long-absence watch",
+  absCriticalDays: "Long-absence critical",
+  pctWatch: "Below-watch",
+  pctCritical: "Below-critical",
+};
+
+function display(k: keyof AttendanceSettings, v: AttendanceSettings[keyof AttendanceSettings]) {
+  if (k === "absenceSms") return v ? "on" : "off";
+  if (k === "dayStart" || k === "lateThreshold" || k === "dayEnd") return time12(String(v));
+  if (k === "editWindowHours") return `${v}h`;
+  if (k === "pctWatch" || k === "pctCritical") return `${v}%`;
+  return `${v}`;
+}
+
+export function AttendanceSettingsForm({
+  initial,
+  schoolName,
+}: {
+  initial: AttendanceSettings;
+  schoolName: string;
+}) {
   const router = useRouter();
   const [s, setS] = useState<AttendanceSettings>(initial);
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
 
   const set = <K extends keyof AttendanceSettings>(k: K, v: AttendanceSettings[K]) =>
-    setS((prev) => ({ ...prev, [k]: v }));
-  const num = (k: keyof AttendanceSettings) => (e: { target: { value: string } }) =>
-    set(k, Number(e.target.value) as never);
+    setS((p) => ({ ...p, [k]: v }));
 
-  const dirty = JSON.stringify(s) !== JSON.stringify(initial);
+  const changed = (Object.keys(initial) as (keyof AttendanceSettings)[]).filter(
+    (k) => s[k] !== initial[k],
+  );
+  const dirty = changed.length > 0;
 
   async function save() {
     setBusy(true);
@@ -33,153 +142,278 @@ export function AttendanceSettingsForm({ initial }: { initial: AttendanceSetting
   }
 
   return (
-    <div className="space-y-6">
-      {/* Daily schedule */}
-      <section className="rounded-xl border border-border bg-surface p-6">
-        <h2 className="mb-1 font-display text-base font-semibold text-navy">
-          Daily schedule &amp; marking
-        </h2>
-        <p className="mb-4 text-xs text-navy-3">
-          When the school day runs, and how long teachers can edit a submitted register.
-        </p>
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-          <div>
-            <label className={labelClass}>Day starts</label>
-            <input
-              type="time"
-              value={s.dayStart}
-              onChange={(e) => set("dayStart", e.target.value)}
-              className={`${fieldClass} w-full`}
-            />
-          </div>
-          <div>
-            <label className={labelClass}>Late after</label>
-            <input
-              type="time"
-              value={s.lateThreshold}
-              onChange={(e) => set("lateThreshold", e.target.value)}
-              className={`${fieldClass} w-full`}
-            />
-          </div>
-          <div>
-            <label className={labelClass}>Day ends</label>
-            <input
-              type="time"
-              value={s.dayEnd}
-              onChange={(e) => set("dayEnd", e.target.value)}
-              className={`${fieldClass} w-full`}
-            />
-          </div>
-          <div>
-            <label className={labelClass}>Edit window (hrs)</label>
-            <input
-              type="number"
-              min={0}
-              max={336}
-              value={s.editWindowHours}
-              onChange={num("editWindowHours")}
-              className={`${fieldClass} w-full`}
-            />
-          </div>
-        </div>
-        <p className="mt-2 text-[11px] text-navy-3">
-          After the edit window closes, changes to a register require an approved
-          correction request.
-        </p>
-      </section>
+    <div className="pb-24">
+      {/* ── Region 02 — Daily schedule & marking ─────────────────── */}
+      <SectionHead num="02" title="Daily schedule & marking" meta={`how late is "late"`} />
 
-      {/* Notifications */}
-      <section className="rounded-xl border border-border bg-surface p-6">
-        <h2 className="mb-3 font-display text-base font-semibold text-navy">
-          Notifications
-        </h2>
-        <label className="flex items-start gap-2.5 text-sm">
-          <input
-            type="checkbox"
-            checked={s.absenceSms}
-            onChange={(e) => set("absenceSms", e.target.checked)}
-            className="mt-0.5 h-4 w-4 accent-navy"
+      <div className="rounded-xl border border-border bg-surface p-6">
+        <h3 className="font-display text-lg font-semibold text-navy">
+          A <em className="text-gold">typical</em> day at {schoolName}
+        </h3>
+        <p className="mb-6 text-xs text-navy-3">Edit the times below; the bar follows along.</p>
+
+        {/* Time bar */}
+        <div className="relative mx-1 mb-1 mt-8 h-3 rounded-full bg-bg">
+          <div
+            className="absolute h-3 rounded-full bg-green/30"
+            style={{ left: `${timePos(s.dayStart)}%`, width: `${timePos(s.dayEnd) - timePos(s.dayStart)}%` }}
           />
-          <span className="text-navy-2">
-            Send an absence SMS to the primary guardian when a student is marked absent
-            <span className="mt-0.5 block text-xs text-navy-3">
-              Sent on save. Turn off to mark absences without notifying guardians.
-            </span>
-          </span>
-        </label>
-      </section>
-
-      {/* Flag thresholds */}
-      <section className="rounded-xl border border-border bg-surface p-6">
-        <h2 className="mb-1 font-display text-base font-semibold text-navy">
-          Attention flags
-        </h2>
-        <p className="mb-4 text-xs text-navy-3">
-          When a student is flagged on the dashboard. Critical must be at least as strict
-          as Watching.
-        </p>
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-          <div>
-            <label className={labelClass}>Long absence · watch (days)</label>
-            <input
-              type="number"
-              min={1}
-              max={30}
-              value={s.absWatchDays}
-              onChange={num("absWatchDays")}
-              className={`${fieldClass} w-full`}
-            />
-          </div>
-          <div>
-            <label className={labelClass}>Long absence · critical (days)</label>
-            <input
-              type="number"
-              min={1}
-              max={60}
-              value={s.absCriticalDays}
-              onChange={num("absCriticalDays")}
-              className={`${fieldClass} w-full`}
-            />
-          </div>
-          <div>
-            <label className={labelClass}>Below · watch (%)</label>
-            <input
-              type="number"
-              min={1}
-              max={100}
-              value={s.pctWatch}
-              onChange={num("pctWatch")}
-              className={`${fieldClass} w-full`}
-            />
-          </div>
-          <div>
-            <label className={labelClass}>Below · critical (%)</label>
-            <input
-              type="number"
-              min={1}
-              max={100}
-              value={s.pctCritical}
-              onChange={num("pctCritical")}
-              className={`${fieldClass} w-full`}
-            />
-          </div>
+          {[
+            { t: s.dayStart, lbl: "Day starts", color: "border-green" },
+            { t: s.lateThreshold, lbl: "Late after", color: "border-gold" },
+            { t: s.dayEnd, lbl: "Day ends", color: "border-terra" },
+          ].map((m) => (
+            <div
+              key={m.lbl}
+              className="absolute -translate-x-1/2"
+              style={{ left: `${timePos(m.t)}%`, top: "-2px" }}
+            >
+              <div className="absolute bottom-5 left-1/2 -translate-x-1/2 whitespace-nowrap text-center">
+                <div className="font-mono text-[11px] font-semibold text-navy">{time12(m.t)}</div>
+              </div>
+              <div className={cn("h-[22px] w-[22px] rounded-full border-[2.5px] bg-surface", m.color)} />
+              <div className="absolute top-6 left-1/2 -translate-x-1/2 whitespace-nowrap text-center text-[9px] font-bold uppercase tracking-wide text-navy-3">
+                {m.lbl}
+              </div>
+            </div>
+          ))}
         </div>
-      </section>
+        <div className="mt-10 flex justify-between font-mono text-[9px] text-navy-3">
+          {["6 AM", "8 AM", "10 AM", "12 PM", "2 PM", "4 PM", "6 PM"].map((h) => (
+            <span key={h}>{h}</span>
+          ))}
+        </div>
 
-      <div className="flex items-center gap-3">
-        <button
-          onClick={save}
-          disabled={busy || !dirty}
-          className="rounded-md bg-navy px-5 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-50"
-        >
-          {busy ? "Saving…" : "Save settings"}
-        </button>
-        {msg && (
-          <span className={`text-sm ${msg.ok ? "text-green" : "text-terra"}`}>
-            {msg.text}
-          </span>
-        )}
+        {/* Schedule controls */}
+        <div className="mt-6 grid grid-cols-1 gap-5 sm:grid-cols-3">
+          {[
+            {
+              k: "dayStart" as const,
+              label: "School day starts",
+              help: "Time before which students must arrive to be marked Present.",
+            },
+            {
+              k: "lateThreshold" as const,
+              label: "Late threshold",
+              help: "Students arriving after this are marked Late instead of Present.",
+            },
+            {
+              k: "dayEnd" as const,
+              label: "School day ends",
+              help: "Used for the daily auto-SMS to absent students' guardians.",
+            },
+          ].map((f) => (
+            <div key={f.k}>
+              <label className="mb-1 block text-[10px] font-bold uppercase tracking-[0.14em] text-navy-3">
+                {f.label}
+              </label>
+              <input
+                type="time"
+                value={s[f.k]}
+                onChange={(e) => set(f.k, e.target.value)}
+                className="w-full rounded-md border border-border-2 bg-bg px-3 py-2 font-mono text-sm font-semibold text-navy outline-none focus:border-gold focus:bg-surface"
+              />
+              <p className="mt-1 text-[11px] italic text-navy-3">{f.help}</p>
+            </div>
+          ))}
+        </div>
       </div>
+
+      {/* Edit-window card */}
+      <div className="mt-4 flex flex-wrap items-center justify-between gap-4 rounded-xl border border-border bg-surface p-6">
+        <div className="max-w-xl">
+          <div className="font-display text-sm font-semibold text-navy">
+            Register edit <em className="text-gold">window</em>
+          </div>
+          <p className="mt-1 text-xs text-navy-3">
+            After a register is submitted, teachers can edit it freely for this long. After the
+            window closes, edits require <b className="font-semibold text-navy-2">your approval</b>{" "}
+            through the edit-request flow.
+          </p>
+        </div>
+        <Stepper
+          value={s.editWindowHours}
+          onChange={(v) => set("editWindowHours", v)}
+          min={0}
+          max={336}
+          suffix="hours"
+        />
+      </div>
+
+      {/* ── Region 03 — Notifications & alert rules ──────────────── */}
+      <SectionHead num="03" title="Notifications & alert rules" meta="what the system says to whom" />
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {/* SMS to parents */}
+        <div className="rounded-xl border border-border bg-surface p-5">
+          <div className="text-[9px] font-bold uppercase tracking-[0.14em] text-gold">
+            SMS to parents
+          </div>
+          <h3 className="mt-1 font-display text-base font-semibold text-navy">
+            When to <em className="text-gold">auto-message</em> guardians
+          </h3>
+          <p className="mt-1 text-xs text-navy-3">
+            Short SMS sent automatically to a guardian when their child&apos;s attendance changes.
+            Each costs{" "}
+            <b className="font-semibold text-navy-2">GHS {SMS_SEGMENT_RATE_GHS.toFixed(3)}</b> per
+            recipient · sent through your school&apos;s SMS account.
+          </p>
+          <div className="mt-3 flex items-start justify-between gap-3 rounded-lg border border-border bg-bg p-3">
+            <div className="min-w-0">
+              <div className="text-[13px] font-bold text-navy">
+                Absence SMS · end of day
+              </div>
+              <p className="mt-0.5 text-[11px] italic text-navy-3">
+                &ldquo;James was absent today. Please contact the school if there is a reason.&rdquo;
+                Sent to guardians of absent students when you submit the register.
+              </p>
+            </div>
+            <Toggle on={s.absenceSms} onChange={(v) => set("absenceSms", v)} />
+          </div>
+          <p className="mt-2 text-[11px] text-navy-3">
+            Late-arrival, reassurance and auto-correction SMS are on the roadmap.
+          </p>
+        </div>
+
+        {/* Pattern detection */}
+        <div className="rounded-xl border border-border bg-surface p-5">
+          <div className="text-[9px] font-bold uppercase tracking-[0.14em] text-gold">
+            Pattern detection
+          </div>
+          <h3 className="mt-1 font-display text-base font-semibold text-navy">
+            When the system <em className="text-gold">flags</em> a student
+          </h3>
+          <p className="mt-1 text-xs text-navy-3">
+            Evaluated at end of day, after registers close. New flags appear next morning on your
+            dashboard.
+          </p>
+
+          <FlagBlock letter="L" tone="text-terra" title="Long absence">
+            <RuleRow severity="watching" text={`at ${s.absWatchDays}+ consecutive absent days`}>
+              <Stepper value={s.absWatchDays} onChange={(v) => set("absWatchDays", v)} min={1} max={30} suffix="d" />
+            </RuleRow>
+            <RuleRow severity="critical" text={`at ${s.absCriticalDays}+ consecutive absent days`}>
+              <Stepper value={s.absCriticalDays} onChange={(v) => set("absCriticalDays", v)} min={1} max={60} suffix="d" />
+            </RuleRow>
+          </FlagBlock>
+
+          <FlagBlock letter="B" tone="text-warn" title="Below threshold">
+            <RuleRow severity="watching" text={`term attendance drops below ${s.pctWatch}%`}>
+              <Stepper value={s.pctWatch} onChange={(v) => set("pctWatch", v)} min={1} max={100} suffix="%" />
+            </RuleRow>
+            <RuleRow severity="critical" text={`term attendance drops below ${s.pctCritical}%`}>
+              <Stepper value={s.pctCritical} onChange={(v) => set("pctCritical", v)} min={1} max={100} suffix="%" />
+            </RuleRow>
+          </FlagBlock>
+
+          <FlagBlock letter="P" tone="text-gold" title="Pattern shift">
+            <RuleRow severity="watching" text={`drop of ${FLAG_THRESHOLDS.dropPct}%+ over rolling 14 days`} />
+            <RuleRow
+              severity="watching"
+              text={`same-day-of-week pattern · ${FLAG_THRESHOLDS.dowMiss} of ${FLAG_THRESHOLDS.dowWindow}`}
+            />
+            <p className="mt-1 text-[10px] italic text-navy-3">Fixed defaults — not yet adjustable.</p>
+          </FlagBlock>
+        </div>
+      </div>
+
+      {/* ── Sticky save bar ──────────────────────────────────────── */}
+      <div className="sticky bottom-0 z-10 mt-6 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-border bg-surface px-5 py-3 shadow-sm">
+        <div className="flex min-w-0 flex-wrap items-center gap-2 text-[11px]">
+          {dirty ? (
+            <>
+              <span className="rounded-pill bg-terra-bg px-2 py-0.5 text-[9px] font-bold uppercase text-terra">
+                {changed.length} unsaved change{changed.length === 1 ? "" : "s"}
+              </span>
+              <span className="text-navy-2">
+                {changed
+                  .map(
+                    (k) => `${FIELD_LABEL[k]}: ${display(k, initial[k])} → ${display(k, s[k])}`,
+                  )
+                  .join(" · ")}
+              </span>
+            </>
+          ) : (
+            <span className="text-navy-3">No unsaved changes.</span>
+          )}
+          {msg && (
+            <span className={msg.ok ? "text-green" : "text-terra"}>{msg.text}</span>
+          )}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setS(ATTENDANCE_SETTINGS_DEFAULTS)}
+            className="rounded-md px-3 py-2 text-xs font-semibold text-navy-3 hover:text-gold"
+          >
+            Reset to defaults
+          </button>
+          <button
+            type="button"
+            onClick={() => setS(initial)}
+            disabled={!dirty}
+            className="rounded-md border border-border-2 bg-bg px-3 py-2 text-sm font-semibold text-navy disabled:opacity-50"
+          >
+            Discard
+          </button>
+          <button
+            onClick={save}
+            disabled={busy || !dirty}
+            className="rounded-md bg-navy px-5 py-2 text-sm font-bold text-bg transition-colors hover:bg-navy-deep disabled:opacity-50"
+          >
+            {busy ? "Saving…" : "Save changes"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function FlagBlock({
+  letter,
+  tone,
+  title,
+  children,
+}: {
+  letter: string;
+  tone: string;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="mt-3 rounded-lg border border-border bg-bg p-3">
+      <div className="mb-2 flex items-center gap-2 text-[11px] font-bold text-navy">
+        <span className={cn("font-display", tone)}>{letter}</span>
+        {title}
+      </div>
+      <div className="space-y-1.5">{children}</div>
+    </div>
+  );
+}
+
+function RuleRow({
+  severity,
+  text,
+  children,
+}: {
+  severity: "watching" | "critical";
+  text: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <div className="flex min-w-0 items-center gap-2">
+        <span
+          className={cn(
+            "shrink-0 rounded-pill px-2 py-0.5 text-[9px] font-bold uppercase",
+            severity === "critical" ? "bg-terra-bg text-terra" : "bg-warn-bg text-warn",
+          )}
+        >
+          {severity}
+        </span>
+        <span className="text-[11px] text-navy-2">{text}</span>
+      </div>
+      {children}
     </div>
   );
 }


### PR DESCRIPTION
Finishes the attendance settings surface (`Surfaces/schoolup-attendance-settings.html`) by re-skinning **Regions 02 & 03** — pairs with R6 ([#81](https://github.com/Omnischools/omnischools/pull/81), Region 01 calendar). The form now owns its own numbered region heads.

## Region 02 — Daily schedule & marking
- **"A typical day at {school}"** schedule card with a colour-coded **time-bar** — green school-zone fill + 3 markers (Day starts green / Late after gold / Day ends terra) positioned across a 6 AM–6 PM axis + hour axis.
- The three time inputs gain **per-field consequence help** (Present / Late / daily auto-SMS).
- **Edit window** moved into a labelled **stepper** card (`24 hours`, − / +) with the "require your approval" copy.

## Region 03 — Notifications & alert rules (2-col)
- **SMS to parents**: the absence-SMS setting as a green **pill toggle** with the sample message + **per-recipient cost** (`GHS 0.035 per recipient`, mirroring `SMS_SEGMENT_RATE_GHS`).
- **Pattern detection**: the four existing thresholds (long-absence watch/critical days, below watch/critical %) as **severity-pill rule rows with mini-steppers**; the **pattern-shift** rules (30% rolling drop, 4-of-6 day-of-week) shown **read-only** from `FLAG_THRESHOLDS` ("fixed defaults — not yet adjustable").
- **Sticky save bar**: "{n} unsaved changes" pill + **old→new diff** summary, Reset to defaults, Discard, Save changes. Same `updateAttendanceSettings` action + validation.

## Deferred (named, MVP2 / need infra)
Late-arrival / reassurance / auto-correction SMS toggles + daily-digest card (new schema + scheduled send); per-day SMS cost estimates (need avg-absentee analytics); making pattern-shift thresholds editable; term-selector pills, settings sub-tabs, holiday inline-edit + term-date edit (new actions); GES holiday import.

## Verification
`typecheck` + `lint` + `build` clean. Live on a seeded settings row: time-bar markers (8:00/8:15/3:00), per-field help, edit-window stepper, SMS toggle + cost, L/B steppers + read-only P rows. Toggling SMS + bumping a stepper showed **"2 unsaved changes · Absence SMS: on → off · Long-absence watch: 3 → 4"**, and **Save persisted** (reload shows "4+ consecutive", SMS off). Zero console errors. Seeded settings row removed; term reverted; temp scripts removed.

No schema/RLS changes — **nothing to paste on prod.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)