### PR TITLE
feat(reports): catalogue hub + detail routes (R1)

### DIFF
--- a/omnischools/app/(app)/reports/discounts/page.tsx
+++ b/omnischools/app/(app)/reports/discounts/page.tsx
@@ -1,0 +1,137 @@
+import { requireSchool } from "@/lib/auth/server";
+import { getFinanceReport, ghs, num, ordinal } from "@/lib/reports/finance-data";
+import { ExportCsv } from "@/components/reports/export-csv";
+import { PrintButton } from "@/components/reports/print-button";
+import { ReportHeader } from "@/components/reports/report-header";
+import { schoolFile } from "@/lib/filename";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Discounts given" };
+
+export default async function DiscountsPage() {
+  const { school } = await requireSchool();
+  const r = await getFinanceReport(school.id, null);
+
+  const catName = new Map(r.catRows.map((c) => [c.id, c.name]));
+  const tiersByDiscount = new Map<string, { rank: number; value: number }[]>();
+  for (const t of r.discTierRows) {
+    const arr = tiersByDiscount.get(t.discountId) ?? [];
+    arr.push({ rank: t.rank, value: num(t.value) });
+    tiersByDiscount.set(t.discountId, arr);
+  }
+  const valueText = (d: (typeof r.discRows)[number]) => {
+    if (d.isTiered) {
+      return (tiersByDiscount.get(d.id) ?? [])
+        .sort((a, b) => a.rank - b.rank)
+        .map((t) => `${ordinal(t.rank)} ${d.kind === "PERCENT" ? `${t.value}%` : ghs(t.value)}`)
+        .join(" · ");
+    }
+    return d.kind === "PERCENT" ? `${num(d.value)}%` : ghs(num(d.value));
+  };
+
+  return (
+    <div className="mx-auto max-w-page">
+      <ReportHeader
+        crumb="Discounts given"
+        pre="Discounts"
+        gold="given"
+        lede="The fees you chose not to collect — by tier and by recipient."
+        actions={
+          <>
+            {r.discRows.length > 0 && (
+              <ExportCsv
+                filename={schoolFile(school.name, "discounts.csv")}
+                headers={["Discount", "Value", "Applies to", "Tiered", "Approval", "Applied"]}
+                rows={r.discRows.map((d) => [
+                  d.name,
+                  valueText(d),
+                  d.appliesToCategoryId ? (catName.get(d.appliesToCategoryId) ?? "Whole invoice") : "Whole invoice",
+                  d.isTiered ? "Yes" : "No",
+                  d.requiresApproval ? (d.approvedAt ? "Approved" : "Pending") : "—",
+                  String(d.appliedCount),
+                ])}
+              />
+            )}
+            <PrintButton label="Export PDF" />
+          </>
+        }
+      />
+
+      <div className="mb-6 grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <div className="rounded-xl border border-navy bg-navy p-5">
+          <div className="text-[10px] font-bold uppercase tracking-[0.1em] text-gold-soft">Total discounted</div>
+          <div className="mt-1.5 font-display text-2xl font-semibold text-bg">{ghs(r.discountTotal)}</div>
+          <div className="mt-0.5 text-xs text-bg/60">
+            {r.billed > 0 ? `${Math.round((r.discountTotal / r.billed) * 100)}% of total billed` : "no invoices yet"}
+          </div>
+        </div>
+        <Kpi label="Discounted invoices" value={String(r.discountedCount)} sub="this period" />
+        <Kpi label="Discounts configured" value={String(r.discRows.length)} sub="active rules" />
+        <Kpi
+          label="Tiered discounts"
+          value={String(r.discRows.filter((d) => d.isTiered).length)}
+          sub="e.g. sibling 1st/2nd/3rd"
+        />
+      </div>
+
+      <h2 className="mb-3 font-display text-lg font-semibold text-navy">Discounts in effect</h2>
+      {r.discRows.length === 0 ? (
+        <Empty>No discounts configured. Set them up under Billing.</Empty>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-border bg-surface">
+          <table className="w-full text-sm">
+            <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
+              <tr>
+                <th className="px-4 py-3 font-semibold">Discount</th>
+                <th className="px-4 py-3 font-semibold">Value</th>
+                <th className="px-4 py-3 font-semibold">Applies to</th>
+                <th className="px-4 py-3 text-right font-semibold">Applied</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {r.discRows.map((d) => (
+                <tr key={d.id} className="hover:bg-bg">
+                  <td className="px-4 py-3 font-medium text-navy">
+                    {d.name}
+                    {d.requiresApproval && !d.approvedAt && (
+                      <span className="ml-2 rounded-pill bg-warn-bg px-2 py-0.5 text-[11px] font-medium text-warn">
+                        Pending approval
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-navy-2">{valueText(d)}</td>
+                  <td className="px-4 py-3 text-navy-2">
+                    {d.appliesToCategoryId ? (catName.get(d.appliesToCategoryId) ?? "Whole invoice") : "Whole invoice"}
+                  </td>
+                  <td className="px-4 py-3 text-right font-mono text-navy-2">{d.appliedCount}×</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+      <p className="mt-3 text-xs italic text-navy-3">
+        Per-application breakdown (tier shares, timeline, top recipients, per-student rows) needs a
+        discount-application table — flagged for a schema-backed slice.
+      </p>
+    </div>
+  );
+}
+
+function Kpi({ label, value, sub }: { label: string; value: string; sub: string }) {
+  return (
+    <div className="rounded-xl border border-border bg-surface p-5">
+      <div className="text-[10px] font-bold uppercase tracking-[0.1em] text-navy-3">{label}</div>
+      <div className="mt-1.5 font-display text-2xl font-semibold text-navy">{value}</div>
+      <div className="mt-0.5 text-xs text-navy-3">{sub}</div>
+    </div>
+  );
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
+      {children}
+    </p>
+  );
+}

--- a/omnischools/app/(app)/reports/finance/collection-trend/page.tsx
+++ b/omnischools/app/(app)/reports/finance/collection-trend/page.tsx
@@ -1,0 +1,93 @@
+import Link from "next/link";
+import { requireSchool } from "@/lib/auth/server";
+import { getFinanceReport, ghs, num } from "@/lib/reports/finance-data";
+import { ExportCsv } from "@/components/reports/export-csv";
+import { PrintButton } from "@/components/reports/print-button";
+import { ReportHeader } from "@/components/reports/report-header";
+import { schoolFile } from "@/lib/filename";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Collection trend" };
+
+export default async function CollectionTrendPage() {
+  const { school } = await requireSchool();
+  const r = await getFinanceReport(school.id, null);
+  const maxMonth = Math.max(1, ...r.monthly.map((m) => num(m.amount)));
+  const peak = r.monthly.reduce((p, m) => (num(m.amount) > num(p?.amount ?? 0) ? m : p), r.monthly[0]);
+
+  return (
+    <div className="mx-auto max-w-page">
+      <ReportHeader
+        crumb="Finance / Collection trend"
+        pre="Collection"
+        gold="trend"
+        lede="Collection timing and pace across the period."
+        actions={
+          <>
+            <ExportCsv
+              filename={schoolFile(school.name, "collection-trend.csv")}
+              headers={["Month", "Collected"]}
+              rows={r.monthly.map((m) => [m.month, num(m.amount).toFixed(2)])}
+            />
+            <PrintButton label="Export PDF" />
+            <Link
+              href="/reports/outstanding"
+              className="rounded-md bg-navy px-3 py-2 text-sm font-semibold text-bg hover:bg-navy-deep"
+            >
+              Open balances report →
+            </Link>
+          </>
+        }
+      />
+
+      <div className="mb-6 grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <Kpi featured label="Collected to date" value={ghs(r.collected)} sub={`${r.rate}% of ${ghs(r.billed)} invoiced`} />
+        <Kpi label="Still outstanding" value={ghs(r.outstanding)} tone="text-terra" sub="across all classes" />
+        <Kpi label="Collection rate" value={`${r.rate}%`} sub={r.rate >= 80 ? "healthy" : "needs follow-up"} />
+        <Kpi label="Peak month" value={peak ? ghs(num(peak.amount)) : "—"} sub={peak?.month ?? "no payments yet"} />
+      </div>
+
+      <h2 className="mb-3 font-display text-lg font-semibold text-navy">Collection over time</h2>
+      {r.monthly.length === 0 ? (
+        <Empty>No payments recorded yet.</Empty>
+      ) : (
+        <div className="space-y-2 rounded-xl border border-border bg-surface p-5">
+          {r.monthly.map((m) => {
+            const isPeak = m.month === peak?.month;
+            return (
+              <div key={m.month} className="flex items-center gap-3">
+                <span className="w-16 shrink-0 font-mono text-xs text-navy-3">{m.month}</span>
+                <div className="h-5 flex-1 overflow-hidden rounded-full bg-bg">
+                  <div className={`h-full rounded-full ${isPeak ? "bg-green" : "bg-gold"}`} style={{ width: `${(num(m.amount) / maxMonth) * 100}%` }} />
+                </div>
+                <span className="w-28 shrink-0 text-right text-xs font-medium text-navy-2">{ghs(num(m.amount))}</span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+      <p className="mt-3 text-xs italic text-navy-3">
+        Term-on-term cumulative overlay, weekly grid and aging-by-household are coming in a later
+        slice (needs a completed prior term).
+      </p>
+    </div>
+  );
+}
+
+function Kpi({ label, value, sub, tone, featured }: { label: string; value: string; sub: string; tone?: string; featured?: boolean }) {
+  return (
+    <div className={`rounded-xl border p-5 ${featured ? "border-navy bg-navy" : "border-border bg-surface"}`}>
+      <div className={`text-[10px] font-bold uppercase tracking-[0.1em] ${featured ? "text-gold-soft" : "text-navy-3"}`}>{label}</div>
+      <div className={`mt-1.5 font-display text-2xl font-semibold ${featured ? "text-bg" : (tone ?? "text-navy")}`}>{value}</div>
+      <div className={`mt-0.5 text-xs ${featured ? "text-bg/60" : "text-navy-3"}`}>{sub}</div>
+    </div>
+  );
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
+      {children}
+    </p>
+  );
+}

--- a/omnischools/app/(app)/reports/outstanding/page.tsx
+++ b/omnischools/app/(app)/reports/outstanding/page.tsx
@@ -1,0 +1,131 @@
+import Link from "next/link";
+import { requireSchool } from "@/lib/auth/server";
+import { getFinanceReport, ghs, num, AGING } from "@/lib/reports/finance-data";
+import { ExportCsv } from "@/components/reports/export-csv";
+import { PrintButton } from "@/components/reports/print-button";
+import { ReportHeader } from "@/components/reports/report-header";
+import { schoolFile } from "@/lib/filename";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Outstanding balances" };
+
+export default async function OutstandingPage() {
+  const { school } = await requireSchool();
+  const r = await getFinanceReport(school.id, null);
+  const agingMax = Math.max(1, ...AGING.map((b) => r.agingMap.get(b.key)?.amount ?? 0));
+  const debtors = r.byClass.filter((c) => num(c.outstanding) > 0);
+
+  return (
+    <div className="mx-auto max-w-page">
+      <ReportHeader
+        crumb="Outstanding balances"
+        pre="Who hasn't"
+        gold="paid"
+        lede="Unpaid balances grouped by how far past due they are."
+        actions={
+          <>
+            <ExportCsv
+              filename={schoolFile(school.name, "outstanding.csv")}
+              headers={["Bucket", "Outstanding", "Invoices"]}
+              rows={AGING.map((b) => {
+                const a = r.agingMap.get(b.key);
+                return [b.label, num(a?.amount).toFixed(2), String(a?.count ?? 0)];
+              })}
+            />
+            <PrintButton label="Export PDF" />
+          </>
+        }
+      />
+
+      {/* Hero callout */}
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-4 rounded-xl border border-terra/40 bg-terra-bg/40 p-5">
+        <div>
+          <div className="text-[10px] font-bold uppercase tracking-[0.1em] text-navy-3">
+            Currently outstanding
+          </div>
+          <div className="mt-1 font-display text-3xl font-semibold text-terra">
+            {ghs(r.outstanding)}
+          </div>
+        </div>
+        <p className="max-w-sm text-sm text-navy-3">
+          <b className="text-terra">{ghs(r.overdueTotal)}</b> of it is overdue ·{" "}
+          <b className="text-navy-2">{r.overdue30PlusCount}</b> student
+          {r.overdue30PlusCount === 1 ? "" : "s"} are overdue 30+ days.
+        </p>
+      </div>
+
+      {/* Aging strip */}
+      {r.outstanding <= 0 ? (
+        <Empty>Nothing outstanding — every invoice is settled.</Empty>
+      ) : (
+        <div className="rounded-xl border border-border bg-surface p-5">
+          <div className="space-y-2">
+            {AGING.map((b) => {
+              const a = r.agingMap.get(b.key);
+              const amt = a?.amount ?? 0;
+              return (
+                <div key={b.key} className="flex items-center gap-3">
+                  <span className="w-40 shrink-0 text-xs text-navy-2">{b.label}</span>
+                  <div className="h-5 flex-1 overflow-hidden rounded-full bg-bg">
+                    <div className={`h-full rounded-full ${b.tone}`} style={{ width: `${(amt / agingMax) * 100}%` }} />
+                  </div>
+                  <span className="w-14 shrink-0 text-right text-[11px] text-navy-3">{a?.count ?? 0} inv</span>
+                  <span className="w-28 shrink-0 text-right text-xs font-medium text-navy-2">{ghs(amt)}</span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* By class */}
+      <h2 className="mb-3 mt-8 font-display text-lg font-semibold text-navy">Outstanding by class</h2>
+      {debtors.length === 0 ? (
+        <Empty>No outstanding balances by class.</Empty>
+      ) : (
+        <div className="overflow-hidden rounded-xl border border-border bg-surface">
+          <table className="w-full text-sm">
+            <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
+              <tr>
+                <th className="px-4 py-3 font-semibold">Class</th>
+                <th className="px-4 py-3 text-right font-semibold">Billed</th>
+                <th className="px-4 py-3 text-right font-semibold">Collected</th>
+                <th className="px-4 py-3 text-right font-semibold">Outstanding</th>
+                <th className="px-4 py-3"></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {debtors.map((c) => (
+                <tr key={c.className} className="hover:bg-bg">
+                  <td className="px-4 py-3 font-medium text-navy">{c.className}</td>
+                  <td className="px-4 py-3 text-right text-navy-2">{ghs(num(c.billed))}</td>
+                  <td className="px-4 py-3 text-right text-green">{ghs(num(c.collected))}</td>
+                  <td className="px-4 py-3 text-right font-medium text-terra">{ghs(num(c.outstanding))}</td>
+                  <td className="px-4 py-3 text-right">
+                    {c.classId && (
+                      <Link href={`/reports/class/${c.classId}`} className="text-xs font-semibold text-gold hover:underline">
+                        View debtors →
+                      </Link>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+      <p className="mt-3 text-xs italic text-navy-3">
+        Student-level outstanding table with guardian contact and per-row reminders is coming in
+        the next slice.
+      </p>
+    </div>
+  );
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
+      {children}
+    </p>
+  );
+}

--- a/omnischools/app/(app)/reports/page.tsx
+++ b/omnischools/app/(app)/reports/page.tsx
@@ -1,723 +1,157 @@
-import { and, eq, ne, isNull, isNotNull, asc, gte, lt, sql, desc } from "drizzle-orm";
-import Link from "next/link";
 import { requireSchool } from "@/lib/auth/server";
-import { withSchool } from "@/lib/db/rls";
-import {
-  invoices,
-  payments,
-  students,
-  classes,
-  receipts,
-  users,
-  discounts,
-  discountTiers,
-  feeCategories,
-} from "@/db/schema";
-import { ExportCsv } from "@/components/reports/export-csv";
-import { PrintButton } from "@/components/reports/print-button";
-import { schoolFile } from "@/lib/filename";
-
-const ordinal = (n: number) =>
-  n === 1 ? "1st" : n === 2 ? "2nd" : n === 3 ? "3rd" : `${n}th`;
+import { getFinanceReport, ghs } from "@/lib/reports/finance-data";
+import { ReportCatalog, type ReportCard } from "@/components/reports/report-catalog";
 
 export const dynamic = "force-dynamic";
 
-const ghs = (n: number) =>
-  `GHS ${n.toLocaleString("en-GH", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
-const num = (v: unknown) => Number(v ?? 0);
-
-const METHOD_LABEL: Record<string, string> = {
-  MTN_MOMO: "MTN MoMo",
-  TELECEL_CASH: "Telecel Cash",
-  AIRTELTIGO_MONEY: "AirtelTigo Money",
-  BANK_TRANSFER: "Bank transfer",
-  CASH: "Cash",
-  CHEQUE: "Cheque",
-  OTHER: "Other",
-};
-
-export default async function ReportsPage({
-  searchParams,
-}: {
-  searchParams?: { year?: string };
-}) {
+export default async function ReportsPage() {
   const { school } = await requireSchool();
+  const r = await getFinanceReport(school.id, null);
 
-  // Period scope: an academic year ("2025/26") narrows every figure. Invoices
-  // filter by their academic_year column; payments/voids by the Sep–Aug window.
-  const selectedYear =
-    searchParams?.year && searchParams.year !== "all" ? searchParams.year : null;
-  let windowStart: Date | null = null;
-  let windowEnd: Date | null = null;
-  if (selectedYear) {
-    const sy = Number.parseInt(selectedYear.slice(0, 4), 10);
-    if (!Number.isNaN(sy)) {
-      windowStart = new Date(Date.UTC(sy, 8, 1));
-      windowEnd = new Date(Date.UTC(sy + 1, 8, 1));
-    }
-  }
-  const yearInv = selectedYear ? eq(invoices.academicYear, selectedYear) : undefined;
-  const payWindow =
-    windowStart && windowEnd
-      ? and(gte(payments.paidAt, windowStart), lt(payments.paidAt, windowEnd))
-      : undefined;
-  const voidWindow =
-    windowStart && windowEnd
-      ? and(gte(payments.voidedAt, windowStart), lt(payments.voidedAt, windowEnd))
-      : undefined;
-
-  const [
-    [totals],
-    byClass,
-    monthly,
-    byMethod,
-    agingRows,
-    voids,
-    discRows,
-    discTierRows,
-    [discTotal],
-    catRows,
-    yearRows,
-  ] = await Promise.all([
-    withSchool(school.id, (tx) =>
-      tx
-        .select({
-          billed: sql<string>`coalesce(sum(${invoices.billedAmount}), 0)`,
-          collected: sql<string>`coalesce(sum(${invoices.paidAmount}), 0)`,
-          outstanding: sql<string>`coalesce(sum(${invoices.balanceAmount}), 0)`,
-          invoiceCount: sql<number>`count(*)`,
-        })
-        .from(invoices)
-        .where(
-          and(eq(invoices.schoolId, school.id), ne(invoices.status, "VOIDED"), yearInv),
-        ),
-    ),
-    withSchool(school.id, (tx) =>
-      tx
-        .select({
-          classId: classes.id,
-          className: sql<string>`coalesce(${classes.name}, '— Unassigned —')`,
-          billed: sql<string>`coalesce(sum(${invoices.billedAmount}), 0)`,
-          collected: sql<string>`coalesce(sum(${invoices.paidAmount}), 0)`,
-          outstanding: sql<string>`coalesce(sum(${invoices.balanceAmount}), 0)`,
-        })
-        .from(invoices)
-        .innerJoin(students, eq(invoices.studentId, students.id))
-        .leftJoin(classes, eq(students.classId, classes.id))
-        .where(
-          and(eq(invoices.schoolId, school.id), ne(invoices.status, "VOIDED"), yearInv),
-        )
-        .groupBy(classes.id, classes.name)
-        .orderBy(desc(sql`sum(${invoices.balanceAmount})`)),
-    ),
-    withSchool(school.id, (tx) =>
-      tx
-        .select({
-          month: sql<string>`to_char(${payments.paidAt}, 'YYYY-MM')`,
-          amount: sql<string>`coalesce(sum(${payments.netAmount}), 0)`,
-        })
-        .from(payments)
-        .where(and(eq(payments.schoolId, school.id), isNull(payments.voidedAt), payWindow))
-        .groupBy(sql`to_char(${payments.paidAt}, 'YYYY-MM')`)
-        .orderBy(sql`to_char(${payments.paidAt}, 'YYYY-MM')`),
-    ),
-    withSchool(school.id, (tx) =>
-      tx
-        .select({
-          method: payments.method,
-          amount: sql<string>`coalesce(sum(${payments.netAmount}), 0)`,
-          count: sql<number>`count(*)`,
-        })
-        .from(payments)
-        .where(and(eq(payments.schoolId, school.id), isNull(payments.voidedAt), payWindow))
-        .groupBy(payments.method),
-    ),
-    // Outstanding balance bucketed by how far past due it is.
-    withSchool(school.id, (tx) =>
-      tx
-        .select({
-          bucket: sql<string>`case
-            when ${invoices.dueAt} is null or ${invoices.dueAt} >= now() then 'current'
-            when now() - ${invoices.dueAt} <= interval '30 days' then 'd30'
-            when now() - ${invoices.dueAt} <= interval '60 days' then 'd60'
-            when now() - ${invoices.dueAt} <= interval '90 days' then 'd90'
-            else 'd90plus'
-          end`,
-          amount: sql<string>`coalesce(sum(${invoices.balanceAmount}), 0)`,
-          count: sql<number>`count(*)`,
-        })
-        .from(invoices)
-        .where(
-          and(
-            eq(invoices.schoolId, school.id),
-            ne(invoices.status, "VOIDED"),
-            sql`${invoices.balanceAmount} > 0`,
-            yearInv,
-          ),
-        )
-        .groupBy(sql`1`),
-    ),
-    // Voided / refunded payments (audit-grade reason capture from the Fees void flow).
-    withSchool(school.id, (tx) =>
-      tx
-        .select({
-          voidedAt: payments.voidedAt,
-          amount: payments.grossAmount,
-          method: payments.method,
-          isRefund: payments.voidIsRefund,
-          reason: payments.voidReason,
-          firstName: students.firstName,
-          lastName: students.lastName,
-          receiptNumber: receipts.receiptNumber,
-          voidedBy: users.fullName,
-        })
-        .from(payments)
-        .innerJoin(students, eq(payments.studentId, students.id))
-        .leftJoin(receipts, eq(receipts.paymentId, payments.id))
-        .leftJoin(users, eq(payments.voidedByUserId, users.id))
-        .where(
-          and(eq(payments.schoolId, school.id), isNotNull(payments.voidedAt), voidWindow),
-        )
-        .orderBy(desc(payments.voidedAt))
-        .limit(100),
-    ),
-    withSchool(school.id, (tx) =>
-      tx
-        .select()
-        .from(discounts)
-        .where(eq(discounts.schoolId, school.id))
-        .orderBy(asc(discounts.name)),
-    ),
-    withSchool(school.id, (tx) =>
-      tx
-        .select({
-          discountId: discountTiers.discountId,
-          rank: discountTiers.rank,
-          value: discountTiers.value,
-        })
-        .from(discountTiers)
-        .where(eq(discountTiers.schoolId, school.id)),
-    ),
-    withSchool(school.id, (tx) =>
-      tx
-        .select({
-          total: sql<string>`coalesce(sum(${invoices.discountAmount}), 0)`,
-          count: sql<number>`count(*) filter (where ${invoices.discountAmount} > 0)`,
-        })
-        .from(invoices)
-        .where(
-          and(eq(invoices.schoolId, school.id), ne(invoices.status, "VOIDED"), yearInv),
-        ),
-    ),
-    withSchool(school.id, (tx) =>
-      tx
-        .select({ id: feeCategories.id, name: feeCategories.name })
-        .from(feeCategories)
-        .where(eq(feeCategories.schoolId, school.id)),
-    ),
-    withSchool(school.id, (tx) =>
-      tx
-        .selectDistinct({ year: invoices.academicYear })
-        .from(invoices)
-        .where(eq(invoices.schoolId, school.id))
-        .orderBy(desc(invoices.academicYear)),
-    ),
-  ]);
-
-  const billed = num(totals?.billed);
-  const collected = num(totals?.collected);
-  const outstanding = num(totals?.outstanding);
-  const rate = billed > 0 ? Math.round((collected / billed) * 100) : 0;
-  const maxMonth = Math.max(1, ...monthly.map((m) => num(m.amount)));
-  const classRate = (b: unknown, c: unknown) =>
-    num(b) > 0 ? Math.round((num(c) / num(b)) * 100) : 0;
-
-  const AGING = [
-    { key: "current", label: "Not yet due", tone: "bg-navy" },
-    { key: "d30", label: "1–30 days overdue", tone: "bg-gold" },
-    { key: "d60", label: "31–60 days overdue", tone: "bg-warn" },
-    { key: "d90", label: "61–90 days overdue", tone: "bg-terra" },
-    { key: "d90plus", label: "90+ days overdue", tone: "bg-terra" },
-  ];
-  const agingMap = new Map(
-    agingRows.map((r) => [r.bucket, { amount: num(r.amount), count: num(r.count) }]),
-  );
-  const agingMax = Math.max(1, ...AGING.map((b) => agingMap.get(b.key)?.amount ?? 0));
-  const overdueTotal = AGING.filter((b) => b.key !== "current").reduce(
-    (s, b) => s + (agingMap.get(b.key)?.amount ?? 0),
-    0,
-  );
-
-  const catName = new Map(catRows.map((c) => [c.id, c.name]));
-  const tiersByDiscount = new Map<string, { rank: number; value: number }[]>();
-  for (const t of discTierRows) {
-    const arr = tiersByDiscount.get(t.discountId) ?? [];
-    arr.push({ rank: t.rank, value: num(t.value) });
-    tiersByDiscount.set(t.discountId, arr);
-  }
-  const discountTotal = num(discTotal?.total);
-  const discountedCount = num(discTotal?.count);
-  const discountValueText = (d: (typeof discRows)[number]) => {
-    if (d.isTiered) {
-      return (tiersByDiscount.get(d.id) ?? [])
-        .sort((a, b) => a.rank - b.rank)
-        .map(
-          (t) =>
-            `${ordinal(t.rank)} ${d.kind === "PERCENT" ? `${t.value}%` : ghs(t.value)}`,
-        )
-        .join(" · ");
-    }
-    return d.kind === "PERCENT" ? `${num(d.value)}%` : ghs(num(d.value));
-  };
-
-  const kpis = [
+  const cards: ReportCard[] = [
     {
-      label: "Total billed",
-      value: ghs(billed),
-      sub: `${num(totals?.invoiceCount)} invoices`,
+      category: "finance",
+      href: "/reports/term-collection",
+      icon: "$",
+      iconTone: "bg-gold-bg text-gold",
+      name: "Term collection summary",
+      desc: "How much you've collected this term, by method and by class.",
+      featured: true,
+      snapshotLabel: "Collected to date",
+      snapshotValue: ghs(r.collected),
+      snapshotTone: "text-green",
+      snapshotSub: `${r.rate}% of ${ghs(r.billed)} billed`,
     },
-    { label: "Collected", value: ghs(collected), sub: `${rate}% of billed` },
-    { label: "Outstanding", value: ghs(outstanding), sub: "across all classes" },
     {
-      label: "Collection rate",
-      value: `${rate}%`,
-      sub: rate >= 80 ? "healthy" : "needs follow-up",
+      category: "finance",
+      href: "/reports/outstanding",
+      icon: "!",
+      iconTone: "bg-terra-bg text-terra",
+      name: "Outstanding balances",
+      desc: "Who hasn't paid, grouped by aging bucket. Send reminders directly.",
+      snapshotLabel: "Currently outstanding",
+      snapshotValue: ghs(r.outstanding),
+      snapshotTone: "text-terra",
+      snapshotSub: `${r.overdue30PlusCount} student${r.overdue30PlusCount === 1 ? "" : "s"} overdue 30+ days`,
+    },
+    {
+      category: "finance",
+      href: "/reports/discounts",
+      icon: "%",
+      iconTone: "bg-green-bg text-green",
+      name: "Discounts given",
+      desc: "Total discount value applied this term, broken down by tier.",
+      snapshotLabel: "Discounts applied",
+      snapshotValue: ghs(r.discountTotal),
+      snapshotSub: `${r.discountedCount} invoice${r.discountedCount === 1 ? "" : "s"} discounted`,
+    },
+    {
+      category: "finance",
+      href: "/reports/finance/collection-trend",
+      icon: "↗",
+      iconTone: "bg-navy text-gold",
+      name: "Collection trend",
+      desc: "Term-on-term collection rates and timing patterns.",
+      snapshotLabel: "Collection rate",
+      snapshotValue: `${r.rate}%`,
+      snapshotSub: "across the period to date",
+    },
+    {
+      category: "finance",
+      href: "/reports/voids-refunds",
+      icon: "×",
+      iconTone: "bg-terra-bg text-terra",
+      name: "Voids & refunds",
+      desc: "Reversed transactions this term with reasons summarised.",
+      snapshotLabel: "Reversed",
+      snapshotValue: r.voidTotal > 0 ? `−${ghs(r.voidTotal)}` : ghs(0),
+      snapshotTone: r.voidTotal > 0 ? "text-terra" : "text-navy",
+      snapshotSub: `${r.voids.length} event${r.voids.length === 1 ? "" : "s"}`,
+    },
+    {
+      category: "academic",
+      icon: "A",
+      iconTone: "bg-bg text-navy-3",
+      name: "Class performance",
+      desc: "Average grades by class, with term-on-term comparison.",
+      comingSoon: true,
+      snapshotLabel: "Academic data needed",
+      snapshotValue: "Available in MVP2",
+      snapshotSub: "Once gradebook has 2+ terms of data",
+    },
+    {
+      category: "academic",
+      icon: "B",
+      iconTone: "bg-bg text-navy-3",
+      name: "Subject performance",
+      desc: "Per-subject averages across the school on the 1–9 scale.",
+      comingSoon: true,
+      snapshotLabel: "Academic data needed",
+      snapshotValue: "Available in MVP2",
+      snapshotSub: "Needs a full term of graded entries",
+    },
+    {
+      category: "operational",
+      icon: "S",
+      iconTone: "bg-bg text-navy-3",
+      name: "School statistics",
+      desc: "Headcount, class composition, gender split and enrolment flow.",
+      comingSoon: true,
+      snapshotLabel: "Coming soon",
+      snapshotValue: "In build",
+      snapshotSub: "Headcount & composition rollups",
+    },
+    {
+      category: "operational",
+      icon: "@",
+      iconTone: "bg-bg text-navy-3",
+      name: "Attendance summary",
+      desc: "Term attendance rates by class and the students needing attention.",
+      comingSoon: true,
+      snapshotLabel: "Coming soon",
+      snapshotValue: "Available in MVP2",
+      snapshotSub: "Rolls up the attendance module",
+    },
+    {
+      category: "operational",
+      icon: "E",
+      iconTone: "bg-bg text-navy-3",
+      name: "Enrolment & roll",
+      desc: "Admissions, withdrawals and transfers over the term.",
+      comingSoon: true,
+      snapshotLabel: "Coming soon",
+      snapshotValue: "Available in MVP2",
+      snapshotSub: "Term-window enrolment deltas",
     },
   ];
 
   return (
-    <div className="mx-auto max-w-page space-y-8">
-      <div className="flex flex-wrap items-start justify-between gap-3">
+    <div className="mx-auto max-w-page">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gold">
+        Omnischools · Reports
+      </div>
+      <div className="mt-1 flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h1 className="font-display text-3xl font-semibold text-navy">Reports</h1>
-          <p className="text-sm text-navy-3">
-            Fees collected, outstanding by class, and collection trends — for the bursar.
-            {selectedYear && (
-              <>
-                {" "}
-                Showing <b className="text-navy">{selectedYear}</b>.
-              </>
-            )}
+          <h1 className="font-display text-3xl font-semibold text-navy">
+            Answers, not <em className="text-gold">spreadsheets</em>
+          </h1>
+          <div className="mb-3 mt-2 h-0.5 w-16 bg-gold" />
+          <p className="max-w-2xl text-sm text-navy-3">
+            Each report answers a specific question. Open any card for the detail; export to CSV
+            or PDF for filing.
           </p>
         </div>
-        <PrintButton />
+        <span
+          title="Coming soon — scheduled report delivery"
+          className="cursor-default rounded-md border border-border-2 bg-bg px-3 py-2 text-sm font-semibold text-navy-3 opacity-60"
+        >
+          Export all (zip)
+        </span>
       </div>
 
-      {yearRows.length > 0 && (
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="text-xs font-semibold uppercase tracking-wide text-navy-3">
-            Period
-          </span>
-          <PeriodPill href="/reports" active={!selectedYear}>
-            All time
-          </PeriodPill>
-          {yearRows.map((y) => (
-            <PeriodPill
-              key={y.year}
-              href={`/reports?year=${encodeURIComponent(y.year)}`}
-              active={selectedYear === y.year}
-            >
-              {y.year}
-            </PeriodPill>
-          ))}
-        </div>
-      )}
-
-      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
-        {kpis.map((k) => (
-          <div key={k.label} className="rounded-xl border border-border bg-surface p-5">
-            <div className="text-xs font-semibold uppercase tracking-wide text-navy-3">
-              {k.label}
-            </div>
-            <div className="mt-1.5 font-display text-2xl font-semibold text-navy">
-              {k.value}
-            </div>
-            <div className="mt-0.5 text-xs text-navy-3">{k.sub}</div>
-          </div>
-        ))}
+      <div className="mt-6">
+        <ReportCatalog cards={cards} />
       </div>
-
-      {/* Outstanding by class */}
-      <section>
-        <div className="mb-3 flex items-center justify-between">
-          <h2 className="font-display text-lg font-semibold text-navy">
-            Outstanding by class
-          </h2>
-          <ExportCsv
-            filename={schoolFile(school.name, "outstanding-by-class.csv")}
-            headers={["Class", "Billed", "Collected", "Outstanding", "Rate %"]}
-            rows={byClass.map((c) => [
-              c.className,
-              num(c.billed).toFixed(2),
-              num(c.collected).toFixed(2),
-              num(c.outstanding).toFixed(2),
-              String(classRate(c.billed, c.collected)),
-            ])}
-          />
-        </div>
-        {byClass.length === 0 ? (
-          <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
-            No invoices yet. Issue fees from the Fees module to see collections here.
-          </p>
-        ) : (
-          <div className="overflow-hidden rounded-xl border border-border bg-surface">
-            <table className="w-full text-sm">
-              <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
-                <tr>
-                  <th className="px-4 py-3 font-semibold">Class</th>
-                  <th className="px-4 py-3 text-right font-semibold">Billed</th>
-                  <th className="px-4 py-3 text-right font-semibold">Collected</th>
-                  <th className="px-4 py-3 text-right font-semibold">Outstanding</th>
-                  <th className="px-4 py-3 text-right font-semibold">Rate</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border">
-                {byClass.map((c) => {
-                  const r = classRate(c.billed, c.collected);
-                  return (
-                    <tr key={c.className} className="hover:bg-bg">
-                      <td className="px-4 py-3 font-medium text-navy">
-                        {c.classId ? (
-                          <Link
-                            href={`/reports/class/${c.classId}`}
-                            className="hover:text-gold"
-                          >
-                            {c.className}
-                          </Link>
-                        ) : (
-                          c.className
-                        )}
-                      </td>
-                      <td className="px-4 py-3 text-right text-navy-2">
-                        {ghs(num(c.billed))}
-                      </td>
-                      <td className="px-4 py-3 text-right text-green">
-                        {ghs(num(c.collected))}
-                      </td>
-                      <td className="px-4 py-3 text-right font-medium text-terra">
-                        {ghs(num(c.outstanding))}
-                      </td>
-                      <td
-                        className={`px-4 py-3 text-right font-medium ${r >= 80 ? "text-green" : r >= 50 ? "text-navy-2" : "text-terra"}`}
-                      >
-                        {r}%
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </section>
-
-      {/* Aging of receivables */}
-      <section>
-        <div className="mb-3 flex items-center justify-between">
-          <h2 className="font-display text-lg font-semibold text-navy">
-            Aging of receivables
-          </h2>
-          <ExportCsv
-            filename={schoolFile(school.name, "aging.csv")}
-            headers={["Bucket", "Outstanding", "Invoices"]}
-            rows={AGING.map((b) => {
-              const a = agingMap.get(b.key);
-              return [b.label, num(a?.amount).toFixed(2), String(a?.count ?? 0)];
-            })}
-          />
-        </div>
-        {outstanding <= 0 ? (
-          <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
-            Nothing outstanding — every invoice is settled.
-          </p>
-        ) : (
-          <div className="rounded-xl border border-border bg-surface p-5">
-            <p className="mb-3 text-sm text-navy-3">
-              <b className="text-terra">{ghs(overdueTotal)}</b> overdue of{" "}
-              <b className="text-navy">{ghs(outstanding)}</b> outstanding
-            </p>
-            <div className="space-y-2">
-              {AGING.map((b) => {
-                const a = agingMap.get(b.key);
-                const amt = a?.amount ?? 0;
-                return (
-                  <div key={b.key} className="flex items-center gap-3">
-                    <span className="w-40 shrink-0 text-xs text-navy-2">{b.label}</span>
-                    <div className="h-5 flex-1 overflow-hidden rounded-full bg-bg">
-                      <div
-                        className={`h-full rounded-full ${b.tone}`}
-                        style={{ width: `${(amt / agingMax) * 100}%` }}
-                      />
-                    </div>
-                    <span className="w-14 shrink-0 text-right text-[11px] text-navy-3">
-                      {a?.count ?? 0} inv
-                    </span>
-                    <span className="w-28 shrink-0 text-right text-xs font-medium text-navy-2">
-                      {ghs(amt)}
-                    </span>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        )}
-      </section>
-
-      <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
-        {/* Monthly trend */}
-        <section>
-          <div className="mb-3 flex items-center justify-between">
-            <h2 className="font-display text-lg font-semibold text-navy">
-              Monthly collections
-            </h2>
-            <ExportCsv
-              filename={schoolFile(school.name, "monthly-collections.csv")}
-              headers={["Month", "Collected"]}
-              rows={monthly.map((m) => [m.month, num(m.amount).toFixed(2)])}
-            />
-          </div>
-          {monthly.length === 0 ? (
-            <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
-              No payments recorded yet.
-            </p>
-          ) : (
-            <div className="space-y-2 rounded-xl border border-border bg-surface p-5">
-              {monthly.map((m) => (
-                <div key={m.month} className="flex items-center gap-3">
-                  <span className="w-16 shrink-0 font-mono text-xs text-navy-3">
-                    {m.month}
-                  </span>
-                  <div className="h-5 flex-1 overflow-hidden rounded-full bg-bg">
-                    <div
-                      className="h-full rounded-full bg-navy"
-                      style={{ width: `${(num(m.amount) / maxMonth) * 100}%` }}
-                    />
-                  </div>
-                  <span className="w-28 shrink-0 text-right text-xs font-medium text-navy-2">
-                    {ghs(num(m.amount))}
-                  </span>
-                </div>
-              ))}
-            </div>
-          )}
-        </section>
-
-        {/* By method */}
-        <section>
-          <h2 className="mb-3 font-display text-lg font-semibold text-navy">
-            Collections by method
-          </h2>
-          {byMethod.length === 0 ? (
-            <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
-              No payments recorded yet.
-            </p>
-          ) : (
-            <div className="overflow-hidden rounded-xl border border-border bg-surface">
-              <table className="w-full text-sm">
-                <tbody className="divide-y divide-border">
-                  {byMethod.map((m) => (
-                    <tr key={m.method} className="hover:bg-bg">
-                      <td className="px-4 py-3 font-medium text-navy">
-                        {METHOD_LABEL[m.method] ?? m.method}
-                      </td>
-                      <td className="px-4 py-3 text-navy-3">{num(m.count)} payments</td>
-                      <td className="px-4 py-3 text-right font-medium text-navy-2">
-                        {ghs(num(m.amount))}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </section>
-      </div>
-
-      {/* Voids & refunds */}
-      <section>
-        <div className="mb-3 flex items-center justify-between">
-          <h2 className="font-display text-lg font-semibold text-navy">
-            Voids &amp; refunds
-          </h2>
-          {voids.length > 0 && (
-            <ExportCsv
-              filename={schoolFile(school.name, "voids-refunds.csv")}
-              headers={[
-                "Date",
-                "Student",
-                "Receipt",
-                "Amount",
-                "Method",
-                "Type",
-                "Reason",
-                "By",
-              ]}
-              rows={voids.map((v) => [
-                v.voidedAt ? new Date(v.voidedAt).toISOString().slice(0, 10) : "",
-                `${v.lastName}, ${v.firstName}`,
-                v.receiptNumber ?? "",
-                num(v.amount).toFixed(2),
-                METHOD_LABEL[v.method] ?? v.method,
-                v.isRefund ? "Refund" : "Void",
-                v.reason ?? "",
-                v.voidedBy ?? "",
-              ])}
-            />
-          )}
-        </div>
-        {voids.length === 0 ? (
-          <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
-            No voided or refunded payments.
-          </p>
-        ) : (
-          <div className="overflow-x-auto rounded-xl border border-border bg-surface">
-            <table className="w-full text-sm">
-              <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
-                <tr>
-                  <th className="px-4 py-3 font-semibold">Date</th>
-                  <th className="px-4 py-3 font-semibold">Student</th>
-                  <th className="px-4 py-3 font-semibold">Receipt</th>
-                  <th className="px-4 py-3 text-right font-semibold">Amount</th>
-                  <th className="px-4 py-3 font-semibold">Type</th>
-                  <th className="px-4 py-3 font-semibold">Reason</th>
-                  <th className="px-4 py-3 font-semibold">By</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border">
-                {voids.map((v, i) => (
-                  <tr key={i} className="hover:bg-bg">
-                    <td className="whitespace-nowrap px-4 py-3 font-mono text-xs text-navy-3">
-                      {v.voidedAt
-                        ? new Date(v.voidedAt).toLocaleDateString("en-GB", {
-                            day: "numeric",
-                            month: "short",
-                            year: "numeric",
-                          })
-                        : "—"}
-                    </td>
-                    <td className="px-4 py-3 font-medium text-navy">
-                      {v.lastName}, {v.firstName}
-                    </td>
-                    <td className="px-4 py-3 font-mono text-xs text-navy-2">
-                      {v.receiptNumber ?? "—"}
-                    </td>
-                    <td className="px-4 py-3 text-right font-medium text-navy">
-                      {ghs(num(v.amount))}
-                    </td>
-                    <td className="px-4 py-3">
-                      <span
-                        className={`rounded-pill px-2 py-0.5 text-xs font-medium ${v.isRefund ? "bg-terra-bg text-terra" : "bg-bg text-navy-3"}`}
-                      >
-                        {v.isRefund ? "Refund" : "Void"}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 text-navy-2">{v.reason ?? "—"}</td>
-                    <td className="px-4 py-3 text-navy-3">{v.voidedBy ?? "—"}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </section>
-
-      {/* Discounts given */}
-      <section>
-        <div className="mb-3 flex items-center justify-between">
-          <h2 className="font-display text-lg font-semibold text-navy">Discounts given</h2>
-          {discRows.length > 0 && (
-            <ExportCsv
-              filename={schoolFile(school.name, "discounts.csv")}
-              headers={[
-                "Discount",
-                "Value",
-                "Applies to",
-                "Tiered",
-                "Approval",
-                "Applied",
-              ]}
-              rows={discRows.map((d) => [
-                d.name,
-                discountValueText(d),
-                d.appliesToCategoryId
-                  ? (catName.get(d.appliesToCategoryId) ?? "Whole invoice")
-                  : "Whole invoice",
-                d.isTiered ? "Yes" : "No",
-                d.requiresApproval ? (d.approvedAt ? "Approved" : "Pending") : "—",
-                String(d.appliedCount),
-              ])}
-            />
-          )}
-        </div>
-        <p className="mb-3 text-sm text-navy-3">
-          <b className="text-navy">{ghs(discountTotal)}</b> discounted across{" "}
-          {discountedCount} invoice{discountedCount === 1 ? "" : "s"}.
-        </p>
-        {discRows.length === 0 ? (
-          <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
-            No discounts configured. Set them up under Billing.
-          </p>
-        ) : (
-          <div className="overflow-x-auto rounded-xl border border-border bg-surface">
-            <table className="w-full text-sm">
-              <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
-                <tr>
-                  <th className="px-4 py-3 font-semibold">Discount</th>
-                  <th className="px-4 py-3 font-semibold">Value</th>
-                  <th className="px-4 py-3 font-semibold">Applies to</th>
-                  <th className="px-4 py-3 text-right font-semibold">Applied</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border">
-                {discRows.map((d) => (
-                  <tr key={d.id} className="hover:bg-bg">
-                    <td className="px-4 py-3 font-medium text-navy">
-                      {d.name}
-                      {d.requiresApproval && !d.approvedAt && (
-                        <span className="ml-2 rounded-pill bg-warn-bg px-2 py-0.5 text-[11px] font-medium text-warn">
-                          Pending approval
-                        </span>
-                      )}
-                    </td>
-                    <td className="px-4 py-3 text-navy-2">{discountValueText(d)}</td>
-                    <td className="px-4 py-3 text-navy-2">
-                      {d.appliesToCategoryId
-                        ? (catName.get(d.appliesToCategoryId) ?? "Whole invoice")
-                        : "Whole invoice"}
-                    </td>
-                    <td className="px-4 py-3 text-right font-mono text-navy-2">
-                      {d.appliedCount}×
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </section>
     </div>
-  );
-}
-
-function PeriodPill({
-  href,
-  active,
-  children,
-}: {
-  href: string;
-  active: boolean;
-  children: React.ReactNode;
-}) {
-  return (
-    <Link
-      href={href}
-      className={`rounded-pill border px-3 py-1 text-xs font-semibold transition-colors ${
-        active
-          ? "border-navy bg-navy text-bg"
-          : "border-border-2 bg-surface text-navy-2 hover:border-gold"
-      }`}
-    >
-      {children}
-    </Link>
   );
 }

--- a/omnischools/app/(app)/reports/term-collection/page.tsx
+++ b/omnischools/app/(app)/reports/term-collection/page.tsx
@@ -1,0 +1,176 @@
+import Link from "next/link";
+import { requireSchool } from "@/lib/auth/server";
+import { getFinanceReport, ghs, num, METHOD_LABEL } from "@/lib/reports/finance-data";
+import { ExportCsv } from "@/components/reports/export-csv";
+import { PrintButton } from "@/components/reports/print-button";
+import { ReportHeader } from "@/components/reports/report-header";
+import { schoolFile } from "@/lib/filename";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Term collection" };
+
+const classRate = (b: unknown, c: unknown) =>
+  num(b) > 0 ? Math.round((num(c) / num(b)) * 100) : 0;
+
+export default async function TermCollectionPage() {
+  const { school } = await requireSchool();
+  const r = await getFinanceReport(school.id, null);
+  const maxMonth = Math.max(1, ...r.monthly.map((m) => num(m.amount)));
+  const methodTotal = Math.max(1, r.byMethod.reduce((s, m) => s + num(m.amount), 0));
+
+  const kpis = [
+    { label: "Total billed", value: ghs(r.billed), sub: `${num(r.totals?.invoiceCount)} invoices`, featured: false, tone: "text-navy" },
+    { label: "Collected", value: ghs(r.collected), sub: `${r.rate}% of billed`, featured: true, tone: "" },
+    { label: "Outstanding", value: ghs(r.outstanding), sub: "across all classes", featured: false, tone: "text-terra" },
+    { label: "Collection rate", value: `${r.rate}%`, sub: r.rate >= 80 ? "healthy" : "needs follow-up", featured: false, tone: "text-navy" },
+  ];
+
+  return (
+    <div className="mx-auto max-w-page">
+      <ReportHeader
+        crumb="Term collection"
+        pre="Term"
+        gold="collection"
+        lede="How much you've collected so far, by method and by class."
+        actions={
+          <>
+            <ExportCsv
+              filename={schoolFile(school.name, "term-collection.csv")}
+              headers={["Class", "Billed", "Collected", "Outstanding", "Rate %"]}
+              rows={r.byClass.map((c) => [
+                c.className,
+                num(c.billed).toFixed(2),
+                num(c.collected).toFixed(2),
+                num(c.outstanding).toFixed(2),
+                String(classRate(c.billed, c.collected)),
+              ])}
+            />
+            <PrintButton label="Export PDF" />
+          </>
+        }
+      />
+
+      {/* KPI strip */}
+      <div className="mb-6 grid grid-cols-2 gap-4 lg:grid-cols-4">
+        {kpis.map((k) => (
+          <div
+            key={k.label}
+            className={`rounded-xl border p-5 ${k.featured ? "border-navy bg-navy" : "border-border bg-surface"}`}
+          >
+            <div className={`text-[10px] font-bold uppercase tracking-[0.1em] ${k.featured ? "text-gold-soft" : "text-navy-3"}`}>
+              {k.label}
+            </div>
+            <div className={`mt-1.5 font-display text-2xl font-semibold ${k.featured ? "text-bg" : k.tone}`}>
+              {k.value}
+            </div>
+            <div className={`mt-0.5 text-xs ${k.featured ? "text-bg/60" : "text-navy-3"}`}>{k.sub}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* By class */}
+      <h2 className="mb-3 font-display text-lg font-semibold text-navy">Collection rate per class</h2>
+      {r.byClass.length === 0 ? (
+        <Empty>No invoices yet. Issue fees from the Fees module to see collections here.</Empty>
+      ) : (
+        <div className="overflow-hidden rounded-xl border border-border bg-surface">
+          <table className="w-full text-sm">
+            <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
+              <tr>
+                <th className="px-4 py-3 font-semibold">Class</th>
+                <th className="px-4 py-3 font-semibold">Collection rate</th>
+                <th className="px-4 py-3 text-right font-semibold">Billed</th>
+                <th className="px-4 py-3 text-right font-semibold">Collected</th>
+                <th className="px-4 py-3"></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {r.byClass.map((c) => {
+                const rate = classRate(c.billed, c.collected);
+                const tone = rate >= 70 ? "bg-green" : rate >= 50 ? "bg-gold" : "bg-terra";
+                return (
+                  <tr key={c.className} className="hover:bg-bg">
+                    <td className="px-4 py-3 font-medium text-navy">{c.className}</td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-2">
+                        <div className="h-2 w-28 overflow-hidden rounded-full bg-bg">
+                          <div className={`h-full rounded-full ${tone}`} style={{ width: `${rate}%` }} />
+                        </div>
+                        <span className="font-mono text-xs font-semibold text-navy-2">{rate}%</span>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-right text-navy-2">{ghs(num(c.billed))}</td>
+                    <td className="px-4 py-3 text-right text-green">{ghs(num(c.collected))}</td>
+                    <td className="px-4 py-3 text-right">
+                      {c.classId && (
+                        <Link href={`/reports/class/${c.classId}`} className="text-xs font-semibold text-gold hover:underline">
+                          View →
+                        </Link>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div className="mt-8 grid grid-cols-1 gap-8 lg:grid-cols-2">
+        {/* Monthly */}
+        <section>
+          <h2 className="mb-3 font-display text-lg font-semibold text-navy">Collection over time</h2>
+          {r.monthly.length === 0 ? (
+            <Empty>No payments recorded yet.</Empty>
+          ) : (
+            <div className="space-y-2 rounded-xl border border-border bg-surface p-5">
+              {r.monthly.map((m) => (
+                <div key={m.month} className="flex items-center gap-3">
+                  <span className="w-16 shrink-0 font-mono text-xs text-navy-3">{m.month}</span>
+                  <div className="h-5 flex-1 overflow-hidden rounded-full bg-bg">
+                    <div className="h-full rounded-full bg-gold" style={{ width: `${(num(m.amount) / maxMonth) * 100}%` }} />
+                  </div>
+                  <span className="w-28 shrink-0 text-right text-xs font-medium text-navy-2">{ghs(num(m.amount))}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* By method */}
+        <section>
+          <h2 className="mb-3 font-display text-lg font-semibold text-navy">Where it came from</h2>
+          {r.byMethod.length === 0 ? (
+            <Empty>No payments recorded yet.</Empty>
+          ) : (
+            <div className="space-y-2 rounded-xl border border-border bg-surface p-5">
+              {r.byMethod
+                .slice()
+                .sort((a, b) => num(b.amount) - num(a.amount))
+                .map((m) => {
+                  const pct = Math.round((num(m.amount) / methodTotal) * 100);
+                  return (
+                    <div key={m.method} className="flex items-center justify-between gap-3">
+                      <span className="text-sm font-medium text-navy">{METHOD_LABEL[m.method] ?? m.method}</span>
+                      <span className="flex items-baseline gap-2">
+                        <span className="text-sm font-medium text-navy-2">{ghs(num(m.amount))}</span>
+                        <span className="w-9 text-right font-mono text-xs text-navy-3">{pct}%</span>
+                      </span>
+                    </div>
+                  );
+                })}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
+      {children}
+    </p>
+  );
+}

--- a/omnischools/app/(app)/reports/voids-refunds/page.tsx
+++ b/omnischools/app/(app)/reports/voids-refunds/page.tsx
@@ -1,0 +1,151 @@
+import { requireSchool } from "@/lib/auth/server";
+import { getFinanceReport, ghs, num, METHOD_LABEL } from "@/lib/reports/finance-data";
+import { ExportCsv } from "@/components/reports/export-csv";
+import { PrintButton } from "@/components/reports/print-button";
+import { ReportHeader } from "@/components/reports/report-header";
+import { schoolFile } from "@/lib/filename";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Voids & refunds" };
+
+export default async function VoidsRefundsPage() {
+  const { school } = await requireSchool();
+  const r = await getFinanceReport(school.id, null);
+  const refunds = r.voids.filter((v) => v.isRefund);
+  const justVoids = r.voids.filter((v) => !v.isRefund);
+  const refundTotal = refunds.reduce((s, v) => s + num(v.amount), 0);
+  const voidOnlyTotal = justVoids.reduce((s, v) => s + num(v.amount), 0);
+  const ratio = r.collected > 0 ? (r.voidTotal / r.collected) * 100 : 0;
+  const healthy = ratio < 2;
+
+  return (
+    <div className="mx-auto max-w-page">
+      <ReportHeader
+        crumb="Voids & refunds"
+        pre="Voids &"
+        gold="refunds"
+        lede="Reversed transactions with their reasons. Low numbers are healthy; spikes warrant a closer look."
+        actions={
+          <>
+            {r.voids.length > 0 && (
+              <ExportCsv
+                filename={schoolFile(school.name, "voids-refunds.csv")}
+                headers={["Date", "Student", "Receipt", "Amount", "Method", "Type", "Reason", "By"]}
+                rows={r.voids.map((v) => [
+                  v.voidedAt ? new Date(v.voidedAt).toISOString().slice(0, 10) : "",
+                  `${v.lastName}, ${v.firstName}`,
+                  v.receiptNumber ?? "",
+                  num(v.amount).toFixed(2),
+                  METHOD_LABEL[v.method] ?? v.method,
+                  v.isRefund ? "Refund" : "Void",
+                  v.reason ?? "",
+                  v.voidedBy ?? "",
+                ])}
+              />
+            )}
+            <PrintButton label="Export PDF" />
+          </>
+        }
+      />
+
+      {/* Health banner */}
+      <div
+        className={`mb-6 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-xl border px-4 py-3 text-sm ${
+          healthy ? "border-green/40 bg-green-bg/50" : "border-warn/40 bg-warn-bg/50"
+        }`}
+      >
+        <span className={`font-semibold ${healthy ? "text-green" : "text-warn"}`}>
+          {healthy ? "Healthy reversal rate" : "Elevated reversal rate"} · {ratio.toFixed(2)}% of collected
+        </span>
+        <span className="text-navy-2">
+          benchmark <b className="font-semibold">under 2%</b> · {r.voids.length} event
+          {r.voids.length === 1 ? "" : "s"} this period.
+        </span>
+      </div>
+
+      {/* KPI strip */}
+      <div className="mb-6 grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <div className="rounded-xl border border-terra/50 bg-terra-bg/40 p-5">
+          <div className="text-[10px] font-bold uppercase tracking-[0.1em] text-terra">Total reversed</div>
+          <div className="mt-1.5 font-display text-2xl font-semibold text-terra">
+            {r.voidTotal > 0 ? `−${ghs(r.voidTotal)}` : ghs(0)}
+          </div>
+          <div className="mt-0.5 text-xs text-navy-3">{ratio.toFixed(2)}% of {ghs(r.collected)} collected</div>
+        </div>
+        <Kpi label="Voids" value={String(justVoids.length)} sub={`${ghs(voidOnlyTotal)} · record corrections`} />
+        <Kpi label="Refunds" value={String(refunds.length)} sub={`${ghs(refundTotal)} · money returned`} />
+        <Kpi
+          label="Avg per event"
+          value={r.voids.length ? ghs(r.voidTotal / r.voids.length) : ghs(0)}
+          sub="across all reversals"
+        />
+      </div>
+
+      {/* Event list */}
+      <h2 className="mb-3 font-display text-lg font-semibold text-navy">Every reversal this period</h2>
+      {r.voids.length === 0 ? (
+        <Empty>No voided or refunded payments.</Empty>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-border bg-surface">
+          <table className="w-full text-sm">
+            <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
+              <tr>
+                <th className="px-4 py-3 font-semibold">When</th>
+                <th className="px-4 py-3 font-semibold">Type</th>
+                <th className="px-4 py-3 font-semibold">Student &amp; reason</th>
+                <th className="px-4 py-3 text-right font-semibold">Amount</th>
+                <th className="px-4 py-3 font-semibold">Receipt</th>
+                <th className="px-4 py-3 font-semibold">Recorded by</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {r.voids.map((v, i) => (
+                <tr key={i} className={v.isRefund ? "bg-terra-bg/30" : "hover:bg-bg"}>
+                  <td className="whitespace-nowrap px-4 py-3 font-mono text-xs text-navy-3">
+                    {v.voidedAt
+                      ? new Date(v.voidedAt).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })
+                      : "—"}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className={`rounded-pill px-2 py-0.5 text-xs font-medium ${v.isRefund ? "bg-terra-bg text-terra" : "bg-bg text-navy-3"}`}>
+                      {v.isRefund ? "Refund" : "Void"}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="font-medium text-navy">{v.lastName}, {v.firstName}</div>
+                    <div className="text-xs italic text-navy-3">{v.reason ?? "—"}</div>
+                  </td>
+                  <td className="px-4 py-3 text-right font-medium text-navy">{ghs(num(v.amount))}</td>
+                  <td className="px-4 py-3 font-mono text-xs text-gold">{v.receiptNumber ?? "—"}</td>
+                  <td className="px-4 py-3 text-navy-3">{v.voidedBy ?? "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+      <p className="mt-3 text-xs italic text-navy-3">
+        Void-vs-refund split cards, weekly trend chart and recorder analysis are coming in a later
+        slice.
+      </p>
+    </div>
+  );
+}
+
+function Kpi({ label, value, sub }: { label: string; value: string; sub: string }) {
+  return (
+    <div className="rounded-xl border border-border bg-surface p-5">
+      <div className="text-[10px] font-bold uppercase tracking-[0.1em] text-navy-3">{label}</div>
+      <div className="mt-1.5 font-display text-2xl font-semibold text-navy">{value}</div>
+      <div className="mt-0.5 text-xs text-navy-3">{sub}</div>
+    </div>
+  );
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
+      {children}
+    </p>
+  );
+}

--- a/omnischools/components/reports/report-catalog.tsx
+++ b/omnischools/components/reports/report-catalog.tsx
@@ -1,0 +1,124 @@
+"use client";
+import { useState } from "react";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+
+export type ReportCard = {
+  category: "finance" | "academic" | "operational";
+  href?: string;
+  icon: string;
+  iconTone: string;
+  name: string;
+  desc: string;
+  featured?: boolean;
+  comingSoon?: boolean;
+  snapshotLabel: string;
+  snapshotValue: string;
+  snapshotTone?: string;
+  snapshotSub: string;
+};
+
+const TABS: { key: ReportCard["category"]; label: string }[] = [
+  { key: "finance", label: "Finance" },
+  { key: "academic", label: "Academic" },
+  { key: "operational", label: "Operational" },
+];
+
+export function ReportCatalog({ cards }: { cards: ReportCard[] }) {
+  const [tab, setTab] = useState<ReportCard["category"]>("finance");
+  const count = (k: ReportCard["category"]) => cards.filter((c) => c.category === k).length;
+  const shown = cards.filter((c) => c.category === tab);
+
+  return (
+    <div>
+      {/* Category tabs */}
+      <div className="mb-5 flex flex-wrap gap-5 border-b border-border">
+        {TABS.map((t) => {
+          const active = tab === t.key;
+          return (
+            <button
+              key={t.key}
+              onClick={() => setTab(t.key)}
+              className={cn(
+                "flex items-center gap-1.5 border-b-2 pb-2.5 text-sm font-semibold transition-colors",
+                active
+                  ? "border-gold text-navy"
+                  : "border-transparent text-navy-3 hover:text-navy",
+              )}
+            >
+              {t.label}
+              <span
+                className={cn(
+                  "rounded-pill px-1.5 py-0.5 text-[10px] font-bold",
+                  active ? "bg-gold-bg text-gold" : "bg-bg text-navy-3",
+                )}
+              >
+                {count(t.key)}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Card grid */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {shown.map((c) => (
+          <ReportCardView key={c.name} card={c} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ReportCardView({ card: c }: { card: ReportCard }) {
+  const body = (
+    <>
+      {c.featured && (
+        <span className="absolute right-4 top-4 rounded-pill bg-gold px-2 py-0.5 text-[9px] font-bold uppercase tracking-wide text-navy">
+          Most used
+        </span>
+      )}
+      {c.comingSoon && (
+        <span className="absolute right-4 top-4 rounded-pill border border-border-2 bg-bg px-2 py-0.5 text-[9px] font-bold uppercase tracking-wide text-navy-3">
+          MVP2
+        </span>
+      )}
+      <div
+        className={cn(
+          "flex h-9 w-9 items-center justify-center rounded-lg font-display text-lg font-bold",
+          c.iconTone,
+        )}
+      >
+        {c.icon}
+      </div>
+      <h3 className="mt-3 font-display text-[17px] font-semibold text-navy">{c.name}</h3>
+      <p className="mt-1 text-xs leading-relaxed text-navy-3">{c.desc}</p>
+      <div className="mt-3 border-t border-dashed border-border-2 pt-3">
+        <div className="text-[9px] font-bold uppercase tracking-[0.1em] text-navy-3">
+          {c.snapshotLabel}
+        </div>
+        <div className={cn("mt-0.5 font-display text-xl font-semibold", c.snapshotTone ?? "text-navy")}>
+          {c.snapshotValue}
+        </div>
+        <div className="mt-0.5 text-[10px] text-navy-3">{c.snapshotSub}</div>
+      </div>
+    </>
+  );
+
+  const base = "relative block rounded-xl border p-5";
+  if (c.comingSoon || !c.href) {
+    return <div className={cn(base, "border-border bg-surface opacity-60")}>{body}</div>;
+  }
+  return (
+    <Link
+      href={c.href}
+      className={cn(
+        base,
+        "transition-shadow hover:shadow-md",
+        c.featured ? "border-gold-soft bg-gold-bg/40" : "border-border bg-surface",
+      )}
+    >
+      {body}
+    </Link>
+  );
+}

--- a/omnischools/components/reports/report-header.tsx
+++ b/omnischools/components/reports/report-header.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+
+/** Shared detail-route header: crumb (Reports / X) + display title with a gold-italic word + actions. */
+export function ReportHeader({
+  crumb,
+  pre,
+  gold,
+  lede,
+  actions,
+}: {
+  crumb: string;
+  pre: string;
+  gold: string;
+  lede?: string;
+  actions?: React.ReactNode;
+}) {
+  return (
+    <div className="mb-5 flex flex-wrap items-start justify-between gap-3">
+      <div>
+        <div className="text-xs uppercase tracking-wide text-navy-3 print:hidden">
+          <Link href="/reports" className="font-semibold text-gold hover:underline">
+            Reports
+          </Link>{" "}
+          / {crumb}
+        </div>
+        <h1 className="mt-1 font-display text-3xl font-semibold text-navy">
+          {pre} <em className="text-gold">{gold}</em>
+        </h1>
+        {lede && <p className="mt-0.5 max-w-2xl text-sm text-navy-3">{lede}</p>}
+      </div>
+      {actions && <div className="flex flex-wrap items-center gap-2 print:hidden">{actions}</div>}
+    </div>
+  );
+}

--- a/omnischools/lib/reports/finance-data.ts
+++ b/omnischools/lib/reports/finance-data.ts
@@ -1,0 +1,259 @@
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  gte,
+  isNotNull,
+  isNull,
+  lt,
+  ne,
+  sql,
+} from "drizzle-orm";
+import { withSchool } from "@/lib/db/rls";
+import {
+  invoices,
+  payments,
+  students,
+  classes,
+  receipts,
+  users,
+  discounts,
+  discountTiers,
+  feeCategories,
+} from "@/db/schema";
+
+/** Shared finance aggregates for the Reports module (hub snapshots + every detail route). */
+
+export const ghs = (n: number) =>
+  `GHS ${n.toLocaleString("en-GH", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+export const num = (v: unknown) => Number(v ?? 0);
+export const ordinal = (n: number) =>
+  n === 1 ? "1st" : n === 2 ? "2nd" : n === 3 ? "3rd" : `${n}th`;
+
+export const METHOD_LABEL: Record<string, string> = {
+  MTN_MOMO: "MTN MoMo",
+  TELECEL_CASH: "Telecel Cash",
+  AIRTELTIGO_MONEY: "AirtelTigo Money",
+  BANK_TRANSFER: "Bank transfer",
+  CASH: "Cash",
+  CHEQUE: "Cheque",
+  OTHER: "Other",
+};
+
+export const AGING = [
+  { key: "current", label: "Not yet due", tone: "bg-navy" },
+  { key: "d30", label: "1–30 days overdue", tone: "bg-gold" },
+  { key: "d60", label: "31–60 days overdue", tone: "bg-warn" },
+  { key: "d90", label: "61–90 days overdue", tone: "bg-terra" },
+  { key: "d90plus", label: "90+ days overdue", tone: "bg-terra" },
+] as const;
+
+export type YearWindow = { start: Date; end: Date } | null;
+
+/** Sep–Aug window for an academic year label like "2025/26". */
+export function yearWindow(selectedYear: string | null): YearWindow {
+  if (!selectedYear) return null;
+  const sy = Number.parseInt(selectedYear.slice(0, 4), 10);
+  if (Number.isNaN(sy)) return null;
+  return { start: new Date(Date.UTC(sy, 8, 1)), end: new Date(Date.UTC(sy + 1, 8, 1)) };
+}
+
+export async function getFinanceReport(schoolId: string, selectedYear: string | null) {
+  const win = yearWindow(selectedYear);
+  const yearInv = selectedYear ? eq(invoices.academicYear, selectedYear) : undefined;
+  const payWindow = win
+    ? and(gte(payments.paidAt, win.start), lt(payments.paidAt, win.end))
+    : undefined;
+  const voidWindow = win
+    ? and(gte(payments.voidedAt, win.start), lt(payments.voidedAt, win.end))
+    : undefined;
+
+  const [
+    [totals],
+    byClass,
+    monthly,
+    byMethod,
+    agingRows,
+    voids,
+    discRows,
+    discTierRows,
+    [discTotal],
+    catRows,
+    yearRows,
+  ] = await Promise.all([
+    withSchool(schoolId, (tx) =>
+      tx
+        .select({
+          billed: sql<string>`coalesce(sum(${invoices.billedAmount}), 0)`,
+          collected: sql<string>`coalesce(sum(${invoices.paidAmount}), 0)`,
+          outstanding: sql<string>`coalesce(sum(${invoices.balanceAmount}), 0)`,
+          invoiceCount: sql<number>`count(*)`,
+        })
+        .from(invoices)
+        .where(and(eq(invoices.schoolId, schoolId), ne(invoices.status, "VOIDED"), yearInv)),
+    ),
+    withSchool(schoolId, (tx) =>
+      tx
+        .select({
+          classId: classes.id,
+          className: sql<string>`coalesce(${classes.name}, '— Unassigned —')`,
+          billed: sql<string>`coalesce(sum(${invoices.billedAmount}), 0)`,
+          collected: sql<string>`coalesce(sum(${invoices.paidAmount}), 0)`,
+          outstanding: sql<string>`coalesce(sum(${invoices.balanceAmount}), 0)`,
+        })
+        .from(invoices)
+        .innerJoin(students, eq(invoices.studentId, students.id))
+        .leftJoin(classes, eq(students.classId, classes.id))
+        .where(and(eq(invoices.schoolId, schoolId), ne(invoices.status, "VOIDED"), yearInv))
+        .groupBy(classes.id, classes.name)
+        .orderBy(desc(sql`sum(${invoices.balanceAmount})`)),
+    ),
+    withSchool(schoolId, (tx) =>
+      tx
+        .select({
+          month: sql<string>`to_char(${payments.paidAt}, 'YYYY-MM')`,
+          amount: sql<string>`coalesce(sum(${payments.netAmount}), 0)`,
+        })
+        .from(payments)
+        .where(and(eq(payments.schoolId, schoolId), isNull(payments.voidedAt), payWindow))
+        .groupBy(sql`to_char(${payments.paidAt}, 'YYYY-MM')`)
+        .orderBy(sql`to_char(${payments.paidAt}, 'YYYY-MM')`),
+    ),
+    withSchool(schoolId, (tx) =>
+      tx
+        .select({
+          method: payments.method,
+          amount: sql<string>`coalesce(sum(${payments.netAmount}), 0)`,
+          count: sql<number>`count(*)`,
+        })
+        .from(payments)
+        .where(and(eq(payments.schoolId, schoolId), isNull(payments.voidedAt), payWindow))
+        .groupBy(payments.method),
+    ),
+    withSchool(schoolId, (tx) =>
+      tx
+        .select({
+          bucket: sql<string>`case
+            when ${invoices.dueAt} is null or ${invoices.dueAt} >= now() then 'current'
+            when now() - ${invoices.dueAt} <= interval '30 days' then 'd30'
+            when now() - ${invoices.dueAt} <= interval '60 days' then 'd60'
+            when now() - ${invoices.dueAt} <= interval '90 days' then 'd90'
+            else 'd90plus'
+          end`,
+          amount: sql<string>`coalesce(sum(${invoices.balanceAmount}), 0)`,
+          count: sql<number>`count(*)`,
+        })
+        .from(invoices)
+        .where(
+          and(
+            eq(invoices.schoolId, schoolId),
+            ne(invoices.status, "VOIDED"),
+            sql`${invoices.balanceAmount} > 0`,
+            yearInv,
+          ),
+        )
+        .groupBy(sql`1`),
+    ),
+    withSchool(schoolId, (tx) =>
+      tx
+        .select({
+          voidedAt: payments.voidedAt,
+          amount: payments.grossAmount,
+          method: payments.method,
+          isRefund: payments.voidIsRefund,
+          reason: payments.voidReason,
+          firstName: students.firstName,
+          lastName: students.lastName,
+          receiptNumber: receipts.receiptNumber,
+          voidedBy: users.fullName,
+        })
+        .from(payments)
+        .innerJoin(students, eq(payments.studentId, students.id))
+        .leftJoin(receipts, eq(receipts.paymentId, payments.id))
+        .leftJoin(users, eq(payments.voidedByUserId, users.id))
+        .where(and(eq(payments.schoolId, schoolId), isNotNull(payments.voidedAt), voidWindow))
+        .orderBy(desc(payments.voidedAt))
+        .limit(100),
+    ),
+    withSchool(schoolId, (tx) =>
+      tx.select().from(discounts).where(eq(discounts.schoolId, schoolId)).orderBy(asc(discounts.name)),
+    ),
+    withSchool(schoolId, (tx) =>
+      tx
+        .select({
+          discountId: discountTiers.discountId,
+          rank: discountTiers.rank,
+          value: discountTiers.value,
+        })
+        .from(discountTiers)
+        .where(eq(discountTiers.schoolId, schoolId)),
+    ),
+    withSchool(schoolId, (tx) =>
+      tx
+        .select({
+          total: sql<string>`coalesce(sum(${invoices.discountAmount}), 0)`,
+          count: sql<number>`count(*) filter (where ${invoices.discountAmount} > 0)`,
+        })
+        .from(invoices)
+        .where(and(eq(invoices.schoolId, schoolId), ne(invoices.status, "VOIDED"), yearInv)),
+    ),
+    withSchool(schoolId, (tx) =>
+      tx
+        .select({ id: feeCategories.id, name: feeCategories.name })
+        .from(feeCategories)
+        .where(eq(feeCategories.schoolId, schoolId)),
+    ),
+    withSchool(schoolId, (tx) =>
+      tx
+        .selectDistinct({ year: invoices.academicYear })
+        .from(invoices)
+        .where(eq(invoices.schoolId, schoolId))
+        .orderBy(desc(invoices.academicYear)),
+    ),
+  ]);
+
+  const billed = num(totals?.billed);
+  const collected = num(totals?.collected);
+  const outstanding = num(totals?.outstanding);
+  const rate = billed > 0 ? Math.round((collected / billed) * 100) : 0;
+
+  const agingMap = new Map(
+    agingRows.map((r) => [r.bucket, { amount: num(r.amount), count: num(r.count) }]),
+  );
+  const overdueTotal = AGING.filter((b) => b.key !== "current").reduce(
+    (s, b) => s + (agingMap.get(b.key)?.amount ?? 0),
+    0,
+  );
+  const overdue30PlusCount = (["d60", "d90", "d90plus"] as const).reduce(
+    (s, k) => s + (agingMap.get(k)?.count ?? 0),
+    0,
+  );
+
+  const voidTotal = voids.reduce((s, v) => s + num(v.amount), 0);
+
+  return {
+    selectedYear,
+    totals,
+    billed,
+    collected,
+    outstanding,
+    rate,
+    byClass,
+    monthly,
+    byMethod,
+    agingMap,
+    overdueTotal,
+    overdue30PlusCount,
+    voids,
+    voidTotal,
+    discRows,
+    discTierRows,
+    discountTotal: num(discTotal?.total),
+    discountedCount: num(discTotal?.count),
+    catRows,
+    yearRows,
+  };
+}
+
+export type FinanceReport = Awaited<ReturnType<typeof getFinanceReport>>;


### PR DESCRIPTION
First **Reports-module** replication slice, from the surface-cartographer module audit of `schoolup-reports` + `school-stats` + `collection-trend` + `discounts-report` + `voids-refunds`.

## Why this is a reframe, not an add-on
The current `/reports` was a single **flat stat-dump** page; the surfaces specify a **card-catalogue hub** ("Answers, not *spreadsheets*") fanning out to **one detail route per report**. This slice flips the architecture and routes the existing content, so later slices upgrade each detail route to full surface fidelity.

## What changed
- **`/reports` → catalogue hub** (`schoolup-reports.html` §01): eyebrow, Fraunces **"Answers, not *spreadsheets*"**, gold rule, lede; **Finance / Academic / Operational** tabs with counts (**5 / 2 / 3**); card grid with **live finance snapshots** (Term collection, Outstanding +30+-overdue count, Discounts, Collection trend, Voids & refunds) + **MVP2 coming-soon cards**. "MOST USED" / "MVP2" badges; "Export all (zip)" + scheduling rendered disabled (MVP2).
- **New detail routes** (existing flat content split + re-skinned under a shared crumb header):
  - `/reports/term-collection` — KPI strip (incl. featured-navy), per-class **rate bars** + drill, collection-over-time, by-method %
  - `/reports/outstanding` — terra hero + aging strip + by-class debtors
  - `/reports/finance/collection-trend` — KPIs + monthly bars + peak
  - `/reports/voids-refunds` — **health banner** (2% benchmark), featured-terra KPI, event table
  - `/reports/discounts` — KPIs + configured-discounts table
- **Shared:** `lib/reports/finance-data.ts` (one `getFinanceReport` reused by the hub + every route) + `components/reports/{report-catalog, report-header}`.

## Deferred (named, from the audit)
Student-level outstanding table + per-row reminders (S4); term-on-term overlay / weekly grid / aging-by-household (S6); void split cards + recorder analysis (S5); **School stats** (needs `classes.target_capacity` migration); **Discounts per-application report** (needs a new `invoice_discount_application` table + **manual prod RLS paste**); true PDF/zip export, scheduling, academic performance, term-on-term comparisons — all **MVP2**.

## Verification
`typecheck` + `lint` + `build` clean. Live on a seeded finance scenario: hub snapshots (**collected GHS 2,500.00 / 64%, outstanding GHS 1,400.00, discounts GHS 100.00, reversed −GHS 340.00**) and every detail route render with real data (term-collection KPIs + class/method tables; voids "Elevated reversal rate · 13.60%"). Zero console errors. Seed + temp scripts removed.

No schema/RLS changes — **nothing to paste on prod.**

> Process note: ran the upgraded **surface-cartographer** agent in module-audit mode to map all 5 Reports surfaces vs the build before building (the agent `.md` is gitignored/local tooling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)