### PR TITLE
feat(reports): outstanding balances — student debtor table (R2 · S4)

### DIFF
--- a/omnischools/app/(app)/reports/outstanding/page.tsx
+++ b/omnischools/app/(app)/reports/outstanding/page.tsx
@@ -1,19 +1,117 @@
-import Link from "next/link";
+import { and, eq, inArray, ne, sql } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
-import { getFinanceReport, ghs, num, AGING } from "@/lib/reports/finance-data";
+import { withSchool } from "@/lib/db/rls";
+import { invoices, students, classes, studentGuardians } from "@/db/schema";
+import { getFinanceReport, ghs, num } from "@/lib/reports/finance-data";
 import { ExportCsv } from "@/components/reports/export-csv";
 import { PrintButton } from "@/components/reports/print-button";
 import { ReportHeader } from "@/components/reports/report-header";
+import { BulkRemindersButton } from "@/components/reports/bulk-reminders-button";
+import { OutstandingTable, type DebtorRow, type DebtorBucket } from "@/components/reports/outstanding-table";
 import { schoolFile } from "@/lib/filename";
 
 export const dynamic = "force-dynamic";
 export const metadata = { title: "Outstanding balances" };
 
+const WEEK_MS = 7 * 86_400_000;
+const weekday = (d: Date) => d.toLocaleDateString("en-GB", { weekday: "short" });
+const shortDate = (d: Date) => d.toLocaleDateString("en-GB", { day: "numeric", month: "short" });
+
+function bucketOf(oldestDue: Date | string | null, now: number): { bucket: DebtorBucket; label: string } {
+  if (!oldestDue) return { bucket: "notYetDue", label: "No due date" };
+  const due = new Date(oldestDue).getTime();
+  const overdue = Math.floor((now - due) / 86_400_000);
+  if (overdue > 30) return { bucket: "d30plus", label: `${overdue} days` };
+  if (overdue >= 1) return { bucket: "d1to30", label: `${overdue} days` };
+  if (due - now <= WEEK_MS) return { bucket: "dueThisWeek", label: `due ${weekday(new Date(due))}` };
+  return { bucket: "notYetDue", label: `due ${shortDate(new Date(due))}` };
+}
+
 export default async function OutstandingPage() {
   const { school } = await requireSchool();
-  const r = await getFinanceReport(school.id, null);
-  const agingMax = Math.max(1, ...AGING.map((b) => r.agingMap.get(b.key)?.amount ?? 0));
-  const debtors = r.byClass.filter((c) => num(c.outstanding) > 0);
+  const now = Date.now();
+
+  const [r, debtorRows] = await Promise.all([
+    getFinanceReport(school.id, null),
+    withSchool(school.id, (tx) =>
+      tx
+        .select({
+          studentId: students.id,
+          firstName: students.firstName,
+          lastName: students.lastName,
+          code: students.studentCode,
+          className: sql<string>`coalesce(${classes.name}, '— Unassigned —')`,
+          billed: sql<string>`coalesce(sum(${invoices.billedAmount}), 0)`,
+          paid: sql<string>`coalesce(sum(${invoices.paidAmount}), 0)`,
+          balance: sql<string>`coalesce(sum(${invoices.balanceAmount}), 0)`,
+          oldestDue: sql<string | null>`min(${invoices.dueAt}) filter (where ${invoices.balanceAmount} > 0)`,
+        })
+        .from(invoices)
+        .innerJoin(students, eq(invoices.studentId, students.id))
+        .leftJoin(classes, eq(students.classId, classes.id))
+        .where(and(eq(invoices.schoolId, school.id), ne(invoices.status, "VOIDED")))
+        .groupBy(students.id, students.firstName, students.lastName, students.studentCode, classes.name)
+        .having(sql`coalesce(sum(${invoices.balanceAmount}), 0) > 0`),
+    ),
+  ]);
+
+  const ids = debtorRows.map((d) => d.studentId);
+  const guardians = ids.length
+    ? await withSchool(school.id, (tx) =>
+        tx
+          .select({
+            studentId: studentGuardians.studentId,
+            name: studentGuardians.name,
+            phone: studentGuardians.phone,
+            isPrimary: studentGuardians.isPrimary,
+          })
+          .from(studentGuardians)
+          .where(inArray(studentGuardians.studentId, ids)),
+      )
+    : [];
+  const primary = new Map<string, { name: string; phone: string }>();
+  for (const g of guardians) {
+    if (g.isPrimary || !primary.has(g.studentId)) primary.set(g.studentId, { name: g.name, phone: g.phone });
+  }
+
+  const rows: DebtorRow[] = debtorRows
+    .map((d) => {
+      const { bucket, label } = bucketOf(d.oldestDue, now);
+      const g = primary.get(d.studentId) ?? null;
+      const row: DebtorRow = {
+        studentId: d.studentId,
+        name: `${d.firstName} ${d.lastName}`,
+        initials: `${d.firstName[0] ?? ""}${d.lastName[0] ?? ""}`.toUpperCase(),
+        code: d.code,
+        className: d.className,
+        billed: ghs(num(d.billed)),
+        paid: ghs(num(d.paid)),
+        balance: ghs(num(d.balance)),
+        guardianName: g?.name ?? null,
+        guardianPhone: g?.phone ?? null,
+        bucket,
+        agingLabel: label,
+      };
+      return { row, bal: num(d.balance) };
+    })
+    .sort((a, b) => b.bal - a.bal)
+    .map((x) => x.row);
+
+  const classList = Array.from(new Set(rows.map((d) => d.className))).sort();
+  const overdueCount = rows.filter((d) => d.bucket === "d1to30" || d.bucket === "d30plus").length;
+  const over30 = rows.filter((d) => d.bucket === "d30plus").length;
+
+  // 4-card aging strip (per-student bucketing of total balance)
+  const STRIP: { key: DebtorBucket; label: string; accent: string; note: string }[] = [
+    { key: "notYetDue", label: "Not yet due", accent: "#5C6675", note: "due later this term" },
+    { key: "dueThisWeek", label: "Due this week", accent: "#2F6B47", note: "expected to settle" },
+    { key: "d1to30", label: "1–30 days overdue", accent: "#C58A2E", note: "gentle reminder due" },
+    { key: "d30plus", label: "30+ days overdue", accent: "#B84A39", note: "escalation needed" },
+  ];
+  const stripData = (k: DebtorBucket) => {
+    const list = debtorRows.filter((d) => bucketOf(d.oldestDue, now).bucket === k);
+    return { amount: list.reduce((s, d) => s + num(d.balance), 0), count: list.length };
+  };
 
   return (
     <div className="mx-auto max-w-page">
@@ -21,16 +119,23 @@ export default async function OutstandingPage() {
         crumb="Outstanding balances"
         pre="Who hasn't"
         gold="paid"
-        lede="Unpaid balances grouped by how far past due they are."
+        lede="Unpaid balances grouped by how far past due they are. Send a reminder straight to the guardian."
         actions={
           <>
+            <BulkRemindersButton count={overdueCount} />
             <ExportCsv
               filename={schoolFile(school.name, "outstanding.csv")}
-              headers={["Bucket", "Outstanding", "Invoices"]}
-              rows={AGING.map((b) => {
-                const a = r.agingMap.get(b.key);
-                return [b.label, num(a?.amount).toFixed(2), String(a?.count ?? 0)];
-              })}
+              headers={["Student", "Class", "Billed", "Paid", "Balance", "Guardian", "Phone", "Aging"]}
+              rows={rows.map((d) => [
+                d.name,
+                d.className,
+                d.billed.replace("GHS ", ""),
+                d.paid.replace("GHS ", ""),
+                d.balance.replace("GHS ", ""),
+                d.guardianName ?? "",
+                d.guardianPhone ?? "",
+                d.agingLabel,
+              ])}
             />
             <PrintButton label="Export PDF" />
           </>
@@ -40,92 +145,44 @@ export default async function OutstandingPage() {
       {/* Hero callout */}
       <div className="mb-6 flex flex-wrap items-center justify-between gap-4 rounded-xl border border-terra/40 bg-terra-bg/40 p-5">
         <div>
-          <div className="text-[10px] font-bold uppercase tracking-[0.1em] text-navy-3">
-            Currently outstanding
-          </div>
-          <div className="mt-1 font-display text-3xl font-semibold text-terra">
-            {ghs(r.outstanding)}
-          </div>
+          <div className="text-[10px] font-bold uppercase tracking-[0.1em] text-navy-3">Currently outstanding</div>
+          <div className="mt-1 font-display text-3xl font-semibold text-terra">{ghs(r.outstanding)}</div>
         </div>
         <p className="max-w-sm text-sm text-navy-3">
-          <b className="text-terra">{ghs(r.overdueTotal)}</b> of it is overdue ·{" "}
-          <b className="text-navy-2">{r.overdue30PlusCount}</b> student
-          {r.overdue30PlusCount === 1 ? "" : "s"} are overdue 30+ days.
+          <b className="text-navy-2">{rows.length}</b> student{rows.length === 1 ? "" : "s"} with unpaid
+          balances · <b className="text-terra">{over30}</b> overdue 30+ days.
         </p>
       </div>
 
       {/* Aging strip */}
-      {r.outstanding <= 0 ? (
-        <Empty>Nothing outstanding — every invoice is settled.</Empty>
+      {rows.length === 0 ? (
+        <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
+          Nothing outstanding — every invoice is settled.
+        </p>
       ) : (
-        <div className="rounded-xl border border-border bg-surface p-5">
-          <div className="space-y-2">
-            {AGING.map((b) => {
-              const a = r.agingMap.get(b.key);
-              const amt = a?.amount ?? 0;
+        <>
+          <div className="mb-6 grid grid-cols-2 gap-4 lg:grid-cols-4">
+            {STRIP.map((s) => {
+              const d = stripData(s.key);
               return (
-                <div key={b.key} className="flex items-center gap-3">
-                  <span className="w-40 shrink-0 text-xs text-navy-2">{b.label}</span>
-                  <div className="h-5 flex-1 overflow-hidden rounded-full bg-bg">
-                    <div className={`h-full rounded-full ${b.tone}`} style={{ width: `${(amt / agingMax) * 100}%` }} />
+                <div
+                  key={s.key}
+                  style={{ borderTopWidth: 3, borderTopColor: s.accent }}
+                  className="rounded-xl border border-border bg-surface p-4"
+                >
+                  <div className="text-[10px] font-bold uppercase tracking-[0.1em] text-navy-3">{s.label}</div>
+                  <div className="mt-1.5 font-display text-xl font-semibold text-navy">{ghs(d.amount)}</div>
+                  <div className="mt-0.5 text-[11px] text-navy-3">
+                    {d.count} student{d.count === 1 ? "" : "s"} · {s.note}
                   </div>
-                  <span className="w-14 shrink-0 text-right text-[11px] text-navy-3">{a?.count ?? 0} inv</span>
-                  <span className="w-28 shrink-0 text-right text-xs font-medium text-navy-2">{ghs(amt)}</span>
                 </div>
               );
             })}
           </div>
-        </div>
-      )}
 
-      {/* By class */}
-      <h2 className="mb-3 mt-8 font-display text-lg font-semibold text-navy">Outstanding by class</h2>
-      {debtors.length === 0 ? (
-        <Empty>No outstanding balances by class.</Empty>
-      ) : (
-        <div className="overflow-hidden rounded-xl border border-border bg-surface">
-          <table className="w-full text-sm">
-            <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
-              <tr>
-                <th className="px-4 py-3 font-semibold">Class</th>
-                <th className="px-4 py-3 text-right font-semibold">Billed</th>
-                <th className="px-4 py-3 text-right font-semibold">Collected</th>
-                <th className="px-4 py-3 text-right font-semibold">Outstanding</th>
-                <th className="px-4 py-3"></th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              {debtors.map((c) => (
-                <tr key={c.className} className="hover:bg-bg">
-                  <td className="px-4 py-3 font-medium text-navy">{c.className}</td>
-                  <td className="px-4 py-3 text-right text-navy-2">{ghs(num(c.billed))}</td>
-                  <td className="px-4 py-3 text-right text-green">{ghs(num(c.collected))}</td>
-                  <td className="px-4 py-3 text-right font-medium text-terra">{ghs(num(c.outstanding))}</td>
-                  <td className="px-4 py-3 text-right">
-                    {c.classId && (
-                      <Link href={`/reports/class/${c.classId}`} className="text-xs font-semibold text-gold hover:underline">
-                        View debtors →
-                      </Link>
-                    )}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+          <OutstandingTable rows={rows} classes={classList} />
+        </>
       )}
-      <p className="mt-3 text-xs italic text-navy-3">
-        Student-level outstanding table with guardian contact and per-row reminders is coming in
-        the next slice.
-      </p>
     </div>
-  );
-}
-
-function Empty({ children }: { children: React.ReactNode }) {
-  return (
-    <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
-      {children}
-    </p>
   );
 }

--- a/omnischools/components/reports/bulk-reminders-button.tsx
+++ b/omnischools/components/reports/bulk-reminders-button.tsx
@@ -1,0 +1,33 @@
+"use client";
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { sendFeeReminders } from "@/lib/actions/billing";
+
+/** "Send reminders to all overdue (N)" — bulk fee-reminder SMS to every overdue debtor's primary guardian. */
+export function BulkRemindersButton({ count }: { count: number }) {
+  const router = useRouter();
+  const [pending, start] = useTransition();
+  const [msg, setMsg] = useState<string | null>(null);
+
+  if (count === 0) return null;
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      <button
+        onClick={() =>
+          start(async () => {
+            setMsg(null);
+            const res = await sendFeeReminders();
+            setMsg(res.ok ? `Sent ${res.sent ?? count}` : (res.error ?? "Could not send."));
+            if (res.ok) router.refresh();
+          })
+        }
+        disabled={pending}
+        className="rounded-md bg-gold px-3 py-2 text-sm font-semibold text-navy transition-colors hover:opacity-90 disabled:opacity-50 print:hidden"
+      >
+        {pending ? "Sending…" : `Send reminders to all overdue (${count})`}
+      </button>
+      {msg && <span className="text-xs font-medium text-green">{msg}</span>}
+    </span>
+  );
+}

--- a/omnischools/components/reports/outstanding-table.tsx
+++ b/omnischools/components/reports/outstanding-table.tsx
@@ -1,0 +1,183 @@
+"use client";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { SendReminderButton } from "@/components/reports/send-reminder-button";
+
+export type DebtorBucket = "notYetDue" | "dueThisWeek" | "d1to30" | "d30plus";
+export type DebtorRow = {
+  studentId: string;
+  name: string;
+  initials: string;
+  code: string;
+  className: string;
+  billed: string;
+  paid: string;
+  balance: string;
+  guardianName: string | null;
+  guardianPhone: string | null;
+  bucket: DebtorBucket;
+  agingLabel: string;
+};
+
+const FILTERS: { key: "all" | DebtorBucket; label: string }[] = [
+  { key: "all", label: "All" },
+  { key: "notYetDue", label: "Not yet due" },
+  { key: "dueThisWeek", label: "Due this week" },
+  { key: "d1to30", label: "1–30 overdue" },
+  { key: "d30plus", label: "30+ overdue" },
+];
+
+const PILL: Record<DebtorBucket, string> = {
+  d30plus: "bg-terra-bg text-terra",
+  d1to30: "bg-warn-bg text-warn",
+  dueThisWeek: "bg-green-bg text-green",
+  notYetDue: "bg-bg text-navy-3",
+};
+
+export function OutstandingTable({ rows, classes }: { rows: DebtorRow[]; classes: string[] }) {
+  const [tab, setTab] = useState<"all" | DebtorBucket>("all");
+  const [cls, setCls] = useState("all");
+  const [q, setQ] = useState("");
+
+  const count = (k: "all" | DebtorBucket) =>
+    k === "all" ? rows.length : rows.filter((r) => r.bucket === k).length;
+
+  const shown = rows.filter((r) => {
+    if (tab !== "all" && r.bucket !== tab) return false;
+    if (cls !== "all" && r.className !== cls) return false;
+    if (q.trim()) {
+      const needle = q.trim().toLowerCase();
+      if (
+        !r.name.toLowerCase().includes(needle) &&
+        !(r.guardianName ?? "").toLowerCase().includes(needle)
+      )
+        return false;
+    }
+    return true;
+  });
+
+  return (
+    <div>
+      {/* Filter strip */}
+      <div className="mb-3 flex flex-wrap items-center gap-2 print:hidden">
+        {FILTERS.map((f) => {
+          const active = tab === f.key;
+          return (
+            <button
+              key={f.key}
+              onClick={() => setTab(f.key)}
+              className={cn(
+                "rounded-pill border px-2.5 py-1 text-xs font-semibold transition-colors",
+                active
+                  ? "border-navy bg-navy text-bg"
+                  : "border-border-2 bg-surface text-navy-2 hover:border-gold",
+              )}
+            >
+              {f.label}{" "}
+              <span className={active ? "text-bg/70" : "text-navy-3"}>{count(f.key)}</span>
+            </button>
+          );
+        })}
+        <span className="mx-1 h-5 w-px bg-border" />
+        <select
+          value={cls}
+          onChange={(e) => setCls(e.target.value)}
+          className="rounded-md border border-border-2 bg-bg px-2.5 py-1.5 text-xs text-navy outline-none focus:border-gold"
+        >
+          <option value="all">All classes</option>
+          {classes.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+        <input
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Search by student or guardian…"
+          className="w-56 rounded-md border border-border-2 bg-bg px-3 py-1.5 text-xs text-navy outline-none placeholder:italic placeholder:text-navy-3 focus:border-gold"
+        />
+      </div>
+
+      <div className="overflow-x-auto rounded-xl border border-border bg-surface">
+        <table className="w-full text-sm">
+          <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
+            <tr>
+              <th className="px-4 py-3 font-semibold">Student</th>
+              <th className="px-4 py-3 font-semibold">Class</th>
+              <th className="px-4 py-3 text-right font-semibold">Billed</th>
+              <th className="px-4 py-3 text-right font-semibold">Paid</th>
+              <th className="px-4 py-3 text-right font-semibold">Balance</th>
+              <th className="px-4 py-3 font-semibold">Aging</th>
+              <th className="px-4 py-3"></th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {shown.map((r) => {
+              const overdue = r.bucket === "d1to30" || r.bucket === "d30plus";
+              return (
+                <tr
+                  key={r.studentId}
+                  className={r.bucket === "d30plus" ? "bg-terra-bg/30" : "hover:bg-bg"}
+                >
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2.5">
+                      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gold-bg font-display text-[11px] font-semibold text-navy">
+                        {r.initials}
+                      </span>
+                      <div className="min-w-0">
+                        <div className="font-medium text-navy">{r.name}</div>
+                        <div className="text-[11px] text-navy-3">
+                          {r.guardianName ? (
+                            <>
+                              {r.guardianName}
+                              {r.guardianPhone ? ` · ${r.guardianPhone}` : ""}
+                            </>
+                          ) : (
+                            <span className="italic">no guardian on file</span>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-navy-2">{r.className}</td>
+                  <td className="px-4 py-3 text-right text-navy-2">{r.billed}</td>
+                  <td className="px-4 py-3 text-right text-green">{r.paid}</td>
+                  <td className="px-4 py-3 text-right font-medium text-terra">{r.balance}</td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={cn(
+                        "rounded-pill px-2 py-0.5 text-xs font-medium",
+                        PILL[r.bucket],
+                      )}
+                    >
+                      {r.agingLabel}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    {overdue ? (
+                      r.guardianPhone ? (
+                        <SendReminderButton studentId={r.studentId} />
+                      ) : (
+                        <span className="text-[11px] italic text-navy-3">no phone</span>
+                      )
+                    ) : (
+                      <span className="text-[11px] text-navy-3">Not yet due</span>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+            {shown.length === 0 && (
+              <tr>
+                <td colSpan={7} className="px-4 py-6 text-center text-sm text-navy-3">
+                  No students match this filter.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Brings `/reports/outstanding` to the `schoolup-reports.html` §03 spec — the highest-value detail upgrade. **Schema-free.** Builds on the hub from [#86](https://github.com/Omnischools/omnischools/pull/86).

## What changed
- **Terra hero callout** — "Currently outstanding" {total} + "{N} students with unpaid balances · {M} overdue 30+ days".
- **4-card aging strip** (coloured top-bar): Not yet due / Due this week / 1—30 days overdue / 30+ days overdue — amount + student count per bucket (per-student bucketing by the **oldest unpaid invoice's due date**).
- **Student-level debtor table** (new query: invoices grouped per student with balance > 0 → class + **primary guardian**): avatar + name + **guardian · phone**, class, billed, paid, balance, an **aging pill** (`42 days` terra / `18 days` warn / `due Fri` green / `due 12 May`), 30+-overdue rows tinted, sorted by balance.
- **Per-row action**: **Remind** (`sendReminderToStudent`) for overdue debtors with a phone, "no phone" when missing, "Not yet due" otherwise.
- **Client filter strip**: bucket pills with counts + class select + search (student or guardian).
- **Header**: bulk **"Send reminders to all overdue (N)"** (`sendFeeReminders`) + Export CSV + Export PDF.

## Verification
`typecheck` + `lint` + `build` clean. Live on a seeded 4-debtor scenario (one per bucket): hero **GHS 2,700.00 / "4 students · 1 overdue 30+"**, aging strip **800 / 500 / 1,000 / 400**, pills **All 4** + one each, bulk **"(2)"**, per-row **Remind** vs **Not yet due**, the **30+ filter** narrows to one row, and a live reminder fired `[sms:console] → +233…002: …outstanding fee balance of GHS 400.00…`. Zero console errors. Seed + temp scripts removed.

No schema/RLS changes — **nothing to paste on prod.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)