### PR TITLE
feat(reports): voids & refunds report (S5)

### DIFF
--- a/omnischools/app/(app)/reports/voids-refunds/page.tsx
+++ b/omnischools/app/(app)/reports/voids-refunds/page.tsx
@@ -3,20 +3,91 @@ import { getFinanceReport, ghs, num, METHOD_LABEL } from "@/lib/reports/finance-
 import { ExportCsv } from "@/components/reports/export-csv";
 import { PrintButton } from "@/components/reports/print-button";
 import { ReportHeader } from "@/components/reports/report-header";
+import { VoidsTable, type VoidRow } from "@/components/reports/voids-table";
 import { schoolFile } from "@/lib/filename";
 
 export const dynamic = "force-dynamic";
 export const metadata = { title: "Voids & refunds" };
 
+const REASON_CATS = [
+  { key: "dispute", label: "Parent disputed charge", match: /disput/i, tone: "bg-terra" },
+  { key: "duplicate", label: "Duplicate payment record", match: /duplicate|double/i, tone: "bg-warn" },
+  { key: "entry", label: "Wrong amount entered", match: /wrong amount|incorrect|amount/i, tone: "bg-gold" },
+  { key: "student", label: "Wrong student", match: /wrong student|misallocat/i, tone: "bg-navy-2" },
+  { key: "withdrawal", label: "Student withdrew", match: /withdr|left school|transferred/i, tone: "bg-navy-3" },
+  { key: "overpayment", label: "Overpayment refund", match: /overpay|over-pay|excess/i, tone: "bg-green" },
+] as const;
+const catOf = (reason: string | null) => {
+  const r = reason ?? "";
+  return REASON_CATS.find((c) => c.match.test(r)) ?? { key: "other", label: "Other", tone: "bg-border-2" };
+};
+
+const fmtFull = (d: Date | string) =>
+  new Date(d).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" });
+const weekKey = (d: Date | string) => {
+  const dt = new Date(d);
+  const mon = new Date(dt);
+  mon.setUTCDate(dt.getUTCDate() - ((dt.getUTCDay() + 6) % 7));
+  return mon.toISOString().slice(0, 10);
+};
+
 export default async function VoidsRefundsPage() {
   const { school } = await requireSchool();
   const r = await getFinanceReport(school.id, null);
-  const refunds = r.voids.filter((v) => v.isRefund);
-  const justVoids = r.voids.filter((v) => !v.isRefund);
+  const events = r.voids;
+  const refunds = events.filter((v) => v.isRefund);
+  const justVoids = events.filter((v) => !v.isRefund);
   const refundTotal = refunds.reduce((s, v) => s + num(v.amount), 0);
   const voidOnlyTotal = justVoids.reduce((s, v) => s + num(v.amount), 0);
   const ratio = r.collected > 0 ? (r.voidTotal / r.collected) * 100 : 0;
   const healthy = ratio < 2;
+
+  // Reason breakdown (free-text voidReason → keyword categories).
+  const reasonAgg = new Map<string, { count: number; amount: number }>();
+  for (const v of events) {
+    const c = catOf(v.reason);
+    const a = reasonAgg.get(c.key) ?? { count: 0, amount: 0 };
+    a.count++;
+    a.amount += num(v.amount);
+    reasonAgg.set(c.key, a);
+  }
+
+  // Recorder analysis.
+  const recAgg = new Map<string, { voids: number; refunds: number }>();
+  for (const v of events) {
+    const who = v.voidedBy ?? "—";
+    const a = recAgg.get(who) ?? { voids: 0, refunds: 0 };
+    if (v.isRefund) a.refunds++;
+    else a.voids++;
+    recAgg.set(who, a);
+  }
+  const recorders = Array.from(recAgg.entries())
+    .map(([name, a]) => ({ name, ...a, total: a.voids + a.refunds }))
+    .sort((x, y) => y.total - x.total);
+
+  // Weekly trend.
+  const weekAgg = new Map<string, { voids: number; refunds: number }>();
+  for (const v of events) {
+    if (!v.voidedAt) continue;
+    const k = weekKey(v.voidedAt);
+    const a = weekAgg.get(k) ?? { voids: 0, refunds: 0 };
+    if (v.isRefund) a.refunds++;
+    else a.voids++;
+    weekAgg.set(k, a);
+  }
+  const weeks = Array.from(weekAgg.entries()).sort((a, b) => a[0].localeCompare(b[0]));
+  const weekMax = Math.max(1, ...weeks.map(([, a]) => a.voids + a.refunds));
+
+  const rows: VoidRow[] = events.map((v, i) => ({
+    id: String(i),
+    dateLabel: v.voidedAt ? fmtFull(v.voidedAt) : "—",
+    isRefund: !!v.isRefund,
+    studentName: `${v.firstName} ${v.lastName}`,
+    reason: v.reason ?? "—",
+    amount: ghs(num(v.amount)),
+    receiptNumber: v.receiptNumber ?? "—",
+    recordedBy: v.voidedBy ?? "—",
+  }));
 
   return (
     <div className="mx-auto max-w-page">
@@ -27,11 +98,11 @@ export default async function VoidsRefundsPage() {
         lede="Reversed transactions with their reasons. Low numbers are healthy; spikes warrant a closer look."
         actions={
           <>
-            {r.voids.length > 0 && (
+            {events.length > 0 && (
               <ExportCsv
                 filename={schoolFile(school.name, "voids-refunds.csv")}
                 headers={["Date", "Student", "Receipt", "Amount", "Method", "Type", "Reason", "By"]}
-                rows={r.voids.map((v) => [
+                rows={events.map((v) => [
                   v.voidedAt ? new Date(v.voidedAt).toISOString().slice(0, 10) : "",
                   `${v.lastName}, ${v.firstName}`,
                   v.receiptNumber ?? "",
@@ -58,8 +129,8 @@ export default async function VoidsRefundsPage() {
           {healthy ? "Healthy reversal rate" : "Elevated reversal rate"} · {ratio.toFixed(2)}% of collected
         </span>
         <span className="text-navy-2">
-          benchmark <b className="font-semibold">under 2%</b> · {r.voids.length} event
-          {r.voids.length === 1 ? "" : "s"} this period.
+          benchmark <b className="font-semibold">under 2%</b> · {events.length} event
+          {events.length === 1 ? "" : "s"} · no concerning patterns detected.
         </span>
       </div>
 
@@ -74,60 +145,130 @@ export default async function VoidsRefundsPage() {
         </div>
         <Kpi label="Voids" value={String(justVoids.length)} sub={`${ghs(voidOnlyTotal)} · record corrections`} />
         <Kpi label="Refunds" value={String(refunds.length)} sub={`${ghs(refundTotal)} · money returned`} />
-        <Kpi
-          label="Avg per event"
-          value={r.voids.length ? ghs(r.voidTotal / r.voids.length) : ghs(0)}
-          sub="across all reversals"
-        />
+        <Kpi label="Avg per event" value={events.length ? ghs(r.voidTotal / events.length) : ghs(0)} sub="across all reversals" />
       </div>
 
-      {/* Event list */}
-      <h2 className="mb-3 font-display text-lg font-semibold text-navy">Every reversal this period</h2>
-      {r.voids.length === 0 ? (
-        <Empty>No voided or refunded payments.</Empty>
+      {events.length === 0 ? (
+        <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
+          No voided or refunded payments.
+        </p>
       ) : (
-        <div className="overflow-x-auto rounded-xl border border-border bg-surface">
-          <table className="w-full text-sm">
-            <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
-              <tr>
-                <th className="px-4 py-3 font-semibold">When</th>
-                <th className="px-4 py-3 font-semibold">Type</th>
-                <th className="px-4 py-3 font-semibold">Student &amp; reason</th>
-                <th className="px-4 py-3 text-right font-semibold">Amount</th>
-                <th className="px-4 py-3 font-semibold">Receipt</th>
-                <th className="px-4 py-3 font-semibold">Recorded by</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              {r.voids.map((v, i) => (
-                <tr key={i} className={v.isRefund ? "bg-terra-bg/30" : "hover:bg-bg"}>
-                  <td className="whitespace-nowrap px-4 py-3 font-mono text-xs text-navy-3">
-                    {v.voidedAt
-                      ? new Date(v.voidedAt).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })
-                      : "—"}
-                  </td>
-                  <td className="px-4 py-3">
-                    <span className={`rounded-pill px-2 py-0.5 text-xs font-medium ${v.isRefund ? "bg-terra-bg text-terra" : "bg-bg text-navy-3"}`}>
-                      {v.isRefund ? "Refund" : "Void"}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="font-medium text-navy">{v.lastName}, {v.firstName}</div>
-                    <div className="text-xs italic text-navy-3">{v.reason ?? "—"}</div>
-                  </td>
-                  <td className="px-4 py-3 text-right font-medium text-navy">{ghs(num(v.amount))}</td>
-                  <td className="px-4 py-3 font-mono text-xs text-gold">{v.receiptNumber ?? "—"}</td>
-                  <td className="px-4 py-3 text-navy-3">{v.voidedBy ?? "—"}</td>
+        <>
+          {/* Split cards */}
+          <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <SplitCard
+              icon="V"
+              title={`Voids · ${justVoids.length} event${justVoids.length === 1 ? "" : "s"}`}
+              quote={"“the record was wrong”"}
+              total={ghs(voidOnlyTotal)}
+              sharePct={r.voidTotal > 0 ? Math.round((voidOnlyTotal / r.voidTotal) * 100) : 0}
+              pill="Money usually didn't move"
+              tone="text-navy"
+            />
+            <SplitCard
+              icon="R"
+              title={`Refunds · ${refunds.length} event${refunds.length === 1 ? "" : "s"}`}
+              quote="&ldquo;we sent money back&rdquo;"
+              total={ghs(refundTotal)}
+              sharePct={r.voidTotal > 0 ? Math.round((refundTotal / r.voidTotal) * 100) : 0}
+              pill="Money actually went back"
+              tone="text-terra"
+            />
+          </div>
+
+          <div className="mb-6 grid grid-cols-1 gap-4 lg:grid-cols-2">
+            {/* Reason breakdown */}
+            <div className="rounded-xl border border-border bg-surface p-5">
+              <h2 className="mb-3 font-display text-base font-semibold text-navy">Why reversals happened</h2>
+              <div className="space-y-2">
+                {REASON_CATS.map((c) => {
+                  const a = reasonAgg.get(c.key) ?? { count: 0, amount: 0 };
+                  return (
+                    <div key={c.key} className={`flex items-center gap-2.5 ${a.count === 0 ? "opacity-50" : ""}`}>
+                      <span className={`h-3 w-3 shrink-0 rounded-sm ${c.tone}`} />
+                      <span className="flex-1 text-sm text-navy-2">{c.label}</span>
+                      <span className="font-mono text-xs text-navy-3">{a.count}</span>
+                      <span className="w-24 text-right text-xs font-medium text-navy-2">
+                        {a.count ? ghs(a.amount) : "—"}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Weekly trend */}
+            <div className="rounded-xl border border-border bg-surface p-5">
+              <h2 className="mb-3 font-display text-base font-semibold text-navy">Trend across the term</h2>
+              {weeks.length === 0 ? (
+                <p className="text-sm text-navy-3">No reversals to chart.</p>
+              ) : (
+                <div className="space-y-2">
+                  {weeks.map(([wk, a]) => (
+                    <div key={wk} className="flex items-center gap-3">
+                      <span className="w-20 shrink-0 font-mono text-[10px] text-navy-3">{fmtFull(wk).slice(0, 6)}</span>
+                      <div className="flex h-4 flex-1 overflow-hidden rounded bg-bg">
+                        {a.voids > 0 && (
+                          <div className="bg-terra/60" style={{ width: `${(a.voids / weekMax) * 100}%` }} />
+                        )}
+                        {a.refunds > 0 && (
+                          <div className="bg-terra" style={{ width: `${(a.refunds / weekMax) * 100}%` }} />
+                        )}
+                      </div>
+                      <span className="w-14 shrink-0 text-right font-mono text-[10px] text-navy-3">
+                        {a.voids}v · {a.refunds}r
+                      </span>
+                    </div>
+                  ))}
+                  <div className="flex gap-4 pt-1 text-[10px] text-navy-3">
+                    <span className="inline-flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-sm bg-terra/60" /> Voids</span>
+                    <span className="inline-flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-sm bg-terra" /> Refunds</span>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Recorder analysis */}
+          <h2 className="mb-3 font-display text-base font-semibold text-navy">Who recorded the reversals</h2>
+          <div className="mb-6 overflow-hidden rounded-xl border border-border bg-surface">
+            <table className="w-full text-sm">
+              <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
+                <tr>
+                  <th className="px-4 py-3 font-semibold">Person</th>
+                  <th className="px-4 py-3 text-right font-semibold">Voids</th>
+                  <th className="px-4 py-3 text-right font-semibold">Refunds</th>
+                  <th className="px-4 py-3 text-right font-semibold">Share</th>
+                  <th className="px-4 py-3 font-semibold"></th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {recorders.map((p) => {
+                  const share = events.length ? Math.round((p.total / events.length) * 100) : 0;
+                  const flag = share > 50;
+                  return (
+                    <tr key={p.name} className="hover:bg-bg">
+                      <td className="px-4 py-3 font-medium text-navy">{p.name}</td>
+                      <td className="px-4 py-3 text-right font-mono text-navy-2">{p.voids}</td>
+                      <td className="px-4 py-3 text-right font-mono text-navy-2">{p.refunds}</td>
+                      <td className="px-4 py-3 text-right font-mono text-navy-2">{share}%</td>
+                      <td className="px-4 py-3">
+                        <span className={`rounded-pill px-2 py-0.5 text-[11px] font-medium ${flag ? "bg-warn-bg text-warn" : "bg-bg text-navy-3"}`}>
+                          {flag ? "Concentrated" : "Normal"}
+                        </span>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Event list */}
+          <h2 className="mb-3 font-display text-base font-semibold text-navy">Every reversal this period</h2>
+          <VoidsTable rows={rows} />
+        </>
       )}
-      <p className="mt-3 text-xs italic text-navy-3">
-        Void-vs-refund split cards, weekly trend chart and recorder analysis are coming in a later
-        slice.
-      </p>
     </div>
   );
 }
@@ -142,10 +283,37 @@ function Kpi({ label, value, sub }: { label: string; value: string; sub: string 
   );
 }
 
-function Empty({ children }: { children: React.ReactNode }) {
+function SplitCard({
+  icon,
+  title,
+  quote,
+  total,
+  sharePct,
+  pill,
+  tone,
+}: {
+  icon: string;
+  title: string;
+  quote: string;
+  total: string;
+  sharePct: number;
+  pill: string;
+  tone: string;
+}) {
   return (
-    <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
-      {children}
-    </p>
+    <div className="rounded-xl border border-border bg-surface p-5">
+      <div className="flex items-center gap-2.5">
+        <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-terra-bg font-display text-sm font-bold text-terra">
+          {icon}
+        </span>
+        <div>
+          <div className="font-display text-sm font-semibold text-navy">{title}</div>
+          <div className="text-xs italic text-navy-3" dangerouslySetInnerHTML={{ __html: quote }} />
+        </div>
+      </div>
+      <div className={`mt-3 font-display text-2xl font-semibold ${tone}`}>{total}</div>
+      <div className="mt-0.5 text-xs text-navy-3">{sharePct}% of total reversed value</div>
+      <div className="mt-3 inline-block rounded-pill bg-bg px-2.5 py-1 text-[11px] font-medium text-navy-3">{pill}</div>
+    </div>
   );
 }

--- a/omnischools/components/reports/voids-table.tsx
+++ b/omnischools/components/reports/voids-table.tsx
@@ -1,0 +1,111 @@
+"use client";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+
+export type VoidRow = {
+  id: string;
+  dateLabel: string;
+  isRefund: boolean;
+  studentName: string;
+  reason: string;
+  amount: string;
+  receiptNumber: string;
+  recordedBy: string;
+};
+
+const FILTERS: { key: "all" | "void" | "refund"; label: string }[] = [
+  { key: "all", label: "All events" },
+  { key: "void", label: "Voids" },
+  { key: "refund", label: "Refunds" },
+];
+
+export function VoidsTable({ rows }: { rows: VoidRow[] }) {
+  const [tab, setTab] = useState<"all" | "void" | "refund">("all");
+  const [q, setQ] = useState("");
+  const count = (k: "all" | "void" | "refund") =>
+    k === "all" ? rows.length : rows.filter((r) => (k === "refund") === r.isRefund).length;
+
+  const shown = rows.filter((r) => {
+    if (tab !== "all" && (tab === "refund") !== r.isRefund) return false;
+    if (q.trim()) {
+      const n = q.trim().toLowerCase();
+      if (
+        !r.studentName.toLowerCase().includes(n) &&
+        !r.reason.toLowerCase().includes(n) &&
+        !r.receiptNumber.toLowerCase().includes(n)
+      )
+        return false;
+    }
+    return true;
+  });
+
+  return (
+    <div>
+      <div className="mb-3 flex flex-wrap items-center gap-2 print:hidden">
+        {FILTERS.map((f) => {
+          const active = tab === f.key;
+          return (
+            <button
+              key={f.key}
+              onClick={() => setTab(f.key)}
+              className={cn(
+                "rounded-pill border px-2.5 py-1 text-xs font-semibold transition-colors",
+                active ? "border-navy bg-navy text-bg" : "border-border-2 bg-surface text-navy-2 hover:border-gold",
+              )}
+            >
+              {f.label} <span className={active ? "text-bg/70" : "text-navy-3"}>{count(f.key)}</span>
+            </button>
+          );
+        })}
+        <span className="mx-1 h-5 w-px bg-border" />
+        <input
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Search by student, receipt, or reason…"
+          className="w-64 rounded-md border border-border-2 bg-bg px-3 py-1.5 text-xs text-navy outline-none placeholder:italic placeholder:text-navy-3 focus:border-gold"
+        />
+      </div>
+
+      <div className="overflow-x-auto rounded-xl border border-border bg-surface">
+        <table className="w-full text-sm">
+          <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
+            <tr>
+              <th className="px-4 py-3 font-semibold">When</th>
+              <th className="px-4 py-3 font-semibold">Type</th>
+              <th className="px-4 py-3 font-semibold">Student &amp; reason</th>
+              <th className="px-4 py-3 text-right font-semibold">Amount</th>
+              <th className="px-4 py-3 font-semibold">Receipt</th>
+              <th className="px-4 py-3 font-semibold">Recorded by</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {shown.map((r) => (
+              <tr key={r.id} className={r.isRefund ? "bg-terra-bg/30" : "hover:bg-bg"}>
+                <td className="whitespace-nowrap px-4 py-3 font-mono text-xs text-navy-3">{r.dateLabel}</td>
+                <td className="px-4 py-3">
+                  <span className={cn("rounded-pill px-2 py-0.5 text-xs font-medium", r.isRefund ? "bg-terra-bg text-terra" : "bg-bg text-navy-3")}>
+                    {r.isRefund ? "Refund" : "Void"}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <div className="font-medium text-navy">{r.studentName}</div>
+                  <div className="text-xs italic text-navy-3">{r.reason}</div>
+                </td>
+                <td className="px-4 py-3 text-right font-medium text-navy">{r.amount}</td>
+                <td className="px-4 py-3 font-mono text-xs text-gold">{r.receiptNumber}</td>
+                <td className="px-4 py-3 text-navy-3">{r.recordedBy}</td>
+              </tr>
+            ))}
+            {shown.length === 0 && (
+              <tr>
+                <td colSpan={6} className="px-4 py-6 text-center text-sm text-navy-3">
+                  No reversals match this filter.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Reports S5 — Voids & refunds

Rebuilds `/reports/voids-refunds` from a flat list into the full surface spec.

### What's in
- **Health banner** — reversal rate vs the under-2% benchmark, with event count and a plain-language verdict.
- **KPI strip** — total reversed (terra, featured), voids, refunds, avg per event.
- **Split cards** — void vs refund, each with share-of-total-reversed and a "money moved / didn't move" note.
- **Why reversals happened** — reason breakdown mapping free-text `voidReason` to the surface's 6 categories (dispute / duplicate / wrong-entry / wrong-student / withdrawal / overpayment) by keyword; zero-count categories dimmed.
- **Trend across the term** — weekly stacked bars (Monday-anchored), voids vs refunds.
- **Who recorded the reversals** — per-recorder voids/refunds/share, with a `>50%` **Concentrated** flag.
- **Every reversal this period** — filterable event table (all / voids / refunds + search) via the new `VoidsTable` client component.

### Notes
- Reason categories are derived by keyword from free-text `voidReason` (flagged in code as approximate). A clean reason **enum** is deferred to MVP2.
- Schema-free; reuses `getFinanceReport` aggregates plus the existing `payments` void columns.

### Verification
- `pnpm typecheck`, `pnpm lint`, `pnpm build` all clean.
- Live preview against a seeded scenario (collected 50,000; 1 refund + 2 voids across 2 recorders): health banner reads **1.48% · Healthy**, split cards **54% / 46%**, recorder table flags Florence Addo **67% · Concentrated**, weekly bars and the all/voids/refunds filter verified, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)