### PR TITLE
feat(reports): term collection — weekly chart + KPI fidelity (S3)

### DIFF
--- a/omnischools/app/(app)/reports/term-collection/page.tsx
+++ b/omnischools/app/(app)/reports/term-collection/page.tsx
@@ -4,6 +4,7 @@ import { getFinanceReport, ghs, num, METHOD_LABEL } from "@/lib/reports/finance-
 import { ExportCsv } from "@/components/reports/export-csv";
 import { PrintButton } from "@/components/reports/print-button";
 import { ReportHeader } from "@/components/reports/report-header";
+import { WeeklyBars } from "@/components/reports/weekly-bars";
 import { schoolFile } from "@/lib/filename";
 
 export const dynamic = "force-dynamic";
@@ -12,17 +13,38 @@ export const metadata = { title: "Term collection" };
 const classRate = (b: unknown, c: unknown) =>
   num(b) > 0 ? Math.round((num(c) / num(b)) * 100) : 0;
 
+const METHOD_SWATCH: Record<string, string> = {
+  MTN_MOMO: "#C8975B",
+  CASH: "#2F6B47",
+  BANK_TRANSFER: "#1A2B47",
+  TELECEL_CASH: "#B84A39",
+  AIRTELTIGO_MONEY: "#C58A2E",
+};
+
+const fmtWeek = (iso: string) =>
+  new Date(`${iso}T00:00:00Z`).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" });
+
+// Periods stay visual until the term-calendar infra lands (MVP2 wires real windows).
+const PERIODS = ["This week", "This month", "This term", "Academic year", "Custom…"] as const;
+
 export default async function TermCollectionPage() {
   const { school } = await requireSchool();
   const r = await getFinanceReport(school.id, null);
-  const maxMonth = Math.max(1, ...r.monthly.map((m) => num(m.amount)));
+
+  // Trailing window so the chart reads like a term rather than the whole history.
+  const weeksAll = r.weekly.map((w) => ({ iso: w.weekStart, amount: num(w.amount) }));
+  const weeksWin = weeksAll.slice(-16);
+  const weeks = weeksWin.map((w, i) => ({ label: `W${i + 1}`, amount: w.amount, iso: w.iso }));
+  const peakIdx = weeks.length
+    ? weeks.reduce((p, w, i) => (w.amount > weeks[p].amount ? i : p), 0)
+    : 0;
   const methodTotal = Math.max(1, r.byMethod.reduce((s, m) => s + num(m.amount), 0));
 
   const kpis = [
-    { label: "Total billed", value: ghs(r.billed), sub: `${num(r.totals?.invoiceCount)} invoices`, featured: false, tone: "text-navy" },
-    { label: "Collected", value: ghs(r.collected), sub: `${r.rate}% of billed`, featured: true, tone: "" },
-    { label: "Outstanding", value: ghs(r.outstanding), sub: "across all classes", featured: false, tone: "text-terra" },
-    { label: "Collection rate", value: `${r.rate}%`, sub: r.rate >= 80 ? "healthy" : "needs follow-up", featured: false, tone: "text-navy" },
+    { label: "Total billed", value: ghs(r.billed), sub: `${num(r.totals?.invoiceCount)} invoices · ${num(r.totals?.studentCount)} students`, featured: false, tone: "text-navy" },
+    { label: "Collected", value: ghs(r.collected), sub: `${r.rate}% of billed`, featured: true, tone: "", arrow: true },
+    { label: "Outstanding", value: ghs(r.outstanding), sub: `${num(r.totals?.debtorCount)} students with balances`, featured: false, tone: "text-navy" },
+    { label: "Reversed", value: `−${ghs(r.voidTotal)}`, sub: `${r.voids.length} voids & refunds`, featured: false, tone: "text-terra" },
   ];
 
   return (
@@ -31,7 +53,7 @@ export default async function TermCollectionPage() {
         crumb="Term collection"
         pre="Term"
         gold="collection"
-        lede="How much you've collected so far, by method and by class."
+        lede="How much you've collected this term, by method and by class."
         actions={
           <>
             <ExportCsv
@@ -50,8 +72,24 @@ export default async function TermCollectionPage() {
         }
       />
 
+      {/* Period bar */}
+      <div className="mb-6 flex flex-wrap items-center gap-2 print:hidden">
+        <span className="mr-1 text-[10px] font-bold uppercase tracking-[0.1em] text-navy-3">Period</span>
+        {PERIODS.map((p) => {
+          const active = p === "This term";
+          return (
+            <span
+              key={p}
+              className={`rounded-pill border px-3 py-1 text-xs font-semibold ${active ? "border-navy bg-navy text-bg" : "border-border-2 bg-surface text-navy-3"}`}
+            >
+              {p}
+            </span>
+          );
+        })}
+      </div>
+
       {/* KPI strip */}
-      <div className="mb-6 grid grid-cols-2 gap-4 lg:grid-cols-4">
+      <div className="mb-8 grid grid-cols-2 gap-4 lg:grid-cols-4">
         {kpis.map((k) => (
           <div
             key={k.label}
@@ -63,99 +101,70 @@ export default async function TermCollectionPage() {
             <div className={`mt-1.5 font-display text-2xl font-semibold ${k.featured ? "text-bg" : k.tone}`}>
               {k.value}
             </div>
-            <div className={`mt-0.5 text-xs ${k.featured ? "text-bg/60" : "text-navy-3"}`}>{k.sub}</div>
+            <div className={`mt-0.5 text-xs ${k.featured ? "text-gold-soft" : "text-navy-3"}`}>
+              {k.arrow && <span className="mr-1 text-green">↑</span>}
+              {k.sub}
+            </div>
           </div>
         ))}
       </div>
 
-      {/* By class */}
-      <h2 className="mb-3 font-display text-lg font-semibold text-navy">Collection rate per class</h2>
-      {r.byClass.length === 0 ? (
-        <Empty>No invoices yet. Issue fees from the Fees module to see collections here.</Empty>
-      ) : (
-        <div className="overflow-hidden rounded-xl border border-border bg-surface">
-          <table className="w-full text-sm">
-            <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
-              <tr>
-                <th className="px-4 py-3 font-semibold">Class</th>
-                <th className="px-4 py-3 font-semibold">Collection rate</th>
-                <th className="px-4 py-3 text-right font-semibold">Billed</th>
-                <th className="px-4 py-3 text-right font-semibold">Collected</th>
-                <th className="px-4 py-3"></th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              {r.byClass.map((c) => {
-                const rate = classRate(c.billed, c.collected);
-                const tone = rate >= 70 ? "bg-green" : rate >= 50 ? "bg-gold" : "bg-terra";
-                return (
-                  <tr key={c.className} className="hover:bg-bg">
-                    <td className="px-4 py-3 font-medium text-navy">{c.className}</td>
-                    <td className="px-4 py-3">
-                      <div className="flex items-center gap-2">
-                        <div className="h-2 w-28 overflow-hidden rounded-full bg-bg">
-                          <div className={`h-full rounded-full ${tone}`} style={{ width: `${rate}%` }} />
-                        </div>
-                        <span className="font-mono text-xs font-semibold text-navy-2">{rate}%</span>
-                      </div>
-                    </td>
-                    <td className="px-4 py-3 text-right text-navy-2">{ghs(num(c.billed))}</td>
-                    <td className="px-4 py-3 text-right text-green">{ghs(num(c.collected))}</td>
-                    <td className="px-4 py-3 text-right">
-                      {c.classId && (
-                        <Link href={`/reports/class/${c.classId}`} className="text-xs font-semibold text-gold hover:underline">
-                          View →
-                        </Link>
-                      )}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      )}
-
-      <div className="mt-8 grid grid-cols-1 gap-8 lg:grid-cols-2">
-        {/* Monthly */}
-        <section>
-          <h2 className="mb-3 font-display text-lg font-semibold text-navy">Collection over time</h2>
-          {r.monthly.length === 0 ? (
+      {/* Weekly chart + method, side by side */}
+      <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
+        <section className="rounded-xl border border-border bg-surface p-5">
+          <div className="mb-4 flex items-start justify-between gap-3">
+            <div>
+              <div className="text-[10px] font-bold uppercase tracking-[0.1em] text-navy-3">Weekly collection</div>
+              <h3 className="mt-0.5 font-display text-lg font-semibold text-navy">Pattern across the term</h3>
+            </div>
+            {weeks.length > 0 && (
+              <div className="max-w-[10rem] text-right text-xs text-navy-3">
+                Peak in <b className="text-navy">Week {peakIdx + 1}</b> when most parents settle term fees
+              </div>
+            )}
+          </div>
+          {weeks.length === 0 ? (
             <Empty>No payments recorded yet.</Empty>
           ) : (
-            <div className="space-y-2 rounded-xl border border-border bg-surface p-5">
-              {r.monthly.map((m) => (
-                <div key={m.month} className="flex items-center gap-3">
-                  <span className="w-16 shrink-0 font-mono text-xs text-navy-3">{m.month}</span>
-                  <div className="h-5 flex-1 overflow-hidden rounded-full bg-bg">
-                    <div className="h-full rounded-full bg-gold" style={{ width: `${(num(m.amount) / maxMonth) * 100}%` }} />
-                  </div>
-                  <span className="w-28 shrink-0 text-right text-xs font-medium text-navy-2">{ghs(num(m.amount))}</span>
-                </div>
-              ))}
-            </div>
+            <>
+              <WeeklyBars weeks={weeks.map((w) => ({ label: w.label, amount: w.amount }))} />
+              <div className="mt-4 flex justify-between text-[11px] text-navy-3">
+                <span>
+                  Collecting since <b className="text-navy">{fmtWeek(weeks[0].iso)}</b>
+                </span>
+                <span>
+                  <b className="text-navy">{weeks.length}</b> {weeks.length === 1 ? "week" : "weeks"} shown
+                </span>
+              </div>
+            </>
           )}
         </section>
 
-        {/* By method */}
-        <section>
-          <h2 className="mb-3 font-display text-lg font-semibold text-navy">Where it came from</h2>
+        <section className="rounded-xl border border-border bg-surface p-5">
+          <div className="mb-4">
+            <div className="text-[10px] font-bold uppercase tracking-[0.1em] text-navy-3">By payment method</div>
+            <h3 className="mt-0.5 font-display text-lg font-semibold text-navy">Where it came from</h3>
+          </div>
           {r.byMethod.length === 0 ? (
             <Empty>No payments recorded yet.</Empty>
           ) : (
-            <div className="space-y-2 rounded-xl border border-border bg-surface p-5">
+            <div className="space-y-3">
               {r.byMethod
                 .slice()
                 .sort((a, b) => num(b.amount) - num(a.amount))
                 .map((m) => {
                   const pct = Math.round((num(m.amount) / methodTotal) * 100);
                   return (
-                    <div key={m.method} className="flex items-center justify-between gap-3">
-                      <span className="text-sm font-medium text-navy">{METHOD_LABEL[m.method] ?? m.method}</span>
-                      <span className="flex items-baseline gap-2">
-                        <span className="text-sm font-medium text-navy-2">{ghs(num(m.amount))}</span>
-                        <span className="w-9 text-right font-mono text-xs text-navy-3">{pct}%</span>
-                      </span>
+                    <div key={m.method} className="flex items-center gap-3">
+                      <span
+                        className="h-3 w-3 shrink-0 rounded-sm"
+                        style={{ backgroundColor: METHOD_SWATCH[m.method] ?? "#5C6675" }}
+                      />
+                      <div className="min-w-0 flex-1">
+                        <div className="text-sm font-medium text-navy">{METHOD_LABEL[m.method] ?? m.method}</div>
+                        <div className="font-mono text-xs text-navy-3">{ghs(num(m.amount))}</div>
+                      </div>
+                      <span className="w-10 shrink-0 text-right font-mono text-sm font-semibold text-navy-2">{pct}%</span>
                     </div>
                   );
                 })}
@@ -163,6 +172,65 @@ export default async function TermCollectionPage() {
           )}
         </section>
       </div>
+
+      {/* By class */}
+      <section className="mt-8 rounded-xl border border-border bg-surface p-5">
+        <div className="mb-4 flex items-start justify-between gap-3">
+          <div>
+            <div className="text-[10px] font-bold uppercase tracking-[0.1em] text-navy-3">By class</div>
+            <h3 className="mt-0.5 font-display text-lg font-semibold text-navy">Collection rate per class</h3>
+          </div>
+          <div className="max-w-[12rem] text-right text-xs text-navy-3">
+            Click a class to see <b className="text-navy">which students</b> are outstanding
+          </div>
+        </div>
+        {r.byClass.length === 0 ? (
+          <Empty>No invoices yet. Issue fees from the Fees module to see collections here.</Empty>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="border-b border-border text-left text-xs uppercase tracking-wide text-navy-3">
+                <tr>
+                  <th className="py-2 font-semibold">Class</th>
+                  <th className="py-2 font-semibold">Collection rate</th>
+                  <th className="py-2 text-right font-semibold">Billed</th>
+                  <th className="py-2 text-right font-semibold">Collected</th>
+                  <th className="py-2"></th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {r.byClass.map((c) => {
+                  const rate = classRate(c.billed, c.collected);
+                  const tone = rate >= 70 ? "bg-green" : rate >= 50 ? "bg-warn" : "bg-terra";
+                  const pctTone = rate >= 70 ? "text-green" : rate >= 50 ? "text-warn" : "text-terra";
+                  return (
+                    <tr key={c.className} className="hover:bg-bg">
+                      <td className="py-3 font-medium text-navy">{c.className}</td>
+                      <td className="py-3">
+                        <div className="flex items-center gap-2">
+                          <div className="h-2 w-32 overflow-hidden rounded-full bg-bg">
+                            <div className={`h-full rounded-full ${tone}`} style={{ width: `${rate}%` }} />
+                          </div>
+                          <span className={`font-mono text-xs font-semibold ${pctTone}`}>{rate}%</span>
+                        </div>
+                      </td>
+                      <td className="py-3 text-right text-navy-2">{ghs(num(c.billed))}</td>
+                      <td className="py-3 text-right text-green">{ghs(num(c.collected))}</td>
+                      <td className="py-3 text-right">
+                        {c.classId && (
+                          <Link href={`/reports/class/${c.classId}`} className="text-xs font-semibold text-gold hover:underline">
+                            View →
+                          </Link>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
     </div>
   );
 }

--- a/omnischools/components/reports/weekly-bars.tsx
+++ b/omnischools/components/reports/weekly-bars.tsx
@@ -1,0 +1,54 @@
+import { ghs } from "@/lib/reports/finance-data";
+
+export type WeekBar = { label: string; amount: number };
+
+const kLabel = (n: number) =>
+  n >= 1000 ? `${(n / 1000).toLocaleString("en-GH", { maximumFractionDigits: n % 1000 === 0 ? 0 : 1 })}k` : String(Math.round(n));
+
+/**
+ * Vertical weekly collection chart — replicates the surface's bar-chart:
+ * grid lines with k-labels, one column per week, the peak week in green, the rest navy.
+ */
+export function WeeklyBars({ weeks }: { weeks: WeekBar[] }) {
+  const max = Math.max(1, ...weeks.map((w) => w.amount));
+  const peak = weeks.reduce((p, w, i) => (w.amount > weeks[p].amount ? i : p), 0);
+  const lines = [1, 0.75, 0.5, 0.25].map((f) => ({ pct: f * 100, label: kLabel(max * f) }));
+
+  return (
+    <div>
+      {/* plot area */}
+      <div className="relative ml-10 flex h-56 items-end gap-1.5">
+        {/* grid lines */}
+        {lines.map((l) => (
+          <div
+            key={l.pct}
+            className="pointer-events-none absolute inset-x-0 border-t border-dashed border-border"
+            style={{ bottom: `${l.pct}%` }}
+          >
+            <span className="absolute -left-10 -top-2 w-9 text-right font-mono text-[10px] text-navy-3">
+              {l.label}
+            </span>
+          </div>
+        ))}
+        {/* bars */}
+        {weeks.map((w, i) => (
+          <div key={w.label} className="group flex h-full flex-1 items-end justify-center">
+            <div
+              className={`w-full max-w-[28px] rounded-t-sm transition-opacity ${i === peak ? "bg-green" : "bg-navy opacity-80 group-hover:opacity-100"}`}
+              style={{ height: `${Math.max(1.5, (w.amount / max) * 100)}%` }}
+              title={`${w.label}: ${ghs(w.amount)}`}
+            />
+          </div>
+        ))}
+      </div>
+      {/* x-axis labels */}
+      <div className="ml-10 flex gap-1.5">
+        {weeks.map((w) => (
+          <span key={w.label} className="flex-1 text-center font-mono text-[10px] text-navy-3">
+            {w.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/omnischools/lib/reports/finance-data.ts
+++ b/omnischools/lib/reports/finance-data.ts
@@ -73,6 +73,7 @@ export async function getFinanceReport(schoolId: string, selectedYear: string | 
     [totals],
     byClass,
     monthly,
+    weekly,
     byMethod,
     agingRows,
     voids,
@@ -89,6 +90,8 @@ export async function getFinanceReport(schoolId: string, selectedYear: string | 
           collected: sql<string>`coalesce(sum(${invoices.paidAmount}), 0)`,
           outstanding: sql<string>`coalesce(sum(${invoices.balanceAmount}), 0)`,
           invoiceCount: sql<number>`count(*)`,
+          studentCount: sql<number>`count(distinct ${invoices.studentId})`,
+          debtorCount: sql<number>`count(distinct ${invoices.studentId}) filter (where ${invoices.balanceAmount} > 0)`,
         })
         .from(invoices)
         .where(and(eq(invoices.schoolId, schoolId), ne(invoices.status, "VOIDED"), yearInv)),
@@ -119,6 +122,17 @@ export async function getFinanceReport(schoolId: string, selectedYear: string | 
         .where(and(eq(payments.schoolId, schoolId), isNull(payments.voidedAt), payWindow))
         .groupBy(sql`to_char(${payments.paidAt}, 'YYYY-MM')`)
         .orderBy(sql`to_char(${payments.paidAt}, 'YYYY-MM')`),
+    ),
+    withSchool(schoolId, (tx) =>
+      tx
+        .select({
+          weekStart: sql<string>`to_char(date_trunc('week', ${payments.paidAt}), 'YYYY-MM-DD')`,
+          amount: sql<string>`coalesce(sum(${payments.netAmount}), 0)`,
+        })
+        .from(payments)
+        .where(and(eq(payments.schoolId, schoolId), isNull(payments.voidedAt), payWindow))
+        .groupBy(sql`date_trunc('week', ${payments.paidAt})`)
+        .orderBy(sql`date_trunc('week', ${payments.paidAt})`),
     ),
     withSchool(schoolId, (tx) =>
       tx
@@ -241,6 +255,7 @@ export async function getFinanceReport(schoolId: string, selectedYear: string | 
     rate,
     byClass,
     monthly,
+    weekly,
     byMethod,
     agingMap,
     overdueTotal,


### PR DESCRIPTION
## Reports S3 — Term collection

Rebuilds `/reports/term-collection` to match the **schoolup-reports.html → "Term collection · detail"** surface. The old page showed monthly horizontal bars and a Collection-rate KPI; the surface specifies a **weekly vertical bar chart** and a different KPI strip.

### What changed
- **Period bar** — This week / This month / This term / Academic year / Custom… (term active). Real period filtering needs term-calendar infra and is **deferred to MVP2**; the bar is visual for now.
- **KPI strip** aligned to the surface:
  - Total billed → `N invoices · N students`
  - **Collected** (featured navy card) → `↑ X% of billed`
  - Outstanding → `N students with balances`
  - **Reversed** (terra) → `N voids & refunds` — replaces the old Collection-rate card.
- **Weekly collection chart** (new `WeeklyBars`) — grid lines with k-labels, one bar per week, **peak week in green**, navy decay; footer "Collecting since … · N weeks shown". Trailing 16-week window so it reads like a term.
- **By payment method** restyled with colour swatches; **by-class** table with rate-coded progress bars (green ≥70 / warn 50–69 / terra <50).

### Data
- Added a **weekly** `netAmount` series + distinct **student/debtor counts** to the shared `getFinanceReport` (the collection-trend slice reuses the weekly series).

### Bug fixes (latent, surfaced here)
Two design-token opacity bugs caught during live verification: `text-bg/70` and `bg-navy/80` produce **invalid CSS** with the raw-hex tokens (no alpha channel), so the opacity modifier was dropped — the featured-card sub fell back to navy-on-navy (invisible) and the chart bars rendered transparent. Switched to solid tokens (`text-gold-soft`) and the standalone `opacity-80` utility.

### Verification
- `pnpm typecheck`, `pnpm lint`, `pnpm build` all clean.
- Live preview on a seeded 6-class / 11-week scenario: collection reads **62%** (matching the surface), weekly bars show the peak-and-decay with **W3 green**, KPI/method/class sections verified, featured-card sub now visible, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)