### PR TITLE
feat(reports): collection trend — term overlay, weekly grid, aging-by-household (S6)

### DIFF
--- a/omnischools/app/(app)/reports/finance/collection-trend/page.tsx
+++ b/omnischools/app/(app)/reports/finance/collection-trend/page.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import { requireSchool } from "@/lib/auth/server";
-import { getFinanceReport, ghs, num } from "@/lib/reports/finance-data";
+import { ghs } from "@/lib/reports/finance-data";
+import { getCollectionTrend } from "@/lib/reports/collection-trend-data";
+import { CumulativeOverlay } from "@/components/reports/cumulative-overlay";
 import { ExportCsv } from "@/components/reports/export-csv";
 import { PrintButton } from "@/components/reports/print-button";
 import { ReportHeader } from "@/components/reports/report-header";
@@ -9,11 +11,25 @@ import { schoolFile } from "@/lib/filename";
 export const dynamic = "force-dynamic";
 export const metadata = { title: "Collection trend" };
 
+const fmtDate = (d: Date | null) =>
+  d
+    ? d.toLocaleDateString("en-GB", {
+        day: "numeric",
+        month: "short",
+        year: "numeric",
+        timeZone: "UTC",
+      })
+    : "—";
+
+/** "1 invoice" / "3 invoices" — naive English pluralisation for count labels. */
+const plur = (n: number, word: string) => `${n} ${word}${n === 1 ? "" : "s"}`;
+
 export default async function CollectionTrendPage() {
   const { school } = await requireSchool();
-  const r = await getFinanceReport(school.id, null);
-  const maxMonth = Math.max(1, ...r.monthly.map((m) => num(m.amount)));
-  const peak = r.monthly.reduce((p, m) => (num(m.amount) > num(p?.amount ?? 0) ? m : p), r.monthly[0]);
+  const r = await getCollectionTrend(school.id);
+  const cur = r.currentTerm;
+  const prior = r.priorTerm;
+  const wk = r.currentWeekIndex;
 
   return (
     <div className="mx-auto max-w-page">
@@ -21,67 +37,654 @@ export default async function CollectionTrendPage() {
         crumb="Finance / Collection trend"
         pre="Collection"
         gold="trend"
-        lede="Collection timing and pace across the period."
+        lede="Collection velocity and pace — this term against last."
         actions={
           <>
             <ExportCsv
               filename={schoolFile(school.name, "collection-trend.csv")}
-              headers={["Month", "Collected"]}
-              rows={r.monthly.map((m) => [m.month, num(m.amount).toFixed(2)])}
+              headers={[
+                "Week",
+                "Dates",
+                "Collected",
+                "Payments",
+                "Students",
+                "Last term",
+                "Delta %",
+              ]}
+              rows={r.weeklyRows.map((w) => [
+                String(w.week),
+                `${w.startLabel}–${w.endLabel}`,
+                w.amount.toFixed(2),
+                String(w.paymentsCount),
+                String(w.studentsCount),
+                w.priorAmount == null ? "" : w.priorAmount.toFixed(2),
+                w.deltaPct == null ? "" : String(w.deltaPct),
+              ])}
             />
             <PrintButton label="Export PDF" />
-            <Link
-              href="/reports/outstanding"
-              className="rounded-md bg-navy px-3 py-2 text-sm font-semibold text-bg hover:bg-navy-deep"
-            >
-              Open balances report →
-            </Link>
           </>
         }
       />
 
-      <div className="mb-6 grid grid-cols-2 gap-4 lg:grid-cols-4">
-        <Kpi featured label="Collected to date" value={ghs(r.collected)} sub={`${r.rate}% of ${ghs(r.billed)} invoiced`} />
-        <Kpi label="Still outstanding" value={ghs(r.outstanding)} tone="text-terra" sub="across all classes" />
-        <Kpi label="Collection rate" value={`${r.rate}%`} sub={r.rate >= 80 ? "healthy" : "needs follow-up"} />
-        <Kpi label="Peak month" value={peak ? ghs(num(peak.amount)) : "—"} sub={peak?.month ?? "no payments yet"} />
+      {/* Term pills */}
+      <div className="mb-6 flex flex-wrap gap-1.5">
+        {prior && (
+          <TermPill label={prior.label} year={prior.academicYear} state="prior" />
+        )}
+        {cur && (
+          <TermPill label={cur.label} year={cur.academicYear} state="current" active />
+        )}
+        {!cur && (
+          <span className="text-sm text-navy-3">No academic terms configured yet.</span>
+        )}
       </div>
 
-      <h2 className="mb-3 font-display text-lg font-semibold text-navy">Collection over time</h2>
-      {r.monthly.length === 0 ? (
-        <Empty>No payments recorded yet.</Empty>
-      ) : (
-        <div className="space-y-2 rounded-xl border border-border bg-surface p-5">
-          {r.monthly.map((m) => {
-            const isPeak = m.month === peak?.month;
-            return (
-              <div key={m.month} className="flex items-center gap-3">
-                <span className="w-16 shrink-0 font-mono text-xs text-navy-3">{m.month}</span>
-                <div className="h-5 flex-1 overflow-hidden rounded-full bg-bg">
-                  <div className={`h-full rounded-full ${isPeak ? "bg-green" : "bg-gold"}`} style={{ width: `${(num(m.amount) / maxMonth) * 100}%` }} />
-                </div>
-                <span className="w-28 shrink-0 text-right text-xs font-medium text-navy-2">{ghs(num(m.amount))}</span>
+      {/* ============ REGION 01 — WHERE WE ARE ============ */}
+      <Region
+        num="01"
+        pre="Where we"
+        gold="are"
+        meta={cur ? `${r.householdsOutstanding} households outstanding` : undefined}
+      >
+        <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+          {/* Hero */}
+          <div className="col-span-2 flex flex-col gap-1.5 rounded-xl border border-navy bg-navy p-5 lg:col-span-1">
+            <div className="text-[9px] font-bold uppercase tracking-[0.16em] text-gold-soft">
+              Collected · {cur?.label ?? "this term"} to date
+            </div>
+            <div className="mt-0.5 font-display text-[36px] font-semibold leading-none text-gold">
+              <span className="mr-1 text-sm font-medium text-gold-soft">GHS</span>
+              {r.currentCollected.toLocaleString("en-GH", {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2,
+              })}
+            </div>
+            <div className="text-[11px] text-gold-soft">
+              <b className="font-semibold text-bg">{r.currentRate}%</b> of {ghs(r.currentBilled)} invoiced
+            </div>
+            {/* pace bar */}
+            <div className="mt-1.5">
+              <div className="mb-1 flex items-baseline justify-between font-mono text-[10px] font-semibold text-gold-soft">
+                <span>0%</span>
+                <span className="text-bg">now: {r.currentRate}%</span>
+                <span>100%</span>
               </div>
-            );
-          })}
+              <div className="relative h-1.5 rounded-pill bg-white/10">
+                <div
+                  className="h-full rounded-pill bg-gold"
+                  style={{ width: `${Math.min(100, r.currentRate)}%` }}
+                />
+                {r.hasPrior && (
+                  <div
+                    className="absolute -top-0.5 h-2.5 w-0.5 bg-white/70"
+                    style={{ left: `${Math.min(100, r.priorRateAtSameWeek)}%` }}
+                    title="expected pace"
+                  />
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Velocity */}
+          {r.hasPrior ? (
+            <div className="flex flex-col gap-1.5 rounded-xl border border-gold-soft bg-gold-bg p-5">
+              <span
+                className={`self-start rounded-pill px-2 py-0.5 text-[9px] font-bold uppercase tracking-[0.08em] text-white ${
+                  r.gapCedis >= 0 ? "bg-green" : "bg-terra"
+                }`}
+              >
+                {Math.abs(Math.round(r.gapPoints))}% {r.gapCedis >= 0 ? "ahead" : "behind"}
+              </span>
+              <div className="text-[9px] font-bold uppercase tracking-[0.16em] text-navy-3">
+                vs {prior?.label} at week {wk}
+              </div>
+              <div
+                className={`font-display text-[32px] font-semibold italic leading-none ${
+                  r.gapCedis >= 0 ? "text-green" : "text-terra"
+                }`}
+              >
+                {r.gapCedis >= 0 ? "+" : "−"}
+                <em className="not-italic">{ghs(Math.abs(r.gapCedis))}</em>
+              </div>
+              <div className="text-[11px] text-navy-3">
+                Last term we&apos;d collected{" "}
+                <b className="font-semibold text-navy-2">{r.priorRateAtSameWeek}%</b> by this point
+              </div>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-1.5 rounded-xl border border-border bg-surface p-5">
+              <div className="text-[9px] font-bold uppercase tracking-[0.16em] text-navy-3">
+                Term-on-term
+              </div>
+              <div className="font-display text-2xl font-semibold leading-tight text-navy-3">
+                No prior term to compare
+              </div>
+              <div className="text-[11px] text-navy-3">
+                Velocity vs last term appears once a previous term has data.
+              </div>
+            </div>
+          )}
+
+          {/* Avg weekly */}
+          <div className="flex flex-col gap-1.5 rounded-xl border border-border bg-surface p-5">
+            <div className="text-[9px] font-bold uppercase tracking-[0.16em] text-navy-3">
+              Avg weekly · last 3 wks
+            </div>
+            <div className="mt-0.5 font-display text-[32px] font-semibold leading-none text-navy">
+              <span className="mr-1 text-sm font-medium text-navy-3">GHS</span>
+              {Math.round(r.avgWeeklyLast3).toLocaleString("en-GH")}
+            </div>
+            <div className="text-[11px] text-navy-3">
+              {r.avgWeeklyLast3 >= r.avgWeeklyFirst3 ? "up" : "down"} from{" "}
+              <b className="font-semibold text-navy-2">
+                GHS {Math.round(r.avgWeeklyFirst3).toLocaleString("en-GH")}
+              </b>{" "}
+              in wks 1-3
+            </div>
+          </div>
+
+          {/* Outstanding */}
+          <div className="flex flex-col gap-1.5 rounded-xl border border-border bg-surface p-5">
+            <div className="text-[9px] font-bold uppercase tracking-[0.16em] text-navy-3">
+              Still outstanding
+            </div>
+            <div className="mt-0.5 font-display text-[32px] font-semibold leading-none text-terra">
+              <span className="mr-1 text-sm font-medium text-navy-3">GHS</span>
+              {r.outstandingTotal.toLocaleString("en-GH", {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2,
+              })}
+            </div>
+            <div className="text-[11px] text-navy-3">
+              <b className="font-semibold text-navy-2">{plur(r.aging.totalInvoices, "invoice")}</b>{" "}
+              from {plur(r.householdsOutstanding, "household")}
+            </div>
+          </div>
         </div>
-      )}
-      <p className="mt-3 text-xs italic text-navy-3">
-        Term-on-term cumulative overlay, weekly grid and aging-by-household are coming in a later
-        slice (needs a completed prior term).
-      </p>
+      </Region>
+
+      {/* ============ REGION 02 — CUMULATIVE OVERLAY ============ */}
+      <Region
+        num="02"
+        pre="Cumulative"
+        gold="collection"
+        post=" · this term vs last"
+        meta="Weekly cumulative · GHS thousands"
+      >
+        {!r.hasPeriods || !cur ? (
+          <Empty>
+            Configure academic terms (Settings → Term &amp; calendar) to see term-on-term trends.
+          </Empty>
+        ) : (
+          <div className="rounded-xl border border-border bg-surface p-6">
+            <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
+              <div>
+                <div className="mb-1 text-[9px] font-bold uppercase tracking-[0.16em] text-navy-3">
+                  {cur.label} {cur.academicYear}
+                  {prior ? ` vs ${prior.label} ${prior.academicYear}` : ""}
+                </div>
+                <div className="font-display text-lg font-semibold text-navy">
+                  Cumulative <em className="not-italic text-gold">collection</em> curve
+                </div>
+              </div>
+              <div className="flex items-center gap-4 text-[11px] text-navy-2">
+                <span className="inline-flex items-center gap-1.5">
+                  <span className="h-[3px] w-5 rounded-sm bg-gold" />
+                  <b className="font-semibold text-navy">This term</b>
+                </span>
+                {r.hasPrior && (
+                  <>
+                    <span className="inline-flex items-center gap-1.5">
+                      <span className="h-[3px] w-5 rounded-sm bg-navy-3" />
+                      Last term
+                    </span>
+                    <span className="inline-flex items-center gap-1.5">
+                      <span className="h-0 w-5 border-t-2 border-dashed border-navy-3" />
+                      Expected pace
+                    </span>
+                  </>
+                )}
+              </div>
+            </div>
+
+            <CumulativeOverlay
+              current={r.cumulative.current}
+              prior={r.cumulative.prior}
+              totalWeeks={r.cumulative.totalWeeks}
+              currentWeekIndex={r.cumulative.currentWeekIndex}
+              yMax={r.cumulative.yMax}
+              currentLabel={`today · ${r.currentRate}%`}
+              priorLabel={prior ? `last term wk ${wk}` : undefined}
+            />
+
+            {/* chart foot */}
+            <div
+              className={`mt-4 grid gap-3 border-t border-border pt-4 ${
+                r.hasPrior ? "grid-cols-2 lg:grid-cols-4" : "grid-cols-1"
+              }`}
+            >
+              {r.hasPrior && (
+                <FootCell
+                  label={`${prior?.label} final · last yr`}
+                  value={ghs(r.priorFinal)}
+                  meta={`${r.priorFinalRate}% of invoiced`}
+                />
+              )}
+              <FootCell
+                label={`At wk ${wk} · this term`}
+                value={ghs(r.currentCollected)}
+                meta={`${r.currentRate}% of invoiced`}
+              />
+              {r.hasPrior && (
+                <FootCell
+                  label={`At wk ${wk} · last term`}
+                  value={ghs(r.priorCollectedAtSameWeek)}
+                  meta={`${r.priorRateAtSameWeek}% of invoiced`}
+                  tone="green"
+                />
+              )}
+              {r.hasPrior && (
+                <FootCell
+                  label="Gap to last term"
+                  value={`${r.gapCedis < 0 ? "−" : "+"}${ghs(Math.abs(r.gapCedis))}`}
+                  meta={`${r.gapPoints} percentage points`}
+                  tone="terra"
+                />
+              )}
+            </div>
+          </div>
+        )}
+      </Region>
+
+      {/* ============ REGION 03 — WEEK BY WEEK ============ */}
+      <Region
+        num="03"
+        pre="Week by"
+        gold="week"
+        meta="Each week's collection vs same week last term"
+      >
+        {r.weeklyRows.length === 0 ? (
+          <Empty>No weekly collection yet for this term.</Empty>
+        ) : (
+          <div className="grid grid-cols-2 gap-2.5 md:grid-cols-3 lg:grid-cols-5">
+            {r.weeklyRows.map((w) => {
+              const isCurrent = w.week === wk;
+              return (
+                <div
+                  key={w.week}
+                  className={`relative rounded-[10px] border p-3.5 ${
+                    isCurrent
+                      ? "border-gold bg-gradient-to-b from-gold-bg to-surface"
+                      : "border-border bg-surface"
+                  }`}
+                >
+                  <div className="mb-px font-display text-[11px] font-semibold text-navy">
+                    Week <em className="not-italic font-medium text-gold">{w.week}</em>
+                    {isCurrent ? " · this wk" : ""}
+                  </div>
+                  <div className="mb-2.5 font-mono text-[9px] font-semibold text-navy-3">
+                    {w.startLabel}–{w.endLabel}
+                  </div>
+                  <div className="font-display text-[17px] font-semibold leading-none text-navy">
+                    <span className="mr-0.5 text-[10px] font-medium text-navy-3">GHS</span>
+                    {Math.round(w.amount).toLocaleString("en-GH")}
+                  </div>
+                  <div className="mt-1 text-[10px] text-navy-3">
+                    <b className="font-semibold text-navy-2">{plur(w.paymentsCount, "payment")}</b> ·{" "}
+                    {plur(w.studentsCount, "student")}
+                  </div>
+                  <div className="mt-2 flex h-[3px] overflow-hidden rounded-pill bg-bg">
+                    <div
+                      className="rounded-pill bg-gold"
+                      style={{ width: `${Math.min(100, (w.amount / r.maxWeekly) * 100)}%` }}
+                    />
+                  </div>
+                  {r.hasPrior && w.priorAmount != null && (
+                    <div className="mt-2 flex items-baseline justify-between border-t border-border pt-2 text-[10px]">
+                      <span className="text-navy-3">
+                        Last yr · GHS {Math.round(w.priorAmount).toLocaleString("en-GH")}
+                      </span>
+                      <DeltaTag deltaPct={w.deltaPct} />
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </Region>
+
+      {/* ============ REGION 04 — BY CLASS ============ */}
+      <Region num="04" pre="By" gold="class" meta="Which year groups are leading or lagging">
+        {r.byClass.length === 0 ? (
+          <Empty>No invoiced classes yet for this term.</Empty>
+        ) : (
+          <div className="overflow-hidden rounded-xl border border-border bg-surface">
+            <div className="flex items-center justify-between border-b border-border bg-bg px-5 py-3.5 text-[11px] italic text-navy-3">
+              <span>
+                {r.byClass.length} classes · sorted by outstanding (highest first)
+              </span>
+            </div>
+            <table className="w-full text-sm">
+              <thead className="border-b border-border bg-bg text-left text-[10px] uppercase tracking-wide text-navy-3">
+                <tr>
+                  <th className="px-5 py-3 font-semibold">Class</th>
+                  <th className="px-5 py-3 font-semibold">Collection rate</th>
+                  <th className="px-5 py-3 text-right font-semibold">Billed</th>
+                  <th className="px-5 py-3 text-right font-semibold">Collected</th>
+                  <th className="px-5 py-3"></th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {r.byClass.map((c) => {
+                  const tone =
+                    c.rate >= 70 ? "bg-green" : c.rate >= 50 ? "bg-warn" : "bg-terra";
+                  const pctTone =
+                    c.rate >= 70 ? "text-green" : c.rate >= 50 ? "text-gold" : "text-terra";
+                  return (
+                    <tr key={c.classId ?? c.className} className="hover:bg-bg">
+                      <td className="px-5 py-3.5 font-display font-semibold text-navy">
+                        {c.className}
+                      </td>
+                      <td className="px-5 py-3.5">
+                        <div className="flex items-center gap-3">
+                          <div className="relative h-2.5 w-40 overflow-hidden rounded-pill bg-bg">
+                            <div
+                              className={`h-full rounded-pill ${tone}`}
+                              style={{ width: `${Math.max(4, Math.min(100, c.rate))}%` }}
+                            />
+                          </div>
+                          <span className={`font-display text-sm font-semibold ${pctTone}`}>
+                            {c.rate}%
+                          </span>
+                        </div>
+                      </td>
+                      <td className="px-5 py-3.5 text-right font-mono text-xs font-semibold text-navy">
+                        {ghs(c.billed)}
+                      </td>
+                      <td className="px-5 py-3.5 text-right font-mono text-xs font-semibold text-green">
+                        {ghs(c.collected)}
+                      </td>
+                      <td className="px-5 py-3.5 text-right">
+                        {c.classId && (
+                          <Link
+                            href={`/reports/class/${c.classId}`}
+                            className="text-xs font-semibold text-gold hover:underline"
+                          >
+                            View →
+                          </Link>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Region>
+
+      {/* ============ REGION 05 — AGING ============ */}
+      <Region num="05" pre="Age of" gold="outstanding" post=" balances" meta="How old is the unpaid amount">
+        {r.aging.totalOutstanding <= 0 ? (
+          <Empty>Nothing outstanding — every invoice is settled.</Empty>
+        ) : (
+          <AgingCard aging={r.aging} />
+        )}
+      </Region>
     </div>
   );
 }
 
-function Kpi({ label, value, sub, tone, featured }: { label: string; value: string; sub: string; tone?: string; featured?: boolean }) {
+/* ---------------------------------------------------------------- helpers */
+
+function Region({
+  num,
+  pre,
+  gold,
+  post,
+  meta,
+  children,
+}: {
+  num: string;
+  pre: string;
+  gold: string;
+  post?: string;
+  meta?: string;
+  children: React.ReactNode;
+}) {
   return (
-    <div className={`rounded-xl border p-5 ${featured ? "border-navy bg-navy" : "border-border bg-surface"}`}>
-      <div className={`text-[10px] font-bold uppercase tracking-[0.1em] ${featured ? "text-gold-soft" : "text-navy-3"}`}>{label}</div>
-      <div className={`mt-1.5 font-display text-2xl font-semibold ${featured ? "text-bg" : (tone ?? "text-navy")}`}>{value}</div>
-      <div className={`mt-0.5 text-xs ${featured ? "text-bg/60" : "text-navy-3"}`}>{sub}</div>
+    <div className="mb-9">
+      <div className="mb-3.5 flex items-baseline gap-3">
+        <div className="font-display text-lg font-medium italic text-gold">{num}</div>
+        <h2 className="font-display text-lg font-semibold text-navy">
+          {pre} <em className="font-normal not-italic text-gold">{gold}</em>
+          {post ?? ""}
+        </h2>
+        {meta && (
+          <div className="ml-auto text-[11px] font-semibold text-navy-3">{meta}</div>
+        )}
+      </div>
+      {children}
     </div>
   );
+}
+
+function TermPill({
+  label,
+  year,
+  state,
+  active,
+}: {
+  label: string;
+  year: string;
+  state: string;
+  active?: boolean;
+}) {
+  return (
+    <div
+      className={`inline-flex items-center rounded-pill border px-3 py-1.5 font-display text-xs font-semibold ${
+        active ? "border-navy bg-navy text-bg" : "border-border bg-bg text-navy-3"
+      }`}
+    >
+      {label} <em className="ml-1 italic text-gold">{year}</em>
+      <span
+        className={`ml-1.5 text-[9px] font-bold uppercase tracking-[0.1em] ${
+          active ? "text-gold-soft" : "text-navy-3"
+        }`}
+      >
+        {state}
+      </span>
+    </div>
+  );
+}
+
+function FootCell({
+  label,
+  value,
+  meta,
+  tone,
+}: {
+  label: string;
+  value: string;
+  meta: string;
+  tone?: "green" | "terra";
+}) {
+  const toneClass = tone === "green" ? "text-green" : tone === "terra" ? "text-terra" : "text-navy";
+  return (
+    <div>
+      <div className="mb-1 text-[9px] font-bold uppercase tracking-[0.12em] text-navy-3">
+        {label}
+      </div>
+      <div className={`font-display text-base font-semibold ${toneClass}`}>{value}</div>
+      <div className="mt-0.5 text-[10px] text-navy-3">{meta}</div>
+    </div>
+  );
+}
+
+function DeltaTag({ deltaPct }: { deltaPct: number | null }) {
+  if (deltaPct == null) {
+    return <span className="text-[10px] font-bold tracking-[0.04em] text-navy-3">— flat</span>;
+  }
+  if (Math.abs(deltaPct) < 1) {
+    return <span className="text-[10px] font-bold tracking-[0.04em] text-navy-3">— flat</span>;
+  }
+  const up = deltaPct > 0;
+  return (
+    <span
+      className={`text-[10px] font-bold tracking-[0.04em] ${up ? "text-green" : "text-terra"}`}
+    >
+      {up ? "↑" : "↓"} {Math.abs(Math.round(deltaPct))}%
+    </span>
+  );
+}
+
+function AgingCard({
+  aging,
+}: {
+  aging: {
+    buckets: {
+      key: string;
+      label: string;
+      amount: number;
+      invoiceCount: number;
+      householdCount: number;
+      pct: number;
+    }[];
+    totalOutstanding: number;
+    totalInvoices: number;
+    totalHouseholds: number;
+    oldestIssuedAt: Date | null;
+    oldestAgeDays: number;
+    avgAgeDays: number;
+  };
+}) {
+  const maxBucket = Math.max(1, ...aging.buckets.map((b) => b.amount));
+  const bucketColor: Record<string, string> = {
+    b1: "bg-green",
+    b2: "bg-gold",
+    b3: "bg-warn",
+    b4: "bg-terra",
+  };
+  // range head split: "1—30 days" → number in gold em
+  const rangeParts: Record<string, [string, string, string]> = {
+    b1: ["1—", "30", " days"],
+    b2: ["31—", "60", " days"],
+    b3: ["61—", "90", " days"],
+    b4: ["90+ ", "days", ""],
+  };
+
+  const dominant = aging.buckets.reduce((a, b) => (b.amount > a.amount ? b : a), aging.buckets[0]);
+
+  return (
+    <div className="rounded-xl border border-border bg-surface p-6">
+      {/* headline */}
+      <div className="mb-5 grid grid-cols-1 items-end gap-5 border-b border-border pb-4 sm:grid-cols-[1fr_auto]">
+        <div>
+          <div className="mb-1 text-[9px] font-bold uppercase tracking-[0.16em] text-navy-3">
+            Total outstanding · {aging.totalHouseholds} households
+          </div>
+          <div className="font-display text-[32px] font-semibold leading-none text-terra">
+            <span className="mr-1 text-sm font-medium text-navy-3">GHS</span>
+            {aging.totalOutstanding.toLocaleString("en-GH", {
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2,
+            })}
+          </div>
+          <div className="mt-1 text-xs text-navy-3">
+            {plur(aging.totalInvoices, "invoice")} · oldest invoice issued{" "}
+            <b className="font-semibold text-navy-2">{fmtDate(aging.oldestIssuedAt)}</b> ·{" "}
+            {aging.oldestAgeDays} days ago
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="mb-0.5 text-[9px] font-bold uppercase tracking-[0.12em] text-navy-3">
+            Avg age
+          </div>
+          <div className="font-display text-base font-semibold text-navy">
+            {aging.avgAgeDays} days
+          </div>
+        </div>
+      </div>
+
+      {/* bars */}
+      <div className="grid grid-cols-2 gap-3.5 lg:grid-cols-4">
+        {aging.buckets.map((b) => {
+          const heightPct = b.amount > 0 ? Math.max(4, (b.amount / maxBucket) * 100) : 0;
+          const [p1, p2, p3] = rangeParts[b.key] ?? ["", b.label, ""];
+          const insideTone = b.key === "b2" ? "text-navy" : "text-white";
+          return (
+            <div key={b.key} className="flex flex-col gap-2">
+              <div className="relative flex h-[100px] items-end rounded-md border border-border bg-bg">
+                <div
+                  className={`flex w-full items-start justify-center rounded-b-[5px] pt-2 ${bucketColor[b.key]}`}
+                  style={{ height: `${heightPct}%` }}
+                >
+                  {b.amount > 0 && (
+                    <span className={`font-mono text-[11px] font-bold ${insideTone}`}>
+                      {Math.round(b.amount).toLocaleString("en-GH")}
+                    </span>
+                  )}
+                </div>
+              </div>
+              <div className="text-center">
+                <div className="mb-px font-display text-[13px] font-semibold text-navy">
+                  {p1}
+                  <em className="italic text-gold">{p2}</em>
+                  {p3}
+                </div>
+                {b.amount > 0 ? (
+                  <>
+                    <div className="text-[10px] text-navy-3">
+                      <b className="font-semibold text-navy-2">{plur(b.invoiceCount, "invoice")}</b> ·{" "}
+                      {plur(b.householdCount, "household")}
+                    </div>
+                    <div className="mt-1 font-mono text-[11px] font-bold text-navy">
+                      {b.pct}% of outstanding
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div className="text-[10px] text-navy-3">none yet</div>
+                    <div className="mt-1 font-mono text-[11px] font-bold text-navy-3">—</div>
+                  </>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* callout */}
+      <div className="mt-5 rounded-r-lg border-l-2 border-gold bg-gold-bg px-4 py-3 text-xs leading-relaxed text-navy-2">
+        <div className="mb-1 font-display text-[13px] font-semibold text-navy">
+          What this shape says
+        </div>
+        {dominant && dominant.amount > 0 ? (
+          <span>
+            Most outstanding sits in the{" "}
+            <b className="font-semibold text-navy">{dominant.label}</b> bucket ({dominant.pct}% of
+            the balance). {agingNote(dominant.key)}
+          </span>
+        ) : (
+          <span>No aged balances to interpret yet.</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function agingNote(key: string): string {
+  switch (key) {
+    case "b1":
+      return "That is the healthy pattern — recent invoices still being paid down within the first month.";
+    case "b2":
+      return "These families missed the early-term surge and have not caught up; watch they do not migrate to 61—90 days.";
+    case "b3":
+      return "Balances this old usually need direct follow-up before they harden into long-term debt.";
+    default:
+      return "Balances over 90 days old rarely self-resolve — these households likely need direct outreach.";
+  }
 }
 
 function Empty({ children }: { children: React.ReactNode }) {

--- a/omnischools/components/reports/cumulative-overlay.tsx
+++ b/omnischools/components/reports/cumulative-overlay.tsx
@@ -1,0 +1,252 @@
+/**
+ * Region-02 overlay chart for the Collection-trend report (presentational,
+ * server component). Renders two cumulative-collection series (this term in
+ * gold, last term in navy-3) on a shared weekly x-axis, plus a "NOW" marker.
+ *
+ * Colours are inline hex literals because this is raw SVG — design tokens with
+ * slash-opacity modifiers would silently break, and SVG gradients legitimately
+ * use stop-opacity.
+ */
+export function CumulativeOverlay({
+  current,
+  prior,
+  totalWeeks,
+  currentWeekIndex,
+  yMax,
+  currentLabel,
+  priorLabel,
+}: {
+  current: number[];
+  prior: number[] | null;
+  totalWeeks: number;
+  currentWeekIndex: number;
+  yMax: number;
+  currentLabel?: string;
+  priorLabel?: string;
+}) {
+  const W = 1000;
+  const H = 280;
+  const safeYMax = yMax > 0 ? yMax : 1;
+  const denom = totalWeeks > 1 ? totalWeeks - 1 : 1;
+
+  const x = (week: number) => ((week - 1) / denom) * W;
+  const y = (v: number) => {
+    const clamped = Math.max(0, Math.min(v, safeYMax));
+    return H - (clamped / safeYMax) * H;
+  };
+
+  // current series drawn only up to currentWeekIndex
+  const curPoints = current
+    .slice(0, Math.max(1, currentWeekIndex))
+    .map((v, i) => `${round(x(i + 1))},${round(y(v))}`);
+  const priorPoints = (prior ?? []).map((v, i) => `${round(x(i + 1))},${round(y(v))}`);
+
+  const nowX = round(x(currentWeekIndex));
+
+  // area-fill paths (close down to baseline)
+  const curArea =
+    curPoints.length > 0
+      ? `M ${curPoints[0]} L ${curPoints.join(" L ")} L ${round(x(Math.max(1, currentWeekIndex)))},${H} L ${round(x(1))},${H} Z`
+      : "";
+  const priorArea =
+    priorPoints.length > 0
+      ? `M ${priorPoints[0]} L ${priorPoints.join(" L ")} L ${round(x(prior!.length))},${H} L ${round(x(1))},${H} Z`
+      : "";
+
+  // y-axis labels: yMax, .8, .6, .4, .2, 0
+  const yLabels = [1, 0.8, 0.6, 0.4, 0.2, 0].map((f) => kFmt(safeYMax * f));
+  // x-axis labels Wk 1..Wk N
+  const xLabels = Array.from({ length: totalWeeks }, (_, i) => `Wk ${i + 1}`);
+
+  const curEnd = curPoints.length ? curPoints[curPoints.length - 1].split(",") : null;
+  const curEndVal = current[Math.max(0, Math.min(currentWeekIndex, current.length) - 1)] ?? 0;
+  const priorAtNow = prior ? (prior[Math.max(0, currentWeekIndex - 1)] ?? 0) : 0;
+
+  return (
+    <div className="relative h-[280px]">
+      {/* y-axis labels column */}
+      <div className="absolute bottom-7 left-0 top-0 flex w-14 flex-col justify-between pr-2.5 text-right font-mono text-[9px] font-semibold text-navy-3">
+        {yLabels.map((l, i) => (
+          <div key={i}>{l}</div>
+        ))}
+      </div>
+
+      {/* svg plot area */}
+      <div className="absolute bottom-7 left-14 right-0 top-0">
+        <svg viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" className="h-full w-full">
+          <defs>
+            <linearGradient id="ctPriorGrad" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="#5C6675" stopOpacity="0.08" />
+              <stop offset="100%" stopColor="#5C6675" stopOpacity="0" />
+            </linearGradient>
+            <linearGradient id="ctCurrentGrad" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="#C8975B" stopOpacity="0.18" />
+              <stop offset="100%" stopColor="#C8975B" stopOpacity="0" />
+            </linearGradient>
+          </defs>
+
+          {/* horizontal grid lines (5) */}
+          {[0, 56, 112, 168, 224].map((gy) => (
+            <line
+              key={gy}
+              x1="0"
+              y1={gy}
+              x2={W}
+              y2={gy}
+              stroke="#E5DFD3"
+              strokeWidth="0.5"
+              strokeDasharray="2 4"
+            />
+          ))}
+
+          {/* prior series */}
+          {prior && priorPoints.length > 0 && (
+            <>
+              <path d={priorArea} fill="url(#ctPriorGrad)" />
+              <polyline
+                points={priorPoints.join(" ")}
+                fill="none"
+                stroke="#5C6675"
+                strokeWidth="2"
+                strokeLinejoin="round"
+                strokeLinecap="round"
+              />
+            </>
+          )}
+
+          {/* current series (gold, up to NOW) */}
+          {curPoints.length > 0 && (
+            <>
+              <path d={curArea} fill="url(#ctCurrentGrad)" />
+              <polyline
+                points={curPoints.join(" ")}
+                fill="none"
+                stroke="#C8975B"
+                strokeWidth="2.5"
+                strokeLinejoin="round"
+                strokeLinecap="round"
+              />
+            </>
+          )}
+
+          {/* NOW marker */}
+          <line
+            x1={nowX}
+            y1="0"
+            x2={nowX}
+            y2={H}
+            stroke="#C8975B"
+            strokeWidth="0.5"
+            strokeDasharray="3 3"
+            opacity="0.5"
+          />
+          <text
+            x={nowX + 4}
+            y="14"
+            fontFamily="Manrope"
+            fontSize="9"
+            fontWeight="700"
+            fill="#C8975B"
+            letterSpacing="0.06em"
+          >
+            NOW · WK {currentWeekIndex}
+          </text>
+
+          {/* prior dot at NOW */}
+          {prior && (
+            <>
+              <circle
+                cx={nowX}
+                cy={round(y(priorAtNow))}
+                r="3"
+                fill="#5C6675"
+                stroke="#FAF7F2"
+                strokeWidth="1.5"
+              />
+              <text
+                x={nowX - 10}
+                y={round(y(priorAtNow)) - 6}
+                fontFamily="JetBrains Mono"
+                fontSize="10"
+                fontWeight="700"
+                fill="#5C6675"
+                textAnchor="end"
+              >
+                {kFmt(priorAtNow)}
+              </text>
+              {priorLabel && (
+                <text
+                  x={nowX - 10}
+                  y={round(y(priorAtNow)) + 6}
+                  fontFamily="Fraunces"
+                  fontStyle="italic"
+                  fontSize="9"
+                  fill="#5C6675"
+                  textAnchor="end"
+                >
+                  {priorLabel}
+                </text>
+              )}
+            </>
+          )}
+
+          {/* current end dot */}
+          {curEnd && (
+            <>
+              <circle
+                cx={curEnd[0]}
+                cy={curEnd[1]}
+                r="5"
+                fill="#C8975B"
+                stroke="#FAF7F2"
+                strokeWidth="2"
+              />
+              <text
+                x={Number(curEnd[0]) + 12}
+                y={Number(curEnd[1]) - 2}
+                fontFamily="JetBrains Mono"
+                fontSize="11"
+                fontWeight="700"
+                fill="#1A2B47"
+              >
+                GHS {kFmt(curEndVal)}
+              </text>
+              {currentLabel && (
+                <text
+                  x={Number(curEnd[0]) + 12}
+                  y={Number(curEnd[1]) + 11}
+                  fontFamily="Fraunces"
+                  fontStyle="italic"
+                  fontSize="10"
+                  fill="#C8975B"
+                >
+                  {currentLabel}
+                </text>
+              )}
+            </>
+          )}
+        </svg>
+      </div>
+
+      {/* x-axis labels */}
+      <div className="absolute bottom-0 left-14 right-0 flex h-6 justify-between pt-1.5 font-mono text-[9px] font-semibold text-navy-3">
+        {xLabels.map((l, i) => (
+          <div key={i}>{l}</div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function round(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+/** "178k", "1.2k", "950" style compact label. */
+function kFmt(n: number): string {
+  if (n >= 1000) {
+    const k = n / 1000;
+    return `${k >= 100 ? Math.round(k) : Math.round(k * 10) / 10}k`;
+  }
+  return String(Math.round(n));
+}

--- a/omnischools/lib/reports/collection-trend-data.ts
+++ b/omnischools/lib/reports/collection-trend-data.ts
@@ -1,0 +1,507 @@
+import { and, asc, eq, gte, isNull, lte, ne, sql } from "drizzle-orm";
+import { withSchool } from "@/lib/db/rls";
+import { academicPeriod, classes, invoices, payments, students } from "@/db/schema";
+import { num } from "./finance-data";
+
+/**
+ * Collection-trend aggregates for the Reports → Finance → Collection trend route.
+ * Everything here is derived truthfully from real rows. Term windows come from
+ * `academic_period`; weekly bucketing is done in JS after fetching the raw
+ * payment rows for the relevant date windows (simpler + fine at these volumes).
+ */
+
+const WEEK_MS = 7 * 86_400_000;
+const DAY_MS = 86_400_000;
+
+type Term = {
+  periodId: string;
+  academicYear: string;
+  periodNumber: number;
+  label: string;
+  startsOn: Date;
+  endsOn: Date;
+};
+
+/** Parse a Postgres `date` column ("YYYY-MM-DD") as a UTC midnight Date. */
+function parseDate(d: string | Date): Date {
+  if (d instanceof Date) return d;
+  return new Date(`${d}T00:00:00.000Z`);
+}
+
+function totalWeeks(term: Term): number {
+  return Math.max(1, Math.ceil((+term.endsOn - +term.startsOn) / WEEK_MS));
+}
+
+/** 1-based week index of date `d` within `term` (clamped to >= 1). */
+function weekIndexOf(d: Date, term: Term): number {
+  return Math.max(1, Math.floor((+d - +term.startsOn) / WEEK_MS) + 1);
+}
+
+/** "15-19 Sep" style label for a given week of a term. */
+function weekRangeLabels(term: Term, week: number): { startLabel: string; endLabel: string } {
+  const start = new Date(+term.startsOn + (week - 1) * WEEK_MS);
+  const rawEnd = new Date(+start + 4 * DAY_MS); // Mon–Fri working span
+  const end = +rawEnd > +term.endsOn ? term.endsOn : rawEnd;
+  const fmt = (dt: Date) =>
+    dt.toLocaleDateString("en-GB", { day: "numeric", month: "short", timeZone: "UTC" });
+  return { startLabel: fmt(start), endLabel: fmt(end) };
+}
+
+/** Nice rounded-up axis max for a set of cumulative values. */
+function niceMax(maxValue: number): number {
+  if (maxValue <= 0) return 1000;
+  const pow = Math.pow(10, Math.floor(Math.log10(maxValue)));
+  const steps = [1, 1.25, 1.5, 2, 2.5, 3, 4, 5, 6, 8, 10];
+  for (const s of steps) {
+    const candidate = s * pow;
+    if (candidate >= maxValue) return candidate;
+  }
+  return 10 * pow;
+}
+
+export type WeeklyRow = {
+  week: number;
+  amount: number;
+  paymentsCount: number;
+  studentsCount: number;
+  priorAmount: number | null;
+  deltaPct: number | null;
+  startLabel: string;
+  endLabel: string;
+};
+
+export type ClassRow = {
+  classId: string | null;
+  className: string;
+  billed: number;
+  collected: number;
+  outstanding: number;
+  rate: number;
+};
+
+export type AgingBucket = {
+  key: "b1" | "b2" | "b3" | "b4";
+  label: string;
+  amount: number;
+  invoiceCount: number;
+  householdCount: number;
+  pct: number;
+};
+
+export type CollectionTrend = Awaited<ReturnType<typeof getCollectionTrend>>;
+
+export async function getCollectionTrend(schoolId: string) {
+  const now = new Date();
+
+  // ---- Academic periods (term windows) ------------------------------------
+  const periodRows = await withSchool(schoolId, (tx) =>
+    tx
+      .select({
+        periodId: academicPeriod.periodId,
+        academicYear: academicPeriod.academicYear,
+        periodNumber: academicPeriod.periodNumber,
+        periodLabel: academicPeriod.periodLabel,
+        startsOn: academicPeriod.startsOn,
+        endsOn: academicPeriod.endsOn,
+      })
+      .from(academicPeriod)
+      .where(eq(academicPeriod.schoolId, schoolId))
+      .orderBy(asc(academicPeriod.academicYear), asc(academicPeriod.periodNumber)),
+  );
+
+  const terms: Term[] = periodRows.map((r) => ({
+    periodId: r.periodId,
+    academicYear: r.academicYear,
+    periodNumber: r.periodNumber,
+    label: r.periodLabel,
+    startsOn: parseDate(r.startsOn),
+    endsOn: parseDate(r.endsOn),
+  }));
+
+  const hasPeriods = terms.length > 0;
+
+  // current term = window containing today; else latest startsOn <= today; else last
+  let currentIdx = terms.findIndex((t) => +t.startsOn <= +now && +now <= +t.endsOn);
+  if (currentIdx === -1) {
+    for (let i = terms.length - 1; i >= 0; i--) {
+      if (+terms[i].startsOn <= +now) {
+        currentIdx = i;
+        break;
+      }
+    }
+  }
+  if (currentIdx === -1 && terms.length > 0) currentIdx = terms.length - 1;
+
+  const currentTermObj = currentIdx >= 0 ? terms[currentIdx] : null;
+  const priorTermObj = currentIdx > 0 ? terms[currentIdx - 1] : null;
+  const hasPrior = !!priorTermObj;
+
+  // The academic year we report invoices against (region 1/4/5).
+  const reportYear = currentTermObj?.academicYear ?? null;
+
+  // ---- Weekly collected via raw payment rows ------------------------------
+  type PayRow = { paidAt: Date; netAmount: number; studentId: string };
+
+  async function fetchPayments(from: Date, to: Date): Promise<PayRow[]> {
+    const rows = await withSchool(schoolId, (tx) =>
+      tx
+        .select({
+          paidAt: payments.paidAt,
+          netAmount: payments.netAmount,
+          studentId: payments.studentId,
+        })
+        .from(payments)
+        .where(
+          and(
+            eq(payments.schoolId, schoolId),
+            isNull(payments.voidedAt),
+            gte(payments.paidAt, from),
+            lte(payments.paidAt, to),
+          ),
+        ),
+    );
+    return rows.map((r) => ({
+      paidAt: r.paidAt as Date,
+      netAmount: num(r.netAmount),
+      studentId: r.studentId,
+    }));
+  }
+
+  /** weekly[week] = { amount, payments, students(set) } for weeks 1..totalWeeks */
+  function bucketByWeek(rows: PayRow[], term: Term) {
+    const tw = totalWeeks(term);
+    const buckets = Array.from({ length: tw + 1 }, () => ({
+      amount: 0,
+      paymentsCount: 0,
+      students: new Set<string>(),
+    }));
+    for (const r of rows) {
+      let wk = weekIndexOf(r.paidAt, term);
+      if (wk > tw) wk = tw;
+      const b = buckets[wk];
+      b.amount += r.netAmount;
+      b.paymentsCount += 1;
+      b.students.add(r.studentId);
+    }
+    return buckets;
+  }
+
+  let currentWeekIndex = 1;
+  let currentTotalWeeks = 1;
+  let currentBuckets: ReturnType<typeof bucketByWeek> = [];
+  let priorBuckets: ReturnType<typeof bucketByWeek> = [];
+
+  if (currentTermObj) {
+    currentTotalWeeks = totalWeeks(currentTermObj);
+    currentWeekIndex = Math.min(
+      Math.max(1, weekIndexOf(now, currentTermObj)),
+      currentTotalWeeks,
+    );
+    const curTo = +now < +currentTermObj.endsOn ? now : currentTermObj.endsOn;
+    const curRows = await fetchPayments(currentTermObj.startsOn, curTo);
+    currentBuckets = bucketByWeek(curRows, currentTermObj);
+
+    if (priorTermObj) {
+      const priorRows = await fetchPayments(priorTermObj.startsOn, priorTermObj.endsOn);
+      priorBuckets = bucketByWeek(priorRows, priorTermObj);
+    }
+  }
+
+  // Cumulative arrays (cedis at week i+1), carried forward over the current
+  // term's week axis so current + prior share one x-axis in the overlay.
+  const currentCumArr: number[] = [];
+  {
+    let run = 0;
+    for (let w = 1; w <= currentTotalWeeks; w++) {
+      run += currentBuckets[w]?.amount ?? 0;
+      currentCumArr.push(run);
+    }
+  }
+
+  let priorCumArr: number[] | null = null;
+  if (priorTermObj) {
+    priorCumArr = [];
+    let run = 0;
+    for (let w = 1; w <= currentTotalWeeks; w++) {
+      run += priorBuckets[w]?.amount ?? 0;
+      priorCumArr.push(run);
+    }
+  }
+
+  const currentCollected = currentWeekIndex >= 1 ? (currentCumArr[currentWeekIndex - 1] ?? 0) : 0;
+  const priorCollectedAtSameWeek =
+    priorCumArr && currentWeekIndex >= 1 ? (priorCumArr[currentWeekIndex - 1] ?? 0) : 0;
+  const priorFinal = priorCumArr ? (priorCumArr[priorCumArr.length - 1] ?? 0) : 0;
+
+  // ---- Billed per term (by academicYear) ----------------------------------
+  async function billedForYear(year: string): Promise<number> {
+    const [row] = await withSchool(schoolId, (tx) =>
+      tx
+        .select({ billed: sql<string>`coalesce(sum(${invoices.billedAmount}), 0)` })
+        .from(invoices)
+        .where(
+          and(
+            eq(invoices.schoolId, schoolId),
+            eq(invoices.academicYear, year),
+            ne(invoices.status, "VOIDED"),
+          ),
+        ),
+    );
+    return num(row?.billed);
+  }
+
+  const currentBilled = currentTermObj ? await billedForYear(currentTermObj.academicYear) : 0;
+  const priorBilled = priorTermObj ? await billedForYear(priorTermObj.academicYear) : 0;
+
+  const currentRate = currentBilled > 0 ? round1((currentCollected / currentBilled) * 100) : 0;
+  const priorRateAtSameWeek =
+    priorBilled > 0 ? round1((priorCollectedAtSameWeek / priorBilled) * 100) : 0;
+  const priorFinalRate = priorBilled > 0 ? round1((priorFinal / priorBilled) * 100) : 0;
+
+  const gapCedis = currentCollected - priorCollectedAtSameWeek;
+  const gapPoints = round1(currentRate - priorRateAtSameWeek);
+
+  // Avg weekly (non-cumulative) over last up-to-3 weeks ending at currentWeekIndex
+  function weekAmount(buckets: ReturnType<typeof bucketByWeek>, w: number): number {
+    return buckets[w]?.amount ?? 0;
+  }
+  const last3Weeks: number[] = [];
+  for (let w = Math.max(1, currentWeekIndex - 2); w <= currentWeekIndex; w++) {
+    last3Weeks.push(weekAmount(currentBuckets, w));
+  }
+  const avgWeeklyLast3 = last3Weeks.length ? mean(last3Weeks) : 0;
+
+  const first3Weeks: number[] = [];
+  for (let w = 1; w <= Math.min(3, currentTotalWeeks); w++) {
+    first3Weeks.push(weekAmount(currentBuckets, w));
+  }
+  const avgWeeklyFirst3 = first3Weeks.length ? mean(first3Weeks) : 0;
+
+  // ---- weeklyRows for the grid (week 1..currentWeekIndex) ------------------
+  const weeklyRows: WeeklyRow[] = [];
+  if (currentTermObj) {
+    for (let w = 1; w <= currentWeekIndex; w++) {
+      const cur = currentBuckets[w];
+      const amount = cur?.amount ?? 0;
+      const priorAmount = priorBuckets.length ? (priorBuckets[w]?.amount ?? 0) : null;
+      const hasPriorWeek = priorTermObj && priorAmount !== null;
+      const deltaPct =
+        hasPriorWeek && (priorAmount as number) > 0
+          ? round1(((amount - (priorAmount as number)) / (priorAmount as number)) * 100)
+          : null;
+      const { startLabel, endLabel } = weekRangeLabels(currentTermObj, w);
+      weeklyRows.push({
+        week: w,
+        amount,
+        paymentsCount: cur?.paymentsCount ?? 0,
+        studentsCount: cur?.students.size ?? 0,
+        priorAmount: hasPriorWeek ? (priorAmount as number) : null,
+        deltaPct,
+        startLabel,
+        endLabel,
+      });
+    }
+  }
+  const maxWeekly = Math.max(1, ...weeklyRows.map((r) => r.amount));
+
+  // ---- byClass (invoices grouped by class, current academic year) ----------
+  const classRowsRaw = await withSchool(schoolId, (tx) =>
+    tx
+      .select({
+        classId: classes.id,
+        className: sql<string>`coalesce(${classes.name}, '— Unassigned —')`,
+        billed: sql<string>`coalesce(sum(${invoices.billedAmount}), 0)`,
+        collected: sql<string>`coalesce(sum(${invoices.paidAmount}), 0)`,
+        outstanding: sql<string>`coalesce(sum(${invoices.balanceAmount}), 0)`,
+      })
+      .from(invoices)
+      .innerJoin(students, eq(invoices.studentId, students.id))
+      .leftJoin(classes, eq(students.classId, classes.id))
+      .where(
+        and(
+          eq(invoices.schoolId, schoolId),
+          ne(invoices.status, "VOIDED"),
+          reportYear ? eq(invoices.academicYear, reportYear) : undefined,
+        ),
+      )
+      .groupBy(classes.id, classes.name),
+  );
+
+  const byClass: ClassRow[] = classRowsRaw
+    .map((c) => {
+      const billed = num(c.billed);
+      const collected = num(c.collected);
+      return {
+        classId: c.classId,
+        className: c.className,
+        billed,
+        collected,
+        outstanding: num(c.outstanding),
+        rate: billed > 0 ? round1((collected / billed) * 100) : 0,
+      };
+    })
+    .sort((a, b) => b.outstanding - a.outstanding);
+
+  // ---- Aging by household (from ISSUE date) -------------------------------
+  type AgingInvoiceRow = {
+    balance: number;
+    issuedAt: Date;
+    householdKey: string;
+  };
+  const agingInvoiceRows = await withSchool(schoolId, (tx) =>
+    tx
+      .select({
+        balance: invoices.balanceAmount,
+        issuedAt: invoices.issuedAt,
+        householdId: students.householdId,
+        studentId: students.id,
+      })
+      .from(invoices)
+      .innerJoin(students, eq(invoices.studentId, students.id))
+      .where(
+        and(
+          eq(invoices.schoolId, schoolId),
+          ne(invoices.status, "VOIDED"),
+          sql`${invoices.balanceAmount} > 0`,
+          reportYear ? eq(invoices.academicYear, reportYear) : undefined,
+        ),
+      ),
+  );
+
+  const agingRows: AgingInvoiceRow[] = agingInvoiceRows.map((r) => ({
+    balance: num(r.balance),
+    issuedAt: r.issuedAt as Date,
+    // NULL household → singleton keyed by studentId
+    householdKey: r.householdId ?? `student:${r.studentId}`,
+  }));
+
+  const bucketDefs: { key: AgingBucket["key"]; label: string; test: (age: number) => boolean }[] = [
+    { key: "b1", label: "1—30 days", test: (a) => a <= 30 },
+    { key: "b2", label: "31—60 days", test: (a) => a > 30 && a <= 60 },
+    { key: "b3", label: "61—90 days", test: (a) => a > 60 && a <= 90 },
+    { key: "b4", label: "90+ days", test: (a) => a > 90 },
+  ];
+
+  const bucketAccum = bucketDefs.map((d) => ({
+    key: d.key,
+    label: d.label,
+    amount: 0,
+    invoiceCount: 0,
+    households: new Set<string>(),
+  }));
+
+  let totalOutstanding = 0;
+  let totalInvoices = 0;
+  const allHouseholds = new Set<string>();
+  let oldestIssuedAt: Date | null = null;
+  let weightedAgeSum = 0; // sum(balance * age)
+
+  for (const r of agingRows) {
+    const age = Math.floor((+now - +r.issuedAt) / DAY_MS);
+    totalOutstanding += r.balance;
+    totalInvoices += 1;
+    allHouseholds.add(r.householdKey);
+    weightedAgeSum += r.balance * Math.max(0, age);
+    if (!oldestIssuedAt || +r.issuedAt < +oldestIssuedAt) oldestIssuedAt = r.issuedAt;
+    const def = bucketDefs.find((d) => d.test(Math.max(0, age)));
+    if (def) {
+      const acc = bucketAccum.find((a) => a.key === def.key)!;
+      acc.amount += r.balance;
+      acc.invoiceCount += 1;
+      acc.households.add(r.householdKey);
+    }
+  }
+
+  const agingBuckets: AgingBucket[] = bucketAccum.map((a) => ({
+    key: a.key,
+    label: a.label,
+    amount: a.amount,
+    invoiceCount: a.invoiceCount,
+    householdCount: a.households.size,
+    pct: totalOutstanding > 0 ? round1((a.amount / totalOutstanding) * 100) : 0,
+  }));
+
+  const totalHouseholds = allHouseholds.size;
+  const avgAgeDays = totalOutstanding > 0 ? Math.round(weightedAgeSum / totalOutstanding) : 0;
+  const oldestAgeDays = oldestIssuedAt
+    ? Math.floor((+now - +oldestIssuedAt) / DAY_MS)
+    : 0;
+
+  // Outstanding headline figures (region 1) — same population as aging.
+  const outstandingTotal = totalOutstanding;
+  const householdsOutstanding = totalHouseholds;
+
+  // ---- Chart payload ------------------------------------------------------
+  const yMaxBasis = Math.max(
+    0,
+    ...currentCumArr,
+    ...(priorCumArr ?? []),
+    currentBilled,
+  );
+  const yMax = niceMax(yMaxBasis);
+
+  const cumulative = {
+    current: currentCumArr.slice(0, currentWeekIndex),
+    prior: priorCumArr,
+    totalWeeks: currentTotalWeeks,
+    currentWeekIndex,
+    yMax,
+  };
+
+  return {
+    hasPeriods,
+    hasPrior,
+    currentTerm: currentTermObj
+      ? {
+          label: currentTermObj.label,
+          academicYear: currentTermObj.academicYear,
+          startsOn: currentTermObj.startsOn,
+          endsOn: currentTermObj.endsOn,
+          totalWeeks: currentTotalWeeks,
+        }
+      : null,
+    priorTerm: priorTermObj
+      ? { label: priorTermObj.label, academicYear: priorTermObj.academicYear }
+      : null,
+    currentWeekIndex,
+
+    // headline
+    currentCollected,
+    currentBilled,
+    currentRate,
+    priorCollectedAtSameWeek,
+    priorRateAtSameWeek,
+    priorFinal,
+    priorFinalRate,
+    gapCedis,
+    gapPoints,
+    avgWeeklyLast3,
+    avgWeeklyFirst3,
+    outstandingTotal,
+    householdsOutstanding,
+
+    weeklyRows,
+    maxWeekly,
+
+    byClass,
+
+    aging: {
+      buckets: agingBuckets,
+      totalOutstanding,
+      totalInvoices,
+      totalHouseholds,
+      oldestIssuedAt,
+      oldestAgeDays,
+      avgAgeDays,
+    },
+
+    cumulative,
+  };
+}
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+function mean(arr: number[]): number {
+  return arr.reduce((s, v) => s + v, 0) / arr.length;
+}


### PR DESCRIPTION
## Reports S6 — Collection trend

Rebuilds `/reports/finance/collection-trend` to the **schoolup-collection-trend.html** surface — five numbered regions replacing the old flat monthly bars.

### Regions
1. **Where we are** — collected-to-date hero (with a pace bar + expected-pace marker), a velocity tile (vs last term at the same week, ahead/behind badge), avg-weekly-last-3 vs first-3, and still-outstanding + household count.
2. **Cumulative collection · this term vs last** — an SVG overlay chart: the **gold "this term"** cumulative line stopping at the NOW marker, the **navy-3 "last term"** line carried across the full term axis, area fills, end-point dots, and a 4-cell footer (prior final / this term @wk / last term @wk / gap in cedis + percentage points).
3. **Week by week** — per-week tiles (collected, payments, students, mini-bar) with a **vs-last-term delta** (↑/↓/flat).
4. **By class** — rate-coded progress bars (green ≥70 / warn 50–69 / terra <50), billed/collected, drill-through.
5. **Age of outstanding balances** — **aging-by-household** buckets (1–30 / 31–60 / 61–90 / 90+ days from issue date) with invoice + household counts, amount-weighted avg age, oldest-invoice age, and a dominant-bucket interpretation callout.

### Architecture
- New **`lib/reports/collection-trend-data.ts`** — `getCollectionTrend(schoolId)`. Term windows come from the existing **`academic_period`** table (current = window containing today; prior = the period before it). Weekly bucketing + cumulative carry-forward + aging-by-household (via `students.householdId`, NULL → singleton) are computed truthfully from real rows.
- New **`components/reports/cumulative-overlay.tsx`** — pure presentational SVG, scaled to the data.
- **Self-contained**: does not touch the shared `getFinanceReport`, so it merges independently of the other Reports slices (S1/S3/S5).

### Honesty / fallbacks (verify against live data)
- Week date labels assume a **Mon–Fri working span** off the term start (no school-calendar working-day source).
- **Expected-pace** marker = prior term's rate at the same week; omitted entirely when there's no prior term.
- Graceful empty states: no `academic_period` rows → region 2 shows a "Configure academic terms" card and regions 1/3 zero out; no prior term → velocity/overlay-prior elements drop out; nothing outstanding → aging shows the settled state.

### Verification
- `pnpm typecheck`, `pnpm lint`, `pnpm build` all clean.
- Live preview on a seeded **two-term** scenario (prior Term 3 2024/25 completed; current Term 1 2025/26 at week 6; 12 students / 8 households / 3 classes): every figure reconciles — collected **GHS 41,000 (68.3%)**, last term **81.7%** at wk 6, gap **−GHS 8,000 / −13.4 pts**, weekly deltas, aging buckets **31.6 / 47.4 / 21.1%** across 7 households (avg age 42 days). Overlay lines, NOW marker, and 4-cell footer render correctly; no console errors. Singular/plural and the by-class rate de-duplication fixed during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)