### PR TITLE
feat(reports): functional PERIOD filter (term-collection + discounts)

### DIFF
--- a/omnischools/app/(app)/reports/discounts/page.tsx
+++ b/omnischools/app/(app)/reports/discounts/page.tsx
@@ -8,13 +8,13 @@ import {
   DiscountApplicationsTable,
   type DiscountAppRow,
 } from "@/components/reports/discount-applications-table";
+import { PeriodBar } from "@/components/reports/period-bar";
+import { resolvePeriod, weeksIn } from "@/lib/reports/period";
+import { getReportTerm } from "@/lib/reports/report-term";
 import { schoolFile } from "@/lib/filename";
 
 export const dynamic = "force-dynamic";
 export const metadata = { title: "Discounts given" };
-
-// Periods stay visual until the term-calendar filtering infra lands; "This term" active.
-const PERIODS = ["This week", "This month", "This term", "Academic year", "Custom…"] as const;
 
 /** colorKey → solid token bg class, used for tier-breakdown bars, swatches & timeline segments. */
 const FILL_CLASS: Record<string, string> = {
@@ -37,13 +37,15 @@ const kLabel = (n: number) =>
     ? `${(n / 1000).toLocaleString("en-GH", { maximumFractionDigits: n % 1000 === 0 ? 0 : 1 })}k`
     : String(Math.round(n));
 
-export default async function DiscountsPage() {
+export default async function DiscountsPage({
+  searchParams,
+}: {
+  searchParams: { period?: string; from?: string; to?: string };
+}) {
   const { school } = await requireSchool();
-  const r = await getDiscountsReport(school.id);
-
-  const periodLabel = r.currentTerm
-    ? `${r.currentTerm.periodLabel} · ${r.currentTerm.academicYear}`
-    : "This term";
+  const term = await getReportTerm(school.id);
+  const period = resolvePeriod(searchParams, term, new Date());
+  const r = await getDiscountsReport(school.id, { start: period.start, end: period.end });
 
   const tableRows: DiscountAppRow[] = r.rows;
 
@@ -75,20 +77,13 @@ export default async function DiscountsPage() {
       />
 
       {/* Period bar */}
-      <div className="mb-6 flex flex-wrap items-center gap-2 print:hidden">
-        <span className="mr-1 text-[10px] font-bold uppercase tracking-[0.1em] text-navy-3">Period</span>
-        {PERIODS.map((p) => {
-          const active = p === "This term";
-          return (
-            <span
-              key={p}
-              className={`rounded-pill border px-3 py-1 text-xs font-semibold ${active ? "border-navy bg-navy text-bg" : "border-border-2 bg-surface text-navy-3"}`}
-            >
-              {active ? periodLabel : p}
-            </span>
-          );
-        })}
-      </div>
+      <PeriodBar
+        activeKey={period.key}
+        termLabel={term ? `${term.label} · ${term.academicYear}` : null}
+        termWeeks={term ? weeksIn(term.start, term.end) : null}
+        from={period.from}
+        to={period.to}
+      />
 
       {r.applicationCount === 0 ? (
         <Empty>
@@ -128,11 +123,19 @@ export default async function DiscountsPage() {
                   : "no applications yet"
               }
             />
-            <Kpi
-              label="New this term"
-              value={String(r.newThisTerm)}
-              sub={r.newBreakdown || (r.hasTerm ? "none in the term window" : "no term set")}
-            />
+            {period.key === "term" ? (
+              <Kpi
+                label="New this term"
+                value={String(r.newThisTerm)}
+                sub={r.newBreakdown || (r.hasTerm ? "none in the term window" : "no term set")}
+              />
+            ) : (
+              <Kpi
+                label="Schemes in use"
+                value={String(r.schemesInUse)}
+                sub={`across this ${period.key === "custom" ? "range" : period.key}`}
+              />
+            )}
           </div>
 
           {/* Tier breakdown */}

--- a/omnischools/app/(app)/reports/term-collection/page.tsx
+++ b/omnischools/app/(app)/reports/term-collection/page.tsx
@@ -5,6 +5,9 @@ import { ExportCsv } from "@/components/reports/export-csv";
 import { PrintButton } from "@/components/reports/print-button";
 import { ReportHeader } from "@/components/reports/report-header";
 import { WeeklyBars } from "@/components/reports/weekly-bars";
+import { PeriodBar } from "@/components/reports/period-bar";
+import { resolvePeriod, weeksIn } from "@/lib/reports/period";
+import { getReportTerm } from "@/lib/reports/report-term";
 import { schoolFile } from "@/lib/filename";
 
 export const dynamic = "force-dynamic";
@@ -24,12 +27,15 @@ const METHOD_SWATCH: Record<string, string> = {
 const fmtWeek = (iso: string) =>
   new Date(`${iso}T00:00:00Z`).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" });
 
-// Periods stay visual until the term-calendar infra lands (MVP2 wires real windows).
-const PERIODS = ["This week", "This month", "This term", "Academic year", "Custom…"] as const;
-
-export default async function TermCollectionPage() {
+export default async function TermCollectionPage({
+  searchParams,
+}: {
+  searchParams: { period?: string; from?: string; to?: string };
+}) {
   const { school } = await requireSchool();
-  const r = await getFinanceReport(school.id, null);
+  const term = await getReportTerm(school.id);
+  const period = resolvePeriod(searchParams, term, new Date());
+  const r = await getFinanceReport(school.id, null, { start: period.start, end: period.end });
 
   // Trailing window so the chart reads like a term rather than the whole history.
   const weeksAll = r.weekly.map((w) => ({ iso: w.weekStart, amount: num(w.amount) }));
@@ -73,20 +79,13 @@ export default async function TermCollectionPage() {
       />
 
       {/* Period bar */}
-      <div className="mb-6 flex flex-wrap items-center gap-2 print:hidden">
-        <span className="mr-1 text-[10px] font-bold uppercase tracking-[0.1em] text-navy-3">Period</span>
-        {PERIODS.map((p) => {
-          const active = p === "This term";
-          return (
-            <span
-              key={p}
-              className={`rounded-pill border px-3 py-1 text-xs font-semibold ${active ? "border-navy bg-navy text-bg" : "border-border-2 bg-surface text-navy-3"}`}
-            >
-              {p}
-            </span>
-          );
-        })}
-      </div>
+      <PeriodBar
+        activeKey={period.key}
+        termLabel={term ? `${term.label} · ${term.academicYear}` : null}
+        termWeeks={term ? weeksIn(term.start, term.end) : null}
+        from={period.from}
+        to={period.to}
+      />
 
       {/* KPI strip */}
       <div className="mb-8 grid grid-cols-2 gap-4 lg:grid-cols-4">

--- a/omnischools/components/reports/period-bar.tsx
+++ b/omnischools/components/reports/period-bar.tsx
@@ -1,0 +1,110 @@
+"use client";
+import { useState } from "react";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import { cn } from "@/lib/utils";
+import { PERIOD_KEYS, PERIOD_LABELS, type PeriodKey } from "@/lib/reports/period";
+
+/**
+ * Functional PERIOD filter. Each pill writes `?period=<key>` (plus `from`/`to`
+ * for custom) to the URL; the server page resolves the window and re-queries.
+ */
+export function PeriodBar({
+  activeKey,
+  termLabel,
+  termWeeks,
+  from = "",
+  to = "",
+}: {
+  activeKey: PeriodKey;
+  termLabel?: string | null;
+  termWeeks?: number | null;
+  from?: string;
+  to?: string;
+}) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const params = useSearchParams();
+  const [open, setOpen] = useState(activeKey === "custom");
+  const [cFrom, setCFrom] = useState(from);
+  const [cTo, setCTo] = useState(to);
+
+  function go(next: Record<string, string | undefined>) {
+    const sp = new URLSearchParams(params.toString());
+    for (const [k, v] of Object.entries(next)) {
+      if (v == null || v === "") sp.delete(k);
+      else sp.set(k, v);
+    }
+    router.push(`${pathname}?${sp.toString()}`);
+  }
+
+  function pick(key: PeriodKey) {
+    if (key === "custom") {
+      setOpen(true);
+      if (cFrom && cTo) go({ period: "custom", from: cFrom, to: cTo });
+      return;
+    }
+    setOpen(false);
+    go({ period: key, from: undefined, to: undefined });
+  }
+
+  const labelFor = (key: PeriodKey) =>
+    key === "term" && termLabel ? termLabel : PERIOD_LABELS[key];
+
+  return (
+    <div className="mb-6 print:hidden">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="mr-1 text-[10px] font-bold uppercase tracking-[0.1em] text-navy-3">Period</span>
+        {PERIOD_KEYS.map((key) => {
+          const active = key === activeKey;
+          return (
+            <button
+              key={key}
+              onClick={() => pick(key)}
+              className={cn(
+                "rounded-pill border px-3 py-1 text-xs font-semibold transition-colors",
+                active
+                  ? "border-navy bg-navy text-bg"
+                  : "border-border-2 bg-surface text-navy-3 hover:border-gold hover:text-navy-2",
+              )}
+            >
+              {labelFor(key)}
+              {key === "term" && active && termWeeks ? (
+                <span className="ml-1 font-normal text-gold-soft">{termWeeks} weeks</span>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+
+      {open && (
+        <div className="mt-2 flex flex-wrap items-end gap-2 rounded-lg border border-border bg-surface p-3">
+          <label className="flex flex-col gap-1 text-[10px] font-bold uppercase tracking-[0.08em] text-navy-3">
+            From
+            <input
+              type="date"
+              value={cFrom}
+              onChange={(e) => setCFrom(e.target.value)}
+              className="rounded-md border border-border-2 bg-bg px-2 py-1.5 text-xs text-navy outline-none focus:border-gold"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-[10px] font-bold uppercase tracking-[0.08em] text-navy-3">
+            To
+            <input
+              type="date"
+              value={cTo}
+              onChange={(e) => setCTo(e.target.value)}
+              className="rounded-md border border-border-2 bg-bg px-2 py-1.5 text-xs text-navy outline-none focus:border-gold"
+            />
+          </label>
+          <button
+            onClick={() => cFrom && cTo && go({ period: "custom", from: cFrom, to: cTo })}
+            disabled={!cFrom || !cTo}
+            className="rounded-md bg-navy px-3 py-1.5 text-xs font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-50"
+          >
+            Apply
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/omnischools/lib/reports/discounts-data.ts
+++ b/omnischools/lib/reports/discounts-data.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, ne, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gte, lt, ne, sql } from "drizzle-orm";
 import { withSchool } from "@/lib/db/rls";
 import {
   invoices,
@@ -48,8 +48,13 @@ type AppRow = {
   className: string;
 };
 
-export async function getDiscountsReport(schoolId: string) {
+export async function getDiscountsReport(
+  schoolId: string,
+  /** Date window from the PERIOD filter; scopes billed (issue date) + applications (applied date). */
+  period?: { start: Date; end: Date } | null,
+) {
   return withSchool(schoolId, async (tx) => {
+    const win = period ?? null;
     // 1. Current term: window containing today, else latest started, else last.
     const periods = await tx
       .select({
@@ -81,7 +86,11 @@ export async function getDiscountsReport(schoolId: string) {
         and(
           eq(invoices.schoolId, schoolId),
           ne(invoices.status, "VOIDED"),
-          reportYear ? eq(invoices.academicYear, reportYear) : undefined,
+          win
+            ? and(gte(invoices.issuedAt, win.start), lt(invoices.issuedAt, win.end))
+            : reportYear
+              ? eq(invoices.academicYear, reportYear)
+              : undefined,
         ),
       );
     const totalBilled = num(billedRow?.total);
@@ -113,7 +122,14 @@ export async function getDiscountsReport(schoolId: string) {
         and(
           eq(invoiceDiscountApplications.schoolId, schoolId),
           ne(invoices.status, "VOIDED"),
-          reportYear ? eq(invoices.academicYear, reportYear) : undefined,
+          win
+            ? and(
+                gte(invoiceDiscountApplications.appliedAt, win.start),
+                lt(invoiceDiscountApplications.appliedAt, win.end),
+              )
+            : reportYear
+              ? eq(invoices.academicYear, reportYear)
+              : undefined,
         ),
       )
       .orderBy(desc(invoiceDiscountApplications.appliedAt));
@@ -226,13 +242,16 @@ export async function getDiscountsReport(schoolId: string) {
         .join(" · ");
     }
 
-    // 7. Timeline — weekly buckets across the current term, else calendar months.
-    //    Each bucket carries a per-scheme amount map for stacked bars.
+    // 7. Timeline — weekly buckets across the active window (≤ 20 weeks), else
+    //    calendar months. Each bucket carries a per-scheme amount map for stacking.
     const MS_WEEK = 7 * 24 * 60 * 60 * 1000;
+    const tlStartMs = win ? +win.start : currentTerm ? +new Date(`${currentTerm.startsOn}T00:00:00Z`) : null;
+    const tlEndMs = win ? +win.end : currentTerm ? +new Date(`${currentTerm.endsOn}T00:00:00Z`) : null;
+    const tlWeekly = tlStartMs != null && tlEndMs != null && tlEndMs - tlStartMs <= 20 * MS_WEEK;
     let timelineWeeks: { label: string; segments: Record<string, number> }[] = [];
-    if (currentTerm) {
-      const start = new Date(`${currentTerm.startsOn}T00:00:00Z`).getTime();
-      const end = new Date(`${currentTerm.endsOn}T00:00:00Z`).getTime();
+    if (tlStartMs != null && tlEndMs != null && tlWeekly) {
+      const start = tlStartMs;
+      const end = tlEndMs;
       const weekCount = Math.max(1, Math.ceil((end - start) / MS_WEEK) + 1);
       timelineWeeks = Array.from({ length: weekCount }, (_, i) => ({
         label: `W${i + 1}`,
@@ -333,6 +352,7 @@ export async function getDiscountsReport(schoolId: string) {
       studentCount,
       stackedStudentCount,
       byScheme,
+      schemesInUse: byScheme.length,
       mostUsedScheme,
       newThisTerm,
       newBreakdown,

--- a/omnischools/lib/reports/finance-data.ts
+++ b/omnischools/lib/reports/finance-data.ts
@@ -59,9 +59,19 @@ export function yearWindow(selectedYear: string | null): YearWindow {
   return { start: new Date(Date.UTC(sy, 8, 1)), end: new Date(Date.UTC(sy + 1, 8, 1)) };
 }
 
-export async function getFinanceReport(schoolId: string, selectedYear: string | null) {
-  const win = yearWindow(selectedYear);
-  const yearInv = selectedYear ? eq(invoices.academicYear, selectedYear) : undefined;
+export async function getFinanceReport(
+  schoolId: string,
+  selectedYear: string | null,
+  /** Explicit date window (from the PERIOD filter); overrides the academic-year window. */
+  period?: { start: Date; end: Date } | null,
+) {
+  const win = period ?? yearWindow(selectedYear);
+  // Period scopes invoices by issue date; the year selector scopes by academic-year label.
+  const invFilter = period
+    ? and(gte(invoices.issuedAt, period.start), lt(invoices.issuedAt, period.end))
+    : selectedYear
+      ? eq(invoices.academicYear, selectedYear)
+      : undefined;
   const payWindow = win
     ? and(gte(payments.paidAt, win.start), lt(payments.paidAt, win.end))
     : undefined;
@@ -94,7 +104,7 @@ export async function getFinanceReport(schoolId: string, selectedYear: string | 
           debtorCount: sql<number>`count(distinct ${invoices.studentId}) filter (where ${invoices.balanceAmount} > 0)`,
         })
         .from(invoices)
-        .where(and(eq(invoices.schoolId, schoolId), ne(invoices.status, "VOIDED"), yearInv)),
+        .where(and(eq(invoices.schoolId, schoolId), ne(invoices.status, "VOIDED"), invFilter)),
     ),
     withSchool(schoolId, (tx) =>
       tx
@@ -108,7 +118,7 @@ export async function getFinanceReport(schoolId: string, selectedYear: string | 
         .from(invoices)
         .innerJoin(students, eq(invoices.studentId, students.id))
         .leftJoin(classes, eq(students.classId, classes.id))
-        .where(and(eq(invoices.schoolId, schoolId), ne(invoices.status, "VOIDED"), yearInv))
+        .where(and(eq(invoices.schoolId, schoolId), ne(invoices.status, "VOIDED"), invFilter))
         .groupBy(classes.id, classes.name)
         .orderBy(desc(sql`sum(${invoices.balanceAmount})`)),
     ),
@@ -164,7 +174,7 @@ export async function getFinanceReport(schoolId: string, selectedYear: string | 
             eq(invoices.schoolId, schoolId),
             ne(invoices.status, "VOIDED"),
             sql`${invoices.balanceAmount} > 0`,
-            yearInv,
+            invFilter,
           ),
         )
         .groupBy(sql`1`),
@@ -210,7 +220,7 @@ export async function getFinanceReport(schoolId: string, selectedYear: string | 
           count: sql<number>`count(*) filter (where ${invoices.discountAmount} > 0)`,
         })
         .from(invoices)
-        .where(and(eq(invoices.schoolId, schoolId), ne(invoices.status, "VOIDED"), yearInv)),
+        .where(and(eq(invoices.schoolId, schoolId), ne(invoices.status, "VOIDED"), invFilter)),
     ),
     withSchool(schoolId, (tx) =>
       tx

--- a/omnischools/lib/reports/period.ts
+++ b/omnischools/lib/reports/period.ts
@@ -1,0 +1,116 @@
+/**
+ * PERIOD filter for the Reports module — pure date logic, no DB imports, so it's
+ * safe to import from both server pages and the client <PeriodBar>.
+ *
+ * A selected period resolves to a half-open [start, end) window. Server pages pass
+ * the window into the data layer (invoices by issue date, payments by paid date).
+ */
+
+export type PeriodKey = "week" | "month" | "term" | "year" | "custom";
+
+export const PERIOD_KEYS: PeriodKey[] = ["week", "month", "term", "year", "custom"];
+
+export const PERIOD_LABELS: Record<PeriodKey, string> = {
+  week: "This week",
+  month: "This month",
+  term: "This term",
+  year: "Academic year",
+  custom: "Custom…",
+};
+
+export type TermInfo = {
+  label: string; // e.g. "Term 3"
+  academicYear: string; // e.g. "2025/26"
+  start: Date;
+  end: Date;
+} | null;
+
+export type ResolvedPeriod = {
+  key: PeriodKey;
+  label: string; // display label for the active state
+  start: Date;
+  end: Date;
+  from?: string; // echoed custom inputs (YYYY-MM-DD)
+  to?: string;
+};
+
+const DAY = 86_400_000;
+const midnightUTC = (d: Date) => new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+const parseISO = (s?: string) => {
+  if (!s) return null;
+  const d = new Date(`${s}T00:00:00.000Z`);
+  return Number.isNaN(+d) ? null : d;
+};
+
+/** Sep–Aug academic-year window containing `now`. */
+export function academicYearWindow(now: Date): { start: Date; end: Date; label: string } {
+  const y = now.getUTCFullYear();
+  const startYear = now.getUTCMonth() >= 8 ? y : y - 1; // Sep (month 8) rolls the year
+  const start = new Date(Date.UTC(startYear, 8, 1));
+  const end = new Date(Date.UTC(startYear + 1, 8, 1));
+  return { start, end, label: `${startYear}/${String((startYear + 1) % 100).padStart(2, "0")}` };
+}
+
+/** Number of (partial) weeks a window spans. */
+export function weeksIn(start: Date, end: Date): number {
+  return Math.max(1, Math.ceil((+end - +start) / (7 * DAY)));
+}
+
+/**
+ * Resolve the active period from query params + the school's current term.
+ * Defaults to "term" when a term is configured, else "year".
+ */
+export function resolvePeriod(
+  params: { period?: string; from?: string; to?: string },
+  term: TermInfo,
+  now: Date,
+): ResolvedPeriod {
+  const raw = (params.period ?? "").toLowerCase();
+  let key: PeriodKey = (PERIOD_KEYS as string[]).includes(raw)
+    ? (raw as PeriodKey)
+    : term
+      ? "term"
+      : "year";
+  // "term" is only meaningful when a term exists; fall back to year otherwise.
+  if (key === "term" && !term) key = "year";
+
+  const today = midnightUTC(now);
+
+  if (key === "week") {
+    const dow = (today.getUTCDay() + 6) % 7; // Monday = 0
+    const start = new Date(+today - dow * DAY);
+    return { key, label: "This week", start, end: new Date(+start + 7 * DAY) };
+  }
+  if (key === "month") {
+    const start = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
+    const end = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth() + 1, 1));
+    return { key, label: "This month", start, end };
+  }
+  if (key === "term" && term) {
+    // inclusive end → half-open by adding a day
+    return {
+      key,
+      label: `${term.label} · ${term.academicYear}`,
+      start: term.start,
+      end: new Date(+term.end + DAY),
+    };
+  }
+  if (key === "custom") {
+    const from = parseISO(params.from);
+    const to = parseISO(params.to);
+    if (from && to && +to >= +from) {
+      return {
+        key,
+        label: "Custom",
+        start: from,
+        end: new Date(+to + DAY),
+        from: params.from,
+        to: params.to,
+      };
+    }
+    // invalid/empty custom → fall through to academic year
+  }
+
+  const ay = academicYearWindow(now);
+  return { key: "year", label: `Academic year ${ay.label}`, start: ay.start, end: ay.end };
+}

--- a/omnischools/lib/reports/report-term.ts
+++ b/omnischools/lib/reports/report-term.ts
@@ -1,0 +1,36 @@
+import { asc, eq } from "drizzle-orm";
+import { withSchool } from "@/lib/db/rls";
+import { academicPeriod } from "@/db/schema";
+import type { TermInfo } from "./period";
+
+/**
+ * The school's "current" academic term — the window containing today, else the
+ * latest term that has started, else the last configured term. Powers the PERIOD
+ * filter's "This term" option and pill label. Returns null when no term is set.
+ */
+export async function getReportTerm(schoolId: string): Promise<TermInfo> {
+  const rows = await withSchool(schoolId, (tx) =>
+    tx
+      .select({
+        label: academicPeriod.periodLabel,
+        academicYear: academicPeriod.academicYear,
+        startsOn: academicPeriod.startsOn,
+        endsOn: academicPeriod.endsOn,
+      })
+      .from(academicPeriod)
+      .where(eq(academicPeriod.schoolId, schoolId))
+      .orderBy(asc(academicPeriod.startsOn)),
+  );
+  if (!rows.length) return null;
+  const today = new Date().toISOString().slice(0, 10);
+  const cur =
+    rows.find((r) => r.startsOn <= today && r.endsOn >= today) ??
+    [...rows].reverse().find((r) => r.startsOn <= today) ??
+    rows[rows.length - 1];
+  return {
+    label: cur.label,
+    academicYear: cur.academicYear,
+    start: new Date(`${cur.startsOn}T00:00:00.000Z`),
+    end: new Date(`${cur.endsOn}T00:00:00.000Z`),
+  };
+}


### PR DESCRIPTION
## Reports — functional PERIOD filter

The PERIOD bar on **Term collection** and **Discounts** was a decorative strip of static chips. This wires it to a real date-window filter driven by a `?period=` query param.

### Options
**This week · This month · This term · Academic year · Custom (from–to)**
- *This term* uses the school's current `academic_period` window (the pill shows its label + week count).
- *Academic year* uses the Sep–Aug window.
- *Custom* opens two date inputs + Apply.

### How it works
- **`lib/reports/period.ts`** — pure, client-safe resolver (`resolvePeriod`) → a half-open `[start, end)` window. No DB imports, so the client `PeriodBar` can share its types.
- **`components/reports/period-bar.tsx`** — client component; each pill writes `?period=<key>` (+ `from`/`to`) to the URL and the server page re-queries. Active pill highlighted.
- **`lib/reports/report-term.ts`** — resolves the current term for the pages.
- **`getFinanceReport` / `getDiscountsReport`** now accept an explicit window: invoices scoped by **issue date**, payments by **paid date**, discount applications by **applied date**. No-arg callers (the hub) are unaffected.
- Discounts' 4th KPI switches **"New this term" → "Schemes in use"** for non-term windows so the label stays truthful.

### Semantics
The window scopes the **billing cohort** by issue date — e.g. "This week" shows invoices *issued* this week (0 in the demo, since none were), "Academic year" shows the full year. This keeps billed/collected/outstanding internally consistent within the selected window.

### Verification (live)
- **Term collection** re-scopes correctly: This term **GHS 43,200** · This week **GHS 0** · Academic year **GHS 70,800**; URL updates to `?period=…`; active pill tracks.
- **Discounts** scopes applications + the timeline and swaps KPI4 to "Schemes in use".
- `pnpm typecheck`, `pnpm lint`, `pnpm build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)