### PR TITLE
feat(reports): back link to hub on every report detail page

### DIFF
--- a/omnischools/components/reports/report-header.tsx
+++ b/omnischools/components/reports/report-header.tsx
@@ -1,6 +1,10 @@
 import Link from "next/link";
 
-/** Shared detail-route header: crumb (Reports / X) + display title with a gold-italic word + actions. */
+/**
+ * Shared detail-route header: a back link to the Reports hub (matching the
+ * app-wide "← Label" convention), a crumb, a display title with a gold-italic
+ * word, and optional actions.
+ */
 export function ReportHeader({
   crumb,
   pre,
@@ -15,20 +19,23 @@ export function ReportHeader({
   actions?: React.ReactNode;
 }) {
   return (
-    <div className="mb-5 flex flex-wrap items-start justify-between gap-3">
-      <div>
-        <div className="text-xs uppercase tracking-wide text-navy-3 print:hidden">
-          <Link href="/reports" className="font-semibold text-gold hover:underline">
-            Reports
-          </Link>{" "}
-          / {crumb}
+    <div className="mb-5">
+      <Link
+        href="/reports"
+        className="mb-2 inline-block text-sm text-navy-3 transition-colors hover:text-gold print:hidden"
+      >
+        ← Reports
+      </Link>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-xs uppercase tracking-wide text-navy-3 print:hidden">{crumb}</div>
+          <h1 className="mt-1 font-display text-3xl font-semibold text-navy">
+            {pre} <em className="text-gold">{gold}</em>
+          </h1>
+          {lede && <p className="mt-0.5 max-w-2xl text-sm text-navy-3">{lede}</p>}
         </div>
-        <h1 className="mt-1 font-display text-3xl font-semibold text-navy">
-          {pre} <em className="text-gold">{gold}</em>
-        </h1>
-        {lede && <p className="mt-0.5 max-w-2xl text-sm text-navy-3">{lede}</p>}
+        {actions && <div className="flex flex-wrap items-center gap-2 print:hidden">{actions}</div>}
       </div>
-      {actions && <div className="flex flex-wrap items-center gap-2 print:hidden">{actions}</div>}
     </div>
   );
 }


### PR DESCRIPTION
## Reports — "← Reports" back link

The reworked report subpages (Term collection, Discounts, Outstanding, Voids & refunds, Collection trend, School stats) had only a subtle breadcrumb and no obvious way back to the Reports hub. This adds a **"← Reports"** back link.

### One place, all six pages
All six detail routes render through the shared `ReportHeader`, so the link is added there once and appears on every one.

### Design — matched, not redesigned
I kept the **app-wide back-link convention** already used by Students, Fees, Classes, Inbox, Gradebook and Settings — `← Label`, `text-sm` / `text-navy-3` → `hover:text-gold`. So it's consistent with the rest of the app **by construction**, and no other page needed a redesign. (You'd invited a redesign if it improved things, but a bespoke button would've meant re-skinning every other page's back link for consistency — matching the existing one is cleaner and lower-risk. Happy to do a fancier shared `BackLink` component across the whole app as a separate pass if you'd prefer.)

The breadcrumb now shows just the page path; the back link supplies the Reports affordance, so the previously-duplicated "Reports" link was removed.

### Verification (live)
- "← Reports" renders at the top of the detail pages and **navigates to `/reports`** (confirmed on School stats + Term collection).
- Styling matches the convention (navy-3, 14px, gold on hover).
- `pnpm typecheck`, `pnpm lint`, `pnpm build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)