### PR TITLE
refactor(ui): shared BackLink component across the app

### DIFF
--- a/omnischools/app/(app)/attendance/[classId]/page.tsx
+++ b/omnischools/app/(app)/attendance/[classId]/page.tsx
@@ -22,6 +22,7 @@ import {
   type EarlierReg,
 } from "@/components/attendance/register-switcher";
 import type { AttendanceStatus } from "@/lib/attendance-status";
+import { BackLink } from "@/components/ui/back-link";
 
 export const dynamic = "force-dynamic";
 
@@ -367,9 +368,7 @@ export default async function TakeAttendancePage({
   if (roster.length === 0) {
     return (
       <div className="mx-auto max-w-3xl">
-        <Link href="/attendance" className="text-sm text-navy-3 hover:text-gold">
-          ← Attendance
-        </Link>
+        <BackLink href="/attendance" label="Attendance" />
         <h1 className="mb-1 mt-2 font-display text-3xl font-semibold text-navy">
           {data.cls.name}
         </h1>

--- a/omnischools/app/(app)/classes/[id]/page.tsx
+++ b/omnischools/app/(app)/classes/[id]/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import { and, asc, eq, isNull } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
@@ -9,6 +8,7 @@ import { ClassTeacherSelect } from "@/components/classes/class-teacher-select";
 import { RosterManager } from "@/components/classes/roster-manager";
 import { SubjectsManager } from "@/components/classes/subjects-manager";
 import { TimetableBuilder } from "@/components/classes/timetable-builder";
+import { BackLink } from "@/components/ui/back-link";
 
 export const dynamic = "force-dynamic";
 
@@ -97,9 +97,7 @@ export default async function ClassDetailPage({ params }: { params: { id: string
   return (
     <div className="mx-auto max-w-page space-y-8">
       <div>
-        <Link href="/classes" className="text-sm text-navy-3 hover:text-gold">
-          ← Classes
-        </Link>
+        <BackLink href="/classes" label="Classes" />
         <div className="mt-2 flex flex-wrap items-center justify-between gap-3">
           <div>
             <h1 className="font-display text-3xl font-semibold text-navy">{cls.name}</h1>

--- a/omnischools/app/(app)/fees/[studentId]/page.tsx
+++ b/omnischools/app/(app)/fees/[studentId]/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import { and, desc, eq } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
@@ -8,6 +7,7 @@ import { num, daysOverdue } from "@/lib/fees-helpers";
 import { IssueInvoiceForm } from "@/components/fees/issue-invoice-form";
 import { RecordPaymentForm } from "@/components/fees/record-payment-form";
 import { VoidPaymentButton } from "@/components/fees/void-payment-button";
+import { BackLink } from "@/components/ui/back-link";
 
 export const dynamic = "force-dynamic";
 
@@ -90,9 +90,7 @@ export default async function StudentFeesPage({
 
   return (
     <div className="mx-auto max-w-page">
-      <Link href="/fees" className="text-sm text-navy-3 hover:text-gold">
-        ← Fees
-      </Link>
+      <BackLink href="/fees" label="Fees" />
       <div className="mb-6 mt-2 flex flex-wrap items-end justify-between gap-4">
         <div>
           <h1 className="font-display text-3xl font-semibold text-navy">

--- a/omnischools/app/(app)/gradebook/report/[studentId]/page.tsx
+++ b/omnischools/app/(app)/gradebook/report/[studentId]/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import { and, asc, eq } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
@@ -11,6 +10,7 @@ import {
   reportCards,
 } from "@/db/schema";
 import { PrintButton } from "@/components/gradebook/print-button";
+import { BackLink } from "@/components/ui/back-link";
 
 export const dynamic = "force-dynamic";
 
@@ -72,9 +72,7 @@ export default async function ReportCardPage({
   return (
     <div className="mx-auto max-w-3xl">
       <div className="mb-4 flex items-center justify-between print:hidden">
-        <Link href="/gradebook/reports" className="text-sm text-navy-3 hover:text-gold">
-          ← Report cards
-        </Link>
+        <BackLink href="/gradebook/reports" label="Report cards" />
         <PrintButton />
       </div>
 

--- a/omnischools/app/(app)/gradebook/reports/page.tsx
+++ b/omnischools/app/(app)/gradebook/reports/page.tsx
@@ -5,6 +5,7 @@ import { withSchool } from "@/lib/db/rls";
 import { classes, students, academicPeriod, reportCards } from "@/db/schema";
 import { GradebookSelectors } from "@/components/gradebook/selectors";
 import { GenerateReports } from "@/components/gradebook/generate-reports";
+import { BackLink } from "@/components/ui/back-link";
 
 export const dynamic = "force-dynamic";
 
@@ -107,9 +108,7 @@ export default async function ReportsPage({
 
   return (
     <div className="mx-auto max-w-page">
-      <Link href="/gradebook" className="text-sm text-navy-3 hover:text-gold">
-        ← Gradebook
-      </Link>
+      <BackLink href="/gradebook" label="Gradebook" />
       <h1 className="mb-1 mt-2 font-display text-3xl font-semibold text-navy">
         Report cards
       </h1>

--- a/omnischools/app/(app)/inbox/[id]/page.tsx
+++ b/omnischools/app/(app)/inbox/[id]/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import { and, asc, eq } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
@@ -7,6 +6,7 @@ import { conversations, inboxMessages, students } from "@/db/schema";
 import { loadStaffOptions } from "@/lib/data/staff-options";
 import { ReplyBox } from "@/components/inbox/reply-box";
 import { ConversationControls } from "@/components/inbox/conversation-controls";
+import { BackLink } from "@/components/ui/back-link";
 
 export const dynamic = "force-dynamic";
 
@@ -63,9 +63,7 @@ export default async function ConversationPage({ params }: { params: { id: strin
   return (
     <div className="mx-auto flex max-w-prose flex-col gap-4">
       <div>
-        <Link href="/inbox" className="text-sm text-navy-3 hover:text-gold">
-          ← Inbox
-        </Link>
+        <BackLink href="/inbox" label="Inbox" />
         <div className="mt-2 flex flex-wrap items-center justify-between gap-3">
           <div>
             <h1 className="font-display text-2xl font-semibold text-navy">

--- a/omnischools/app/(app)/reports/class/[classId]/page.tsx
+++ b/omnischools/app/(app)/reports/class/[classId]/page.tsx
@@ -8,6 +8,7 @@ import { SendReminderButton } from "@/components/reports/send-reminder-button";
 import { PrintButton } from "@/components/reports/print-button";
 import { ExportCsv } from "@/components/reports/export-csv";
 import { schoolFile } from "@/lib/filename";
+import { BackLink } from "@/components/ui/back-link";
 
 export const dynamic = "force-dynamic";
 
@@ -57,9 +58,7 @@ export default async function ClassReportPage({
 
   return (
     <div className="mx-auto max-w-page">
-      <Link href="/reports" className="text-sm text-navy-3 hover:text-gold print:hidden">
-        ← Reports
-      </Link>
+      <BackLink href="/reports" label="Reports" />
       <div className="mb-6 mt-2 flex flex-wrap items-end justify-between gap-3">
         <div>
           <h1 className="font-display text-3xl font-semibold text-navy">{cls.name}</h1>

--- a/omnischools/app/(app)/settings/academic/page.tsx
+++ b/omnischools/app/(app)/settings/academic/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { asc, eq } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
@@ -12,6 +11,7 @@ import { currentAcademicYearLabel } from "@/lib/onboarding";
 import { TermDatesForm } from "@/components/settings/term-dates-form";
 import { GradeScaleEditor } from "@/components/settings/grade-scale-editor";
 import { WeightsForm } from "@/components/settings/weights-form";
+import { BackLink } from "@/components/ui/back-link";
 
 export const dynamic = "force-dynamic";
 export const metadata = { title: "Academic structure" };
@@ -50,9 +50,7 @@ export default async function AcademicSettingsPage() {
 
   return (
     <div className="mx-auto max-w-page">
-      <Link href="/settings" className="text-sm text-navy-3 hover:text-gold">
-        ← Settings
-      </Link>
+      <BackLink href="/settings" label="Settings" />
       <div className="mb-6 mt-2">
         <h1 className="font-display text-3xl font-semibold text-navy">
           Academic <em className="not-italic text-gold [font-style:italic]">structure.</em>

--- a/omnischools/app/(app)/settings/audit/page.tsx
+++ b/omnischools/app/(app)/settings/audit/page.tsx
@@ -3,6 +3,7 @@ import { and, desc, eq, sql } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import { auditLog, users } from "@/db/schema";
+import { BackLink } from "@/components/ui/back-link";
 
 export const dynamic = "force-dynamic";
 export const metadata = { title: "Audit log" };
@@ -83,9 +84,7 @@ export default async function AuditLogPage({
 
   return (
     <div className="mx-auto max-w-page">
-      <Link href="/settings" className="text-sm text-navy-3 hover:text-gold">
-        ← Settings
-      </Link>
+      <BackLink href="/settings" label="Settings" />
       <div className="mb-5 mt-2">
         <h1 className="font-display text-3xl font-semibold text-navy">
           Audit <em className="not-italic text-gold [font-style:italic]">log.</em>

--- a/omnischools/app/(app)/settings/branding/page.tsx
+++ b/omnischools/app/(app)/settings/branding/page.tsx
@@ -1,9 +1,9 @@
-import Link from "next/link";
 import { eq } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import { schools } from "@/db/schema";
 import { BrandingForm } from "@/components/settings/branding-form";
+import { BackLink } from "@/components/ui/back-link";
 
 export const dynamic = "force-dynamic";
 export const metadata = { title: "Branding & identity" };
@@ -26,9 +26,7 @@ export default async function BrandingPage() {
 
   return (
     <div className="mx-auto max-w-page">
-      <Link href="/settings" className="text-sm text-navy-3 hover:text-gold">
-        ← Settings
-      </Link>
+      <BackLink href="/settings" label="Settings" />
       <div className="mb-6 mt-2">
         <h1 className="font-display text-3xl font-semibold text-navy">
           Branding &amp; <em className="not-italic text-gold [font-style:italic]">identity.</em>

--- a/omnischools/app/(app)/settings/export/page.tsx
+++ b/omnischools/app/(app)/settings/export/page.tsx
@@ -1,6 +1,6 @@
-import Link from "next/link";
 import { requireSchool } from "@/lib/auth/server";
 import { ExportPanel } from "@/components/settings/export-panel";
+import { BackLink } from "@/components/ui/back-link";
 
 export const dynamic = "force-dynamic";
 export const metadata = { title: "Data export" };
@@ -9,9 +9,7 @@ export default async function DataExportPage() {
   await requireSchool();
   return (
     <div className="mx-auto max-w-page">
-      <Link href="/settings" className="text-sm text-navy-3 hover:text-gold">
-        ← Settings
-      </Link>
+      <BackLink href="/settings" label="Settings" />
       <div className="mb-6 mt-2">
         <h1 className="font-display text-3xl font-semibold text-navy">
           Data <em className="not-italic text-gold [font-style:italic]">export.</em>

--- a/omnischools/app/(app)/settings/retention/page.tsx
+++ b/omnischools/app/(app)/settings/retention/page.tsx
@@ -1,9 +1,9 @@
-import Link from "next/link";
 import { eq } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import { schools } from "@/db/schema";
 import { RetentionForm } from "@/components/settings/retention-form";
+import { BackLink } from "@/components/ui/back-link";
 
 export const dynamic = "force-dynamic";
 export const metadata = { title: "Retention policy" };
@@ -22,9 +22,7 @@ export default async function RetentionPage() {
 
   return (
     <div className="mx-auto max-w-page">
-      <Link href="/settings" className="text-sm text-navy-3 hover:text-gold">
-        ← Settings
-      </Link>
+      <BackLink href="/settings" label="Settings" />
       <div className="mb-6 mt-2">
         <h1 className="font-display text-3xl font-semibold text-navy">
           Retention <em className="not-italic text-gold [font-style:italic]">policy.</em>

--- a/omnischools/app/(app)/settings/school/page.tsx
+++ b/omnischools/app/(app)/settings/school/page.tsx
@@ -1,9 +1,9 @@
-import Link from "next/link";
 import { eq } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import { schools, regions, districts } from "@/db/schema";
 import { SchoolInfoForm } from "@/components/settings/school-info-form";
+import { BackLink } from "@/components/ui/back-link";
 
 export const dynamic = "force-dynamic";
 export const metadata = { title: "School info" };
@@ -37,9 +37,7 @@ export default async function SchoolInfoPage() {
 
   return (
     <div className="mx-auto max-w-page">
-      <Link href="/settings" className="text-sm text-navy-3 hover:text-gold">
-        ← Settings
-      </Link>
+      <BackLink href="/settings" label="Settings" />
       <div className="mb-6 mt-2">
         <h1 className="font-display text-3xl font-semibold text-navy">
           School <em className="not-italic text-gold [font-style:italic]">info.</em>

--- a/omnischools/app/(app)/settings/security/page.tsx
+++ b/omnischools/app/(app)/settings/security/page.tsx
@@ -1,9 +1,9 @@
-import Link from "next/link";
 import { eq } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import { schools } from "@/db/schema";
 import { SecurityForm } from "@/components/settings/security-form";
+import { BackLink } from "@/components/ui/back-link";
 
 export const dynamic = "force-dynamic";
 export const metadata = { title: "Login & security" };
@@ -19,9 +19,7 @@ export default async function SecurityPage() {
 
   return (
     <div className="mx-auto max-w-page">
-      <Link href="/settings" className="text-sm text-navy-3 hover:text-gold">
-        ← Settings
-      </Link>
+      <BackLink href="/settings" label="Settings" />
       <div className="mb-6 mt-2">
         <h1 className="font-display text-3xl font-semibold text-navy">
           Login &amp; <em className="not-italic text-gold [font-style:italic]">security.</em>

--- a/omnischools/app/(app)/staff/import/page.tsx
+++ b/omnischools/app/(app)/staff/import/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { requireSchool } from "@/lib/auth/server";
 import { StaffImport } from "@/components/staff/staff-import";
+import { BackLink } from "@/components/ui/back-link";
 
 export const dynamic = "force-dynamic";
 export const metadata = { title: "Import staff" };
@@ -10,9 +11,7 @@ export default async function ImportStaffPage() {
 
   return (
     <div className="mx-auto max-w-page">
-      <Link href="/staff" className="text-sm text-navy-3 hover:text-gold">
-        ← Staff
-      </Link>
+      <BackLink href="/staff" label="Staff" />
       <div className="mb-6 mt-2 flex flex-wrap items-center justify-between gap-3">
         <div>
           <h1 className="font-display text-3xl font-semibold text-navy">Import staff</h1>

--- a/omnischools/app/(app)/students/[id]/edit/page.tsx
+++ b/omnischools/app/(app)/students/[id]/edit/page.tsx
@@ -1,10 +1,10 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import { and, asc, eq } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import { students, studentGuardians, classes } from "@/db/schema";
 import { EditStudentForm } from "@/components/students/edit-student-form";
+import { BackLink } from "@/components/ui/back-link";
 
 export const dynamic = "force-dynamic";
 export const metadata = { title: "Edit student" };
@@ -40,12 +40,7 @@ export default async function EditStudentPage({ params }: { params: { id: string
 
   return (
     <div className="mx-auto max-w-3xl">
-      <Link
-        href={`/students/${student.id}`}
-        className="text-sm text-navy-3 hover:text-gold"
-      >
-        ← Back to student
-      </Link>
+      <BackLink href={`/students/${student.id}`} label="Back to student" />
       <h1 className="mb-6 mt-2 font-display text-3xl font-semibold text-navy">
         Edit {student.firstName} {student.lastName}
       </h1>

--- a/omnischools/app/(app)/students/[id]/page.tsx
+++ b/omnischools/app/(app)/students/[id]/page.tsx
@@ -4,6 +4,7 @@ import { and, eq } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import { students, studentGuardians } from "@/db/schema";
+import { BackLink } from "@/components/ui/back-link";
 
 export const dynamic = "force-dynamic";
 
@@ -36,9 +37,7 @@ export default async function StudentDetailPage({ params }: { params: { id: stri
 
   return (
     <div className="mx-auto max-w-3xl">
-      <Link href="/students" className="text-sm text-navy-3 hover:text-gold">
-        ← Students
-      </Link>
+      <BackLink href="/students" label="Students" />
       <div className="mt-2 flex items-start justify-between gap-3">
         <div>
           <h1 className="mb-1 font-display text-3xl font-semibold text-navy">

--- a/omnischools/app/(app)/students/import/page.tsx
+++ b/omnischools/app/(app)/students/import/page.tsx
@@ -4,6 +4,7 @@ import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import { classes } from "@/db/schema";
 import { StudentImport } from "@/components/students/student-import";
+import { BackLink } from "@/components/ui/back-link";
 
 export const dynamic = "force-dynamic";
 export const metadata = { title: "Import students" };
@@ -22,9 +23,7 @@ export default async function ImportStudentsPage() {
 
   return (
     <div className="mx-auto max-w-page">
-      <Link href="/students" className="text-sm text-navy-3 hover:text-gold">
-        ← Students
-      </Link>
+      <BackLink href="/students" label="Students" />
       <div className="mb-6 mt-2 flex flex-wrap items-center justify-between gap-3">
         <div>
           <h1 className="font-display text-3xl font-semibold text-navy">

--- a/omnischools/app/(app)/students/new/page.tsx
+++ b/omnischools/app/(app)/students/new/page.tsx
@@ -1,9 +1,9 @@
-import Link from "next/link";
 import { and, asc, eq } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import { classes } from "@/db/schema";
 import { NewStudentForm } from "@/components/students/new-student-form";
+import { BackLink } from "@/components/ui/back-link";
 
 export const metadata = { title: "Add student" };
 export const dynamic = "force-dynamic";
@@ -20,9 +20,7 @@ export default async function NewStudentPage() {
 
   return (
     <div className="mx-auto max-w-3xl">
-      <Link href="/students" className="text-sm text-navy-3 hover:text-gold">
-        ← Students
-      </Link>
+      <BackLink href="/students" label="Students" />
       <h1 className="mb-6 mt-2 font-display text-3xl font-semibold text-navy">
         Add a student
       </h1>

--- a/omnischools/components/reports/report-header.tsx
+++ b/omnischools/components/reports/report-header.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import { BackLink } from "@/components/ui/back-link";
 
 /**
  * Shared detail-route header: a back link to the Reports hub (matching the
@@ -20,12 +20,7 @@ export function ReportHeader({
 }) {
   return (
     <div className="mb-5">
-      <Link
-        href="/reports"
-        className="mb-2 inline-block text-sm text-navy-3 transition-colors hover:text-gold print:hidden"
-      >
-        ← Reports
-      </Link>
+      <BackLink href="/reports" label="Reports" className="mb-2" />
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <div className="text-xs uppercase tracking-wide text-navy-3 print:hidden">{crumb}</div>

--- a/omnischools/components/ui/back-link.tsx
+++ b/omnischools/components/ui/back-link.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+
+/**
+ * App-wide back link: "← {label}" → href. The shared version of the ad-hoc
+ * `← Label` links used across the app. Navy-3, gold on hover, with the arrow
+ * nudging left on hover. Hidden in print. Pass `className` for placement (margin).
+ */
+export function BackLink({
+  href,
+  label,
+  className,
+}: {
+  href: string;
+  label: string;
+  className?: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className={cn(
+        "group inline-flex items-center gap-1.5 text-sm text-navy-3 transition-colors hover:text-gold print:hidden",
+        className,
+      )}
+    >
+      <span aria-hidden className="transition-transform group-hover:-translate-x-0.5">
+        ←
+      </span>
+      {label}
+    </Link>
+  );
+}


### PR DESCRIPTION
## Shared `BackLink` component

You picked **variant A** (the current text-link look) for the shared back button. This extracts the repeated ad-hoc `← Label` links into one component and rolls it across the whole app — so the back affordance is consistent and lives in one place.

### What it is
`components/ui/back-link.tsx`:
```tsx
<BackLink href="/students" label="Students" />
```
Renders `← {label}` — `text-sm`, `text-navy-3` → `hover:text-gold`, `print:hidden`, with the arrow **nudging left on hover** (the one small enhancement over the old links). Takes an optional `className` for spacing.

### Rolled out to 20 call sites
- **Reports** (via `ReportHeader`, so all six detail pages), `reports/class/[classId]`
- **Students** (detail / new / import / edit — dynamic `/students/{id}` href preserved)
- **Fees**, **Classes**, **Inbox**, **Staff import**, **Attendance**, **Gradebook** (reports + report card)
- **Settings** sub-pages (school, security, academic, audit, export, branding, retention)

For each: replaced the inline link, preserved the exact href + label, and removed the now-unused `next/link` import where `Link` was no longer referenced.

### Left untouched (different purpose/style, not section nav)
- Login "← Use a different number" (a state-reset button)
- Onboarding "← Back" (wizard step control)
- Marketing "← Home" (gold marketing style)

### Verification
- `pnpm typecheck`, `pnpm lint`, `pnpm build` all clean.
- Verified live: renders navy-3 / 14px / `inline-flex` with the `group-hover` arrow nudge; no visual change vs. before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)