### PR TITLE
feat(ui): shared EmptyState primitive + dedup (empty-states PR1)

### DIFF
--- a/omnischools/app/(app)/attendance/student/[studentId]/page.tsx
+++ b/omnischools/app/(app)/attendance/student/[studentId]/page.tsx
@@ -17,6 +17,7 @@ import { computeAttendanceFlags } from "@/lib/attendance-flags";
 import { isHoliday, type HolidayRange } from "@/lib/school-calendar";
 import { ATTENDANCE_STATUS_META, type AttendanceStatus } from "@/lib/attendance-status";
 import { PrintButton } from "@/components/reports/print-button";
+import { EmptyState } from "@/components/ui/empty-state";
 
 export const dynamic = "force-dynamic";
 
@@ -466,9 +467,9 @@ export default async function StudentAttendancePage({
         </span>
       </div>
       {!term ? (
-        <Empty>No active term — set term dates in Settings to see the register grid.</Empty>
+        <EmptyState tone="muted">No active term — set term dates in Settings to see the register grid.</EmptyState>
       ) : weeks.length === 0 ? (
-        <Empty>No school days in this term yet.</Empty>
+        <EmptyState tone="muted">No school days in this term yet.</EmptyState>
       ) : (
         <div className="space-y-2">
           {weeks.map((w) => (
@@ -683,14 +684,6 @@ function Glance({
         </div>
       )}
     </div>
-  );
-}
-
-function Empty({ children }: { children: React.ReactNode }) {
-  return (
-    <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
-      {children}
-    </p>
   );
 }
 

--- a/omnischools/app/(app)/attendance/term-grid/page.tsx
+++ b/omnischools/app/(app)/attendance/term-grid/page.tsx
@@ -13,6 +13,7 @@ import {
 import { isHoliday, schoolDaysInRange, type HolidayRange } from "@/lib/school-calendar";
 import { PrintButton } from "@/components/reports/print-button";
 import { ATTENDANCE_STATUS_META, type AttendanceStatus } from "@/lib/attendance-status";
+import { EmptyState } from "@/components/ui/empty-state";
 
 export const dynamic = "force-dynamic";
 
@@ -266,11 +267,11 @@ export default async function TermGridPage({
       </div>
 
       {!cls ? (
-        <Empty>No classes yet.</Empty>
+        <EmptyState tone="muted" className="p-10">No classes yet.</EmptyState>
       ) : !term ? (
-        <Empty>No active term — set term dates in Settings to see the grid.</Empty>
+        <EmptyState tone="muted" className="p-10">No active term — set term dates in Settings to see the grid.</EmptyState>
       ) : data.roster.length === 0 ? (
-        <Empty>No students in this class.</Empty>
+        <EmptyState tone="muted" className="p-10">No students in this class.</EmptyState>
       ) : (
         <>
           {/* ── Controls: month nav + legend ─────────────────── */}
@@ -477,14 +478,6 @@ function ClassTitle({ name }: { name: string }) {
       </>
     );
   return <>{name}</>;
-}
-
-function Empty({ children }: { children: React.ReactNode }) {
-  return (
-    <p className="rounded-xl border border-dashed border-border-2 bg-surface p-10 text-center text-sm text-navy-3">
-      {children}
-    </p>
-  );
 }
 
 function NavBtn({

--- a/omnischools/app/(app)/reports/discounts/page.tsx
+++ b/omnischools/app/(app)/reports/discounts/page.tsx
@@ -9,6 +9,7 @@ import {
   type DiscountAppRow,
 } from "@/components/reports/discount-applications-table";
 import { PeriodBar } from "@/components/reports/period-bar";
+import { EmptyState } from "@/components/ui/empty-state";
 import { resolvePeriod, weeksIn } from "@/lib/reports/period";
 import { getReportTerm } from "@/lib/reports/report-term";
 import { schoolFile } from "@/lib/filename";
@@ -86,11 +87,11 @@ export default async function DiscountsPage({
       />
 
       {r.applicationCount === 0 ? (
-        <Empty>
+        <EmptyState tone="muted">
           No discount applications recorded yet. Discounts are attributed to a scheme from issuance
           onward — issue an invoice and pick a discount scheme (or apply a sibling/bursary discount)
           to populate this report. Historical freeform discounts aren&rsquo;t attributed.
-        </Empty>
+        </EmptyState>
       ) : (
         <>
           {/* KPI strip */}
@@ -140,7 +141,7 @@ export default async function DiscountsPage({
 
           {/* Tier breakdown */}
           {r.byScheme.length === 0 ? (
-            <Empty>No schemes have applications yet.</Empty>
+            <EmptyState tone="muted">No schemes have applications yet.</EmptyState>
           ) : (
             <div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
               {r.byScheme.map((s) => (
@@ -196,7 +197,7 @@ export default async function DiscountsPage({
                 <h3 className="mt-0.5 font-display text-lg font-semibold text-navy">Largest amounts</h3>
               </div>
               {r.topRecipients.length === 0 ? (
-                <Empty>No recipients yet.</Empty>
+                <EmptyState tone="muted">No recipients yet.</EmptyState>
               ) : (
                 <div className="space-y-1">
                   {r.topRecipients.map((t, i) => (
@@ -333,13 +334,5 @@ function Kpi({
       </div>
       <div className="mt-0.5 text-xs text-navy-3">{sub}</div>
     </div>
-  );
-}
-
-function Empty({ children }: { children: React.ReactNode }) {
-  return (
-    <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
-      {children}
-    </p>
   );
 }

--- a/omnischools/app/(app)/reports/finance/collection-trend/page.tsx
+++ b/omnischools/app/(app)/reports/finance/collection-trend/page.tsx
@@ -6,6 +6,7 @@ import { CumulativeOverlay } from "@/components/reports/cumulative-overlay";
 import { ExportCsv } from "@/components/reports/export-csv";
 import { PrintButton } from "@/components/reports/print-button";
 import { ReportHeader } from "@/components/reports/report-header";
+import { EmptyState } from "@/components/ui/empty-state";
 import { schoolFile } from "@/lib/filename";
 
 export const dynamic = "force-dynamic";
@@ -212,9 +213,9 @@ export default async function CollectionTrendPage() {
         meta="Weekly cumulative · GHS thousands"
       >
         {!r.hasPeriods || !cur ? (
-          <Empty>
+          <EmptyState tone="muted">
             Configure academic terms (Settings → Term &amp; calendar) to see term-on-term trends.
-          </Empty>
+          </EmptyState>
         ) : (
           <div className="rounded-xl border border-border bg-surface p-6">
             <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
@@ -304,7 +305,7 @@ export default async function CollectionTrendPage() {
         meta="Each week's collection vs same week last term"
       >
         {r.weeklyRows.length === 0 ? (
-          <Empty>No weekly collection yet for this term.</Empty>
+          <EmptyState tone="muted">No weekly collection yet for this term.</EmptyState>
         ) : (
           <div className="grid grid-cols-2 gap-2.5 md:grid-cols-3 lg:grid-cols-5">
             {r.weeklyRows.map((w) => {
@@ -357,7 +358,7 @@ export default async function CollectionTrendPage() {
       {/* ============ REGION 04 — BY CLASS ============ */}
       <Region num="04" pre="By" gold="class" meta="Which year groups are leading or lagging">
         {r.byClass.length === 0 ? (
-          <Empty>No invoiced classes yet for this term.</Empty>
+          <EmptyState tone="muted">No invoiced classes yet for this term.</EmptyState>
         ) : (
           <div className="overflow-hidden rounded-xl border border-border bg-surface">
             <div className="flex items-center justify-between border-b border-border bg-bg px-5 py-3.5 text-[11px] italic text-navy-3">
@@ -427,7 +428,7 @@ export default async function CollectionTrendPage() {
       {/* ============ REGION 05 — AGING ============ */}
       <Region num="05" pre="Age of" gold="outstanding" post=" balances" meta="How old is the unpaid amount">
         {r.aging.totalOutstanding <= 0 ? (
-          <Empty>Nothing outstanding — every invoice is settled.</Empty>
+          <EmptyState tone="muted">Nothing outstanding — every invoice is settled.</EmptyState>
         ) : (
           <AgingCard aging={r.aging} />
         )}
@@ -685,12 +686,4 @@ function agingNote(key: string): string {
     default:
       return "Balances over 90 days old rarely self-resolve — these households likely need direct outreach.";
   }
-}
-
-function Empty({ children }: { children: React.ReactNode }) {
-  return (
-    <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
-      {children}
-    </p>
-  );
 }

--- a/omnischools/app/(app)/reports/school-stats/page.tsx
+++ b/omnischools/app/(app)/reports/school-stats/page.tsx
@@ -3,6 +3,7 @@ import { getSchoolStats, type ClassComposition } from "@/lib/reports/school-stat
 import { ExportCsv } from "@/components/reports/export-csv";
 import { PrintButton } from "@/components/reports/print-button";
 import { ReportHeader } from "@/components/reports/report-header";
+import { EmptyState } from "@/components/ui/empty-state";
 import { schoolFile } from "@/lib/filename";
 
 export const dynamic = "force-dynamic";
@@ -144,7 +145,7 @@ export default async function SchoolStatsPage() {
           </div>
 
           {s.byClass.length === 0 ? (
-            <Empty>No active classes yet. Create classes to see composition here.</Empty>
+            <EmptyState tone="muted" className="m-6">No active classes yet. Create classes to see composition here.</EmptyState>
           ) : (
             <>
               {/* Column heads */}
@@ -176,7 +177,7 @@ export default async function SchoolStatsPage() {
           </div>
           <div className="px-6 py-6">
             {gender.total === 0 ? (
-              <Empty>No active students to break down yet.</Empty>
+              <EmptyState tone="muted" className="m-6">No active students to break down yet.</EmptyState>
             ) : (
               <div className="text-center">
                 <GenderDonut female={gender.female} total={gender.total} />
@@ -479,13 +480,5 @@ function FlowRow({
       </div>
       <div className={`font-display text-[22px] font-semibold ${numTone}`}>{value}</div>
     </div>
-  );
-}
-
-function Empty({ children }: { children: React.ReactNode }) {
-  return (
-    <p className="m-6 rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
-      {children}
-    </p>
   );
 }

--- a/omnischools/app/(app)/reports/term-collection/page.tsx
+++ b/omnischools/app/(app)/reports/term-collection/page.tsx
@@ -5,6 +5,7 @@ import { ExportCsv } from "@/components/reports/export-csv";
 import { PrintButton } from "@/components/reports/print-button";
 import { ReportHeader } from "@/components/reports/report-header";
 import { WeeklyBars } from "@/components/reports/weekly-bars";
+import { EmptyState } from "@/components/ui/empty-state";
 import { PeriodBar } from "@/components/reports/period-bar";
 import { resolvePeriod, weeksIn } from "@/lib/reports/period";
 import { getReportTerm } from "@/lib/reports/report-term";
@@ -123,7 +124,7 @@ export default async function TermCollectionPage({
             )}
           </div>
           {weeks.length === 0 ? (
-            <Empty>No payments recorded yet.</Empty>
+            <EmptyState tone="muted">No payments recorded yet.</EmptyState>
           ) : (
             <>
               <WeeklyBars weeks={weeks.map((w) => ({ label: w.label, amount: w.amount }))} />
@@ -145,7 +146,7 @@ export default async function TermCollectionPage({
             <h3 className="mt-0.5 font-display text-lg font-semibold text-navy">Where it came from</h3>
           </div>
           {r.byMethod.length === 0 ? (
-            <Empty>No payments recorded yet.</Empty>
+            <EmptyState tone="muted">No payments recorded yet.</EmptyState>
           ) : (
             <div className="space-y-3">
               {r.byMethod
@@ -184,7 +185,7 @@ export default async function TermCollectionPage({
           </div>
         </div>
         {r.byClass.length === 0 ? (
-          <Empty>No invoices yet. Issue fees from the Fees module to see collections here.</Empty>
+          <EmptyState tone="muted">No invoices yet. Issue fees from the Fees module to see collections here.</EmptyState>
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
@@ -231,13 +232,5 @@ export default async function TermCollectionPage({
         )}
       </section>
     </div>
-  );
-}
-
-function Empty({ children }: { children: React.ReactNode }) {
-  return (
-    <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
-      {children}
-    </p>
   );
 }

--- a/omnischools/components/ui/empty-state.tsx
+++ b/omnischools/components/ui/empty-state.tsx
@@ -1,0 +1,140 @@
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+
+export type EmptyAction = {
+  label: string;
+  href?: string;
+  variant?: "gold" | "navy" | "outline" | "link";
+};
+
+const ACTION_CLASS: Record<NonNullable<EmptyAction["variant"]>, string> = {
+  gold: "rounded-md bg-gold px-4 py-2 text-sm font-semibold text-navy transition-colors hover:bg-gold-soft",
+  navy: "rounded-md bg-navy px-4 py-2 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep",
+  outline:
+    "rounded-md border border-gold px-4 py-2 text-sm font-semibold text-gold transition-colors hover:bg-gold-bg",
+  link: "text-sm font-semibold text-gold hover:underline",
+};
+
+function Action({ action }: { action: EmptyAction }) {
+  const cls = ACTION_CLASS[action.variant ?? "gold"];
+  return action.href ? (
+    <Link href={action.href} className={cls}>
+      {action.label}
+    </Link>
+  ) : (
+    <span className={cls}>{action.label}</span>
+  );
+}
+
+/**
+ * Shared empty-state primitive (replicates the schoolup-empty-states surfaces).
+ * - `tone="muted"` = the calm single-line dashed card used across the app today.
+ * - `tone="default"` = a centered dashed card with optional icon tile, eyebrow,
+ *   Fraunces title (pass an <em> for the gold-italic accent), body, meta and actions.
+ * - `tone="navy"` = the celebratory day-one hero treatment.
+ * Icons accept a lucide node OR a serif glyph string (rendered in the gold tile).
+ */
+export function EmptyState({
+  icon,
+  eyebrow,
+  title,
+  body,
+  meta,
+  primary,
+  secondary,
+  tone = "default",
+  framed = true,
+  className,
+  children,
+}: {
+  icon?: React.ReactNode;
+  eyebrow?: string;
+  title?: React.ReactNode;
+  body?: React.ReactNode;
+  meta?: string;
+  primary?: EmptyAction;
+  secondary?: EmptyAction;
+  tone?: "default" | "navy" | "muted";
+  framed?: boolean;
+  className?: string;
+  children?: React.ReactNode;
+}) {
+  if (tone === "muted") {
+    return (
+      <p
+        className={cn(
+          "rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3",
+          className,
+        )}
+      >
+        {body ?? children}
+      </p>
+    );
+  }
+
+  const navy = tone === "navy";
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center gap-3 rounded-xl p-10 text-center",
+        framed && (navy ? "border border-navy bg-navy" : "border border-dashed border-border-2 bg-surface"),
+        className,
+      )}
+    >
+      {icon != null && (
+        <div
+          aria-hidden
+          className={cn(
+            "flex h-11 w-11 items-center justify-center rounded-[10px] font-display text-lg font-bold",
+            navy ? "bg-white/10 text-gold" : "bg-gold-bg text-gold",
+          )}
+        >
+          {icon}
+        </div>
+      )}
+      {eyebrow && (
+        <div
+          className={cn(
+            "text-[10px] font-bold uppercase tracking-[0.14em]",
+            navy ? "text-gold-soft" : "text-gold",
+          )}
+        >
+          {eyebrow}
+        </div>
+      )}
+      {title && (
+        <h3 className={cn("font-display text-lg font-semibold", navy ? "text-bg" : "text-navy")}>
+          {title}
+        </h3>
+      )}
+      {(body ?? children) && (
+        <p
+          className={cn(
+            "max-w-md text-sm leading-relaxed",
+            navy ? "text-gold-soft" : "text-navy-2",
+          )}
+        >
+          {body ?? children}
+        </p>
+      )}
+      {meta && (
+        <div
+          className={cn(
+            "text-[10px] font-bold uppercase tracking-[0.1em]",
+            navy ? "text-gold-soft" : "text-navy-3",
+          )}
+        >
+          {meta}
+        </div>
+      )}
+      {(primary || secondary) && (
+        <div className="mt-1 flex flex-wrap items-center justify-center gap-3">
+          {primary && <Action action={primary} />}
+          {secondary && (
+            <Action action={{ ...secondary, variant: secondary.variant ?? "link" }} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Empty states — PR1: the shared primitive

First slice of replicating the **schoolup-empty-states** / **schoolup-empty-states-modules** surfaces. Audited with the surface-cartographer (module-audit mode); the build had **no shared empty-state primitive** — 6 duplicated private `Empty` helpers, ~20 inline dashed cards, and a few bare `<p>` one-liners. This PR adds the primitive and collapses the duplicates, with **zero visual change**.

### `components/ui/empty-state.tsx`
Three tones:
- **`muted`** — the calm single-line dashed card the app uses today.
- **`default`** — centered dashed card with optional gold **icon tile**, gold **eyebrow**, Fraunces **title** (pass `<em>` for the gold-italic accent), body, meta, and gold / navy / outline / link **actions**.
- **`navy`** — the celebratory day-one hero treatment.

Icons accept a lucide node **or** a serif glyph string (the surfaces use both). Token-safe — no slash-opacity on the raw-hex tokens (only `bg-white/10`, a real RGB).

### Dedup (zero regression)
Replaced the **6 duplicated private `Empty` helpers** (4 Reports routes + 2 Attendance routes — 17 call sites) with `<EmptyState tone="muted">`, preserving each file's exact spacing (default `p-8`; term-grid `p-10`; school-stats `m-6`) — pixel-identical.

### Next (separate PRs)
- **PR2** — migrate the remaining inline dashed cards → `EmptyState`, adding the surface's icon + primary CTA where the action already exists (list/detail pages).
- **PR5** — Students **path-picker** empty state.
- **Deferred for your input** — Billing issue-card (needs data/verify), Gradebook empty-column (**needs schema**), role-aware first-run dashboards (**needs schema/role infra**), and the named MVP2 affordances (CSV template, import-undo, product tour, callback).

### Verification
- `pnpm typecheck`, `pnpm lint`, `pnpm build` all clean; no residual `Empty` helpers; muted render is byte-identical to the old dashed `<p>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)