### PR TITLE
feat(ui): migrate remaining empty states to EmptyState (empty-states PR2)

### DIFF
--- a/omnischools/app/(app)/admissions/page.tsx
+++ b/omnischools/app/(app)/admissions/page.tsx
@@ -1,9 +1,11 @@
 import Link from "next/link";
+import { ClipboardList } from "lucide-react";
 import { desc, eq } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import { admissionApplications } from "@/db/schema";
 import { AdmissionActions } from "@/components/admissions/admission-actions";
+import { EmptyState } from "@/components/ui/empty-state";
 
 export const dynamic = "force-dynamic";
 
@@ -46,12 +48,15 @@ export default async function AdmissionsPage() {
       </div>
 
       {apps.length === 0 ? (
-        <div className="border-border-2 bg-surface rounded-xl border border-dashed p-12 text-center">
-          <p className="font-display text-lg text-navy">No applications yet.</p>
-          <p className="mt-1 text-sm text-navy-3">
-            Share your school&apos;s public application link with prospective parents.
-          </p>
-        </div>
+        <EmptyState
+          icon={<ClipboardList className="h-5 w-5" />}
+          title="No applications yet."
+          body="Share your school's public application link with prospective parents."
+          primary={{
+            label: `Open /apply/${school.gesCode} →`,
+            href: `/apply/${encodeURIComponent(school.gesCode)}`,
+          }}
+        />
       ) : (
         <div className="space-y-2">
           {apps.map((a) => {

--- a/omnischools/app/(app)/attendance/[classId]/page.tsx
+++ b/omnischools/app/(app)/attendance/[classId]/page.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/attendance/register-switcher";
 import type { AttendanceStatus } from "@/lib/attendance-status";
 import { BackLink } from "@/components/ui/back-link";
+import { EmptyState } from "@/components/ui/empty-state";
 
 export const dynamic = "force-dynamic";
 
@@ -373,16 +374,13 @@ export default async function TakeAttendancePage({
           {data.cls.name}
         </h1>
         <p className="mb-6 text-sm text-navy-3">0 students</p>
-        <div className="rounded-xl border border-dashed border-border-2 bg-surface p-12 text-center">
-          <p className="font-display text-lg text-navy">No students in this class.</p>
-          <p className="mt-1 text-sm text-navy-3">
-            Assign students from the{" "}
-            <Link href="/attendance" className="text-gold underline">
-              Attendance
-            </Link>{" "}
-            dashboard.
-          </p>
-        </div>
+        <EmptyState tone="muted">
+          No students in this class. Assign students from the{" "}
+          <Link href="/attendance" className="text-gold underline">
+            Attendance
+          </Link>{" "}
+          dashboard.
+        </EmptyState>
       </div>
     );
   }

--- a/omnischools/app/(app)/attendance/page.tsx
+++ b/omnischools/app/(app)/attendance/page.tsx
@@ -12,8 +12,10 @@ import {
   schoolHolidays,
   users,
 } from "@/db/schema";
+import { GraduationCap } from "lucide-react";
 import { NewClassForm, AssignStudent } from "@/components/attendance/class-controls";
 import { CorrectionActions } from "@/components/attendance/correction-actions";
+import { EmptyState } from "@/components/ui/empty-state";
 import { computeAttendanceFlags, FLAG_THRESHOLDS } from "@/lib/attendance-flags";
 import { NeedsAttention } from "@/components/attendance/needs-attention";
 import { TermTrend } from "@/components/attendance/term-trend";
@@ -512,12 +514,11 @@ export default async function AttendancePage() {
       </div>
 
       {data.cls.length === 0 ? (
-        <div className="border-border-2 bg-surface rounded-xl border border-dashed p-12 text-center">
-          <p className="font-display text-lg text-navy">No classes yet.</p>
-          <p className="mt-1 text-sm text-navy-3">
-            Create a class to start taking attendance.
-          </p>
-        </div>
+        <EmptyState
+          icon={<GraduationCap className="h-5 w-5" />}
+          title="No classes yet."
+          body="Create a class to start taking attendance."
+        />
       ) : (
         <>
           {/* 01 · Today's pulse */}
@@ -688,10 +689,10 @@ export default async function AttendancePage() {
                 </div>
               </>
             ) : (
-              <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
+              <EmptyState tone="muted">
                 No active term — this term&apos;s trend appears once the term is running and
                 registers are being marked.
-              </p>
+              </EmptyState>
             )}
           </section>
 
@@ -703,11 +704,11 @@ export default async function AttendancePage() {
             {needsAttention.length > 0 ? (
               <NeedsAttention students={needsAttention} />
             ) : (
-              <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
+              <EmptyState tone="muted">
                 {trend
                   ? "No students flagged — every class is above the attendance thresholds."
                   : "No active term — flags appear once attendance is being marked this term."}
-              </p>
+              </EmptyState>
             )}
           </section>
 
@@ -770,10 +771,10 @@ export default async function AttendancePage() {
                 ))}
               </div>
             ) : (
-              <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
+              <EmptyState tone="muted">
                 No pending edit requests — teacher correction requests will appear here for your
                 co-sign.
-              </p>
+              </EmptyState>
             )}
           </section>
         </>

--- a/omnischools/app/(app)/books/page.tsx
+++ b/omnischools/app/(app)/books/page.tsx
@@ -4,6 +4,7 @@ import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import { bookEntries, bookCategories, fixedAssets } from "@/db/schema";
 import { BooksTabs } from "@/components/books/books-tabs";
+import { EmptyState } from "@/components/ui/empty-state";
 
 export const dynamic = "force-dynamic";
 export const metadata = { title: "Books" };
@@ -126,9 +127,9 @@ export default async function BooksDashboardPage() {
       <div className="mt-6">
         <h2 className="mb-2 font-display text-lg font-semibold text-navy">Recent entries</h2>
         {data.recent.length === 0 ? (
-          <div className="rounded-xl border border-dashed border-border-2 bg-surface p-10 text-center text-sm text-navy-3">
+          <EmptyState tone="muted" className="p-10">
             No entries yet. Record income and expenses from their tabs (coming next).
-          </div>
+          </EmptyState>
         ) : (
           <div className="overflow-x-auto rounded-xl border border-border bg-surface">
             <table className="w-full text-sm">

--- a/omnischools/app/(app)/classes/page.tsx
+++ b/omnischools/app/(app)/classes/page.tsx
@@ -1,3 +1,4 @@
+import { GraduationCap } from "lucide-react";
 import { asc, count, eq } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
@@ -5,6 +6,7 @@ import { classes, students } from "@/db/schema";
 import { loadStaffOptions } from "@/lib/data/staff-options";
 import { CreateClassForm } from "@/components/classes/create-class-form";
 import { ClassesTable } from "@/components/classes/classes-table";
+import { EmptyState } from "@/components/ui/empty-state";
 
 export const dynamic = "force-dynamic";
 
@@ -58,13 +60,11 @@ export default async function ClassesPage() {
       </div>
 
       {classRows.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-border-2 bg-surface p-12 text-center">
-          <p className="font-display text-lg text-navy">No classes yet.</p>
-          <p className="mt-1 text-sm text-navy-3">
-            Create your forms/classes (e.g. JHS 1A) — students, attendance and the
-            timetable all hang off them.
-          </p>
-        </div>
+        <EmptyState
+          icon={<GraduationCap className="h-5 w-5" />}
+          title="No classes yet."
+          body="Create your forms/classes (e.g. JHS 1A) — students, attendance and the timetable all hang off them."
+        />
       ) : (
         <ClassesTable rows={tableRows} staff={staff} />
       )}

--- a/omnischools/app/(app)/communication/page.tsx
+++ b/omnischools/app/(app)/communication/page.tsx
@@ -15,8 +15,10 @@ const fmtWhen = (d: Date | string) => {
   const p = (n: number) => String(n).padStart(2, "0");
   return `${p(date.getDate())}/${p(date.getMonth() + 1)} ${p(date.getHours())}:${p(date.getMinutes())}`;
 };
+import { Megaphone } from "lucide-react";
 import { AnnouncementComposer, TemplateForm } from "@/components/comms/composers";
 import { SmsComposer } from "@/components/comms/sms-composer";
+import { EmptyState } from "@/components/ui/empty-state";
 
 export const dynamic = "force-dynamic";
 
@@ -72,7 +74,10 @@ export default async function CommunicationPage() {
           <AnnouncementComposer classOptions={classOptions} />
           <div className="mt-4 space-y-2">
             {data.recentAnnouncements.length === 0 ? (
-              <p className="text-sm text-navy-3">No announcements yet.</p>
+              <EmptyState
+                icon={<Megaphone className="h-5 w-5" />}
+                title="No announcements yet."
+              />
             ) : (
               data.recentAnnouncements.map((a) => (
                 <div
@@ -126,7 +131,7 @@ export default async function CommunicationPage() {
               Recent sends
             </h3>
             {data.log.length === 0 ? (
-              <p className="text-sm text-navy-3">No messages sent yet.</p>
+              <EmptyState tone="muted">No messages sent yet.</EmptyState>
             ) : (
               <div className="bg-surface overflow-hidden rounded-xl border border-border">
                 <table className="w-full text-sm">

--- a/omnischools/app/(app)/dashboard/page.tsx
+++ b/omnischools/app/(app)/dashboard/page.tsx
@@ -11,6 +11,7 @@ import {
   academicPeriodConfig,
   academicPeriod,
 } from "@/db/schema";
+import { EmptyState } from "@/components/ui/empty-state";
 
 export const dynamic = "force-dynamic";
 
@@ -228,7 +229,9 @@ export default async function DashboardPage() {
         <div className="rounded-xl border border-border bg-surface p-5">
           <h2 className="font-display text-base font-semibold text-navy">Gender mix</h2>
           {genderTotal === 0 ? (
-            <p className="mt-2 text-sm text-navy-3">No students on roll yet.</p>
+            <EmptyState tone="muted" className="mt-2">
+              No students on roll yet.
+            </EmptyState>
           ) : (
             <>
               <div className="mt-3 flex h-3 overflow-hidden rounded-pill">
@@ -269,13 +272,13 @@ export default async function DashboardPage() {
           Class composition
         </h2>
         {stats.byClass.length === 0 ? (
-          <div className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
+          <EmptyState tone="muted">
             No classes yet —{" "}
             <Link href="/classes" className="text-gold underline">
               set them up
             </Link>
             .
-          </div>
+          </EmptyState>
         ) : (
           <div className="overflow-x-auto rounded-xl border border-border bg-surface">
             <table className="w-full text-sm">

--- a/omnischools/app/(app)/fees/[studentId]/page.tsx
+++ b/omnischools/app/(app)/fees/[studentId]/page.tsx
@@ -8,6 +8,7 @@ import { IssueInvoiceForm } from "@/components/fees/issue-invoice-form";
 import { RecordPaymentForm } from "@/components/fees/record-payment-form";
 import { VoidPaymentButton } from "@/components/fees/void-payment-button";
 import { BackLink } from "@/components/ui/back-link";
+import { EmptyState } from "@/components/ui/empty-state";
 
 export const dynamic = "force-dynamic";
 
@@ -124,7 +125,9 @@ export default async function StudentFeesPage({
 
       <h2 className="mb-3 font-display text-xl font-semibold text-navy">Invoices</h2>
       {invs.length === 0 ? (
-        <p className="mb-8 text-sm text-navy-3">No invoices yet.</p>
+        <EmptyState tone="muted" className="mb-8">
+          No invoices yet.
+        </EmptyState>
       ) : (
         <div className="bg-surface mb-8 overflow-hidden rounded-xl border border-border">
           <table className="w-full text-sm">
@@ -183,7 +186,7 @@ export default async function StudentFeesPage({
 
       <h2 className="mb-3 font-display text-xl font-semibold text-navy">Payments</h2>
       {pays.length === 0 ? (
-        <p className="text-sm text-navy-3">No payments yet.</p>
+        <EmptyState tone="muted">No payments yet.</EmptyState>
       ) : (
         <div className="bg-surface overflow-hidden rounded-xl border border-border">
           <table className="w-full text-sm">

--- a/omnischools/app/(app)/fees/page.tsx
+++ b/omnischools/app/(app)/fees/page.tsx
@@ -1,8 +1,10 @@
 import Link from "next/link";
+import { Receipt } from "lucide-react";
 import { and, eq, sql, desc } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import { invoices, students } from "@/db/schema";
+import { EmptyState } from "@/components/ui/empty-state";
 
 export const dynamic = "force-dynamic";
 
@@ -73,16 +75,12 @@ export default async function FeesPage() {
         Students with a balance
       </h2>
       {data.debtors.length === 0 ? (
-        <div className="border-border-2 bg-surface rounded-xl border border-dashed p-12 text-center">
-          <p className="font-display text-lg text-navy">Nothing outstanding.</p>
-          <p className="mt-1 text-sm text-navy-3">
-            Open a student from{" "}
-            <Link href="/students" className="text-gold underline">
-              Students
-            </Link>{" "}
-            to issue an invoice.
-          </p>
-        </div>
+        <EmptyState
+          icon={<Receipt className="h-5 w-5" />}
+          title="Nothing outstanding."
+          body="Open a student from Students to issue an invoice."
+          primary={{ label: "Open Students →", href: "/students" }}
+        />
       ) : (
         <div className="bg-surface overflow-hidden rounded-xl border border-border">
           <table className="w-full text-sm">

--- a/omnischools/app/(app)/gradebook/reports/page.tsx
+++ b/omnischools/app/(app)/gradebook/reports/page.tsx
@@ -6,6 +6,7 @@ import { classes, students, academicPeriod, reportCards } from "@/db/schema";
 import { GradebookSelectors } from "@/components/gradebook/selectors";
 import { GenerateReports } from "@/components/gradebook/generate-reports";
 import { BackLink } from "@/components/ui/back-link";
+import { EmptyState } from "@/components/ui/empty-state";
 
 export const dynamic = "force-dynamic";
 
@@ -27,9 +28,9 @@ export default async function ReportsPage({
   });
 
   let body: React.ReactNode = (
-    <div className="border-border-2 bg-surface rounded-xl border border-dashed p-12 text-center text-sm text-navy-3">
+    <EmptyState tone="muted" className="p-12">
       Choose a class and period.
-    </div>
+    </EmptyState>
   );
 
   if (classId && periodId) {
@@ -64,7 +65,7 @@ export default async function ReportsPage({
           <GenerateReports classId={classId} periodId={periodId} />
         </div>
         {roster.length === 0 ? (
-          <p className="text-sm text-navy-3">No students in this class.</p>
+          <EmptyState tone="muted">No students in this class.</EmptyState>
         ) : (
           <div className="bg-surface overflow-hidden rounded-xl border border-border">
             <table className="w-full text-sm">

--- a/omnischools/app/(app)/inbox/page.tsx
+++ b/omnischools/app/(app)/inbox/page.tsx
@@ -1,9 +1,11 @@
 import Link from "next/link";
+import { MessageSquare } from "lucide-react";
 import { desc, eq, sql } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import { conversations, users } from "@/db/schema";
 import { NewConversationForm } from "@/components/inbox/new-conversation-form";
+import { EmptyState } from "@/components/ui/empty-state";
 
 export const dynamic = "force-dynamic";
 
@@ -57,14 +59,17 @@ export default async function InboxPage() {
       </div>
 
       {rows.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-border-2 bg-surface p-12 text-center">
-          <p className="font-display text-lg text-navy">No conversations yet.</p>
-          <p className="mt-1 text-sm text-navy-3">
-            Start a message to a parent, or wire your SMS provider’s webhook to{" "}
-            <code className="font-mono text-xs">/api/inbox/inbound</code> so replies land
-            here.
-          </p>
-        </div>
+        <EmptyState
+          icon={<MessageSquare className="h-5 w-5" />}
+          title="No conversations yet."
+          body={
+            <>
+              Start a message to a parent, or wire your SMS provider’s webhook to{" "}
+              <code className="font-mono text-xs">/api/inbox/inbound</code> so replies land
+              here.
+            </>
+          }
+        />
       ) : (
         <div className="divide-y divide-border overflow-hidden rounded-xl border border-border bg-surface">
           {rows.map((r) => (

--- a/omnischools/app/(app)/reports/class/[classId]/page.tsx
+++ b/omnischools/app/(app)/reports/class/[classId]/page.tsx
@@ -9,6 +9,7 @@ import { PrintButton } from "@/components/reports/print-button";
 import { ExportCsv } from "@/components/reports/export-csv";
 import { schoolFile } from "@/lib/filename";
 import { BackLink } from "@/components/ui/back-link";
+import { EmptyState } from "@/components/ui/empty-state";
 
 export const dynamic = "force-dynamic";
 
@@ -85,9 +86,9 @@ export default async function ClassReportPage({
       </div>
 
       {debtors.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-border-2 bg-surface p-12 text-center">
-          <p className="font-display text-lg text-navy">Nothing outstanding in this class.</p>
-        </div>
+        <EmptyState tone="muted" className="p-12">
+          Nothing outstanding in this class.
+        </EmptyState>
       ) : (
         <div className="overflow-hidden rounded-xl border border-border bg-surface">
           <table className="w-full text-sm">

--- a/omnischools/app/(app)/reports/outstanding/page.tsx
+++ b/omnischools/app/(app)/reports/outstanding/page.tsx
@@ -9,6 +9,7 @@ import { ReportHeader } from "@/components/reports/report-header";
 import { BulkRemindersButton } from "@/components/reports/bulk-reminders-button";
 import { OutstandingTable, type DebtorRow, type DebtorBucket } from "@/components/reports/outstanding-table";
 import { schoolFile } from "@/lib/filename";
+import { EmptyState } from "@/components/ui/empty-state";
 
 export const dynamic = "force-dynamic";
 export const metadata = { title: "Outstanding balances" };
@@ -156,9 +157,9 @@ export default async function OutstandingPage() {
 
       {/* Aging strip */}
       {rows.length === 0 ? (
-        <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
+        <EmptyState tone="muted">
           Nothing outstanding — every invoice is settled.
-        </p>
+        </EmptyState>
       ) : (
         <>
           <div className="mb-6 grid grid-cols-2 gap-4 lg:grid-cols-4">

--- a/omnischools/app/(app)/reports/voids-refunds/page.tsx
+++ b/omnischools/app/(app)/reports/voids-refunds/page.tsx
@@ -5,6 +5,7 @@ import { PrintButton } from "@/components/reports/print-button";
 import { ReportHeader } from "@/components/reports/report-header";
 import { VoidsTable, type VoidRow } from "@/components/reports/voids-table";
 import { schoolFile } from "@/lib/filename";
+import { EmptyState } from "@/components/ui/empty-state";
 
 export const dynamic = "force-dynamic";
 export const metadata = { title: "Voids & refunds" };
@@ -149,9 +150,7 @@ export default async function VoidsRefundsPage() {
       </div>
 
       {events.length === 0 ? (
-        <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
-          No voided or refunded payments.
-        </p>
+        <EmptyState tone="muted">No voided or refunded payments.</EmptyState>
       ) : (
         <>
           {/* Split cards */}

--- a/omnischools/app/(app)/settings/audit/page.tsx
+++ b/omnischools/app/(app)/settings/audit/page.tsx
@@ -2,8 +2,10 @@ import Link from "next/link";
 import { and, desc, eq, sql } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
+import { ScrollText } from "lucide-react";
 import { auditLog, users } from "@/db/schema";
 import { BackLink } from "@/components/ui/back-link";
+import { EmptyState } from "@/components/ui/empty-state";
 
 export const dynamic = "force-dynamic";
 export const metadata = { title: "Audit log" };
@@ -101,9 +103,10 @@ export default async function AuditLogPage({
       </div>
 
       {data.rows.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-border-2 bg-surface p-10 text-center text-sm text-navy-3">
-          No audit events yet.
-        </div>
+        <EmptyState
+          icon={<ScrollText className="h-5 w-5" />}
+          title="No audit events yet."
+        />
       ) : (
         <div className="overflow-x-auto rounded-xl border border-border bg-surface">
           <table className="w-full text-sm">

--- a/omnischools/app/(app)/staff/page.tsx
+++ b/omnischools/app/(app)/staff/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Users } from "lucide-react";
 import { and, asc, eq, notInArray } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
@@ -6,6 +7,7 @@ import { users, roles, roleAssignments } from "@/db/schema";
 import { NON_STAFF_ROLE_CODES } from "@/lib/staff-roles";
 import { AddStaffForm } from "@/components/staff/add-staff-form";
 import { StaffTable } from "@/components/staff/staff-table";
+import { EmptyState } from "@/components/ui/empty-state";
 
 export const dynamic = "force-dynamic";
 
@@ -76,13 +78,11 @@ export default async function StaffPage() {
       </div>
 
       {staff.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-border-2 bg-surface p-12 text-center">
-          <p className="font-display text-lg text-navy">No staff yet.</p>
-          <p className="mt-1 text-sm text-navy-3">
-            Add teachers and other staff so they can take attendance, enter scores and
-            collect fees.
-          </p>
-        </div>
+        <EmptyState
+          icon={<Users className="h-5 w-5" />}
+          title="No staff yet."
+          body="Add teachers and other staff so they can take attendance, enter scores and collect fees."
+        />
       ) : (
         <StaffTable staff={staff} />
       )}


### PR DESCRIPTION
## Empty states — PR2: migrate the rest onto the shared primitive

Replaces the ~20 ad-hoc inline dashed cards / bare `<p>` empties across the app with the shared `EmptyState` (from PR1 #96), faithfully — **copy kept verbatim**.

### `default` tone (icon + CTA where a real action exists)
List/index pages get a lucide icon and, only where a real route action fits, a primary CTA:
| Page | Icon | CTA |
|---|---|---|
| Staff | `Users` | none (add is a modal) |
| Classes | `GraduationCap` | none (create is a modal) |
| Admissions | `ClipboardList` | `Open /apply/{gesCode} →` (real public link) |
| Inbox | `MessageSquare` | none (compose is a modal) |
| Communication · announcements | `Megaphone` | none (composer is inline) |
| Fees list | `Receipt` | `Open Students →` |
| Audit log | `ScrollText` | none (fills automatically) |
| Attendance · no classes | `GraduationCap` | none (modal) |

**No CTA was invented** — where the "add/create" action is a client modal with no route, `primary` is correctly omitted.

### `muted` tone (verbatim one-liners)
Sub-list / detail / prompt empties stayed calm single-liners: fees/[id] invoices + payments, communication messages-sent, books entries, attendance active-term / flags / edit-requests + class roster, gradebook-reports prompts, dashboard sub-blocks, and reports outstanding / voids / class. Inline `<Link>`s in the copy are preserved; per-file margins/padding kept via `className`.

The Books **gold chart-of-accounts callout** was left untouched (it already matches the surface tone).

### Verification
- 16 files; `pnpm typecheck`, `pnpm lint`, `pnpm build` all clean; no slash-opacity on the raw-hex tokens.
- Verified live (throwaway preview route, removed before commit) that the `default` tone renders the lucide icon in its gold tile with the gold CTA button.

Independent of the other empty-state PRs (uses the merged `EmptyState`). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)