### PR TITLE
feat(gradebook): assessment columns + empty-column state (empty-states PR4)

### DIFF
--- a/omnischools/app/(app)/gradebook/page.tsx
+++ b/omnischools/app/(app)/gradebook/page.tsx
@@ -8,11 +8,13 @@ import {
   students,
   academicPeriod,
   gradebookConfig,
-  gradebookScores,
+  gradebookColumns,
+  gradebookColumnScores,
 } from "@/db/schema";
 import { GradebookSelectors } from "@/components/gradebook/selectors";
 import { NewSubjectForm } from "@/components/gradebook/new-subject-form";
-import { ScoreGrid } from "@/components/gradebook/score-grid";
+import { ColumnScoreGrid } from "@/components/gradebook/column-score-grid";
+import { GradebookEmptyColumns } from "@/components/gradebook/empty-columns";
 
 export const dynamic = "force-dynamic";
 
@@ -69,32 +71,62 @@ export default async function GradebookPage({
         .orderBy(asc(students.lastName));
       if (roster.length === 0)
         return {
-          roster: [],
-          scores: [] as {
+          roster,
+          columns: [] as {
+            id: string;
+            name: string;
+            category: string;
+            maxScore: string;
+          }[],
+          colScores: [] as {
+            columnId: string;
             studentId: string;
-            classScore: string | null;
-            examScore: string | null;
+            rawScore: string | null;
           }[],
         };
-      const scores = await tx
+
+      const columns = await tx
         .select({
-          studentId: gradebookScores.studentId,
-          classScore: gradebookScores.classScore,
-          examScore: gradebookScores.examScore,
+          id: gradebookColumns.id,
+          name: gradebookColumns.name,
+          category: gradebookColumns.category,
+          maxScore: gradebookColumns.maxScore,
         })
-        .from(gradebookScores)
+        .from(gradebookColumns)
         .where(
           and(
-            eq(gradebookScores.schoolId, school.id),
-            eq(gradebookScores.subjectId, subjectId),
-            eq(gradebookScores.periodId, periodId),
-            inArray(
-              gradebookScores.studentId,
-              roster.map((r) => r.id),
-            ),
+            eq(gradebookColumns.schoolId, school.id),
+            eq(gradebookColumns.classId, classId),
+            eq(gradebookColumns.subjectId, subjectId),
+            eq(gradebookColumns.periodId, periodId),
           ),
-        );
-      return { roster, scores };
+        )
+        .orderBy(asc(gradebookColumns.position));
+
+      const colScores = columns.length
+        ? await tx
+            .select({
+              columnId: gradebookColumnScores.columnId,
+              studentId: gradebookColumnScores.studentId,
+              rawScore: gradebookColumnScores.rawScore,
+            })
+            .from(gradebookColumnScores)
+            .where(
+              and(
+                eq(gradebookColumnScores.schoolId, school.id),
+                inArray(
+                  gradebookColumnScores.columnId,
+                  columns.map((c) => c.id),
+                ),
+                inArray(
+                  gradebookColumnScores.studentId,
+                  roster.map((r) => r.id),
+                ),
+              ),
+            )
+        : [];
+
+      return { roster, columns, colScores };
     });
 
     if (data.roster.length === 0) {
@@ -108,26 +140,51 @@ export default async function GradebookPage({
         </div>
       );
     } else {
-      const byStudent = new Map(data.scores.map((s) => [s.studentId, s]));
-      const roster = data.roster.map((r) => {
-        const s = byStudent.get(r.id);
-        return {
-          id: r.id,
-          name: `${r.lastName}, ${r.firstName}`,
-          code: r.code,
-          classScore: s?.classScore ?? "",
-          examScore: s?.examScore ?? "",
-        };
-      });
-      grid = (
-        <ScoreGrid
-          classId={classId}
-          subjectId={subjectId}
-          periodId={periodId}
-          weights={base.weights}
-          roster={roster}
-        />
-      );
+      const subjectName = base.subs.find((s) => s.id === subjectId)?.name ?? "Subject";
+      const className = base.cls.find((c) => c.id === classId)?.name ?? "Class";
+      const period = base.periods.find((p) => p.periodId === periodId);
+      const termLabel = period?.periodLabel ?? "this term";
+
+      const rosterRows = data.roster.map((r) => ({
+        id: r.id,
+        name: `${r.lastName}, ${r.firstName}`,
+        code: r.code,
+      }));
+
+      if (data.columns.length === 0) {
+        grid = (
+          <GradebookEmptyColumns
+            className={className}
+            subjectName={subjectName}
+            termLabel={termLabel}
+            students={rosterRows}
+            classId={classId}
+            subjectId={subjectId}
+            periodId={periodId}
+          />
+        );
+      } else {
+        grid = (
+          <ColumnScoreGrid
+            columns={data.columns.map((c) => ({
+              id: c.id,
+              name: c.name,
+              category: c.category === "EXAM" ? "EXAM" : "CA",
+              maxScore: Number(c.maxScore),
+            }))}
+            roster={rosterRows}
+            scores={data.colScores.map((s) => ({
+              columnId: s.columnId,
+              studentId: s.studentId,
+              raw: s.rawScore ?? "",
+            }))}
+            weights={base.weights}
+            classId={classId}
+            subjectId={subjectId}
+            periodId={periodId}
+          />
+        );
+      }
     }
   }
 

--- a/omnischools/components/gradebook/add-column-form.tsx
+++ b/omnischools/components/gradebook/add-column-form.tsx
@@ -1,0 +1,92 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { createGradebookColumn } from "@/lib/actions/gradebook";
+
+/** Inline "add an assessment column" form, shared by the empty state and the grid. */
+export function AddColumnForm({
+  classId,
+  subjectId,
+  periodId,
+  onCancel,
+  onDone,
+}: {
+  classId: string;
+  subjectId: string;
+  periodId: string;
+  onCancel?: () => void;
+  onDone?: () => void;
+}) {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [category, setCategory] = useState<"CA" | "EXAM">("CA");
+  const [maxScore, setMaxScore] = useState("10");
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit() {
+    setPending(true);
+    setError(null);
+    const res = await createGradebookColumn({
+      classId,
+      subjectId,
+      periodId,
+      name,
+      category,
+      maxScore,
+    });
+    setPending(false);
+    if (res.ok) {
+      onDone?.();
+      router.refresh();
+    } else setError(res.error);
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          autoFocus
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Column name (e.g. Quiz 1)"
+          className="min-w-[12rem] flex-1 rounded-md border border-border-2 bg-bg px-3 py-2 text-sm text-navy outline-none focus:border-gold"
+        />
+        <select
+          value={category}
+          onChange={(e) => setCategory(e.target.value as "CA" | "EXAM")}
+          className="rounded-md border border-border-2 bg-bg px-3 py-2 text-sm text-navy outline-none focus:border-gold"
+        >
+          <option value="CA">Continuous Assessment</option>
+          <option value="EXAM">Term Exam</option>
+        </select>
+        <input
+          type="number"
+          min="1"
+          step="0.01"
+          value={maxScore}
+          onChange={(e) => setMaxScore(e.target.value)}
+          placeholder="Max"
+          className="w-20 rounded-md border border-border-2 bg-bg px-3 py-2 text-sm text-navy outline-none focus:border-gold"
+        />
+        <button
+          onClick={submit}
+          disabled={pending}
+          className="rounded-md border border-gold bg-gold px-3.5 py-2 text-sm font-semibold text-navy hover:bg-gold-soft disabled:opacity-50"
+        >
+          {pending ? "Adding…" : "Add"}
+        </button>
+        {onCancel && (
+          <button
+            onClick={onCancel}
+            disabled={pending}
+            className="rounded-md px-3 py-2 text-sm font-semibold text-navy-3 hover:text-navy disabled:opacity-50"
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+      {error && <p className="text-sm text-terra">{error}</p>}
+    </div>
+  );
+}

--- a/omnischools/components/gradebook/column-score-grid.tsx
+++ b/omnischools/components/gradebook/column-score-grid.tsx
@@ -1,0 +1,247 @@
+"use client";
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { deleteGradebookColumn, saveColumnScores } from "@/lib/actions/gradebook";
+import { AddColumnForm } from "./add-column-form";
+
+type Column = {
+  id: string;
+  name: string;
+  category: "CA" | "EXAM";
+  maxScore: number;
+};
+type Student = { id: string; name: string; code: string };
+
+const inputCls =
+  "w-16 rounded-md border border-border-2 bg-bg px-2 py-1.5 text-sm font-mono text-navy outline-none focus:border-gold";
+
+function cellKey(columnId: string, studentId: string) {
+  return `${columnId}:${studentId}`;
+}
+
+function round2(n: number) {
+  return Math.round((n + Number.EPSILON) * 100) / 100;
+}
+
+export function ColumnScoreGrid({
+  columns,
+  roster,
+  scores,
+  weights,
+  classId,
+  subjectId,
+  periodId,
+}: {
+  columns: Column[];
+  roster: Student[];
+  /** flat list of existing raw scores, keyed by column + student */
+  scores: { columnId: string; studentId: string; raw: string }[];
+  weights: { cw: number; ew: number };
+  classId: string;
+  subjectId: string;
+  periodId: string;
+}) {
+  const router = useRouter();
+
+  const initial = useMemo(() => {
+    const m: Record<string, string> = {};
+    for (const s of scores) m[cellKey(s.columnId, s.studentId)] = s.raw;
+    return m;
+  }, [scores]);
+
+  const [cells, setCells] = useState<Record<string, string>>(initial);
+  const [dirty, setDirty] = useState<Set<string>>(new Set());
+  const [saving, setSaving] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [showAdd, setShowAdd] = useState(false);
+
+  function set(columnId: string, studentId: string, v: string) {
+    const k = cellKey(columnId, studentId);
+    setCells((c) => ({ ...c, [k]: v }));
+    setDirty((d) => new Set(d).add(k));
+    setMsg(null);
+  }
+
+  // Client-side preview of the rolled-up CA% / Exam% / Total per student. The
+  // server rollup on save is the source of truth; this just mirrors it live.
+  function rollup(studentId: string) {
+    let caRaw = 0,
+      caMax = 0,
+      exRaw = 0,
+      exMax = 0;
+    for (const col of columns) {
+      const raw = cells[cellKey(col.id, studentId)];
+      if (raw == null || raw.trim() === "") continue;
+      const n = Number(raw);
+      if (!Number.isFinite(n)) continue;
+      const v = Math.min(Math.max(n, 0), col.maxScore);
+      if (col.category === "EXAM") {
+        exRaw += v;
+        exMax += col.maxScore;
+      } else {
+        caRaw += v;
+        caMax += col.maxScore;
+      }
+    }
+    const caPct = caMax > 0 ? round2((caRaw / caMax) * 100) : null;
+    const examPct = exMax > 0 ? round2((exRaw / exMax) * 100) : null;
+    const total =
+      caPct == null && examPct == null
+        ? null
+        : round2(((caPct ?? 0) * weights.cw) / 100 + ((examPct ?? 0) * weights.ew) / 100);
+    return { caPct, examPct, total };
+  }
+
+  async function save() {
+    if (dirty.size === 0) {
+      setMsg("Nothing to save.");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    setMsg(null);
+    const payload = Array.from(dirty).map((k) => {
+      const [columnId, studentId] = k.split(":");
+      return { columnId, studentId, raw: cells[k] ?? "" };
+    });
+    const res = await saveColumnScores({
+      classId,
+      subjectId,
+      periodId,
+      scores: payload,
+    });
+    setSaving(false);
+    if (res.ok) {
+      setDirty(new Set());
+      setMsg(`Saved ${res.saved} cell${res.saved === 1 ? "" : "s"}.`);
+      router.refresh();
+    } else setError(res.error);
+  }
+
+  async function removeColumn(columnId: string) {
+    setError(null);
+    const res = await deleteGradebookColumn({ columnId });
+    if (res.ok) router.refresh();
+    else setError(res.error);
+  }
+
+  return (
+    <div>
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <p className="text-xs text-navy-3">
+          Class {weights.cw}% · Exam {weights.ew}% — totals roll up on save.
+        </p>
+        <div className="flex items-center gap-2">
+          {!showAdd && (
+            <button
+              onClick={() => setShowAdd(true)}
+              className="border-border-2 bg-surface rounded-md border px-4 py-2 text-sm font-semibold text-navy hover:bg-gold-bg"
+            >
+              + Add column
+            </button>
+          )}
+          <button
+            onClick={save}
+            disabled={saving || dirty.size === 0}
+            className="text-bg rounded-md bg-navy px-5 py-2 text-sm font-semibold transition-colors hover:bg-navy-deep disabled:opacity-60"
+          >
+            {saving ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </div>
+
+      {showAdd && (
+        <div className="bg-surface mb-3 rounded-xl border border-border p-3">
+          <AddColumnForm
+            classId={classId}
+            subjectId={subjectId}
+            periodId={periodId}
+            onCancel={() => setShowAdd(false)}
+            onDone={() => setShowAdd(false)}
+          />
+        </div>
+      )}
+
+      {msg && (
+        <p className="mb-3 rounded-md bg-green-bg px-3 py-2 text-sm text-green">{msg}</p>
+      )}
+      {error && <p className="mb-3 text-sm text-terra">{error}</p>}
+
+      <div className="bg-surface overflow-x-auto rounded-xl border border-border">
+        <table className="w-full text-sm">
+          <thead className="bg-bg border-b border-border text-left text-xs uppercase tracking-wide text-navy-3">
+            <tr>
+              <th className="bg-bg sticky left-0 z-10 px-4 py-3 font-semibold">Student</th>
+              {columns.map((col) => (
+                <th key={col.id} className="px-3 py-3 text-center font-semibold">
+                  <div className="flex items-center justify-center gap-1.5">
+                    <span className="text-navy">{col.name}</span>
+                    <button
+                      onClick={() => removeColumn(col.id)}
+                      title={`Delete ${col.name}`}
+                      aria-label={`Delete ${col.name}`}
+                      className="text-navy-3 hover:text-terra"
+                    >
+                      ×
+                    </button>
+                  </div>
+                  <div className="mt-0.5 flex items-center justify-center gap-1.5 text-[10px] normal-case">
+                    <span className="font-mono text-navy-3">/{col.maxScore}</span>
+                    <span
+                      className={
+                        col.category === "EXAM"
+                          ? "rounded-full bg-navy px-1.5 py-0.5 text-[9px] font-semibold text-bg"
+                          : "rounded-full bg-gold-bg px-1.5 py-0.5 text-[9px] font-semibold text-gold"
+                      }
+                    >
+                      {col.category === "EXAM" ? "EXAM" : "CA"}
+                    </span>
+                  </div>
+                </th>
+              ))}
+              <th className="px-3 py-3 text-right font-semibold">CA %</th>
+              <th className="px-3 py-3 text-right font-semibold">Exam %</th>
+              <th className="px-3 py-3 text-right font-semibold">Total</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {roster.map((s) => {
+              const r = rollup(s.id);
+              return (
+                <tr key={s.id}>
+                  <td className="bg-surface sticky left-0 z-10 px-4 py-2.5">
+                    <div className="font-medium text-navy">{s.name}</div>
+                    <div className="font-mono text-xs text-navy-3">{s.code}</div>
+                  </td>
+                  {columns.map((col) => (
+                    <td key={col.id} className="px-3 py-2.5 text-center">
+                      <input
+                        className={inputCls}
+                        type="number"
+                        min="0"
+                        max={col.maxScore}
+                        step="0.01"
+                        value={cells[cellKey(col.id, s.id)] ?? ""}
+                        onChange={(e) => set(col.id, s.id, e.target.value)}
+                      />
+                    </td>
+                  ))}
+                  <td className="px-3 py-2.5 text-right text-navy-2">
+                    {r.caPct == null ? "—" : `${r.caPct.toFixed(2)}%`}
+                  </td>
+                  <td className="px-3 py-2.5 text-right text-navy-2">
+                    {r.examPct == null ? "—" : `${r.examPct.toFixed(2)}%`}
+                  </td>
+                  <td className="px-3 py-2.5 text-right font-semibold text-navy">
+                    {r.total == null ? "—" : r.total.toFixed(2)}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/omnischools/components/gradebook/empty-columns.tsx
+++ b/omnischools/components/gradebook/empty-columns.tsx
@@ -1,0 +1,179 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { applyColumnTemplate } from "@/lib/actions/gradebook";
+import { AddColumnForm } from "./add-column-form";
+
+type Student = { id: string; name: string; code: string };
+
+const PREVIEW_COLS = 5;
+
+function initials(name: string): string {
+  const parts = name.replace(",", "").trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "—";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+function classLabel(name: string): string {
+  const compact = name.replace(/[^A-Za-z0-9]/g, "");
+  return (compact.slice(0, 2) || name.slice(0, 2)).toUpperCase();
+}
+
+export function GradebookEmptyColumns({
+  className,
+  subjectName,
+  termLabel,
+  students,
+  classId,
+  subjectId,
+  periodId,
+}: {
+  className: string;
+  subjectName: string;
+  termLabel: string;
+  students: Student[];
+  classId: string;
+  subjectId: string;
+  periodId: string;
+}) {
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+
+  const preview = students.slice(0, 6);
+
+  async function useTemplate() {
+    setPending(true);
+    setError(null);
+    const res = await applyColumnTemplate({ classId, subjectId, periodId });
+    setPending(false);
+    if (res.ok) router.refresh();
+    else setError(res.error);
+  }
+
+  return (
+    <div>
+      {/* Class-context strip */}
+      <div className="bg-surface mb-5 flex items-center gap-3 rounded-xl border border-border p-4">
+        <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-[10px] bg-navy font-display text-sm font-semibold text-gold">
+          {classLabel(className)}
+        </div>
+        <div className="flex-1">
+          <div className="font-display text-base font-semibold text-navy">
+            {className} · {subjectName}
+          </div>
+          <div className="mt-0.5 text-xs text-navy-3">
+            {students.length} student{students.length === 1 ? "" : "s"} · taught by{" "}
+            <span className="font-semibold text-navy">you</span> · {termLabel}
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <span className="rounded-full border border-navy bg-navy px-2.5 py-1 text-[10px] font-semibold text-bg">
+            Continuous Assessment
+          </span>
+          <span className="rounded-full border border-border bg-bg px-2.5 py-1 text-[10px] font-semibold text-navy-3">
+            Term Exam
+          </span>
+        </div>
+      </div>
+
+      {/* Faded preview grid with a floating CTA over it */}
+      <div className="relative bg-surface overflow-hidden rounded-xl border border-border">
+        <div className="opacity-45 pointer-events-none">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b border-border">
+                <th className="px-3.5 py-3 text-left text-[10px] font-bold uppercase tracking-wide text-navy-3">
+                  Student
+                </th>
+                <th
+                  colSpan={PREVIEW_COLS}
+                  className="border-l border-dashed border-border-2 bg-gold-bg px-3.5 py-3 text-center text-[10px] font-bold uppercase tracking-wide text-gold"
+                >
+                  + Add your first column
+                </th>
+                <th className="px-3.5 py-3 text-center text-[10px] font-bold uppercase tracking-wide text-navy-3">
+                  Total
+                </th>
+                <th className="px-3.5 py-3 text-center text-[10px] font-bold uppercase tracking-wide text-navy-3">
+                  Grade
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {preview.map((s) => (
+                <tr key={s.id}>
+                  <td className="px-3.5 py-2.5">
+                    <div className="flex items-center gap-2.5">
+                      <div className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-gold-bg font-display text-[11px] font-semibold text-navy">
+                        {initials(s.name)}
+                      </div>
+                      <div>
+                        <div className="font-semibold text-navy">{s.name}</div>
+                        <div className="font-mono text-[10px] text-navy-3">{s.code}</div>
+                      </div>
+                    </div>
+                  </td>
+                  {Array.from({ length: PREVIEW_COLS + 2 }).map((_, i) => (
+                    <td
+                      key={i}
+                      className="px-3.5 py-2.5 text-center font-display text-sm text-border-2"
+                    >
+                      —
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Floating CTA card, centered over the faded grid */}
+        <div className="absolute left-1/2 top-1/2 z-10 w-[360px] max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-gold bg-surface px-7 pb-5 pt-6 text-center shadow-[0_30px_70px_-20px_rgba(26,43,71,0.22)]">
+          <div className="mx-auto mb-3.5 flex h-11 w-11 items-center justify-center rounded-full bg-gold-bg font-display text-lg font-bold text-gold">
+            +
+          </div>
+          <h4 className="font-display text-base font-semibold text-navy">
+            Add your <em className="not-italic text-gold">first column</em>
+          </h4>
+          <p className="mx-auto mt-1.5 mb-4 text-xs leading-relaxed text-navy-3">
+            A column is one assessment — Quiz 1, Class Test, Assignment 2. Once you add it
+            and set the marks ceiling, you can grade students inline.
+          </p>
+
+          {!showForm ? (
+            <div className="flex justify-center gap-2">
+              <button
+                onClick={useTemplate}
+                disabled={pending}
+                className="border-border-2 bg-surface rounded-md border px-3.5 py-2 text-xs font-semibold text-navy hover:bg-gold-bg disabled:opacity-50"
+              >
+                {pending ? "Adding…" : "Use a quick template"}
+              </button>
+              <button
+                onClick={() => setShowForm(true)}
+                disabled={pending}
+                className="rounded-md border border-gold bg-gold px-3.5 py-2 text-xs font-semibold text-navy hover:bg-gold-soft disabled:opacity-50"
+              >
+                + Add column
+              </button>
+            </div>
+          ) : (
+            <div className="text-left">
+              <AddColumnForm
+                classId={classId}
+                subjectId={subjectId}
+                periodId={periodId}
+                onCancel={() => setShowForm(false)}
+              />
+            </div>
+          )}
+
+          {error && <p className="mt-2 text-xs text-terra">{error}</p>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/omnischools/lib/actions/gradebook.ts
+++ b/omnischools/lib/actions/gradebook.ts
@@ -1,5 +1,5 @@
 "use server";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, asc, eq, inArray, max } from "drizzle-orm";
 import { z } from "zod";
 import { withSchool } from "@/lib/db/rls";
 import { recordAudit } from "@/lib/db/audit";
@@ -12,6 +12,9 @@ import {
   subjects,
   gradebookConfig,
   gradebookScores,
+  gradebookColumns,
+  gradebookColumnScores,
+  gradeScale,
   reportCards,
 } from "@/db/schema";
 
@@ -148,6 +151,489 @@ export async function saveScores(input: unknown): Promise<SaveScoresResult> {
     return { ok: true, saved };
   } catch {
     return { ok: false, error: "Could not save scores. Please try again." };
+  }
+}
+
+// ---------------------------------------------------------- assessment columns
+const CATEGORIES = ["CA", "EXAM"] as const;
+
+const CreateColumnSchema = z.object({
+  classId: z.string().uuid(),
+  subjectId: z.string().uuid(),
+  periodId: z.string().uuid(),
+  name: z.string().trim().min(1, "Name is required.").max(80),
+  category: z.enum(CATEGORIES).default("CA"),
+  maxScore: z.coerce.number().positive("Max score must be greater than 0.").max(1000),
+});
+
+export type CreateColumnResult =
+  | { ok: true; columnId: string }
+  | { ok: false; error: string };
+
+export async function createGradebookColumn(input: unknown): Promise<CreateColumnResult> {
+  const { school } = await requireSchool();
+  const parsed = CreateColumnSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid column." };
+  }
+  const d = parsed.data;
+  const actor = await resolveActor(school.id);
+
+  try {
+    const columnId = await withSchool(school.id, async (tx) => {
+      const [agg] = await tx
+        .select({ maxPos: max(gradebookColumns.position) })
+        .from(gradebookColumns)
+        .where(
+          and(
+            eq(gradebookColumns.schoolId, school.id),
+            eq(gradebookColumns.classId, d.classId),
+            eq(gradebookColumns.subjectId, d.subjectId),
+            eq(gradebookColumns.periodId, d.periodId),
+          ),
+        );
+      const nextPos = (agg?.maxPos ?? -1) + 1;
+      const [col] = await tx
+        .insert(gradebookColumns)
+        .values({
+          schoolId: school.id,
+          classId: d.classId,
+          subjectId: d.subjectId,
+          periodId: d.periodId,
+          name: d.name,
+          category: d.category,
+          maxScore: d.maxScore.toFixed(2),
+          position: nextPos,
+          createdByUserId: actor.id ?? undefined,
+        })
+        .returning();
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "created",
+        entityType: "gradebook_column",
+        entityId: col.id,
+        after: { name: col.name, category: col.category, maxScore: col.maxScore },
+      });
+      return col.id;
+    });
+    safeRevalidate("/gradebook");
+    return { ok: true, columnId };
+  } catch {
+    return { ok: false, error: "Could not add column (name may already exist)." };
+  }
+}
+
+const TemplateSchema = z.object({
+  classId: z.string().uuid(),
+  subjectId: z.string().uuid(),
+  periodId: z.string().uuid(),
+});
+
+/** The standard JHS shape: 3 quizzes, 2 assignments, 1 term exam. */
+const COLUMN_TEMPLATE: { name: string; category: (typeof CATEGORIES)[number]; max: number }[] =
+  [
+    { name: "Quiz 1", category: "CA", max: 10 },
+    { name: "Quiz 2", category: "CA", max: 10 },
+    { name: "Quiz 3", category: "CA", max: 10 },
+    { name: "Assignment 1", category: "CA", max: 10 },
+    { name: "Assignment 2", category: "CA", max: 10 },
+    { name: "Term Exam", category: "EXAM", max: 100 },
+  ];
+
+export type ApplyTemplateResult =
+  | { ok: true; created: number }
+  | { ok: false; error: string };
+
+export async function applyColumnTemplate(input: unknown): Promise<ApplyTemplateResult> {
+  const { school } = await requireSchool();
+  const parsed = TemplateSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: "Invalid input." };
+  const d = parsed.data;
+  const actor = await resolveActor(school.id);
+
+  try {
+    const created = await withSchool(school.id, async (tx) => {
+      const [agg] = await tx
+        .select({ maxPos: max(gradebookColumns.position) })
+        .from(gradebookColumns)
+        .where(
+          and(
+            eq(gradebookColumns.schoolId, school.id),
+            eq(gradebookColumns.classId, d.classId),
+            eq(gradebookColumns.subjectId, d.subjectId),
+            eq(gradebookColumns.periodId, d.periodId),
+          ),
+        );
+      let pos = (agg?.maxPos ?? -1) + 1;
+      const inserted = await tx
+        .insert(gradebookColumns)
+        .values(
+          COLUMN_TEMPLATE.map((t) => ({
+            schoolId: school.id,
+            classId: d.classId,
+            subjectId: d.subjectId,
+            periodId: d.periodId,
+            name: t.name,
+            category: t.category,
+            maxScore: t.max.toFixed(2),
+            position: pos++,
+            createdByUserId: actor.id ?? undefined,
+          })),
+        )
+        .onConflictDoNothing({
+          target: [
+            gradebookColumns.schoolId,
+            gradebookColumns.classId,
+            gradebookColumns.subjectId,
+            gradebookColumns.periodId,
+            gradebookColumns.name,
+          ],
+        })
+        .returning({ id: gradebookColumns.id });
+      if (inserted.length > 0) {
+        await recordAudit(tx, {
+          schoolId: school.id,
+          actorUserId: actor.id ?? undefined,
+          actorRole: actor.role,
+          actionType: "created",
+          entityType: "gradebook_column",
+          entityId: d.subjectId,
+          after: { template: "jhs-standard", created: inserted.length },
+          reason: "Applied column template",
+        });
+      }
+      return inserted.length;
+    });
+    safeRevalidate("/gradebook");
+    return { ok: true, created };
+  } catch {
+    return { ok: false, error: "Could not apply template. Please try again." };
+  }
+}
+
+const DeleteColumnSchema = z.object({ columnId: z.string().uuid() });
+
+export type DeleteColumnResult = { ok: true } | { ok: false; error: string };
+
+export async function deleteGradebookColumn(input: unknown): Promise<DeleteColumnResult> {
+  const { school } = await requireSchool();
+  const parsed = DeleteColumnSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: "Invalid input." };
+  const d = parsed.data;
+  const actor = await resolveActor(school.id);
+
+  try {
+    await withSchool(school.id, async (tx) => {
+      const [col] = await tx
+        .select({
+          id: gradebookColumns.id,
+          classId: gradebookColumns.classId,
+          subjectId: gradebookColumns.subjectId,
+          periodId: gradebookColumns.periodId,
+          name: gradebookColumns.name,
+        })
+        .from(gradebookColumns)
+        .where(
+          and(
+            eq(gradebookColumns.schoolId, school.id),
+            eq(gradebookColumns.id, d.columnId),
+          ),
+        );
+      if (!col) return;
+      await tx
+        .delete(gradebookColumns)
+        .where(
+          and(
+            eq(gradebookColumns.schoolId, school.id),
+            eq(gradebookColumns.id, d.columnId),
+          ),
+        );
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "deleted",
+        entityType: "gradebook_column",
+        entityId: col.id,
+        before: { name: col.name },
+      });
+      await rollupContext(tx, school.id, actor.id ?? undefined, {
+        classId: col.classId,
+        subjectId: col.subjectId,
+        periodId: col.periodId,
+      });
+    });
+    safeRevalidate("/gradebook");
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Could not delete column. Please try again." };
+  }
+}
+
+const SaveColumnScoresSchema = z.object({
+  classId: z.string().uuid(),
+  subjectId: z.string().uuid(),
+  periodId: z.string().uuid(),
+  scores: z.array(
+    z.object({
+      columnId: z.string().uuid(),
+      studentId: z.string().uuid(),
+      raw: z.string(), // "" → clear; otherwise a number string
+    }),
+  ),
+});
+
+export type SaveColumnScoresResult =
+  | { ok: true; saved: number }
+  | { ok: false; error: string };
+
+export async function saveColumnScores(input: unknown): Promise<SaveColumnScoresResult> {
+  const { school } = await requireSchool();
+  const parsed = SaveColumnScoresSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid scores." };
+  }
+  const d = parsed.data;
+  const actor = await resolveActor(school.id);
+
+  try {
+    const saved = await withSchool(school.id, async (tx) => {
+      // Load the columns for this context so we can clamp to each maxScore and
+      // ignore any stray columnId that does not belong here.
+      const cols = await tx
+        .select({
+          id: gradebookColumns.id,
+          maxScore: gradebookColumns.maxScore,
+        })
+        .from(gradebookColumns)
+        .where(
+          and(
+            eq(gradebookColumns.schoolId, school.id),
+            eq(gradebookColumns.classId, d.classId),
+            eq(gradebookColumns.subjectId, d.subjectId),
+            eq(gradebookColumns.periodId, d.periodId),
+          ),
+        );
+      const maxById = new Map(cols.map((c) => [c.id, Number(c.maxScore)]));
+
+      let n = 0;
+      for (const s of d.scores) {
+        const ceiling = maxById.get(s.columnId);
+        if (ceiling == null) continue; // column not in this context
+        const trimmed = s.raw.trim();
+        if (trimmed === "") {
+          await tx
+            .delete(gradebookColumnScores)
+            .where(
+              and(
+                eq(gradebookColumnScores.schoolId, school.id),
+                eq(gradebookColumnScores.columnId, s.columnId),
+                eq(gradebookColumnScores.studentId, s.studentId),
+              ),
+            );
+          n++;
+          continue;
+        }
+        const num = Number(trimmed);
+        if (!Number.isFinite(num)) continue;
+        const clamped = Math.min(Math.max(num, 0), ceiling);
+        await tx
+          .insert(gradebookColumnScores)
+          .values({
+            schoolId: school.id,
+            columnId: s.columnId,
+            studentId: s.studentId,
+            rawScore: clamped.toFixed(2),
+            updatedByUserId: actor.id ?? undefined,
+            updatedAt: new Date(),
+          })
+          .onConflictDoUpdate({
+            target: [
+              gradebookColumnScores.schoolId,
+              gradebookColumnScores.columnId,
+              gradebookColumnScores.studentId,
+            ],
+            set: {
+              rawScore: clamped.toFixed(2),
+              updatedByUserId: actor.id ?? undefined,
+              updatedAt: new Date(),
+            },
+          });
+        n++;
+      }
+
+      await rollupContext(tx, school.id, actor.id ?? undefined, {
+        classId: d.classId,
+        subjectId: d.subjectId,
+        periodId: d.periodId,
+      });
+
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "updated",
+        entityType: "gradebook",
+        entityId: d.subjectId,
+        after: { periodId: d.periodId, cells: n },
+        reason: "Column scores entered",
+      });
+      return n;
+    });
+
+    safeRevalidate("/gradebook");
+    return { ok: true, saved };
+  } catch {
+    return { ok: false, error: "Could not save scores. Please try again." };
+  }
+}
+
+/**
+ * Recompute the per-category percentages and weighted total for every ACTIVE
+ * student in a (class · subject · period) context from their column scores, and
+ * upsert the result into `gradebook_score` so report cards / reports stay in sync.
+ *
+ * caPct  = round( Σ(CA raw)   / Σ(CA max)   * 100, 2 )  when Σ(CA max)   > 0, else null
+ * examPct= round( Σ(EXAM raw) / Σ(EXAM max) * 100, 2 )  when Σ(EXAM max) > 0, else null
+ * total  = round( (caPct ?? 0) * cw/100 + (examPct ?? 0) * ew/100, 2 )  when either is non-null
+ * grade  = gradeScale row with the greatest minScore <= total (null if no scale / null total)
+ */
+async function rollupContext(
+  tx: Tx,
+  schoolId: string,
+  actorId: string | undefined,
+  ctx: { classId: string; subjectId: string; periodId: string },
+): Promise<void> {
+  const roster = await tx
+    .select({ id: students.id })
+    .from(students)
+    .where(
+      and(
+        eq(students.schoolId, schoolId),
+        eq(students.classId, ctx.classId),
+        eq(students.status, "ACTIVE"),
+      ),
+    );
+  if (roster.length === 0) return;
+  const ids = roster.map((r) => r.id);
+
+  const cols = await tx
+    .select({
+      id: gradebookColumns.id,
+      category: gradebookColumns.category,
+      maxScore: gradebookColumns.maxScore,
+    })
+    .from(gradebookColumns)
+    .where(
+      and(
+        eq(gradebookColumns.schoolId, schoolId),
+        eq(gradebookColumns.classId, ctx.classId),
+        eq(gradebookColumns.subjectId, ctx.subjectId),
+        eq(gradebookColumns.periodId, ctx.periodId),
+      ),
+    );
+  const colById = new Map(cols.map((c) => [c.id, c]));
+
+  const rawScores = cols.length
+    ? await tx
+        .select({
+          columnId: gradebookColumnScores.columnId,
+          studentId: gradebookColumnScores.studentId,
+          rawScore: gradebookColumnScores.rawScore,
+        })
+        .from(gradebookColumnScores)
+        .where(
+          and(
+            eq(gradebookColumnScores.schoolId, schoolId),
+            inArray(
+              gradebookColumnScores.columnId,
+              cols.map((c) => c.id),
+            ),
+            inArray(gradebookColumnScores.studentId, ids),
+          ),
+        )
+    : [];
+
+  const { cw, ew } = await getWeights(tx, schoolId);
+
+  // Grade scale, highest threshold first.
+  const scale = await tx
+    .select({ grade: gradeScale.grade, minScore: gradeScale.minScore })
+    .from(gradeScale)
+    .where(eq(gradeScale.schoolId, schoolId))
+    .orderBy(asc(gradeScale.minScore));
+  const gradeForTotal = (total: number): string | null => {
+    let best: string | null = null;
+    for (const g of scale) {
+      if (Number(g.minScore) <= total) best = g.grade;
+    }
+    return best;
+  };
+
+  // Per-student accumulators. A column's max counts toward a student's category
+  // total only when that student has an actual mark for it — an unscored cell is
+  // a dash, not a zero, so it neither helps nor hurts (matches the surface copy).
+  const acc = new Map<
+    string,
+    { caRaw: number; caMax: number; exRaw: number; exMax: number }
+  >();
+  for (const id of ids) acc.set(id, { caRaw: 0, caMax: 0, exRaw: 0, exMax: 0 });
+  for (const r of rawScores) {
+    const a = acc.get(r.studentId);
+    const col = colById.get(r.columnId);
+    if (!a || !col || r.rawScore == null) continue;
+    const raw = Number(r.rawScore);
+    const m = Number(col.maxScore);
+    if (col.category === "EXAM") {
+      a.exRaw += raw;
+      a.exMax += m;
+    } else {
+      a.caRaw += raw;
+      a.caMax += m;
+    }
+  }
+
+  for (const id of ids) {
+    const a = acc.get(id)!;
+    const caPct = a.caMax > 0 ? round2((a.caRaw / a.caMax) * 100) : null;
+    const examPct = a.exMax > 0 ? round2((a.exRaw / a.exMax) * 100) : null;
+    const total =
+      caPct == null && examPct == null
+        ? null
+        : round2(((caPct ?? 0) * cw) / 100 + ((examPct ?? 0) * ew) / 100);
+    const grade = total == null ? null : gradeForTotal(total);
+    await tx
+      .insert(gradebookScores)
+      .values({
+        schoolId,
+        studentId: id,
+        subjectId: ctx.subjectId,
+        periodId: ctx.periodId,
+        classScore: caPct == null ? null : caPct.toFixed(2),
+        examScore: examPct == null ? null : examPct.toFixed(2),
+        total: total == null ? null : total.toFixed(2),
+        grade,
+        updatedByUserId: actorId,
+        updatedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: [
+          gradebookScores.schoolId,
+          gradebookScores.studentId,
+          gradebookScores.subjectId,
+          gradebookScores.periodId,
+        ],
+        set: {
+          classScore: caPct == null ? null : caPct.toFixed(2),
+          examScore: examPct == null ? null : examPct.toFixed(2),
+          total: total == null ? null : total.toFixed(2),
+          grade,
+          updatedByUserId: actorId,
+          updatedAt: new Date(),
+        },
+      });
   }
 }
 


### PR DESCRIPTION
## Empty states — PR4: Gradebook columns + empty-column state

Builds the **columns feature** behind the Gradebook empty-column surface (`schoolup-empty-states-modules` set B §02), on the schema from **#99**.

> **Stacks on #99** (the `gradebook_column` / `gradebook_column_score` schema). Merge #99 first; afterwards this PR's diff collapses to just the feature. Migration `0028` + RLS must be applied (paste in #99).

### UI
- **Empty-column state** (`GradebookEmptyColumns`) — shown when a class·subject·period has a roster but no columns: class-context strip ("JHS 1A · Mathematics · N students · taught by you · {term}"), CA / Term-Exam pills, a **faded** (`opacity-45`) preview grid of the real students with em-dash cells + a "+ Add your first column" header, and a **floating CTA card** with "Use a quick template" + "+ Add column".
- **Column grid** (`ColumnScoreGrid`) — once columns exist: per-column headers (`{name} /{max}`, CA/EXAM tag, `×` delete), a number input per student/column, **Save** of dirty cells, and read-only **CA% / Exam% / Total** trailing columns.
- **`AddColumnForm`** (name · category · marks ceiling) shared by both.

### Actions (`lib/actions/gradebook.ts`)
`createGradebookColumn`, `applyColumnTemplate` (Quiz 1–3 + Assignment 1–2 + Term Exam — the surface's "3 quizzes, 2 assignments, 1 term exam"), `deleteGradebookColumn`, `saveColumnScores`. Each **rolls up** per student: CA% = Σ(CA raw)/Σ(CA max) over **scored** columns, Exam% likewise, Total weighted by `gradebook_config` (50/50), grade via `grade_scale` — and **upserts `gradebook_score`** so report cards / reports stay in sync. Unscored cells stay a dash, not a zero.

### Verification (live, end-to-end)
empty state → **"Use a quick template"** creates the 6 columns → grid → entered Quiz 1 **8/10** + Term Exam **70/100** → rolled up to **CA 80% · Exam 70% · Total 75**, persisted across refresh. `pnpm typecheck` + `pnpm lint` + `pnpm build` clean; no slash-opacity on the raw-hex tokens.

### Note
The old fixed CA/Exam `score-grid.tsx` + `saveScores` action are now **orphaned** (the page uses columns) — left for a small separate cleanup to keep this PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)