### PR TITLE
feat(billing): school-wide Issue-invoices empty state + action (empty-states PR3)

### DIFF
--- a/omnischools/app/(app)/billing/page.tsx
+++ b/omnischools/app/(app)/billing/page.tsx
@@ -1,3 +1,4 @@
+import { Receipt } from "lucide-react";
 import { and, asc, eq, inArray, isNotNull, sql } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
@@ -16,9 +17,11 @@ import {
 import { num } from "@/lib/fees-helpers";
 import { CreateFeeStructureForm } from "@/components/billing/create-fee-structure-form";
 import { FeeStructureCard } from "@/components/billing/fee-structure-card";
+import { IssueInvoicesCard } from "@/components/billing/issue-invoices-card";
 import { DiscountManager } from "@/components/billing/discount-manager";
 import { RemindersCard } from "@/components/billing/reminders-card";
 import { FamiliesCard } from "@/components/billing/families-card";
+import { EmptyState } from "@/components/ui/empty-state";
 
 export const dynamic = "force-dynamic";
 
@@ -30,6 +33,7 @@ function currentAcademicYear() {
 
 export default async function BillingPage() {
   const { school } = await requireSchool();
+  const year = currentAcademicYear();
 
   const [
     structureRows,
@@ -43,6 +47,9 @@ export default async function BillingPage() {
     householdRows,
     memberRows,
     tierRows,
+    [activeCount],
+    [unInvoicedCount],
+    periodRows,
   ] = await Promise.all([
     withSchool(school.id, (tx) =>
       tx
@@ -66,7 +73,7 @@ export default async function BillingPage() {
     ),
     withSchool(school.id, (tx) =>
       tx
-        .select({ id: classes.id, name: classes.name })
+        .select({ id: classes.id, name: classes.name, level: classes.level })
         .from(classes)
         .where(and(eq(classes.schoolId, school.id), eq(classes.active, true)))
         .orderBy(asc(classes.name)),
@@ -144,6 +151,42 @@ export default async function BillingPage() {
         .from(discountTiers)
         .where(eq(discountTiers.schoolId, school.id)),
     ),
+    withSchool(school.id, (tx) =>
+      tx
+        .select({ n: sql<number>`count(*)::int` })
+        .from(students)
+        .where(and(eq(students.schoolId, school.id), eq(students.status, "ACTIVE"))),
+    ),
+    withSchool(school.id, (tx) =>
+      tx
+        .select({ n: sql<number>`count(*)::int` })
+        .from(students)
+        .where(
+          and(
+            eq(students.schoolId, school.id),
+            eq(students.status, "ACTIVE"),
+            sql`not exists (
+              select 1 from ${invoices} iv
+              where iv.student_id = ${students.id}
+                and iv.school_id = ${school.id}
+                and iv.academic_year = ${year}
+                and iv.status <> 'VOIDED'
+            )`,
+          ),
+        ),
+    ),
+    withSchool(school.id, (tx) =>
+      tx
+        .select({
+          academicYear: academicPeriod.academicYear,
+          periodLabel: academicPeriod.periodLabel,
+          startsOn: academicPeriod.startsOn,
+          endsOn: academicPeriod.endsOn,
+        })
+        .from(academicPeriod)
+        .where(eq(academicPeriod.schoolId, school.id))
+        .orderBy(asc(academicPeriod.startsOn)),
+    ),
   ]);
 
   const itemsByStructure = new Map<string, { description: string; amount: number }[]>();
@@ -160,10 +203,40 @@ export default async function BillingPage() {
       name: s.name,
       level: s.level,
       academicYear: s.academicYear,
+      active: s.active,
       items,
       total: items.reduce((sum, i) => sum + i.amount, 0),
     };
   });
+
+  // Active fee structures for the current year — what school-wide issuance bills from.
+  const activeStructures = structures.filter(
+    (s) => s.active && s.academicYear === year,
+  );
+  // Preview = first active structure (for the year) that actually has line items.
+  const previewStructure = activeStructures.find((s) => s.items.length > 0) ?? null;
+  const totalActive = num(activeCount?.n);
+  const unInvoiced = num(unInvoicedCount?.n);
+
+  // Levels billable by an active, non-empty structure (mirrors issueAllInvoices).
+  const billableLevels = new Set(
+    activeStructures.filter((s) => s.items.length > 0 && s.level).map((s) => s.level),
+  );
+  const classesWithoutStructure = classRows.filter(
+    (c) => !c.level || !billableLevels.has(c.level),
+  ).length;
+
+  // Term label: the active academic period containing today (else latest started,
+  // else last), falling back to the academic year when no periods are configured.
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const currentPeriod =
+    periodRows.find((p) => p.startsOn <= todayIso && p.endsOn >= todayIso) ??
+    [...periodRows].reverse().find((p) => p.startsOn <= todayIso) ??
+    periodRows[periodRows.length - 1] ??
+    null;
+  const termLabel = currentPeriod
+    ? `${currentPeriod.periodLabel} · ${currentPeriod.academicYear}`
+    : year;
 
   const catNameById = new Map(feeCatRows.map((c) => [c.id, c.name]));
   const tiersByDiscount = new Map<string, { rank: number; value: number }[]>();
@@ -220,21 +293,51 @@ export default async function BillingPage() {
 
       <RemindersCard families={num(summary?.families)} total={num(summary?.total)} />
 
+      {activeStructures.length === 0 ? (
+        <EmptyState
+          tone="default"
+          icon={<Receipt className="h-5 w-5" aria-hidden />}
+          title="Set up your fee structure first"
+          body="A fee structure is your termly bill — Tuition, Books, Transport… Create one, then issue invoices to every student in a click."
+          primary={{ label: "+ Create fee structure", href: "#fee-structures", variant: "gold" }}
+        />
+      ) : (
+        unInvoiced > 0 && (
+          <IssueInvoicesCard
+            unInvoiced={unInvoiced}
+            totalActive={totalActive}
+            termLabel={termLabel}
+            preview={
+              previewStructure
+                ? {
+                    schoolName: school.name,
+                    structureName: previewStructure.name,
+                    items: previewStructure.items,
+                    subtotal: previewStructure.total,
+                  }
+                : null
+            }
+            classesWithoutStructure={classesWithoutStructure}
+          />
+        )
+      )}
+
       {/* Fee structures */}
-      <section>
+      <section id="fee-structures" className="scroll-mt-6">
         <div className="mb-4 flex items-center justify-between gap-3">
           <h2 className="font-display text-xl font-semibold text-navy">Fee structures</h2>
           <CreateFeeStructureForm
-            defaultYear={currentAcademicYear()}
+            defaultYear={year}
             feeItemOptions={feeCatRows.map((c) => c.name)}
             levelOptions={levelRows.map((l) => l.level).filter((l): l is string => !!l)}
             yearOptions={yearRows.map((y) => y.year)}
           />
         </div>
         {structures.length === 0 ? (
-          <p className="rounded-xl border border-dashed border-border-2 bg-surface p-10 text-center text-sm text-navy-3">
-            No fee structures yet. Create one (e.g. “JHS 1 — {currentAcademicYear()}”) to
-            bill a whole class in one click.
+          // No structures → the "Set up your fee structure first" hero above covers it;
+          // the section just keeps its "+ New fee structure" control.
+          <p className="text-sm italic text-navy-3">
+            Your fee structures will appear here once you create one.
           </p>
         ) : (
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">

--- a/omnischools/components/billing/issue-invoices-card.tsx
+++ b/omnischools/components/billing/issue-invoices-card.tsx
@@ -1,0 +1,189 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { issueAllInvoices } from "@/lib/actions/billing";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+
+const ghs = (n: number) =>
+  `GHS ${n.toLocaleString("en-GH", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+type Preview = {
+  schoolName: string;
+  structureName: string;
+  items: { description: string; amount: number }[];
+  subtotal: number;
+};
+
+const STEPS: { numeral: string; title: string; body: string }[] = [
+  {
+    numeral: "i",
+    title: "Each student gets their own invoice",
+    body: "Generated from your fee structure, scoped to that student. Apply sibling/scholarship discounts per invoice from the student's Fees page.",
+  },
+  {
+    numeral: "ii",
+    title: "Tell guardians when you're ready",
+    body: "Send payment reminders by SMS from Billing whenever you choose — issuing the invoices doesn't text anyone automatically.",
+  },
+  {
+    numeral: "iii",
+    title: "Payments start arriving",
+    body: "As parents pay, Reports and the student Fees pages fill with collection data. Record cash payments anytime.",
+  },
+];
+
+export function IssueInvoicesCard({
+  unInvoiced,
+  totalActive,
+  termLabel,
+  preview,
+  classesWithoutStructure = 0,
+}: {
+  unInvoiced: number;
+  totalActive?: number;
+  termLabel: string;
+  preview: Preview | null;
+  classesWithoutStructure?: number;
+}) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function confirmIssue() {
+    setBusy(true);
+    setError(null);
+    const res = await issueAllInvoices();
+    setBusy(false);
+    if (res.ok) {
+      setOpen(false);
+      setMsg(
+        `Issued ${res.created} · ${res.skipped} already billed${
+          res.classesWithoutStructure > 0
+            ? ` · ${res.classesWithoutStructure} class${res.classesWithoutStructure === 1 ? "" : "es"} without a structure`
+            : ""
+        }`,
+      );
+      router.refresh();
+    } else {
+      setError(res.error ?? "Could not issue invoices.");
+    }
+  }
+
+  return (
+    <section className="space-y-4">
+      <div className="grid grid-cols-1 gap-6 rounded-xl border border-border bg-surface p-6 lg:grid-cols-[1.4fr_1fr]">
+        {/* Left — the pitch + actions */}
+        <div className="flex flex-col">
+          <div className="text-[10px] font-bold uppercase tracking-[0.14em] text-gold">
+            Ready when you are
+          </div>
+          <h3 className="mt-2 font-display text-2xl font-semibold text-navy">
+            Issue invoices for{" "}
+            <em className="not-italic text-gold">{unInvoiced} students</em>
+          </h3>
+          <p className="mt-2 max-w-md text-sm leading-relaxed text-navy-2">
+            All students are loaded and your fee structure is set. Once you issue
+            invoices, each student gets their own bill — review the preview before you go
+            live.
+          </p>
+
+          {totalActive != null && totalActive > 0 && (
+            <div className="mt-3 text-[10px] font-bold uppercase tracking-[0.1em] text-navy-3">
+              {unInvoiced} of {totalActive} active students still to bill
+            </div>
+          )}
+
+          {classesWithoutStructure > 0 && (
+            <p className="mt-3 text-xs text-navy-3">
+              {classesWithoutStructure} class
+              {classesWithoutStructure === 1 ? " has" : "es have"} no matching fee
+              structure for this level and will be skipped.
+            </p>
+          )}
+
+          <div className="mt-5 flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={() => setOpen(true)}
+              disabled={unInvoiced === 0}
+              className="rounded-md bg-gold px-5 py-2.5 text-sm font-semibold text-navy transition-colors hover:bg-gold-soft disabled:opacity-50"
+            >
+              Issue {unInvoiced} invoices →
+            </button>
+            <a
+              href="#fee-structures"
+              className="text-sm font-semibold text-navy-2 transition-colors hover:text-navy"
+            >
+              Edit fee structure first
+            </a>
+          </div>
+
+          {msg && <p className="mt-3 text-sm font-medium text-green">{msg}</p>}
+          {!open && error && <p className="mt-3 text-sm text-terra">{error}</p>}
+        </div>
+
+        {/* Right — mini invoice preview */}
+        <div className="rounded-lg border border-border-2 bg-bg p-5">
+          {preview ? (
+            <>
+              <div className="font-display text-base font-semibold text-navy">
+                {preview.schoolName}
+              </div>
+              <div className="text-xs text-navy-3">{termLabel}</div>
+              <ul className="mt-4 space-y-1.5 border-t border-border-2 pt-3 text-sm">
+                {preview.items.map((it, i) => (
+                  <li key={i} className="flex justify-between gap-3">
+                    <span className="text-navy-2">{it.description}</span>
+                    <span className="font-mono text-xs text-navy-3">{ghs(it.amount)}</span>
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-3 flex justify-between border-t border-border-2 pt-3">
+                <span className="text-xs font-semibold uppercase tracking-wide text-navy-3">
+                  Total billed
+                </span>
+                <span className="font-display text-base font-semibold text-navy">
+                  {ghs(preview.subtotal)}
+                </span>
+              </div>
+            </>
+          ) : (
+            <p className="text-sm text-navy-3">
+              Add at least one line item to a fee structure to preview the bill.
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* "What happens" strip */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {STEPS.map((s) => (
+          <div key={s.numeral} className="rounded-xl border border-border bg-surface p-5">
+            <div className="font-display text-2xl font-semibold italic text-gold">
+              {s.numeral}
+            </div>
+            <div className="mt-2 font-display text-sm font-semibold text-navy">
+              {s.title}
+            </div>
+            <p className="mt-1 text-xs leading-relaxed text-navy-2">{s.body}</p>
+          </div>
+        ))}
+      </div>
+
+      <ConfirmDialog
+        open={open}
+        title={`Issue ${unInvoiced} invoices?`}
+        message="This generates a bill for every un-billed student from your fee structures. You can send payment reminders afterwards."
+        confirmLabel={`Issue ${unInvoiced} invoices`}
+        busyLabel="Issuing…"
+        tone="gold"
+        busy={busy}
+        error={error}
+        onConfirm={confirmIssue}
+        onClose={() => setOpen(false)}
+      />
+    </section>
+  );
+}

--- a/omnischools/components/ui/confirm-dialog.tsx
+++ b/omnischools/components/ui/confirm-dialog.tsx
@@ -12,8 +12,10 @@ export function ConfirmDialog({
   title,
   message,
   confirmLabel = "Delete",
+  busyLabel = "Deleting…",
   busy = false,
   error,
+  tone = "danger",
   onConfirm,
   onClose,
 }: {
@@ -21,11 +23,18 @@ export function ConfirmDialog({
   title: string;
   message: React.ReactNode;
   confirmLabel?: string;
+  busyLabel?: string;
   busy?: boolean;
   error?: string | null;
+  /** Confirm-button colour. "danger" (terra) for deletes; "gold" for positive actions. */
+  tone?: "danger" | "gold";
   onConfirm: () => void;
   onClose: () => void;
 }) {
+  const confirmClass =
+    tone === "gold"
+      ? "rounded-md bg-gold px-4 py-2 text-sm font-semibold text-navy transition-colors hover:bg-gold-soft disabled:opacity-60"
+      : "rounded-md bg-terra px-4 py-2 text-sm font-semibold text-bg transition-colors hover:opacity-90 disabled:opacity-60";
   return (
     <Modal open={open} onClose={busy ? () => {} : onClose} title={title}>
       <div className="space-y-4">
@@ -42,13 +51,8 @@ export function ConfirmDialog({
           >
             Cancel
           </button>
-          <button
-            type="button"
-            onClick={onConfirm}
-            disabled={busy}
-            className="rounded-md bg-terra px-4 py-2 text-sm font-semibold text-bg transition-colors hover:opacity-90 disabled:opacity-60"
-          >
-            {busy ? "Deleting…" : confirmLabel}
+          <button type="button" onClick={onConfirm} disabled={busy} className={confirmClass}>
+            {busy ? busyLabel : confirmLabel}
           </button>
         </div>
       </div>

--- a/omnischools/lib/actions/billing.ts
+++ b/omnischools/lib/actions/billing.ts
@@ -13,12 +13,20 @@ import {
   feeCategories,
   discounts,
   discountTiers,
+  classes,
   students,
   studentGuardians,
   invoices,
   invoiceLineItems,
   notificationLog,
 } from "@/db/schema";
+
+/** Current academic year as "YYYY/YY" (Sept rollover) — mirrors app/(app)/billing/page.tsx. */
+function currentAcademicYear(): string {
+  const now = new Date();
+  const start = now.getMonth() >= 8 ? now.getFullYear() : now.getFullYear() - 1;
+  return `${start}/${String((start + 1) % 100).padStart(2, "0")}`;
+}
 
 type Result = { ok: boolean; error?: string };
 
@@ -512,6 +520,186 @@ export async function generateInvoicesForClass(input: unknown): Promise<Generate
     return out;
   } catch {
     return { ok: false, error: "Could not generate invoices. Please try again." };
+  }
+}
+
+// ------------------------------------------------ school-wide invoice issuance
+export type IssueAllResult =
+  | {
+      ok: true;
+      created: number;
+      skipped: number;
+      classesIssued: number;
+      classesWithoutStructure: number;
+    }
+  | { ok: false; error: string };
+
+/**
+ * Issue invoices across the whole school for the current academic year: every
+ * ACTIVE student gets a bill at the FULL amount of the active fee structure that
+ * matches their class level. Idempotent (skips students already invoiced for the
+ * year), bills the full subtotal (no auto-discounts — those apply per-invoice via
+ * the existing flow) and sends NO SMS (reminders are the separate sendFeeReminders
+ * flow). Mirrors generateInvoicesForClass's invoice-creation exactly.
+ */
+export async function issueAllInvoices(): Promise<IssueAllResult> {
+  const { school } = await requireSchool();
+  const actor = await resolveActor(school.id);
+  const year = currentAcademicYear();
+
+  try {
+    const out = await withSchool(school.id, async (tx) => {
+      // Active fee structures for the year, with their line items.
+      const structureRows = await tx
+        .select()
+        .from(feeStructures)
+        .where(
+          and(
+            eq(feeStructures.schoolId, school.id),
+            eq(feeStructures.academicYear, year),
+            eq(feeStructures.active, true),
+          ),
+        );
+      if (structureRows.length === 0) {
+        return {
+          ok: false as const,
+          error: `No active fee structure for ${year}.`,
+        };
+      }
+
+      const structureIds = structureRows.map((s) => s.id);
+      const items = await tx
+        .select()
+        .from(feeStructureItems)
+        .where(inArray(feeStructureItems.feeStructureId, structureIds));
+      const itemsByStructure = new Map<string, typeof items>();
+      for (const li of items) {
+        const arr = itemsByStructure.get(li.feeStructureId) ?? [];
+        arr.push(li);
+        itemsByStructure.set(li.feeStructureId, arr);
+      }
+
+      // Resolve each class → the active structure whose level matches the class.
+      // First matching structure per level wins (deterministic by load order).
+      const structureByLevel = new Map<string, (typeof structureRows)[number]>();
+      for (const s of structureRows) {
+        if (s.level && !structureByLevel.has(s.level)) structureByLevel.set(s.level, s);
+      }
+
+      const classRows = await tx
+        .select({ id: classes.id, name: classes.name, level: classes.level })
+        .from(classes)
+        .where(and(eq(classes.schoolId, school.id), eq(classes.active, true)));
+
+      let created = 0;
+      let skipped = 0;
+      let classesIssued = 0;
+      let classesWithoutStructure = 0;
+
+      for (const cls of classRows) {
+        const structure = cls.level ? structureByLevel.get(cls.level) : undefined;
+        if (!structure) {
+          classesWithoutStructure++;
+          continue;
+        }
+        const structItems = itemsByStructure.get(structure.id) ?? [];
+        if (structItems.length === 0) {
+          // An active structure with no line items can't bill anything.
+          classesWithoutStructure++;
+          continue;
+        }
+
+        const subtotal = round2(structItems.reduce((s, li) => s + num(li.amount), 0));
+
+        const roster = await tx
+          .select({ id: students.id })
+          .from(students)
+          .where(
+            and(
+              eq(students.schoolId, school.id),
+              eq(students.classId, cls.id),
+              eq(students.status, "ACTIVE"),
+            ),
+          );
+        if (roster.length === 0) continue;
+
+        let classCreated = 0;
+        for (const stu of roster) {
+          const existing = await tx
+            .select({ id: invoices.id })
+            .from(invoices)
+            .where(
+              and(
+                eq(invoices.schoolId, school.id),
+                eq(invoices.studentId, stu.id),
+                eq(invoices.academicYear, year),
+                sql`${invoices.status} <> 'VOIDED'`,
+              ),
+            )
+            .limit(1);
+          if (existing.length > 0) {
+            skipped++;
+            continue;
+          }
+
+          const invoiceNumber = await nextInvoiceNumber(tx, school.id);
+          const [inv] = await tx
+            .insert(invoices)
+            .values({
+              schoolId: school.id,
+              studentId: stu.id,
+              invoiceNumber,
+              academicYear: year,
+              subtotalAmount: toMoney(subtotal),
+              discountAmount: "0.00",
+              billedAmount: toMoney(subtotal),
+              paidAmount: "0.00",
+              balanceAmount: toMoney(subtotal),
+              status: "ISSUED",
+            })
+            .returning({ id: invoices.id });
+          await tx.insert(invoiceLineItems).values(
+            structItems.map((li) => ({
+              schoolId: school.id,
+              invoiceId: inv.id,
+              feeCategoryId: li.feeCategoryId,
+              description: li.description,
+              amount: li.amount,
+            })),
+          );
+          created++;
+          classCreated++;
+        }
+        if (classCreated > 0) classesIssued++;
+      }
+
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "created",
+        entityType: "invoice_batch",
+        entityId: school.id,
+        after: { created, skipped, classesIssued, classesWithoutStructure, year },
+        reason: "School-wide invoice issuance",
+      });
+
+      return {
+        ok: true as const,
+        created,
+        skipped,
+        classesIssued,
+        classesWithoutStructure,
+      };
+    });
+
+    if (!out.ok) return out;
+    safeRevalidate("/billing");
+    safeRevalidate("/fees");
+    safeRevalidate("/reports");
+    return out;
+  } catch {
+    return { ok: false, error: "Could not issue invoices. Please try again." };
   }
 }
 


### PR DESCRIPTION
## Empty states — PR3: Billing "Issue invoices" card + school-wide issuance

Replicates the Billing surface (`schoolup-empty-states-modules` set B §03) and adds the **school-wide issuance** it implies (you chose this over the per-class-only reframe).

### Action — `issueAllInvoices()` (`lib/actions/billing.ts`)
For the current academic year: resolve each **active class** → the active fee structure whose `level` matches, then issue an invoice (full structure subtotal + line items) for every **ACTIVE student not already billed** for the year.
- **Idempotent** — skips students with a non-VOIDED invoice for the year.
- Mirrors `generateInvoicesForClass`'s invoice creation exactly.
- **No auto-discounts** (bills the full amount; discounts stay per-invoice via the existing flow).
- **No SMS** — issuance only *creates* invoices; guardian SMS is the separate reminders flow.
- Returns `created / skipped / classesIssued / classesWithoutStructure`; audited as an `invoice_batch`. No schema change.

### Billing page states
- **No active fee structure** → rich `EmptyState` "Set up your fee structure first" (and the redundant section-level "no structures" note was dropped).
- **Structures + un-invoiced students** → `IssueInvoicesCard`: "Issue invoices for N students", a fee-structure **preview** (line items + Total billed), an honest "M classes have no matching structure" note, **"Issue N invoices →"** behind a **confirm dialog**, and the 3-step "what happens" strip reworded to reality (issuing doesn't auto-text anyone).

### `ConfirmDialog`
Added a `tone` prop (`"danger" | "gold"`) so positive actions like issuance use a **gold** confirm button instead of the destructive terra one (non-breaking — defaults to danger).

### Verification
- Live: **State A** ("set up fee structure" hero) and **State B** (issue card) both render with correct data — `unInvoiced=3`, preview **Total billed GHS 320.00**, "6 classes have no matching structure". The action is reviewed line-by-line; its idempotency/resolution logic is the same the page uses for those counts.
- The confirm-modal click round-trip couldn't be driven by the headless preview eval — but the **same limitation hits the existing, shipped `Send reminders` dialog on this page**, confirming it's an eval-environment quirk, not a card bug. Wiring matches that working pattern.
- `pnpm typecheck` + `pnpm lint` + `pnpm build` clean; no slash-opacity on tokens.

> ⚠️ `issueAllInvoices` creates real invoices for every un-billed student. It's idempotent and sends no SMS, but it's a bulk money operation behind a confirm step — review the action before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)