### PR TITLE
feat(dashboard): role-aware first-run states (empty-states PR6)

### DIFF
--- a/omnischools/app/(app)/dashboard/page.tsx
+++ b/omnischools/app/(app)/dashboard/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { eq, and, gte, lte, sql } from "drizzle-orm";
+import { eq, and, gte, lte, ne, sql } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import {
@@ -10,8 +10,18 @@ import {
   roleAssignments,
   academicPeriodConfig,
   academicPeriod,
+  invoices,
+  announcements,
 } from "@/db/schema";
 import { EmptyState } from "@/components/ui/empty-state";
+import {
+  AdminChecklist,
+  type ChecklistStep,
+} from "@/components/dashboard/admin-checklist";
+import {
+  TeacherHero,
+  type TeacherAssignment,
+} from "@/components/dashboard/teacher-hero";
 
 export const dynamic = "force-dynamic";
 
@@ -24,8 +34,36 @@ const fmtDate = (d: Date) =>
   });
 
 export default async function DashboardPage() {
-  const { school } = await requireSchool();
+  const { user, school } = await requireSchool();
   const today = new Date().toISOString().slice(0, 10);
+
+  const roleSet = new Set(user.roles);
+  const isAdminOrHead = roleSet.has("ADMIN") || roleSet.has("HEADMASTER");
+  const isTeacher = roleSet.has("TEACHER");
+  // A teacher who just joined (and isn't also an admin/head) gets the welcome hero.
+  const isTeacherOnly = isTeacher && !isAdminOrHead;
+
+  // ── Teacher branch: just accepted their invite → welcome hero ────────────
+  if (isTeacherOnly) {
+    const myClasses = await withSchool(school.id, async (tx) =>
+      tx
+        .select({ name: classes.name, level: classes.level })
+        .from(classes)
+        .where(
+          and(
+            eq(classes.schoolId, school.id),
+            eq(classes.active, true),
+            eq(classes.classTeacherUserId, user.id),
+          ),
+        )
+        .orderBy(classes.name),
+    );
+    const assignments: TeacherAssignment[] = myClasses.map((c) => ({
+      className: c.name,
+      note: "Form teacher",
+    }));
+    return <TeacherHero name={user.name} assignments={assignments} />;
+  }
 
   const stats = await withSchool(school.id, async (tx) => {
     const [{ activeStudents }] = await tx
@@ -85,17 +123,87 @@ export default async function DashboardPage() {
       .from(students)
       .where(eq(students.schoolId, school.id))
       .groupBy(students.status);
+    // First-run signals (admin checklist): does the school have a non-voided
+    // invoice and at least one announcement yet?
+    const [{ invoiceCount }] = await tx
+      .select({ invoiceCount: sql<number>`count(*)::int` })
+      .from(invoices)
+      .where(and(eq(invoices.schoolId, school.id), ne(invoices.status, "VOIDED")));
+    const [{ announcementCount }] = await tx
+      .select({ announcementCount: sql<number>`count(*)::int` })
+      .from(announcements)
+      .where(eq(announcements.schoolId, school.id));
     return {
       activeStudents,
       pending,
       classCount,
       teacherCount,
+      periodConfigured: !!cfg,
       academicYear: cfg?.academicYear ?? null,
       term: term?.label ?? null,
       byClass,
       statusRows,
+      invoiceCount,
+      announcementCount,
     };
   });
+
+  // ── Admin / head first-run branch: setup not yet complete → checklist ────
+  if (isAdminOrHead) {
+    const steps: ChecklistStep[] = [
+      {
+        title: "Set up your school",
+        sub: "Academic year, terms and calendar",
+        done: stats.periodConfigured,
+        href: "/settings/academic",
+        cta: "Set up →",
+      },
+      {
+        title: "Invite your teachers",
+        sub: "Add teaching staff so they can take attendance and grade",
+        done: stats.teacherCount > 0,
+        href: "/staff",
+        cta: "Invite teachers →",
+      },
+      {
+        title: "Add your students",
+        sub: "Upload a CSV or add students one by one — the most important step",
+        done: stats.activeStudents > 0,
+        href: "/students",
+        cta: "Add students →",
+      },
+      {
+        title: "Issue Term 1 invoices",
+        sub: "Once students are loaded, send the first round of fee invoices",
+        done: stats.invoiceCount > 0,
+        href: "/billing",
+        cta: "Issue invoices →",
+        locked: stats.activeStudents === 0,
+      },
+      {
+        title: "Send the first announcement",
+        sub: "A welcome message goes out to all parents and students",
+        done: stats.announcementCount > 0,
+        href: "/communication",
+        cta: "Write one →",
+        optional: true,
+      },
+    ];
+    const doneCount = steps.filter((s) => s.done).length;
+    const progressPct = Math.round((doneCount / steps.length) * 100);
+    // First-run = the three foundational steps aren't all done yet.
+    const setupComplete =
+      stats.periodConfigured && stats.teacherCount > 0 && stats.activeStudents > 0;
+    if (!setupComplete) {
+      return (
+        <AdminChecklist
+          steps={steps}
+          progressPct={progressPct}
+          firstName={user.name?.trim().split(/\s+/)[0] ?? null}
+        />
+      );
+    }
+  }
 
   const ratio = stats.teacherCount > 0 ? Math.round(stats.activeStudents / stats.teacherCount) : 0;
   const avgClass =

--- a/omnischools/components/dashboard/admin-checklist.tsx
+++ b/omnischools/components/dashboard/admin-checklist.tsx
@@ -1,0 +1,193 @@
+import Link from "next/link";
+
+export type ChecklistStep = {
+  /** Step title (surface t1). */
+  title: string;
+  /** Sub-copy (surface t2). */
+  sub: string;
+  /** Whether this step is complete. */
+  done: boolean;
+  /** Where the CTA points. */
+  href: string;
+  /** CTA label for the active state, e.g. "Add students →". */
+  cta: string;
+  /** Locked until a prerequisite is met (e.g. invoices need students). */
+  locked?: boolean;
+  /** Optional step — offers "Skip for now" instead of being required. */
+  optional?: boolean;
+};
+
+/**
+ * §01 admin guided checklist (first-run dashboard).
+ * Replicates Surfaces/schoolup-empty-states.html §01.
+ * Token-safe: raw-hex tokens, no slash-opacity on custom tokens.
+ */
+export function AdminChecklist({
+  steps,
+  progressPct,
+  firstName,
+}: {
+  steps: ChecklistStep[];
+  progressPct: number;
+  firstName?: string | null;
+}) {
+  const total = steps.length;
+  const doneCount = steps.filter((s) => s.done).length;
+  const remaining = total - doneCount;
+  // The first pending, actionable (not locked) step is the highlighted one.
+  const activeIndex = steps.findIndex((s) => !s.done && !s.locked);
+
+  return (
+    <div className="mx-auto max-w-page">
+      <div className="mb-1.5 text-[11px] font-bold uppercase tracking-[0.16em] text-gold">
+        Dashboard
+      </div>
+      <h1 className="font-display text-3xl font-semibold text-navy">
+        Welcome to{" "}
+        <em className="not-italic text-gold [font-style:italic]">Omnischools</em>
+        {firstName ? `, ${firstName}.` : "."}
+      </h1>
+      <p className="mt-1.5 text-sm text-navy-2">
+        Your school is set up.{" "}
+        {remaining > 0
+          ? `${remaining} ${remaining === 1 ? "thing" : "things"} left to do before students and parents can start using it.`
+          : "Everything's ready — students and parents can start using it."}
+      </p>
+
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.5fr_1fr] lg:items-start">
+        {/* Checklist card */}
+        <div className="overflow-hidden rounded-xl border border-border bg-surface">
+          <div className="border-b border-border px-6 pb-4 pt-5">
+            <div className="mb-1.5 text-[10px] font-bold uppercase tracking-[0.14em] text-gold">
+              Get-started checklist
+            </div>
+            <h2 className="font-display text-xl font-semibold text-navy">
+              You&apos;re{" "}
+              <em className="not-italic text-gold [font-style:italic]">
+                {progressPct}%
+              </em>{" "}
+              of the way there
+            </h2>
+
+            {/* Segmented progress bar */}
+            <div className="mt-3.5 flex gap-1">
+              {steps.map((s, i) => (
+                <div
+                  key={i}
+                  className={`h-1 flex-1 rounded-sm ${s.done ? "bg-gold" : "bg-border"}`}
+                />
+              ))}
+            </div>
+            <div className="mt-2 text-[11px] font-semibold text-navy-3">
+              <b className="text-gold">
+                {doneCount} of {total} done
+              </b>
+              {remaining > 0 ? " · a few minutes left" : " · all set"}
+            </div>
+          </div>
+
+          <ol>
+            {steps.map((step, i) => {
+              const isActive = i === activeIndex;
+              const num = i + 1;
+              return (
+                <li
+                  key={i}
+                  className={`grid grid-cols-[36px_1fr_auto] items-center gap-3.5 border-b border-border px-6 py-4 last:border-b-0 ${
+                    step.done ? "bg-bg" : isActive ? "bg-gold-bg" : ""
+                  }`}
+                >
+                  {/* Numbered circle */}
+                  <div
+                    className={`flex h-7 w-7 items-center justify-center rounded-full font-display text-[13px] font-semibold ${
+                      step.done
+                        ? "border-[1.5px] border-gold bg-gold text-navy"
+                        : isActive
+                          ? "border-[1.5px] border-gold bg-surface text-navy"
+                          : "border-[1.5px] border-border-2 bg-bg text-navy-3"
+                    }`}
+                  >
+                    {step.done ? "✓" : num}
+                  </div>
+
+                  {/* Body */}
+                  <div>
+                    <div
+                      className={`font-display text-sm font-semibold ${
+                        step.done ? "text-navy-3 line-through" : "text-navy"
+                      }`}
+                    >
+                      {step.title}
+                    </div>
+                    <div className="mt-0.5 text-[11px] text-navy-3">{step.sub}</div>
+                  </div>
+
+                  {/* Action */}
+                  <div className="text-right">
+                    {step.done ? (
+                      <span className="inline-block rounded-md border border-border px-3 py-1.5 text-[11px] font-semibold text-navy-3">
+                        Done ✓
+                      </span>
+                    ) : step.locked ? (
+                      <span className="inline-block cursor-not-allowed rounded-md border border-border bg-bg px-3 py-1.5 text-[11px] font-semibold text-navy-3">
+                        Locked
+                      </span>
+                    ) : isActive ? (
+                      <Link
+                        href={step.href}
+                        className="inline-block rounded-md bg-gold px-3 py-1.5 text-[11px] font-semibold text-navy transition-colors hover:bg-gold-soft"
+                      >
+                        {step.cta}
+                      </Link>
+                    ) : step.optional ? (
+                      <span className="inline-flex items-center gap-2 whitespace-nowrap">
+                        <span className="text-[11px] font-semibold text-navy-3">
+                          Skip for now
+                        </span>
+                        <Link
+                          href={step.href}
+                          className="text-[11px] font-semibold text-gold hover:underline"
+                        >
+                          {step.cta}
+                        </Link>
+                      </span>
+                    ) : (
+                      <Link
+                        href={step.href}
+                        className="inline-block rounded-md border border-border px-3 py-1.5 text-[11px] font-semibold text-navy transition-colors hover:border-gold-soft"
+                      >
+                        {step.cta}
+                      </Link>
+                    )}
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+        </div>
+
+        {/* What to expect side note (callback is MVP2 — no functional CTA) */}
+        <div className="rounded-xl border border-border bg-surface p-6">
+          <div className="mb-2.5 text-[10px] font-bold uppercase tracking-[0.14em] text-gold">
+            What to expect
+          </div>
+          <h3 className="font-display text-base font-semibold text-navy">
+            Your dashboard fills up{" "}
+            <em className="not-italic text-gold [font-style:italic]">this week</em>
+          </h3>
+          <p className="mt-2 text-xs leading-relaxed text-navy-2">
+            As you add students and teachers post their first work, this page will
+            surface daily activity, fee collections, and what needs your attention.{" "}
+            <b className="text-navy">
+              Right now it&apos;s quiet because nobody has done anything yet
+            </b>{" "}
+            — that&apos;s the way it should be.
+          </p>
+          <p className="mt-4 border-t border-border pt-4 text-xs text-navy-3">
+            Need a hand? We&apos;ll reach out this week.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/omnischools/components/dashboard/teacher-hero.tsx
+++ b/omnischools/components/dashboard/teacher-hero.tsx
@@ -1,0 +1,165 @@
+import Link from "next/link";
+
+export type TeacherAssignment = {
+  /** Class name, e.g. "JHS 2A". */
+  className: string;
+  /** Sub-note, e.g. "Mathematics · Form teacher" or "Form teacher". */
+  note: string;
+};
+
+function greetingFor(hour: number): string {
+  if (hour < 12) return "morning";
+  if (hour < 17) return "afternoon";
+  return "evening";
+}
+
+/**
+ * §02 teacher welcome hero (first-run dashboard) — a navy hero card.
+ * Replicates Surfaces/schoolup-empty-states.html §02.
+ * Navy-card text uses text-bg / text-gold-soft / text-gold (NO slash-opacity
+ * on custom tokens); translucent fills use inline rgba / bg-white tints.
+ */
+export function TeacherHero({
+  name,
+  assignments,
+}: {
+  name?: string | null;
+  assignments: TeacherAssignment[];
+}) {
+  const firstName = name?.trim().split(/\s+/)[0] ?? "there";
+  const greeting = greetingFor(new Date().getHours());
+  const n = assignments.length;
+  const summary =
+    n > 0
+      ? `You're teaching ${n} ${n === 1 ? "class" : "classes"} this term.`
+      : "Your classes will be assigned by the school admin shortly.";
+
+  return (
+    <div className="mx-auto max-w-page">
+      <div className="mb-1.5 text-[11px] font-bold uppercase tracking-[0.16em] text-gold">
+        Dashboard
+      </div>
+      <h1 className="font-display text-3xl font-semibold text-navy">
+        Good {greeting},{" "}
+        <em className="not-italic text-gold [font-style:italic]">{firstName}</em>.
+      </h1>
+      <p className="mt-1.5 text-sm text-navy-2">{summary} Your students are on their way.</p>
+
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.2fr_1fr] lg:items-start">
+        {/* Navy welcome hero card */}
+        <div className="relative overflow-hidden rounded-xl bg-navy p-7 text-bg">
+          {/* decorative gold glow — inline rgba (no slash-opacity on tokens) */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute -bottom-16 -right-16 h-52 w-52 rounded-full"
+            style={{ background: "rgba(200,151,91,0.10)" }}
+          />
+          <div className="relative z-[2]">
+            <div className="mb-2.5 text-[10px] font-bold uppercase tracking-[0.14em] text-gold">
+              Your assignments
+            </div>
+            <h2 className="font-display text-2xl font-semibold leading-tight text-bg">
+              {n > 0 ? (
+                <>
+                  {n} {n === 1 ? "class" : "classes"} at this school
+                </>
+              ) : (
+                <>You&apos;re part of the team now</>
+              )}
+            </h2>
+            <p className="mt-3 max-w-md text-[13px] leading-relaxed text-gold-soft">
+              You&apos;re set up. {n > 0 ? "Your classes are listed below — " : ""}
+              student rosters are being uploaded by the admin and will appear here
+              within the next day or two.
+            </p>
+
+            {/* Assignment list */}
+            {n > 0 ? (
+              <div
+                className="mt-5 rounded-lg border p-4"
+                style={{
+                  background: "rgba(255,255,255,0.06)",
+                  borderColor: "rgba(255,255,255,0.10)",
+                }}
+              >
+                <div className="mb-2.5 text-[9px] font-bold uppercase tracking-[0.14em] text-gold">
+                  Your classes
+                </div>
+                {assignments.map((a, i) => (
+                  <div
+                    key={i}
+                    className="flex items-center justify-between border-b py-1.5 text-xs last:border-b-0"
+                    style={{ borderColor: "rgba(255,255,255,0.10)" }}
+                  >
+                    <span className="font-semibold text-bg">{a.className}</span>
+                    <span className="text-gold-soft">{a.note}</span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div
+                className="mt-5 rounded-lg border p-4 text-xs text-gold-soft"
+                style={{
+                  background: "rgba(255,255,255,0.06)",
+                  borderColor: "rgba(255,255,255,0.10)",
+                }}
+              >
+                Your classes will appear here once you&apos;re assigned.
+              </div>
+            )}
+
+            {/* CTAs — "Take a quick tour" is MVP2 (non-functional, muted) */}
+            <div className="mt-5 flex flex-wrap gap-2">
+              <span
+                aria-disabled
+                className="inline-flex cursor-default items-center gap-1.5 rounded-md border px-4 py-2.5 text-[13px] font-semibold text-bg"
+                style={{ borderColor: "rgba(255,255,255,0.30)" }}
+              >
+                Take a quick tour
+              </span>
+              <Link
+                href="/classes"
+                className="inline-flex items-center gap-1.5 rounded-md bg-gold px-4 py-2.5 text-[13px] font-semibold text-navy transition-colors hover:bg-gold-soft"
+              >
+                View my classes →
+              </Link>
+            </div>
+          </div>
+        </div>
+
+        {/* Suggestion tiles (gold-bg icon tiles) */}
+        <div className="space-y-3">
+          <div className="rounded-xl border border-border bg-surface p-6">
+            <div className="mb-3 flex h-9 w-9 items-center justify-center rounded-[10px] bg-gold-bg font-display text-base font-bold text-gold">
+              i
+            </div>
+            <h3 className="font-display text-sm font-semibold text-navy">
+              Get oriented in 3 minutes
+            </h3>
+            <p className="mt-1 text-xs leading-relaxed text-navy-3">
+              A short tour of how to take attendance, post assignments, and grade
+              work. You can skip and explore on your own — nothing is locked.
+            </p>
+            {/* Tour is MVP2 — shown as a static, non-functional hint */}
+            <div className="mt-3 text-[11px] font-bold uppercase tracking-[0.04em] text-navy-3">
+              Tour coming soon
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-border bg-surface p-6">
+            <div className="mb-3 flex h-9 w-9 items-center justify-center rounded-[10px] bg-gold-bg font-display text-base font-bold text-gold">
+              !
+            </div>
+            <h3 className="font-display text-sm font-semibold text-navy">
+              While you wait for students
+            </h3>
+            <p className="mt-1 text-xs leading-relaxed text-navy-3">
+              Draft assignments, prep your gradebook columns, write an announcement —
+              you don&apos;t have to wait for the roster.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Empty states — PR6: role-aware first-run dashboards

Replicates `schoolup-empty-states` set A — the **admin guided checklist** (§01) and the **teacher welcome hero** (§02). The normal dashboard stays the fallback. No schema.

### Branching (`app/(app)/dashboard/page.tsx`)
On the signed-in user's role + setup state:
1. **Teacher** (TEACHER, not admin/head) → `TeacherHero`: time-aware "Good {morning/afternoon/evening}, {firstName}" greeting, a **navy assignments card** (their class-teacher classes, with a "Form teacher" note), "View my classes →", and two suggestion tiles ("Get oriented", "While you wait for students").
2. **Admin/head + first-run** (setup incomplete = not all of {period configured · ≥1 teacher · ≥1 active student}) → `AdminChecklist`: "You're N% of the way there" with a segmented bar and 5 steps — **Set up school / Invite teachers / Add students / Issue invoices (Locked until students) / Send announcement (Skip for now)** — each with a done ✓ / active-gold-CTA / locked / skip state derived from real data (period config, teacher count, active students, invoices-exist, announcements-exist).
3. **Otherwise** → the existing normal dashboard, unchanged.

### Deferred to MVP2 (named)
- Admin "request a callback" panel → a static reassurance note instead (no callback infra).
- Teacher product tour → "Take a quick tour" is non-functional; **"View my classes →"** is the live CTA.

### Verification
- Both states rendered via a throwaway preview route (removed before commit): admin checklist at **40% · 2 of 5 done**, with Done ✓ / active / **Locked** / Skip-for-now states; teacher navy hero + greeting + assignments + 2 gold tiles.
- Live regression: the admin demo (complete setup) **correctly falls through to the normal dashboard** — the first-run gate doesn't fire when set up.
- `pnpm typecheck` + `pnpm lint` + `pnpm build` clean; navy hero is token-safe (solid tokens + inline rgba, no slash-opacity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)