### PR TITLE
feat(onboarding): who-handles-billing choice + admin/accountant roles + Primary labels

### DIFF
--- a/omnischools/components/onboarding/wizard.tsx
+++ b/omnischools/components/onboarding/wizard.tsx
@@ -35,7 +35,12 @@ import {
 import { DEFAULT_FEE_ITEMS } from "@/lib/field-options";
 import { onboardSchool } from "@/lib/actions/onboarding";
 
-type Form = Partial<OnboardInput> & { subtype?: SchoolSubtype };
+type Form = Partial<OnboardInput> & {
+  subtype?: SchoolSubtype;
+  /** UI-only: "I'm also the administrator" — replicates the headmaster's details into
+   * the admin fields at submit. Stripped by the server schema. */
+  adminSameAsHead?: boolean;
+};
 
 const DRAFT_KEY = "omnischools:onboarding-draft";
 
@@ -141,8 +146,19 @@ export function OnboardingWizard() {
     if (current.key === "staff") {
       if (!form.headmasterName) return "Enter the headmaster's name.";
       if (!form.headmasterPhone) return "Enter the headmaster's phone.";
-      if (!form.adminName) return "Enter the admin's name.";
-      if (!form.adminPhone) return "Enter the admin's phone.";
+      if (!form.adminSameAsHead) {
+        if (!form.adminName) return "Enter the admin's name.";
+        if (!form.adminPhone) return "Enter the admin's phone.";
+      }
+      if (!form.billingHandler) return "Choose who handles billing.";
+      if (form.billingHandler === "ACCOUNTANT") {
+        // The invite is optional, but a name needs a phone (and vice-versa) to work.
+        const name = form.accountantName?.trim();
+        const phone = form.accountantPhone?.trim();
+        if ((name && !phone) || (!name && phone)) {
+          return "Add both the accountant's name and phone, or leave both blank to set them up later.";
+        }
+      }
     }
     if (current.key === "billing" && !form.termsAccepted) {
       return "Please accept the Terms & Privacy Policy to continue.";
@@ -195,7 +211,17 @@ export function OnboardingWizard() {
   async function launch() {
     setSubmitting(true);
     setError(null);
-    const res = await onboardSchool(form);
+    // "I'm also the administrator" → replicate the headmaster's details into the admin
+    // fields so the user never re-types them. (adminSameAsHead is UI-only; stripped server-side.)
+    const payload: Form = form.adminSameAsHead
+      ? {
+          ...form,
+          adminName: form.headmasterName,
+          adminPhone: form.headmasterPhone,
+          adminEmail: form.headmasterEmail,
+        }
+      : form;
+    const res = await onboardSchool(payload);
     setSubmitting(false);
     if (res.ok) {
       try {
@@ -544,6 +570,90 @@ function ChipEditor({
         </button>
       </div>
     </div>
+  );
+}
+
+/** Accountant permission summary — three states: yes (✓), read-only (i), no (✕). */
+const ACCOUNTANT_PERMS: { kind: "yes" | "read" | "no"; label: string }[] = [
+  { kind: "yes", label: "Record & void payments" },
+  { kind: "yes", label: "Apply discounts to students" },
+  { kind: "yes", label: "Generate invoices & receipts" },
+  { kind: "yes", label: "Run financial reports" },
+  { kind: "read", label: "View students (read only)" },
+  { kind: "read", label: "View classes (read only)" },
+  { kind: "no", label: "Manage staff or settings" },
+  { kind: "no", label: "Post announcements" },
+];
+
+function PermIcon({ kind }: { kind: "yes" | "read" | "no" }) {
+  const map = {
+    yes: { ch: "✓", cls: "bg-green-bg text-green" },
+    read: { ch: "i", cls: "bg-gold-bg text-gold" },
+    no: { ch: "✕", cls: "bg-bg text-navy-3" },
+  } as const;
+  const { ch, cls } = map[kind];
+  return (
+    <span
+      className={cn(
+        "flex h-4 w-4 shrink-0 items-center justify-center rounded-full text-[10px] font-bold",
+        cls,
+      )}
+      aria-hidden
+    >
+      {ch}
+    </span>
+  );
+}
+
+/** A selectable "who handles billing" card with role pills + a "typical for…" note. */
+function BillingChoiceCard({
+  selected,
+  onSelect,
+  pills,
+  title,
+  desc,
+  who,
+}: {
+  selected: boolean;
+  onSelect: () => void;
+  pills: { label: string; alt: boolean }[];
+  title: string;
+  desc: string;
+  who: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={selected}
+      className={cn(
+        "flex flex-col rounded-xl border p-4 text-left transition-colors",
+        selected
+          ? "border-gold bg-gold-bg"
+          : "border-border-2 bg-surface hover:border-gold-soft",
+      )}
+    >
+      <div className="mb-2 flex flex-wrap items-center gap-1.5">
+        {pills.map((p) => (
+          <span
+            key={p.label}
+            className={cn(
+              "rounded-full px-2 py-0.5 text-[10px] font-semibold",
+              p.alt
+                ? "border border-gold-soft bg-gold-bg text-gold"
+                : "border border-border-2 bg-surface text-navy-2",
+            )}
+          >
+            {p.label}
+          </span>
+        ))}
+      </div>
+      <div className="font-display text-[15px] font-medium text-navy">{title}</div>
+      <div className="mt-1 text-[12px] leading-relaxed text-navy-3">{desc}</div>
+      <div className="mt-2 border-t border-border pt-2 text-[11px] leading-relaxed text-navy-3">
+        {who}
+      </div>
+    </button>
   );
 }
 
@@ -1062,18 +1172,25 @@ function StepBody({
   }
 
   if (stepKey === "staff") {
+    const sameAsHead = !!form.adminSameAsHead;
+    const handler = form.billingHandler;
+    const setHandler = (v: "ADMIN" | "ACCOUNTANT") =>
+      setForm((p) => ({ ...p, billingHandler: v }));
+    const toggleSameAsHead = () =>
+      setForm((p) => ({ ...p, adminSameAsHead: !p.adminSameAsHead }));
     return (
       <div>
         <Head
           pill={`Step ${stepNo} of ${total} · Staff & roles`}
           title="Who runs"
           em="the school?"
-          lede="Two people to start: the Headmaster, and the admin who signs in first and sets up the rest. Both log in with their phone number; email is optional. You can bulk-add the rest of your staff after launch."
+          lede="Start with your own details, name the admin who signs in first, and tell us who handles billing. Everyone logs in with their phone number; email is optional. You can bulk-add the rest of your staff after launch."
         />
         <div className="space-y-6">
+          {/* Your details — the account creator (headmaster). */}
           <div>
             <div className="mb-2.5 text-[11px] font-semibold uppercase tracking-[0.06em] text-navy-3">
-              Headmaster
+              Your details · Headmaster
             </div>
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
               <Field label="Full name" req>
@@ -1102,37 +1219,181 @@ function StepBody({
               </Field>
             </div>
           </div>
+
+          {/* Administrator — with a "same as me" replicate toggle. */}
+          <div>
+            <div className="mb-2.5 flex flex-wrap items-center justify-between gap-2">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.06em] text-navy-3">
+                Admin (first sign-in)
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={sameAsHead}
+                onClick={toggleSameAsHead}
+                className="inline-flex items-center gap-2 text-[12px] font-semibold text-navy"
+              >
+                <span
+                  className={cn(
+                    "relative h-5 w-9 rounded-full transition-colors",
+                    sameAsHead ? "bg-gold" : "bg-border-2",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "absolute top-0.5 h-4 w-4 rounded-full bg-surface transition-all",
+                      sameAsHead ? "left-[18px]" : "left-0.5",
+                    )}
+                  />
+                </span>
+                I&apos;m also the administrator
+              </button>
+            </div>
+            {sameAsHead ? (
+              <p className="rounded-xl border border-dashed border-border-2 bg-gold-bg px-4 py-3 text-[12px] text-navy-2">
+                The admin will be <b>you</b> — we&apos;ll use the name, phone, and email
+                above. The first sign-in is with your phone number.
+              </p>
+            ) : (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                <Field label="Full name" req>
+                  <input
+                    className={inputCls(!!f("adminName"))}
+                    value={f("adminName")}
+                    onChange={(e) => set("adminName", e.target.value)}
+                    placeholder="School Office"
+                  />
+                </Field>
+                <Field label="Phone (login)" req>
+                  <input
+                    className={inputCls(!!f("adminPhone"))}
+                    value={f("adminPhone")}
+                    onChange={(e) => set("adminPhone", e.target.value)}
+                    placeholder="024 000 0000"
+                  />
+                </Field>
+                <Field label="Email — optional">
+                  <input
+                    className={inputCls(!!f("adminEmail"))}
+                    type="email"
+                    value={f("adminEmail")}
+                    onChange={(e) => set("adminEmail", e.target.value)}
+                  />
+                </Field>
+              </div>
+            )}
+          </div>
+
+          {/* Who handles billing? — the surface's two-card choice. */}
           <div>
             <div className="mb-2.5 text-[11px] font-semibold uppercase tracking-[0.06em] text-navy-3">
-              Admin (first sign-in)
+              Who handles billing?
             </div>
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-              <Field label="Full name" req>
-                <input
-                  className={inputCls(!!f("adminName"))}
-                  value={f("adminName")}
-                  onChange={(e) => set("adminName", e.target.value)}
-                  placeholder="School Office"
-                />
-              </Field>
-              <Field label="Phone (login)" req>
-                <input
-                  className={inputCls(!!f("adminPhone"))}
-                  value={f("adminPhone")}
-                  onChange={(e) => set("adminPhone", e.target.value)}
-                  placeholder="024 000 0000"
-                />
-              </Field>
-              <Field label="Email — optional">
-                <input
-                  className={inputCls(!!f("adminEmail"))}
-                  type="email"
-                  value={f("adminEmail")}
-                  onChange={(e) => set("adminEmail", e.target.value)}
-                />
-              </Field>
+            <p className="mb-3 text-[12px] text-navy-3">
+              Some schools combine administration and finance. Others have a dedicated
+              accountant or bursar. Pick what matches yours.
+            </p>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <BillingChoiceCard
+                selected={handler === "ADMIN"}
+                onSelect={() => setHandler("ADMIN")}
+                pills={[
+                  { label: "Admin", alt: false },
+                  { label: "+ Billing", alt: true },
+                ]}
+                title="I'll handle it myself"
+                desc="Admin role includes full access to billing, fees, and payments. Best for smaller schools."
+                who={
+                  <>
+                    Typical for schools with <b>up to ~250 students</b> or where the
+                    headmaster runs everything.
+                  </>
+                }
+              />
+              <BillingChoiceCard
+                selected={handler === "ACCOUNTANT"}
+                onSelect={() => setHandler("ACCOUNTANT")}
+                pills={[
+                  { label: "Admin", alt: false },
+                  { label: "Accountant", alt: true },
+                ]}
+                title="We have an accountant"
+                desc="A separate Accountant role with billing-only access. Admin still oversees, but day-to-day finance is delegated."
+                who={
+                  <>
+                    Typical for schools with a <b>dedicated bursar</b> or{" "}
+                    <b>250+ students</b>. Cleaner audit separation.
+                  </>
+                }
+              />
             </div>
           </div>
+
+          {/* Reveal: invite the accountant — only when "separate" is chosen. */}
+          {handler === "ACCOUNTANT" && (
+            <div className="rounded-xl border border-border bg-bg p-5">
+              <div className="flex items-center justify-between gap-3">
+                <div className="font-display text-base font-medium text-navy">
+                  Invite your accountant
+                </div>
+                <span className="rounded-full border border-gold-soft bg-gold-bg px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.06em] text-gold">
+                  Accountant
+                </span>
+              </div>
+              <p className="mb-4 mt-0.5 text-[12px] text-navy-3">
+                They&apos;ll get a secure link to set their password. You can also do this
+                later from Settings → Roles — leave these blank to just enable the role.
+              </p>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                <Field label="Full name">
+                  <input
+                    className={inputCls(!!f("accountantName"))}
+                    value={f("accountantName")}
+                    onChange={(e) => set("accountantName", e.target.value)}
+                    placeholder="e.g. Joseph Owusu"
+                  />
+                </Field>
+                <Field
+                  label="Phone (login)"
+                  help="Needed so they can set up their account."
+                >
+                  <input
+                    className={inputCls(!!f("accountantPhone"))}
+                    value={f("accountantPhone")}
+                    onChange={(e) => set("accountantPhone", e.target.value)}
+                    placeholder="024 000 0000"
+                  />
+                </Field>
+                <Field label="Email — optional">
+                  <input
+                    className={inputCls(!!f("accountantEmail"))}
+                    type="email"
+                    value={f("accountantEmail")}
+                    onChange={(e) => set("accountantEmail", e.target.value)}
+                    placeholder="accounts@school.edu.gh"
+                  />
+                </Field>
+              </div>
+
+              {/* Permission summary — exactly what an accountant can/can't do. */}
+              <div className="mt-4 rounded-lg border border-border-2 bg-surface p-4">
+                <div className="mb-2.5 text-[11px] font-semibold uppercase tracking-[0.06em] text-navy-3">
+                  What an accountant can do
+                </div>
+                <div className="grid grid-cols-1 gap-x-6 gap-y-1.5 sm:grid-cols-2">
+                  {ACCOUNTANT_PERMS.map((p) => (
+                    <div
+                      key={p.label}
+                      className="flex items-center gap-2 text-[12px] text-navy-2"
+                    >
+                      <PermIcon kind={p.kind} />
+                      {p.label}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
         </div>
       </div>
     );
@@ -1513,7 +1774,20 @@ function ReviewPanel({
       key: "staff",
       rows: [
         ["Headmaster", `${form.headmasterName ?? "—"} · ${form.headmasterPhone ?? "—"}`],
-        ["Admin", `${form.adminName ?? "—"} · ${form.adminPhone ?? "—"}`],
+        [
+          "Admin",
+          form.adminSameAsHead
+            ? "Same as headmaster"
+            : `${form.adminName ?? "—"} · ${form.adminPhone ?? "—"}`,
+        ],
+        [
+          "Finance",
+          form.billingHandler === "ACCOUNTANT"
+            ? form.accountantName?.trim()
+              ? `Accountant · ${form.accountantName.trim()}`
+              : "Separate accountant (invite later)"
+            : "Admin handles billing",
+        ],
       ],
     },
     {

--- a/omnischools/lib/actions/onboarding.ts
+++ b/omnischools/lib/actions/onboarding.ts
@@ -32,6 +32,7 @@ import {
   subjects,
   feeStructures,
   feeStructureItems,
+  invites,
 } from "@/db/schema";
 
 const FOUNDER_EMAIL = "hello@omnischools.gh";
@@ -182,7 +183,7 @@ export async function onboardSchool(input: unknown): Promise<OnboardResult> {
         .insert(schoolProducts)
         .values(productRows.map((p) => ({ schoolId: school.id, product: p })));
 
-      // ensure ADMIN + HEADMASTER roles exist
+      // ensure ADMIN + HEADMASTER + ACCOUNTANT roles exist
       await tx
         .insert(roles)
         .values([
@@ -192,6 +193,11 @@ export async function onboardSchool(input: unknown): Promise<OnboardResult> {
             description: "School office / system admin",
           },
           { code: "HEADMASTER", label: "Headmaster", description: "Head of school" },
+          {
+            code: "ACCOUNTANT",
+            label: "Accountant",
+            description: "Billing, fees & financial reports",
+          },
         ])
         .onConflictDoNothing({ target: roles.code });
       const roleRows = await tx.select().from(roles);
@@ -224,6 +230,31 @@ export async function onboardSchool(input: unknown): Promise<OnboardResult> {
         { userId: adminId, schoolId: school.id, roleId: roleId("ADMIN") },
         { userId: headmasterId, schoolId: school.id, roleId: roleId("HEADMASTER") },
       ]);
+
+      // Separate accountant → create a pending invite (the accept flow then makes the
+      // user + ACCOUNTANT assignment when they set their password). "I'll handle it
+      // myself" keeps billing on the ADMIN role — no extra assignment needed.
+      // Skipped when the accountant fields were left blank (role available later).
+      let accountantInvite: { phone: string; email: string | null; token: string } | null =
+        null;
+      const accName = nz(d.accountantName);
+      const accPhoneRaw = nz(d.accountantPhone);
+      if (d.billingHandler === "ACCOUNTANT" && accName && accPhoneRaw) {
+        const accPhone = normalizeGhanaPhone(accPhoneRaw);
+        const token = crypto.randomUUID().replace(/-/g, "").slice(0, 24);
+        const expiresAt = new Date(Date.now() + 14 * 86400_000);
+        await tx.insert(invites).values({
+          schoolId: school.id,
+          token,
+          role: "ACCOUNTANT",
+          fullName: accName,
+          email: nz(d.accountantEmail),
+          phone: accPhone,
+          expiresAt,
+          invitedByUserId: adminId,
+        });
+        accountantInvite = { phone: accPhone, email: nz(d.accountantEmail), token };
+      }
 
       // academic period config (school override if the wizard set the calendar)
       await tx.insert(academicPeriodConfig).values({
@@ -331,7 +362,13 @@ export async function onboardSchool(input: unknown): Promise<OnboardResult> {
         reason: "School onboarding wizard",
       });
 
-      return { schoolId: school.id, periodsCreated, adminPhone, headmasterPhone };
+      return {
+        schoolId: school.id,
+        periodsCreated,
+        adminPhone,
+        headmasterPhone,
+        accountantInvite,
+      };
     });
 
     // notifications (stubbed providers)
@@ -345,6 +382,23 @@ export async function onboardSchool(input: unknown): Promise<OnboardResult> {
       html: `<p><b>${d.schoolName}</b> (${d.gesCode}, ${d.product}) — ${d.region} / ${d.district}</p>
              <p>Headmaster: ${d.headmasterName} · Admin: ${d.adminName}</p>`,
     });
+    // Accountant invite — secure link to set their password (mirrors createInvite).
+    if (result.accountantInvite) {
+      const base = process.env.NEXT_PUBLIC_SITE_URL ?? "";
+      const link = `${base}/accept/${result.accountantInvite.token}`;
+      const sender = nz(d.shortName) ?? "Omnischools";
+      await sendSms(
+        result.accountantInvite.phone,
+        `${sender}: You've been added as Accountant at ${d.schoolName}. Set up your account: ${link}`,
+      );
+      if (result.accountantInvite.email) {
+        await sendEmail({
+          to: result.accountantInvite.email,
+          subject: `You're invited to ${d.schoolName} on Omnischools`,
+          html: `<p>You've been added as <b>Accountant</b> at ${d.schoolName}.</p><p><a href="${link}">Accept the invite & set your password</a>.</p>`,
+        });
+      }
+    }
     captureEvent("school_onboarded", { product: d.product, region: d.region });
 
     return {

--- a/omnischools/lib/onboarding.ts
+++ b/omnischools/lib/onboarding.ts
@@ -172,16 +172,17 @@ export const defaultGradePreset = (subtype?: SchoolSubtype): "BASIC" | "WASSCE" 
 
 /* --------------------------------------------- academic structure (step 4) */
 
-/** GES Basic ladder — KG through JHS. Seeded as editable class rows for Basic/Multi. */
+/** GES Basic ladder — KG through JHS. Seeded as editable class rows for Basic/Multi.
+ * Primary years use "Primary 1–6" labels (GES designates these "Basic 1–6"). */
 export const GES_BASIC_CLASSES = [
   "KG 1",
   "KG 2",
-  "Basic 1",
-  "Basic 2",
-  "Basic 3",
-  "Basic 4",
-  "Basic 5",
-  "Basic 6",
+  "Primary 1",
+  "Primary 2",
+  "Primary 3",
+  "Primary 4",
+  "Primary 5",
+  "Primary 6",
   "JHS 1",
   "JHS 2",
   "JHS 3",
@@ -384,6 +385,15 @@ export const OnboardSchema = z.object({
   adminName: z.string().min(2, "Admin name is required").max(160),
   adminPhone: z.string().min(7, "Admin phone is required").max(40),
   adminEmail: z.string().email().optional().or(z.literal("")),
+  // Staff step — who handles billing. "ADMIN" = the admin keeps full billing access
+  // (combined); "ACCOUNTANT" = a separate Accountant role, invited below.
+  billingHandler: z.enum(["ADMIN", "ACCOUNTANT"]).optional(),
+  // Accountant invite (only when billingHandler === "ACCOUNTANT"). Phone is required
+  // for a usable invite — the accept flow creates a phone+password account; email is
+  // optional. Leaving these blank just enables the role for later (no invite sent).
+  accountantName: z.string().max(160).optional().or(z.literal("")),
+  accountantPhone: z.string().max(40).optional().or(z.literal("")),
+  accountantEmail: z.string().email().optional().or(z.literal("")),
 });
 
 export type OnboardInput = z.infer<typeof OnboardSchema>;


### PR DESCRIPTION
## Onboarding — reduce admin setup workload (PR1 of 2)

Cuts duplicate typing in the staff step and makes the wizard's choices cascade into the live account. Replicates `schoolup-accountant-role` §01 ("Onboarding · the choice").

### Staff & roles step
- **"Your details · Headmaster"** + an **"I'm also the administrator" toggle** that replicates the creator's name/phone/email into the admin fields at submit — no re-typing. (UI-only flag, stripped server-side.)
- **"Who handles billing?"** — the surface's two-card choice:
  - *I'll handle it myself* → the admin keeps full billing access (combined).
  - *We have an accountant* → a **separate Accountant role**; reveals the **Invite your accountant** card + the **permission summary** (✓ record/void payments · apply discounts · invoices/receipts · financial reports · `i` view students/classes read-only · ✕ manage staff/settings · post announcements).
- Review panel reflects the admin ("Same as headmaster") and the finance choice.

### Server (`onboardSchool`)
- Ensures the `ACCOUNTANT` role exists.
- When a separate accountant with a **name + phone** is provided → creates a **PENDING invite** inline and sends the secure-link SMS/email. The existing `/accept` flow then provisions the user + ACCOUNTANT assignment when they set their password. (Blank → role available later, no invite.)
- "I'll handle it myself" leaves billing on the ADMIN role — no extra assignment.

### The cascade rule
Classes + subjects chosen in the wizard already auto-create on signup. **Verified end-to-end** via a throwaway script (removed): a Basic onboard produced 3 classes (incl. `Primary 1`), 2 subjects, the ACCOUNTANT invite (PENDING, email + normalized phone + token), and — with "I'm also the admin" — both ADMIN + HEADMASTER on a single user.

### Naming
GES Basic ladder relabelled **Primary 1–6** (was Basic 1–6). Only the onboarding constant referenced the old labels.

### Note / divergence
The accountant invite **requires a phone** — the accept flow creates a phone+password account — which inverts the surface's "phone optional / email primary". This is an auth-model constraint, flagged here (not a silent drop).

### Up next (PR2)
Billing-only **enforcement** — role-gated nav + route guards so an accountant sees only Billing/Fees/Reports + read-only Students/Classes (surface §02 "The accountant's view").

`pnpm typecheck` + `pnpm lint` + `pnpm build` clean. UI verified live (toggle note, both cards, reveal, permission grid). No schema migration (reuses `roles`/`invites`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)