### PR TITLE
feat(access): confine finance-only staff (Accountant/Bursar) to billing (empty-states PR2)

### DIFF
--- a/omnischools/app/(app)/classes/page.tsx
+++ b/omnischools/app/(app)/classes/page.tsx
@@ -1,6 +1,7 @@
 import { GraduationCap } from "lucide-react";
 import { asc, count, eq } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
+import { isFinanceOnly } from "@/lib/access";
 import { withSchool } from "@/lib/db/rls";
 import { classes, students } from "@/db/schema";
 import { loadStaffOptions } from "@/lib/data/staff-options";
@@ -11,7 +12,9 @@ import { EmptyState } from "@/components/ui/empty-state";
 export const dynamic = "force-dynamic";
 
 export default async function ClassesPage() {
-  const { school } = await requireSchool();
+  const { school, user } = await requireSchool();
+  // Finance-only staff (Accountant/Bursar) get a read-only view — no write controls.
+  const readOnly = isFinanceOnly(user.roles);
 
   const [classRows, staff, countRows] = await Promise.all([
     withSchool(school.id, (tx) =>
@@ -56,7 +59,7 @@ export default async function ClassesPage() {
             class teacher and build the timetable.
           </p>
         </div>
-        <CreateClassForm />
+        {!readOnly && <CreateClassForm />}
       </div>
 
       {classRows.length === 0 ? (
@@ -66,7 +69,7 @@ export default async function ClassesPage() {
           body="Create your forms/classes (e.g. JHS 1A) — students, attendance and the timetable all hang off them."
         />
       ) : (
-        <ClassesTable rows={tableRows} staff={staff} />
+        <ClassesTable rows={tableRows} staff={staff} readOnly={readOnly} />
       )}
     </div>
   );

--- a/omnischools/app/(app)/layout.tsx
+++ b/omnischools/app/(app)/layout.tsx
@@ -13,7 +13,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
           schoolType: school.schoolType,
           location: school.location,
         }}
-        user={{ name: user.name ?? null, role: user.roles[0] ?? null }}
+        user={{ name: user.name ?? null, roles: user.roles }}
       />
       <div className="flex min-w-0 flex-1 flex-col">
         <header className="flex items-center justify-between gap-4 border-b border-border bg-surface px-6 py-3 print:hidden">

--- a/omnischools/app/(app)/students/page.tsx
+++ b/omnischools/app/(app)/students/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { desc, eq } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
+import { isFinanceOnly } from "@/lib/access";
 import { withSchool } from "@/lib/db/rls";
 import { students } from "@/db/schema";
 import { StudentsTable } from "@/components/students/students-table";
@@ -9,7 +10,9 @@ import { StudentsEmpty } from "@/components/students/students-empty";
 export const dynamic = "force-dynamic";
 
 export default async function StudentsPage() {
-  const { school } = await requireSchool();
+  const { school, user } = await requireSchool();
+  // Finance-only staff (Accountant/Bursar) get a read-only view — no write controls.
+  const readOnly = isFinanceOnly(user.roles);
   const rows = await withSchool(school.id, (tx) =>
     tx
       .select({
@@ -43,23 +46,25 @@ export default async function StudentsPage() {
           <h1 className="font-display text-3xl font-semibold text-navy">Students</h1>
           <p className="text-sm text-navy-3">{rows.length} on roll</p>
         </div>
-        <div className="flex items-center gap-2">
-          <Link
-            href="/students/import"
-            className="rounded-md border border-border-2 px-4 py-2.5 text-sm font-semibold text-navy-2 transition-colors hover:bg-bg"
-          >
-            Import
-          </Link>
-          <Link
-            href="/students/new"
-            className="rounded-md bg-navy px-4 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep"
-          >
-            + Add student
-          </Link>
-        </div>
+        {!readOnly && (
+          <div className="flex items-center gap-2">
+            <Link
+              href="/students/import"
+              className="rounded-md border border-border-2 px-4 py-2.5 text-sm font-semibold text-navy-2 transition-colors hover:bg-bg"
+            >
+              Import
+            </Link>
+            <Link
+              href="/students/new"
+              className="rounded-md bg-navy px-4 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep"
+            >
+              + Add student
+            </Link>
+          </div>
+        )}
       </div>
 
-      <StudentsTable rows={rows} />
+      <StudentsTable rows={rows} readOnly={readOnly} />
     </div>
   );
 }

--- a/omnischools/components/app/sidebar.tsx
+++ b/omnischools/components/app/sidebar.tsx
@@ -19,6 +19,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { isFinanceOnly } from "@/lib/access";
 
 const NAV: { href: string; label: string; Icon: LucideIcon }[] = [
   { href: "/dashboard", label: "Dashboard", Icon: LayoutDashboard },
@@ -42,6 +43,9 @@ const TIER: Record<string, string> = {
   SENIOR: "Senior",
   COMBINED: "Combined",
 };
+
+/** Finance-only (Accountant/Bursar) nav — billing first, then read-only students/classes. */
+const FINANCE_NAV_ORDER = ["/billing", "/fees", "/reports", "/books", "/students", "/classes"];
 
 /** First letters of the first two words, uppercased (e.g. "Christ King" → "CK"). */
 function initials(s: string | null | undefined, fallback = "—"): string {
@@ -67,12 +71,19 @@ export function AppSidebar({
     schoolType: string;
     location: string | null;
   };
-  user: { name: string | null; role: string | null };
+  user: { name: string | null; roles: string[] };
 }) {
   const pathname = usePathname();
   const tierLoc = [TIER[school.schoolType] ?? school.schoolType, school.location]
     .filter(Boolean)
     .join(" · ");
+  // Finance-only staff see a billing-focused nav; everyone else sees the full set.
+  const nav = isFinanceOnly(user.roles)
+    ? FINANCE_NAV_ORDER.map((href) => NAV.find((n) => n.href === href)).filter(
+        (n): n is (typeof NAV)[number] => !!n,
+      )
+    : NAV;
+  const roleLabel = user.roles[0] ? titleCase(user.roles[0]) : "";
 
   return (
     <aside className="hidden w-60 shrink-0 flex-col bg-navy text-bg md:flex print:hidden">
@@ -93,7 +104,7 @@ export function AppSidebar({
 
       {/* Nav */}
       <nav className="flex-1 space-y-0.5 overflow-y-auto px-3 py-3">
-        {NAV.map(({ href, label, Icon }) => {
+        {nav.map(({ href, label, Icon }) => {
           const active = pathname === href || pathname.startsWith(href + "/");
           return (
             <Link
@@ -125,9 +136,7 @@ export function AppSidebar({
           <div className="truncate font-display text-xs font-semibold text-bg">
             {user.name ?? "—"}
           </div>
-          <div className="truncate text-[10px] text-gold-soft">
-            {user.role ? titleCase(user.role) : ""}
-          </div>
+          <div className="truncate text-[10px] text-gold-soft">{roleLabel}</div>
         </div>
       </div>
 

--- a/omnischools/components/classes/classes-table.tsx
+++ b/omnischools/components/classes/classes-table.tsx
@@ -28,12 +28,15 @@ type ClassRow = {
 export function ClassesTable({
   rows,
   staff,
+  readOnly = false,
 }: {
   rows: ClassRow[];
   staff: StaffOption[];
+  readOnly?: boolean;
 }) {
   const router = useRouter();
   const ids = rows.map((r) => r.id);
+  const teacherName = new Map(staff.map((s) => [s.id, s.name]));
   const { selected, toggle, setAll, clear, count } = useSelection();
   const allSelected = ids.length > 0 && ids.every((id) => selected.has(id));
   const someSelected = count > 0 && !allSelected;
@@ -94,27 +97,31 @@ export function ClassesTable({
 
   return (
     <>
-      <BulkBar
-        count={count}
-        singular="class"
-        plural="classes"
-        onClear={clear}
-        onDelete={() => {
-          setDelError(null);
-          setBulkOpen(true);
-        }}
-      />
+      {!readOnly && (
+        <BulkBar
+          count={count}
+          singular="class"
+          plural="classes"
+          onClear={clear}
+          onDelete={() => {
+            setDelError(null);
+            setBulkOpen(true);
+          }}
+        />
+      )}
       <div className="overflow-hidden rounded-xl border border-border bg-surface">
         <table className="w-full text-sm">
           <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
             <tr>
-              <th className="w-10 px-4 py-3">
-                <HeaderCheckbox
-                  checked={allSelected}
-                  indeterminate={someSelected}
-                  onChange={() => setAll(ids, !allSelected)}
-                />
-              </th>
+              {!readOnly && (
+                <th className="w-10 px-4 py-3">
+                  <HeaderCheckbox
+                    checked={allSelected}
+                    indeterminate={someSelected}
+                    onChange={() => setAll(ids, !allSelected)}
+                  />
+                </th>
+              )}
               <th className="px-4 py-3 font-semibold">Class</th>
               <th className="px-4 py-3 font-semibold">Level</th>
               <th className="px-4 py-3 font-semibold">Class teacher</th>
@@ -127,13 +134,15 @@ export function ClassesTable({
               const editing = editId === c.id;
               return (
                 <tr key={c.id} className="align-top transition-colors hover:bg-bg">
-                  <td className="px-4 py-3">
-                    <RowCheckbox
-                      checked={selected.has(c.id)}
-                      onChange={() => toggle(c.id)}
-                      label={`Select ${c.name}`}
-                    />
-                  </td>
+                  {!readOnly && (
+                    <td className="px-4 py-3">
+                      <RowCheckbox
+                        checked={selected.has(c.id)}
+                        onChange={() => toggle(c.id)}
+                        label={`Select ${c.name}`}
+                      />
+                    </td>
+                  )}
                   <td className="px-4 py-3 font-medium text-navy">
                     {editing ? (
                       <input
@@ -166,11 +175,17 @@ export function ClassesTable({
                     )}
                   </td>
                   <td className="px-4 py-3">
-                    <ClassTeacherSelect
-                      classId={c.id}
-                      current={c.teacherId}
-                      staff={staff}
-                    />
+                    {readOnly ? (
+                      <span className="text-navy-2">
+                        {c.teacherId ? (teacherName.get(c.teacherId) ?? "—") : "—"}
+                      </span>
+                    ) : (
+                      <ClassTeacherSelect
+                        classId={c.id}
+                        current={c.teacherId}
+                        staff={staff}
+                      />
+                    )}
                   </td>
                   <td className="px-4 py-3 text-navy-2">{c.size}</td>
                   <td className="whitespace-nowrap px-4 py-3 text-right">
@@ -198,27 +213,35 @@ export function ClassesTable({
                       </>
                     ) : (
                       <>
-                        <button
-                          onClick={() => startEdit(c)}
-                          className="mr-3 text-xs font-semibold text-navy-3 transition-colors hover:text-gold"
-                        >
-                          Edit
-                        </button>
+                        {!readOnly && (
+                          <button
+                            onClick={() => startEdit(c)}
+                            className="mr-3 text-xs font-semibold text-navy-3 transition-colors hover:text-gold"
+                          >
+                            Edit
+                          </button>
+                        )}
                         <Link
                           href={`/classes/${c.id}`}
-                          className="mr-3 text-xs font-semibold text-gold hover:underline"
+                          className={
+                            readOnly
+                              ? "text-xs font-semibold text-gold hover:underline"
+                              : "mr-3 text-xs font-semibold text-gold hover:underline"
+                          }
                         >
                           Open
                         </Link>
-                        <button
-                          onClick={() => {
-                            setDelError(null);
-                            setToDelete(c);
-                          }}
-                          className="text-xs font-semibold text-navy-3 transition-colors hover:text-terra"
-                        >
-                          Delete
-                        </button>
+                        {!readOnly && (
+                          <button
+                            onClick={() => {
+                              setDelError(null);
+                              setToDelete(c);
+                            }}
+                            className="text-xs font-semibold text-navy-3 transition-colors hover:text-terra"
+                          >
+                            Delete
+                          </button>
+                        )}
                       </>
                     )}
                   </td>

--- a/omnischools/components/students/students-table.tsx
+++ b/omnischools/components/students/students-table.tsx
@@ -32,7 +32,13 @@ type StudentRow = {
 
 const cap = (s: string) => s.charAt(0) + s.slice(1).toLowerCase();
 
-export function StudentsTable({ rows }: { rows: StudentRow[] }) {
+export function StudentsTable({
+  rows,
+  readOnly = false,
+}: {
+  rows: StudentRow[];
+  readOnly?: boolean;
+}) {
   const router = useRouter();
   const ids = rows.map((r) => r.id);
   const { selected, toggle, setAll, clear, count } = useSelection();
@@ -82,27 +88,31 @@ export function StudentsTable({ rows }: { rows: StudentRow[] }) {
 
   return (
     <>
-      <BulkBar
-        count={count}
-        singular="student"
-        plural="students"
-        onClear={clear}
-        onDelete={() => {
-          setDelError(null);
-          setBulkOpen(true);
-        }}
-      />
+      {!readOnly && (
+        <BulkBar
+          count={count}
+          singular="student"
+          plural="students"
+          onClear={clear}
+          onDelete={() => {
+            setDelError(null);
+            setBulkOpen(true);
+          }}
+        />
+      )}
       <div className="overflow-hidden rounded-xl border border-border bg-surface">
         <table className="w-full text-sm">
           <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
             <tr>
-              <th className="w-10 px-4 py-3">
-                <HeaderCheckbox
-                  checked={allSelected}
-                  indeterminate={someSelected}
-                  onChange={() => setAll(ids, !allSelected)}
-                />
-              </th>
+              {!readOnly && (
+                <th className="w-10 px-4 py-3">
+                  <HeaderCheckbox
+                    checked={allSelected}
+                    indeterminate={someSelected}
+                    onChange={() => setAll(ids, !allSelected)}
+                  />
+                </th>
+              )}
               <th className="px-4 py-3 font-semibold">Code</th>
               <th className="px-4 py-3 font-semibold">Name</th>
               <th className="px-4 py-3 font-semibold">Gender</th>
@@ -114,13 +124,15 @@ export function StudentsTable({ rows }: { rows: StudentRow[] }) {
           <tbody className="divide-y divide-border">
             {rows.map((s) => (
               <tr key={s.id} className="transition-colors hover:bg-bg">
-                <td className="px-4 py-3">
-                  <RowCheckbox
-                    checked={selected.has(s.id)}
-                    onChange={() => toggle(s.id)}
-                    label={`Select ${s.firstName} ${s.lastName}`}
-                  />
-                </td>
+                {!readOnly && (
+                  <td className="px-4 py-3">
+                    <RowCheckbox
+                      checked={selected.has(s.id)}
+                      onChange={() => toggle(s.id)}
+                      label={`Select ${s.firstName} ${s.lastName}`}
+                    />
+                  </td>
+                )}
                 <td className="px-4 py-3 font-mono text-xs text-navy-2">
                   <Link href={`/students/${s.id}`} className="hover:text-gold">
                     {s.studentCode}
@@ -141,15 +153,17 @@ export function StudentsTable({ rows }: { rows: StudentRow[] }) {
                   </span>
                 </td>
                 <td className="whitespace-nowrap px-4 py-3 text-right">
-                  <button
-                    onClick={() => {
-                      setDelError(null);
-                      setToDelete(s);
-                    }}
-                    className="text-xs font-semibold text-navy-3 transition-colors hover:text-terra"
-                  >
-                    Delete
-                  </button>
+                  {!readOnly && (
+                    <button
+                      onClick={() => {
+                        setDelError(null);
+                        setToDelete(s);
+                      }}
+                      className="text-xs font-semibold text-navy-3 transition-colors hover:text-terra"
+                    >
+                      Delete
+                    </button>
+                  )}
                 </td>
               </tr>
             ))}

--- a/omnischools/lib/access.ts
+++ b/omnischools/lib/access.ts
@@ -1,0 +1,48 @@
+/**
+ * Access policy for finance-only staff (Accountant / Bursar).
+ *
+ * When a user's *only* roles are finance roles — no admin, leadership, or teaching role
+ * — they are confined to the billing-related sections of the app. This mirrors
+ * schoolup-accountant-role §02 ("the accountant's view"): a delegated finance person
+ * sees billing, fees, reports and books, plus read-only students & classes (so they can
+ * look up who to invoice), and nothing else.
+ *
+ * Pure module — safe to import from both client (sidebar) and server (guards).
+ */
+
+/** Roles that, on their own, restrict a user to the finance sections. */
+export const FINANCE_ROLES = ["ACCOUNTANT", "BURSAR"];
+
+/** Section prefixes a finance-only user may reach. Order-independent. */
+export const FINANCE_SECTIONS = [
+  "/billing",
+  "/fees",
+  "/reports",
+  "/books",
+  "/students",
+  "/classes",
+];
+
+/** Sections a finance-only user may reach but only *read* (no create/edit/delete). */
+export const FINANCE_READONLY_SECTIONS = ["/students", "/classes"];
+
+/** Where a finance-only user lands — their billing dashboard. */
+export const FINANCE_HOME = "/billing";
+
+/**
+ * True when every role the user holds is a finance role (and they hold at least one).
+ * A user who is also ADMIN / TEACHER / HEADMASTER / etc. is NOT finance-only and keeps
+ * full access.
+ */
+export function isFinanceOnly(roles: readonly string[]): boolean {
+  const r = roles.filter(Boolean);
+  return r.length > 0 && r.every((role) => FINANCE_ROLES.includes(role));
+}
+
+const matches = (pathname: string, prefix: string) =>
+  pathname === prefix || pathname.startsWith(prefix + "/");
+
+/** True when a finance-only user is allowed to load this path. */
+export function pathAllowedForFinance(pathname: string): boolean {
+  return FINANCE_SECTIONS.some((p) => matches(pathname, p));
+}

--- a/omnischools/lib/actions/attendance.ts
+++ b/omnischools/lib/actions/attendance.ts
@@ -3,7 +3,7 @@ import { and, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 import { withSchool } from "@/lib/db/rls";
 import { recordAudit } from "@/lib/db/audit";
-import { requireSchool, resolveActor } from "@/lib/auth/server";
+import { requireSchool, resolveActor, assertWriteAccess } from "@/lib/auth/server";
 import { sendSms } from "@/lib/sms";
 import { safeRevalidate } from "@/lib/revalidate";
 import { ATTENDANCE_REASON_CODES } from "@/lib/attendance-reasons";
@@ -25,6 +25,7 @@ export type CreateClassResult =
 
 export async function createClass(input: unknown): Promise<CreateClassResult> {
   const { school } = await requireSchool();
+  await assertWriteAccess();
   const parsed = z
     .object({
       name: z.string().min(1).max(60),
@@ -65,6 +66,7 @@ export async function setStudentClass(
   input: unknown,
 ): Promise<{ ok: boolean; error?: string }> {
   const { school } = await requireSchool();
+  await assertWriteAccess();
   const parsed = z
     .object({ studentId: z.string().uuid(), classId: z.string().uuid() })
     .safeParse(input);

--- a/omnischools/lib/actions/classes.ts
+++ b/omnischools/lib/actions/classes.ts
@@ -3,7 +3,7 @@ import { and, eq, inArray, ne } from "drizzle-orm";
 import { z } from "zod";
 import { withSchool } from "@/lib/db/rls";
 import { recordAudit } from "@/lib/db/audit";
-import { requireSchool, resolveActor } from "@/lib/auth/server";
+import { requireSchool, resolveActor, assertWriteAccess } from "@/lib/auth/server";
 import { safeRevalidate } from "@/lib/revalidate";
 import type { Tx } from "@/lib/db";
 import { classes, students, subjects, timetableSlots } from "@/db/schema";
@@ -23,6 +23,7 @@ const CreateClassSchema = z.object({
 
 export async function createClass(input: unknown): Promise<Result> {
   const { school } = await requireSchool();
+  await assertWriteAccess();
   const parsed = CreateClassSchema.safeParse(input);
   if (!parsed.success) {
     return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };
@@ -66,6 +67,7 @@ const UpdateClassSchema = z.object({
 
 export async function updateClass(input: unknown): Promise<Result> {
   const { school } = await requireSchool();
+  await assertWriteAccess();
   const parsed = UpdateClassSchema.safeParse(input);
   if (!parsed.success) {
     return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };
@@ -128,6 +130,7 @@ const DeleteClassSchema = z.object({ classId: z.string().uuid() });
 
 export async function deleteClass(input: unknown): Promise<Result> {
   const { school } = await requireSchool();
+  await assertWriteAccess();
   const parsed = DeleteClassSchema.safeParse(input);
   if (!parsed.success) return { ok: false, error: "Invalid input" };
   const actor = await resolveActor(school.id);
@@ -159,6 +162,7 @@ export async function deleteClasses(
   input: unknown,
 ): Promise<Result & { deleted?: number }> {
   const { school } = await requireSchool();
+  await assertWriteAccess();
   const parsed = DeleteClassesSchema.safeParse(input);
   if (!parsed.success) return { ok: false, error: "Select at least one class" };
   const ids = Array.from(new Set(parsed.data.classIds));
@@ -190,6 +194,7 @@ const SetTeacherSchema = z.object({
 
 export async function setClassTeacher(input: unknown): Promise<Result> {
   const { school } = await requireSchool();
+  await assertWriteAccess();
   const parsed = SetTeacherSchema.safeParse(input);
   if (!parsed.success) return { ok: false, error: "Invalid input" };
   const teacher = nz(parsed.data.userId);
@@ -215,6 +220,7 @@ const AssignStudentsSchema = z.object({
 
 export async function assignStudentsToClass(input: unknown): Promise<Result> {
   const { school } = await requireSchool();
+  await assertWriteAccess();
   const parsed = AssignStudentsSchema.safeParse(input);
   if (!parsed.success) return { ok: false, error: "Select at least one student" };
   try {
@@ -245,6 +251,7 @@ const RemoveStudentSchema = z.object({ studentId: z.string().uuid() });
 
 export async function removeStudentFromClass(input: unknown): Promise<Result> {
   const { school } = await requireSchool();
+  await assertWriteAccess();
   const parsed = RemoveStudentSchema.safeParse(input);
   if (!parsed.success) return { ok: false, error: "Invalid input" };
   try {
@@ -270,6 +277,7 @@ const AddSubjectSchema = z.object({
 
 export async function addSubject(input: unknown): Promise<Result> {
   const { school } = await requireSchool();
+  await assertWriteAccess();
   const parsed = AddSubjectSchema.safeParse(input);
   if (!parsed.success) {
     return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };
@@ -295,6 +303,7 @@ const RenameSubjectSchema = z.object({
 
 export async function renameSubject(input: unknown): Promise<Result> {
   const { school } = await requireSchool();
+  await assertWriteAccess();
   const parsed = RenameSubjectSchema.safeParse(input);
   if (!parsed.success) {
     return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };
@@ -317,6 +326,7 @@ const SubjectActiveSchema = z.object({ id: z.string().uuid(), active: z.boolean(
 
 export async function setSubjectActive(input: unknown): Promise<Result> {
   const { school } = await requireSchool();
+  await assertWriteAccess();
   const parsed = SubjectActiveSchema.safeParse(input);
   if (!parsed.success) return { ok: false, error: "Invalid input" };
   try {
@@ -346,6 +356,7 @@ const AddSlotSchema = z.object({
 
 export async function addTimetableSlot(input: unknown): Promise<Result> {
   const { school } = await requireSchool();
+  await assertWriteAccess();
   const parsed = AddSlotSchema.safeParse(input);
   if (!parsed.success) return { ok: false, error: "Invalid input" };
   const d = parsed.data;
@@ -403,6 +414,7 @@ export async function addTimetableSlots(
   input: unknown,
 ): Promise<Result & { created?: number; skipped?: number }> {
   const { school } = await requireSchool();
+  await assertWriteAccess();
   const parsed = AddSlotsSchema.safeParse(input);
   if (!parsed.success) {
     return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };
@@ -494,6 +506,7 @@ const UpdateSlotSchema = z.object({
 
 export async function updateTimetableSlot(input: unknown): Promise<Result> {
   const { school } = await requireSchool();
+  await assertWriteAccess();
   const parsed = UpdateSlotSchema.safeParse(input);
   if (!parsed.success) return { ok: false, error: "Invalid input" };
   const d = parsed.data;
@@ -576,6 +589,7 @@ const RemoveSlotSchema = z.object({ slotId: z.string().uuid() });
 
 export async function removeTimetableSlot(input: unknown): Promise<Result> {
   const { school } = await requireSchool();
+  await assertWriteAccess();
   const parsed = RemoveSlotSchema.safeParse(input);
   if (!parsed.success) return { ok: false, error: "Invalid input" };
   try {

--- a/omnischools/lib/actions/students.ts
+++ b/omnischools/lib/actions/students.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { safeRevalidate } from "@/lib/revalidate";
 import { withSchool } from "@/lib/db/rls";
 import { recordAudit } from "@/lib/db/audit";
-import { requireSchool, resolveActor } from "@/lib/auth/server";
+import { requireSchool, resolveActor, assertWriteAccess } from "@/lib/auth/server";
 import { normalizeGhanaPhone } from "@/lib/auth";
 import { and, count, eq, inArray } from "drizzle-orm";
 import { nextStudentCode } from "@/lib/students-helpers";
@@ -38,6 +38,7 @@ export type CreateStudentResult =
 
 export async function createStudent(input: unknown): Promise<CreateStudentResult> {
   const { school } = await requireSchool();
+  await assertWriteAccess();
   const parsed = CreateStudentSchema.safeParse(input);
   if (!parsed.success) {
     return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid student" };
@@ -121,6 +122,7 @@ const UpdateStudentSchema = z.object({
 
 export async function updateStudent(input: unknown): Promise<CreateStudentResult> {
   const { school } = await requireSchool();
+  await assertWriteAccess();
   const parsed = UpdateStudentSchema.safeParse(input);
   if (!parsed.success) {
     return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid student" };
@@ -233,6 +235,7 @@ export type ImportStudentsResult =
 
 export async function importStudents(input: unknown): Promise<ImportStudentsResult> {
   const { school } = await requireSchool();
+  await assertWriteAccess();
   const parsed = ImportStudentsSchema.safeParse(input);
   if (!parsed.success) {
     return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid import" };
@@ -354,6 +357,7 @@ const DeleteStudentSchema = z.object({ id: z.string().uuid() });
 
 export async function deleteStudent(input: unknown): Promise<DeleteResult> {
   const { school } = await requireSchool();
+  await assertWriteAccess();
   const parsed = DeleteStudentSchema.safeParse(input);
   if (!parsed.success) return { ok: false, error: "Invalid input" };
   const actor = await resolveActor(school.id);
@@ -416,6 +420,7 @@ export type DeleteStudentsResult = {
 
 export async function deleteStudents(input: unknown): Promise<DeleteStudentsResult> {
   const { school } = await requireSchool();
+  await assertWriteAccess();
   const parsed = DeleteStudentsSchema.safeParse(input);
   if (!parsed.success) return { ok: false, error: "Select at least one student" };
   const ids = Array.from(new Set(parsed.data.ids));

--- a/omnischools/lib/auth/server.ts
+++ b/omnischools/lib/auth/server.ts
@@ -1,9 +1,11 @@
 import { redirect } from "next/navigation";
+import { headers } from "next/headers";
 import { eq, and } from "drizzle-orm";
 import { env } from "@/lib/env";
 import { withoutTenantScope } from "@/lib/db/rls";
 import { schools, roleAssignments, roles, users, districts, regions } from "@/db/schema";
 import { getCurrentUser, type AppUser } from "@/lib/auth";
+import { isFinanceOnly, pathAllowedForFinance, FINANCE_HOME } from "@/lib/access";
 
 export interface ActiveSchool {
   id: string;
@@ -82,7 +84,26 @@ export async function requireSchool(): Promise<{ user: AppUser; school: ActiveSc
   const user = await requireUser();
   const school = await getActiveSchool();
   if (!school) redirect("/start");
+  // Finance-only staff (Accountant/Bursar) are confined to the billing sections.
+  // Runs on every app page (and its server actions) via this shared guard; the path
+  // comes from the middleware-stamped `x-pathname` header.
+  if (isFinanceOnly(user.roles)) {
+    const pathname = headers().get("x-pathname") ?? "";
+    if (pathname && !pathAllowedForFinance(pathname)) redirect(FINANCE_HOME);
+  }
   return { user, school };
+}
+
+/**
+ * Throw if the current user is finance-only (Accountant/Bursar). Call at the top of
+ * mutation actions for records a finance role may only *read* (students, classes) so
+ * read-only access holds even against a hand-crafted request.
+ */
+export async function assertWriteAccess(): Promise<void> {
+  const user = await getCurrentUser();
+  if (user && isFinanceOnly(user.roles)) {
+    throw new Error("Forbidden: your role has read-only access to this record.");
+  }
 }
 
 /**

--- a/omnischools/middleware.ts
+++ b/omnischools/middleware.ts
@@ -1,0 +1,18 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+/**
+ * Stamp the request path onto a header so server components / guards can read the
+ * current pathname (Next.js doesn't expose it in `headers()` by default). Used by
+ * `requireSchool()` to enforce finance-only section access. No DB / auth work here —
+ * role resolution stays in the (DB-backed) server guard.
+ */
+export function middleware(req: NextRequest) {
+  const headers = new Headers(req.headers);
+  headers.set("x-pathname", req.nextUrl.pathname);
+  return NextResponse.next({ request: { headers } });
+}
+
+export const config = {
+  // Everything except Next internals and static assets.
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|.*\\.(?:png|jpg|jpeg|svg|ico|webp)$).*)"],
+};


### PR DESCRIPTION
## Accountant billing-only enforcement (PR2 of 2)

Enforces the accountant's restricted access from `schoolup-accountant-role` §02 ("The accountant's view"). Builds on [#104](https://github.com/Omnischools/omnischools/pull/104), which created the role + invite.

**Who's restricted:** a user whose *only* roles are finance roles (`ACCOUNTANT` / `BURSAR`). Anyone who also holds an admin / leadership / teaching role keeps full access. (`lib/access.ts` · `isFinanceOnly`.)

**Allowed sections:** Billing, Fees, Reports, Books + **read-only** Students & Classes (so they can look up who to invoice).

### Defence in depth
| Layer | What |
|---|---|
| **Nav** | `sidebar.tsx` renders a billing-first nav with only the allowed sections for finance-only users; everything else hidden. |
| **Route guard** | New `middleware.ts` stamps `x-pathname`; `requireSchool()` reads it and redirects finance-only users off any disallowed path to `/billing`. Runs on every page + sub-page (hard loads & direct URLs). |
| **Data layer** | `assertWriteAccess()` throws for finance-only; called in **every** student/class/subject/timetable mutation (`students.ts` ×5, `classes.ts` ×14, `attendance.ts` ×2) — read-only holds even against a hand-crafted POST. |
| **UI** | Students & Classes hide their write controls for finance-only (Import / +Add / create form / bulk-select / row edit & delete / class-teacher select); only "Open" read links remain. |

### Verification
- **Live** (via a temporary, reverted `DEV_FORCE_FINANCE` override): sidebar shows only Billing/Fees/Reports/Books/Students/Classes; `/gradebook` → **redirected to `/billing`**; `/students` reachable but **0 checkboxes, no Add/Import/Delete**; `/classes` read-only (no New class / Edit / Delete / teacher-select, "Open" remains).
- **Unit test** of the access policy — 28 cases (role combinations + allowed/blocked paths, incl. the `/studentsX` non-prefix edge).
- `pnpm typecheck` + `pnpm lint` + `pnpm build` clean; `ƒ Middleware` compiled.

### Notes
- `/reports` is allowed wholesale (this build's reports are primarily financial); per-report-category gating is a future refinement if academic reports are added there.
- No schema, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)