### PR TITLE
feat(students): black & gold list redesign — summary cards + filters (students PR1)

### DIFF
--- a/omnischools/app/(app)/students/page.tsx
+++ b/omnischools/app/(app)/students/page.tsx
@@ -4,7 +4,7 @@ import { requireSchool } from "@/lib/auth/server";
 import { isFinanceOnly } from "@/lib/access";
 import { withSchool } from "@/lib/db/rls";
 import { students } from "@/db/schema";
-import { StudentsTable } from "@/components/students/students-table";
+import { StudentsBrowser } from "@/components/students/students-browser";
 import { StudentsEmpty } from "@/components/students/students-empty";
 
 export const dynamic = "force-dynamic";
@@ -24,11 +24,12 @@ export default async function StudentsPage() {
         sex: students.sex,
         currentClassLabel: students.currentClassLabel,
         status: students.status,
+        dateOfBirth: students.dateOfBirth,
       })
       .from(students)
       .where(eq(students.schoolId, school.id))
       .orderBy(desc(students.createdAt))
-      .limit(200),
+      .limit(500),
   );
 
   if (rows.length === 0) {
@@ -39,12 +40,25 @@ export default async function StudentsPage() {
     );
   }
 
+  const classOptions = Array.from(
+    new Set(rows.map((r) => r.currentClassLabel).filter((c): c is string => !!c)),
+  ).sort();
+
   return (
     <div className="mx-auto max-w-page">
-      <div className="mb-6 flex items-center justify-between">
+      <div className="mb-6 flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h1 className="font-display text-3xl font-semibold text-navy">Students</h1>
-          <p className="text-sm text-navy-3">{rows.length} on roll</p>
+          <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gold">
+            Omnischools · Students
+          </div>
+          <h1 className="mt-1 font-display text-3xl font-semibold text-navy">
+            Every learner, <em className="text-gold">in focus</em>
+          </h1>
+          <div className="mb-3 mt-2 h-0.5 w-16 bg-gold" />
+          <p className="max-w-2xl text-sm text-navy-3">
+            The whole roll at a glance — totals, gender balance and age. Filter by class,
+            gender or status, then open any student for their full record.
+          </p>
         </div>
         {!readOnly && (
           <div className="flex items-center gap-2">
@@ -64,7 +78,7 @@ export default async function StudentsPage() {
         )}
       </div>
 
-      <StudentsTable rows={rows} readOnly={readOnly} />
+      <StudentsBrowser rows={rows} classOptions={classOptions} readOnly={readOnly} />
     </div>
   );
 }

--- a/omnischools/components/students/students-browser.tsx
+++ b/omnischools/components/students/students-browser.tsx
@@ -1,0 +1,205 @@
+"use client";
+import { useMemo, useState } from "react";
+import { StudentsTable, type StudentRow } from "./students-table";
+
+const STATUS_OPTIONS = [
+  "ACTIVE",
+  "INACTIVE",
+  "GRADUATED",
+  "WITHDRAWN",
+  "TRANSFERRED",
+] as const;
+
+const cap = (s: string) =>
+  s.charAt(0).toUpperCase() + s.slice(1).toLowerCase().replaceAll("_", " ");
+
+/** Whole-year age from a YYYY-MM-DD date of birth, or null if unparseable. */
+function ageFromDob(dob: string | null | undefined): number | null {
+  if (!dob) return null;
+  const d = new Date(dob);
+  if (Number.isNaN(d.getTime())) return null;
+  const now = new Date();
+  let age = now.getFullYear() - d.getFullYear();
+  const m = now.getMonth() - d.getMonth();
+  if (m < 0 || (m === 0 && now.getDate() < d.getDate())) age--;
+  return age >= 0 && age < 120 ? age : null;
+}
+
+const selectCls =
+  "rounded-lg border border-border-2 bg-surface px-3 py-2 text-sm text-navy outline-none transition-colors focus:border-gold";
+
+/**
+ * Students list shell — black & gold header lives in the page; this owns the summary
+ * cards (total · gender ratio · average age), the search + dropdown filters, and the
+ * filtered table. Filtering recomputes the cards too, so the numbers always reflect the
+ * current view.
+ */
+export function StudentsBrowser({
+  rows,
+  classOptions,
+  readOnly = false,
+}: {
+  rows: StudentRow[];
+  classOptions: string[];
+  readOnly?: boolean;
+}) {
+  const [search, setSearch] = useState("");
+  const [classFilter, setClassFilter] = useState("");
+  const [genderFilter, setGenderFilter] = useState("");
+  const [statusFilter, setStatusFilter] = useState("");
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return rows.filter((r) => {
+      if (classFilter && r.currentClassLabel !== classFilter) return false;
+      if (genderFilter && r.sex !== genderFilter) return false;
+      if (statusFilter && r.status !== statusFilter) return false;
+      if (q) {
+        const hay =
+          `${r.firstName} ${r.lastName} ${r.otherNames ?? ""} ${r.studentCode}`.toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [rows, search, classFilter, genderFilter, statusFilter]);
+
+  const stats = useMemo(() => {
+    const total = filtered.length;
+    const active = filtered.filter((r) => r.status === "ACTIVE").length;
+    const boys = filtered.filter((r) => r.sex === "MALE").length;
+    const girls = filtered.filter((r) => r.sex === "FEMALE").length;
+    const known = boys + girls;
+    const ages = filtered.map((r) => ageFromDob(r.dateOfBirth)).filter((a): a is number => a !== null);
+    const avgAge = ages.length ? ages.reduce((s, a) => s + a, 0) / ages.length : null;
+    return {
+      total,
+      active,
+      boys,
+      girls,
+      boysPct: known ? Math.round((boys / known) * 100) : 0,
+      girlsPct: known ? Math.round((girls / known) * 100) : 0,
+      avgAge,
+      withDob: ages.length,
+    };
+  }, [filtered]);
+
+  const hasFilters = !!(search || classFilter || genderFilter || statusFilter);
+  const clearAll = () => {
+    setSearch("");
+    setClassFilter("");
+    setGenderFilter("");
+    setStatusFilter("");
+  };
+
+  return (
+    <div>
+      {/* Summary cards — recompute with the filters */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <div className="rounded-xl border border-navy bg-navy p-5 text-bg">
+          <div className="text-[9px] font-bold uppercase tracking-[0.12em] text-gold-soft">
+            Total students
+          </div>
+          <div className="mt-1 font-display text-4xl font-semibold">{stats.total}</div>
+          <div className="mt-0.5 text-[11px] text-gold-soft">
+            {stats.active} active
+            {stats.total - stats.active > 0 ? ` · ${stats.total - stats.active} other` : ""}
+          </div>
+        </div>
+        <div className="rounded-xl border border-border bg-surface p-5">
+          <div className="text-[9px] font-bold uppercase tracking-[0.12em] text-navy-3">
+            Gender ratio · boys : girls
+          </div>
+          <div className="mt-1 font-display text-4xl font-semibold text-navy">
+            {stats.boys} <span className="text-navy-3">:</span> {stats.girls}
+          </div>
+          <div className="mt-0.5 text-[11px] text-navy-3">
+            {stats.boysPct}% boys · {stats.girlsPct}% girls
+          </div>
+        </div>
+        <div className="rounded-xl border border-border bg-surface p-5">
+          <div className="text-[9px] font-bold uppercase tracking-[0.12em] text-navy-3">
+            Average age
+          </div>
+          <div className="mt-1 font-display text-4xl font-semibold text-navy">
+            {stats.avgAge === null ? "—" : stats.avgAge.toFixed(1)}
+            {stats.avgAge !== null && (
+              <span className="ml-1 text-lg font-medium text-navy-3">yrs</span>
+            )}
+          </div>
+          <div className="mt-0.5 text-[11px] text-navy-3">
+            {stats.withDob} of {stats.total} with date of birth
+          </div>
+        </div>
+      </div>
+
+      {/* Filter bar */}
+      <div className="mt-5 flex flex-wrap items-center gap-2">
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search by name or code…"
+          className="min-w-[200px] flex-1 rounded-lg border border-border-2 bg-surface px-3 py-2 text-sm text-navy outline-none transition-colors focus:border-gold"
+          aria-label="Search students"
+        />
+        <select
+          value={classFilter}
+          onChange={(e) => setClassFilter(e.target.value)}
+          className={selectCls}
+          aria-label="Filter by class"
+        >
+          <option value="">All classes</option>
+          {classOptions.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+        <select
+          value={genderFilter}
+          onChange={(e) => setGenderFilter(e.target.value)}
+          className={selectCls}
+          aria-label="Filter by gender"
+        >
+          <option value="">All genders</option>
+          <option value="MALE">Boys</option>
+          <option value="FEMALE">Girls</option>
+        </select>
+        <select
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+          className={selectCls}
+          aria-label="Filter by status"
+        >
+          <option value="">All statuses</option>
+          {STATUS_OPTIONS.map((s) => (
+            <option key={s} value={s}>
+              {cap(s)}
+            </option>
+          ))}
+        </select>
+        {hasFilters && (
+          <button
+            type="button"
+            onClick={clearAll}
+            className="rounded-lg px-3 py-2 text-sm font-semibold text-navy-3 transition-colors hover:text-terra"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      <p className="mb-3 mt-3 text-xs text-navy-3">
+        Showing <span className="font-semibold text-navy">{filtered.length}</span> of{" "}
+        {rows.length} students
+      </p>
+
+      {filtered.length === 0 ? (
+        <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
+          No students match these filters.
+        </p>
+      ) : (
+        <StudentsTable rows={filtered} readOnly={readOnly} />
+      )}
+    </div>
+  );
+}

--- a/omnischools/components/students/students-table.tsx
+++ b/omnischools/components/students/students-table.tsx
@@ -19,7 +19,7 @@ const STATUS_STYLES: Record<string, string> = {
   TRANSFERRED: "bg-warn-bg text-warn",
 };
 
-type StudentRow = {
+export type StudentRow = {
   id: string;
   studentCode: string;
   firstName: string;
@@ -28,6 +28,7 @@ type StudentRow = {
   sex: string;
   currentClassLabel: string | null;
   status: string;
+  dateOfBirth?: string | null;
 };
 
 const cap = (s: string) => s.charAt(0) + s.slice(1).toLowerCase();


### PR DESCRIPTION
## Students list redesign (Students PR1 of 3)

First slice of the Students/Staff revisit. Brings the Students list to the **Reports/Attendance design language** (gold eyebrow + Fraunces title + subtext) and adds the at-a-glance summary + filters from the brief.

### What's here
- **Header** — gold eyebrow "Omnischools · Students", Fraunces title "Every learner, *in focus*" (gold accent), gold rule, subtext.
- **Summary cards** — Total students (navy hero, active vs other) · **Gender ratio boys : girls** (+ %) · **Average age** (whole-year from DOB; shows "—" + "N of M with date of birth" when DOBs are missing).
- **Filters** — search by name/code + dropdowns for **class · gender · status**. Filtering recomputes **both the cards and the list**, with a "Showing X of Y" count and a no-match state.

### Notes
- Client-side filtering over the loaded roll (limit raised 200 → 500). `StudentRow` now carries optional `dateOfBirth`.
- Read-only mode (finance-only, from the accountant PR) flows through to the table unchanged.
- Seeded plausible DOBs on the demo students so the average-age card demonstrates (the demo previously had none).

### Verification
- Live: header + three cards render; selecting **Girls** recomputes Total **39** / ratio **0:39** / "Showing 39 of 78"; average age computes **14.6 yrs** once DOBs exist.
- `pnpm typecheck` + `pnpm lint` + `pnpm build` clean; no slash-opacity on tokens.

### Next in this series
PR2 — student profile 360 (attendance · performance · billing · comms · activity); PR3 — `/students/[id]/billing` + payment void/refund (from `schoolup-void-refund`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)