### PR TITLE
feat(billing): student billing page + payment void/refund flow (students PR3)

### DIFF
--- a/omnischools/app/(app)/billing/payments/[paymentId]/page.tsx
+++ b/omnischools/app/(app)/billing/payments/[paymentId]/page.tsx
@@ -1,0 +1,387 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { and, asc, desc, eq } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import {
+  payments,
+  receipts,
+  paymentAllocations,
+  paymentAuditLog,
+  invoices,
+  students,
+  studentGuardians,
+  classes,
+  users,
+} from "@/db/schema";
+import { num } from "@/lib/fees-helpers";
+import { VoidRefundDrawer } from "@/components/billing/void-refund-drawer";
+
+export const dynamic = "force-dynamic";
+
+const ghs = (v: number) =>
+  `GHS ${v.toLocaleString("en-GH", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+const titleize = (s: string) =>
+  s.replaceAll("_", " ").toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase());
+const fmtDateTime = (d: Date | string) =>
+  (d instanceof Date ? d : new Date(d)).toLocaleString("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+export default async function PaymentDetailPage({
+  params,
+}: {
+  params: { paymentId: string };
+}) {
+  const { school } = await requireSchool();
+
+  const data = await withSchool(school.id, async (tx) => {
+    const [payment] = await tx
+      .select({
+        id: payments.id,
+        studentId: payments.studentId,
+        grossAmount: payments.grossAmount,
+        netAmount: payments.netAmount,
+        method: payments.method,
+        methodReference: payments.methodReference,
+        settlementStatus: payments.settlementStatus,
+        paidAt: payments.paidAt,
+        recordedAt: payments.recordedAt,
+        voidedAt: payments.voidedAt,
+        voidReason: payments.voidReason,
+        voidIsRefund: payments.voidIsRefund,
+        studentFirst: students.firstName,
+        studentLast: students.lastName,
+        studentCode: students.studentCode,
+        classLabel: students.currentClassLabel,
+        className: classes.name,
+      })
+      .from(payments)
+      .innerJoin(students, eq(payments.studentId, students.id))
+      .leftJoin(classes, eq(students.classId, classes.id))
+      .where(and(eq(payments.id, params.paymentId), eq(payments.schoolId, school.id)));
+    if (!payment) return null;
+
+    const [guardian] = await tx
+      .select({ name: studentGuardians.name, phone: studentGuardians.phone })
+      .from(studentGuardians)
+      .where(eq(studentGuardians.studentId, payment.studentId))
+      .orderBy(desc(studentGuardians.isPrimary))
+      .limit(1);
+
+    const [receipt] = await tx
+      .select({
+        receiptNumber: receipts.receiptNumber,
+        generatedAt: receipts.generatedAt,
+        voidedAt: receipts.voidedAt,
+      })
+      .from(receipts)
+      .where(eq(receipts.paymentId, payment.id))
+      .limit(1);
+
+    const allocs = await tx
+      .select({
+        id: paymentAllocations.id,
+        allocationType: paymentAllocations.allocationType,
+        amount: paymentAllocations.amount,
+        voidedAt: paymentAllocations.voidedAt,
+        invoiceId: paymentAllocations.invoiceId,
+        invoiceNumber: invoices.invoiceNumber,
+        academicYear: invoices.academicYear,
+      })
+      .from(paymentAllocations)
+      .leftJoin(invoices, eq(paymentAllocations.invoiceId, invoices.id))
+      .where(eq(paymentAllocations.paymentId, payment.id))
+      .orderBy(asc(paymentAllocations.allocatedAt));
+
+    const audit = await tx
+      .select({
+        id: paymentAuditLog.id,
+        eventType: paymentAuditLog.eventType,
+        actorType: paymentAuditLog.actorType,
+        afterState: paymentAuditLog.afterState,
+        notes: paymentAuditLog.notes,
+        createdAt: paymentAuditLog.createdAt,
+        actorName: users.fullName,
+      })
+      .from(paymentAuditLog)
+      .leftJoin(users, eq(paymentAuditLog.actorUserId, users.id))
+      .where(eq(paymentAuditLog.paymentId, payment.id))
+      .orderBy(desc(paymentAuditLog.createdAt));
+
+    return { payment, guardian, receipt, allocs, audit };
+  });
+
+  if (!data) notFound();
+  const { payment, guardian, receipt, allocs, audit } = data;
+
+  const payer = guardian?.name ?? "—";
+  const studentName = `${payment.studentFirst} ${payment.studentLast}`;
+  const classLabel = payment.className ?? payment.classLabel ?? "—";
+  const gross = num(payment.grossAmount);
+  const isRefund = !!payment.voidedAt && payment.voidIsRefund;
+  const isVoid = !!payment.voidedAt && !payment.voidIsRefund;
+
+  // Money is "applied to" only via live (non-voided) invoice allocations.
+  const invoiceAllocs = allocs.filter(
+    (a) => a.allocationType === "INVOICE" && !a.voidedAt && a.invoiceId,
+  );
+
+  const status = isRefund
+    ? { label: "Refunded", cls: "bg-gold-bg text-navy" }
+    : isVoid
+      ? { label: "Voided", cls: "bg-terra-bg text-terra" }
+      : { label: "Confirmed", cls: "bg-green-bg text-green" };
+
+  return (
+    <div className="mx-auto max-w-page">
+      {/* Crumb */}
+      <div className="text-xs text-navy-3">
+        <Link href="/billing" className="text-gold hover:underline">
+          Billing
+        </Link>{" "}
+        / Payments / <span className="font-mono">{payment.id.slice(0, 8)}</span>
+      </div>
+
+      {/* Header */}
+      <div className="mb-8 mt-2 flex flex-wrap items-start justify-between gap-4">
+        <h1 className="font-display text-3xl font-semibold text-navy">
+          Payment from <em className="not-italic text-gold">{payer}</em>
+        </h1>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            disabled
+            title="Coming soon"
+            className="cursor-not-allowed rounded-md border border-border-2 px-3.5 py-2 text-sm font-semibold text-navy-3 opacity-60"
+          >
+            Download receipt PDF
+          </button>
+          {payment.voidedAt ? (
+            <span
+              className={`rounded-md px-3.5 py-2 text-sm font-semibold ${
+                isRefund ? "bg-gold-bg text-navy" : "bg-terra-bg text-terra"
+              }`}
+            >
+              {isRefund ? "Refunded" : "Voided"}
+              {payment.voidReason ? ` · ${payment.voidReason}` : ""}
+            </span>
+          ) : (
+            <VoidRefundDrawer
+              paymentId={payment.id}
+              amount={gross}
+              payer={payer}
+              studentName={studentName}
+              receiptNumber={receipt?.receiptNumber ?? "—"}
+            />
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
+        {/* Left column */}
+        <div className="space-y-6">
+          {/* Payment record */}
+          <section className="rounded-xl border border-border bg-surface p-6">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <div className="text-[11px] font-bold uppercase tracking-[0.1em] text-navy-3">
+                  Payment record
+                </div>
+                <div
+                  className={`mt-1 font-display text-4xl font-semibold ${
+                    payment.voidedAt ? "text-navy-3" : "text-green"
+                  }`}
+                >
+                  {ghs(gross)}
+                </div>
+              </div>
+              <span
+                className={`rounded-pill px-2.5 py-1 text-xs font-semibold ${status.cls}`}
+              >
+                {status.label}
+              </span>
+            </div>
+
+            <dl className="mt-5 grid grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-2">
+              <Field label="Amount" value={ghs(gross)} />
+              <Field
+                label="Date paid"
+                value={payment.paidAt ? fmtDateTime(payment.paidAt) : "—"}
+              />
+              <Field
+                label="Method"
+                value={titleize(payment.method)}
+                sub={payment.methodReference ?? undefined}
+              />
+              <Field
+                label="Transaction ID"
+                value={payment.methodReference ?? "—"}
+                mono
+              />
+              <Field label="Received from" value={payer} />
+              <Field
+                label="For"
+                value={studentName}
+                sub={`${classLabel} · ${payment.studentCode}`}
+              />
+            </dl>
+
+            {/* Applied to */}
+            <div className="mt-6 border-t border-border pt-5">
+              <div className="mb-2 text-[11px] font-bold uppercase tracking-[0.1em] text-navy-3">
+                Applied to
+              </div>
+              {invoiceAllocs.length === 0 ? (
+                <p className="text-sm text-navy-3">
+                  Not applied to any invoice — held as credit.
+                </p>
+              ) : (
+                <ul className="space-y-2">
+                  {invoiceAllocs.map((a) => (
+                    <li
+                      key={a.id}
+                      className="flex items-center justify-between gap-4 rounded-lg border border-border bg-bg px-4 py-3"
+                    >
+                      <div className="min-w-0">
+                        <span className="font-mono text-sm font-semibold text-gold">
+                          {a.invoiceNumber}
+                        </span>
+                        <span className="ml-2 text-xs text-navy-3">
+                          {a.academicYear ?? ""}
+                        </span>
+                      </div>
+                      <span className="shrink-0 font-medium text-navy">
+                        {ghs(num(a.amount))}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </section>
+
+          {/* Receipt issued */}
+          <section className="rounded-xl border border-border bg-surface p-6">
+            <div className="text-[11px] font-bold uppercase tracking-[0.1em] text-navy-3">
+              Receipt issued
+            </div>
+            {receipt ? (
+              <>
+                <div className="mt-1 flex flex-wrap items-center justify-between gap-3">
+                  <span className="font-mono text-lg font-semibold text-gold">
+                    {receipt.receiptNumber}
+                  </span>
+                  <div className="flex flex-wrap gap-2">
+                    {["View", "Download", "Email"].map((l) => (
+                      <button
+                        key={l}
+                        type="button"
+                        disabled
+                        title="Coming soon"
+                        className="cursor-not-allowed rounded-md border border-border-2 px-2.5 py-1 text-xs font-semibold text-navy-3 opacity-60"
+                      >
+                        {l}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <p className="mt-3 text-xs text-navy-3">
+                  {receipt.voidedAt ? (
+                    <span className="text-terra line-through">
+                      Generated {fmtDateTime(receipt.generatedAt)}
+                    </span>
+                  ) : (
+                    <>Generated {fmtDateTime(receipt.generatedAt)}</>
+                  )}
+                  {receipt.voidedAt && (
+                    <span className="ml-2 font-semibold text-terra no-underline">
+                      · voided
+                    </span>
+                  )}
+                </p>
+              </>
+            ) : (
+              <p className="mt-1 text-sm text-navy-3">No receipt on record.</p>
+            )}
+          </section>
+        </div>
+
+        {/* Right column — Audit trail */}
+        <aside>
+          <section className="rounded-xl border border-border bg-surface p-6">
+            <div className="mb-4 text-[11px] font-bold uppercase tracking-[0.1em] text-navy-3">
+              Audit trail
+            </div>
+            {audit.length === 0 ? (
+              <p className="text-sm text-navy-3">No recorded events for this payment.</p>
+            ) : (
+              <ol className="space-y-4">
+                {audit.map((e) => {
+                  const after = (e.afterState ?? {}) as { isRefund?: boolean };
+                  const dot =
+                    e.eventType === "VOIDED" && after.isRefund === true
+                      ? "bg-gold"
+                      : e.eventType === "VOIDED" || e.eventType === "ALLOCATION_VOIDED"
+                        ? "bg-terra"
+                        : e.eventType === "REFUNDED"
+                          ? "bg-gold"
+                          : "bg-green";
+                  return (
+                    <li key={e.id} className="flex gap-3">
+                      <span
+                        className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${dot}`}
+                        aria-hidden
+                      />
+                      <div className="min-w-0">
+                        <div className="text-sm text-navy">
+                          <b className="font-semibold">{titleize(e.eventType)}</b>
+                          {e.notes ? (
+                            <span className="text-navy-2"> — {e.notes}</span>
+                          ) : null}
+                        </div>
+                        <div className="text-[11px] text-navy-3">
+                          {fmtDateTime(e.createdAt)} ·{" "}
+                          {e.actorName ?? titleize(e.actorType)}
+                        </div>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ol>
+            )}
+          </section>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  value,
+  sub,
+  mono,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  mono?: boolean;
+}) {
+  return (
+    <div>
+      <dt className="text-[11px] font-bold uppercase tracking-[0.1em] text-navy-3">
+        {label}
+      </dt>
+      <dd className={`mt-0.5 text-sm text-navy ${mono ? "font-mono" : ""}`}>{value}</dd>
+      {sub && <dd className="text-xs text-navy-3">{sub}</dd>}
+    </div>
+  );
+}

--- a/omnischools/app/(app)/students/[id]/billing/page.tsx
+++ b/omnischools/app/(app)/students/[id]/billing/page.tsx
@@ -1,0 +1,316 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { and, desc, eq } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import { students, invoices, payments, receipts, discounts } from "@/db/schema";
+import { num, daysOverdue } from "@/lib/fees-helpers";
+import { IssueInvoiceForm } from "@/components/fees/issue-invoice-form";
+import { RecordPaymentForm } from "@/components/fees/record-payment-form";
+import { EmptyState } from "@/components/ui/empty-state";
+
+export const dynamic = "force-dynamic";
+
+const ghs = (v: number) =>
+  `GHS ${v.toLocaleString("en-GH", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+const titleize = (s: string) =>
+  s.replaceAll("_", " ").toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase());
+const fmtDate = (d: Date | string) =>
+  (d instanceof Date ? d : new Date(d)).toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+
+const INV_STATUS: Record<string, string> = {
+  ISSUED: "bg-warn-bg text-warn",
+  PARTIAL: "bg-gold-bg text-navy",
+  PAID: "bg-green-bg text-green",
+  OVERDUE: "bg-terra-bg text-terra",
+  VOIDED: "bg-bg text-navy-3",
+  DRAFT: "bg-bg text-navy-3",
+  EXEMPT: "bg-bg text-navy-3",
+};
+
+export default async function StudentBillingPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const { school } = await requireSchool();
+
+  const data = await withSchool(school.id, async (tx) => {
+    const [student] = await tx
+      .select()
+      .from(students)
+      .where(and(eq(students.id, params.id), eq(students.schoolId, school.id)));
+    if (!student) return null;
+
+    const invs = await tx
+      .select()
+      .from(invoices)
+      .where(eq(invoices.studentId, student.id))
+      .orderBy(desc(invoices.issuedAt));
+
+    const pays = await tx
+      .select({
+        id: payments.id,
+        grossAmount: payments.grossAmount,
+        method: payments.method,
+        settlementStatus: payments.settlementStatus,
+        recordedAt: payments.recordedAt,
+        voidedAt: payments.voidedAt,
+        voidIsRefund: payments.voidIsRefund,
+        receiptNumber: receipts.receiptNumber,
+      })
+      .from(payments)
+      .leftJoin(receipts, eq(receipts.paymentId, payments.id))
+      .where(eq(payments.studentId, student.id))
+      .orderBy(desc(payments.recordedAt));
+
+    const schemes = await tx
+      .select({
+        id: discounts.id,
+        name: discounts.name,
+        kind: discounts.kind,
+        value: discounts.value,
+        isTiered: discounts.isTiered,
+      })
+      .from(discounts)
+      .where(and(eq(discounts.schoolId, school.id), eq(discounts.active, true)))
+      .orderBy(discounts.name);
+
+    return { student, invs, pays, schemes };
+  });
+
+  if (!data) notFound();
+  const { student, invs, pays, schemes } = data;
+  const studentName = `${student.firstName} ${student.lastName}`;
+
+  const live = invs.filter((i) => i.status !== "VOIDED");
+  const totalBilled = live.reduce((s, i) => s + num(i.billedAmount), 0);
+  const totalPaid = live.reduce((s, i) => s + num(i.paidAmount), 0);
+  const balance = live.reduce((s, i) => s + num(i.balanceAmount), 0);
+
+  // Outstanding invoices, oldest first (invs come newest-first), for allocation.
+  const outstanding = invs
+    .filter(
+      (i) => i.status !== "VOIDED" && i.status !== "PAID" && num(i.balanceAmount) > 0,
+    )
+    .slice()
+    .reverse()
+    .map((i) => ({
+      id: i.id,
+      invoiceNumber: i.invoiceNumber,
+      balance: num(i.balanceAmount),
+    }));
+
+  return (
+    <div className="mx-auto max-w-page">
+      {/* Crumb */}
+      <div className="text-xs text-navy-3">
+        <Link href="/students" className="text-gold hover:underline">
+          Students
+        </Link>{" "}
+        /{" "}
+        <Link href={`/students/${student.id}`} className="text-gold hover:underline">
+          {studentName}
+        </Link>{" "}
+        / Billing
+      </div>
+
+      {/* Header */}
+      <div className="mb-8 mt-2">
+        <div className="text-[11px] font-bold uppercase tracking-[0.1em] text-gold">
+          Billing · {studentName}
+        </div>
+        <h1 className="mt-1 font-display text-3xl font-semibold text-navy">
+          {student.firstName} <em className="not-italic text-gold">{student.lastName}</em>
+        </h1>
+        <p className="font-mono text-xs text-navy-3">{student.studentCode}</p>
+      </div>
+
+      {/* Summary cards */}
+      <div className="mb-8 grid grid-cols-1 gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-3">
+        <Summary label="Total billed" value={ghs(totalBilled)} tone="text-navy" />
+        <Summary label="Total paid" value={ghs(totalPaid)} tone="text-green" />
+        <Summary
+          label="Outstanding balance"
+          value={ghs(balance)}
+          tone={balance > 0 ? "text-terra" : "text-green"}
+        />
+      </div>
+
+      {/* Write actions — billing is the accountant's job, so both forms show. */}
+      <div className="mb-8 flex flex-wrap items-start gap-3">
+        <RecordPaymentForm studentId={student.id} outstanding={outstanding} />
+        <IssueInvoiceForm
+          studentId={student.id}
+          schemes={schemes.map((s) => ({
+            id: s.id,
+            name: s.name,
+            kind: s.kind,
+            value: num(s.value),
+            isTiered: s.isTiered,
+          }))}
+        />
+      </div>
+
+      {/* Invoices */}
+      <h2 className="mb-3 font-display text-xl font-semibold text-navy">Invoices</h2>
+      {invs.length === 0 ? (
+        <EmptyState tone="muted" className="mb-8">
+          No invoices yet.
+        </EmptyState>
+      ) : (
+        <div className="mb-8 overflow-hidden rounded-xl border border-border bg-surface">
+          <table className="w-full text-sm">
+            <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
+              <tr>
+                <th className="px-4 py-3 font-semibold">Invoice</th>
+                <th className="px-4 py-3 text-right font-semibold">Billed</th>
+                <th className="px-4 py-3 text-right font-semibold">Paid</th>
+                <th className="px-4 py-3 text-right font-semibold">Balance</th>
+                <th className="px-4 py-3 font-semibold">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {invs.map((i) => {
+                const overdue =
+                  i.status !== "VOIDED" &&
+                  i.status !== "PAID" &&
+                  num(i.balanceAmount) > 0
+                    ? daysOverdue(i.dueAt)
+                    : 0;
+                return (
+                  <tr key={i.id}>
+                    <td className="px-4 py-3 font-mono text-xs text-navy-2">
+                      {i.invoiceNumber}
+                    </td>
+                    <td className="px-4 py-3 text-right text-navy">
+                      {ghs(num(i.billedAmount))}
+                    </td>
+                    <td className="px-4 py-3 text-right text-navy-2">
+                      {ghs(num(i.paidAmount))}
+                    </td>
+                    <td className="px-4 py-3 text-right font-medium text-navy">
+                      {ghs(num(i.balanceAmount))}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex flex-wrap items-center gap-1.5">
+                        <span
+                          className={`rounded-pill px-2 py-0.5 text-xs font-medium ${INV_STATUS[i.status]}`}
+                        >
+                          {i.status.charAt(0) + i.status.slice(1).toLowerCase()}
+                        </span>
+                        {overdue > 0 && (
+                          <span className="rounded-pill bg-terra-bg px-2 py-0.5 text-xs font-medium text-terra">
+                            Overdue {overdue}d
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Payments */}
+      <h2 className="mb-3 font-display text-xl font-semibold text-navy">Payments</h2>
+      {pays.length === 0 ? (
+        <EmptyState tone="muted">No payments yet.</EmptyState>
+      ) : (
+        <div className="overflow-hidden rounded-xl border border-border bg-surface">
+          <table className="w-full text-sm">
+            <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
+              <tr>
+                <th className="px-4 py-3 font-semibold">Receipt</th>
+                <th className="px-4 py-3 font-semibold">Method</th>
+                <th className="px-4 py-3 text-right font-semibold">Amount</th>
+                <th className="px-4 py-3 font-semibold">Date</th>
+                <th className="px-4 py-3 font-semibold">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {pays.map((p) => (
+                <tr
+                  key={p.id}
+                  className={`transition-colors hover:bg-bg ${p.voidedAt ? "opacity-50" : ""}`}
+                >
+                  <td className="px-4 py-3 font-mono text-xs text-navy-2">
+                    <Link
+                      href={`/billing/payments/${p.id}`}
+                      className="hover:text-gold hover:underline"
+                    >
+                      {p.receiptNumber ?? p.id.slice(0, 8)}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-navy-2">
+                    <Link href={`/billing/payments/${p.id}`} className="block">
+                      {titleize(p.method)}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-right font-medium text-navy">
+                    <Link href={`/billing/payments/${p.id}`} className="block">
+                      {ghs(num(p.grossAmount))}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-navy-3">
+                    <Link href={`/billing/payments/${p.id}`} className="block">
+                      {fmtDate(p.recordedAt)}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3">
+                    <Link href={`/billing/payments/${p.id}`} className="block">
+                      {p.voidedAt ? (
+                        <span
+                          className={`rounded-pill px-2 py-0.5 text-xs font-medium ${
+                            p.voidIsRefund
+                              ? "bg-gold-bg text-navy"
+                              : "bg-terra-bg text-terra"
+                          }`}
+                        >
+                          {p.voidIsRefund ? "Refunded" : "Voided"}
+                        </span>
+                      ) : (
+                        <span className="text-navy-2">
+                          {p.settlementStatus.charAt(0) +
+                            p.settlementStatus.slice(1).toLowerCase()}
+                        </span>
+                      )}
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Summary({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: string;
+  tone: string;
+}) {
+  return (
+    <div className="bg-surface p-5">
+      <div className="text-[9px] font-bold uppercase tracking-[0.1em] text-navy-3">
+        {label}
+      </div>
+      <div className={`mt-1 font-display text-2xl font-semibold ${tone}`}>{value}</div>
+    </div>
+  );
+}

--- a/omnischools/app/(app)/students/[id]/page.tsx
+++ b/omnischools/app/(app)/students/[id]/page.tsx
@@ -304,7 +304,7 @@ export default async function StudentDetailPage({ params }: { params: { id: stri
             Edit profile
           </Link>
           <Link
-            href={`/fees/${student.id}`}
+            href={`/students/${student.id}/billing`}
             className="rounded-md border border-border-2 px-3.5 py-2 text-sm font-semibold text-navy-2 transition-colors hover:bg-bg"
           >
             Billing

--- a/omnischools/components/billing/void-refund-drawer.tsx
+++ b/omnischools/components/billing/void-refund-drawer.tsx
@@ -1,0 +1,340 @@
+"use client";
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { voidPayment } from "@/lib/actions/fees";
+
+/**
+ * The void-or-refund decision drawer (schoolup-void-refund Screen 02).
+ *
+ * Two paths share one irreversible action:
+ *  • VOID (terra) — the record was wrong (wrong amount/student/duplicate). The
+ *    receipt is voided. No money moved.
+ *  • REFUND (gold) — the money is being returned. The original receipt stays
+ *    valid; the invoice balance is restored.
+ *
+ * `voidPayment` takes only a reason, so for a refund the "how was it issued"
+ * method text is appended to the reason (`"{reason} · via {method}"`). Partial
+ * refunds aren't supported — a refund always returns the full payment amount.
+ */
+
+const ghs = (n: number) =>
+  `GHS ${n.toLocaleString("en-GH", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+
+const PRESETS = [
+  "Parent disputed charge",
+  "Student withdrew",
+  "Overpayment",
+  "School policy adjustment",
+];
+
+type Decision = "void" | "refund" | null;
+
+export function VoidRefundDrawer({
+  paymentId,
+  amount,
+  payer,
+  studentName,
+  receiptNumber,
+}: {
+  paymentId: string;
+  amount: number;
+  payer: string;
+  studentName: string;
+  receiptNumber: string;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [open, setOpen] = useState(false);
+  const [decision, setDecision] = useState<Decision>(null);
+  const [reason, setReason] = useState("");
+  const [method, setMethod] = useState("");
+  const [confirm, setConfirm] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isRefund = decision === "refund";
+
+  function reset() {
+    setDecision(null);
+    setReason("");
+    setMethod("");
+    setConfirm(false);
+    setError(null);
+  }
+
+  function close() {
+    if (pending) return;
+    setOpen(false);
+    reset();
+  }
+
+  const ready = decision !== null && reason.trim().length >= 3 && confirm;
+
+  function submit() {
+    if (!ready || decision === null) return;
+    setError(null);
+    const composed =
+      isRefund && method.trim()
+        ? `${reason.trim()} · via ${method.trim()}`
+        : reason.trim();
+    startTransition(async () => {
+      const res = await voidPayment({ paymentId, reason: composed, isRefund });
+      if (res.ok) {
+        setOpen(false);
+        reset();
+        router.refresh();
+      } else {
+        setError(res.error ?? "Could not complete the request.");
+      }
+    });
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          reset();
+          setOpen(true);
+        }}
+        className="rounded-md border border-terra px-3.5 py-2 text-sm font-semibold text-terra transition-colors hover:bg-terra-bg"
+      >
+        Void or refund…
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Void or refund payment"
+          className="fixed inset-0 z-50 flex justify-end"
+        >
+          <div
+            onClick={close}
+            style={{ backgroundColor: "rgba(26, 43, 71, 0.5)" }}
+            className="absolute inset-0 backdrop-blur-sm duration-150 animate-in fade-in"
+          />
+          <div className="relative z-10 flex h-full w-full max-w-md flex-col overflow-y-auto border-l border-border bg-surface shadow-xl duration-200 animate-in slide-in-from-right">
+            <div className="flex items-start justify-between gap-4 border-b border-border px-6 py-5">
+              <div>
+                <div className="text-[11px] font-bold uppercase tracking-[0.1em] text-gold">
+                  Decision
+                </div>
+                <h2 className="font-display text-lg font-semibold text-navy">
+                  Void or refund
+                </h2>
+              </div>
+              <button
+                onClick={close}
+                aria-label="Close"
+                className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-navy-3 transition-colors hover:bg-bg hover:text-navy"
+              >
+                ✕
+              </button>
+            </div>
+
+            <div className="flex-1 space-y-5 px-6 py-5">
+              {/* Payment context */}
+              <div className="rounded-lg border border-border bg-bg p-4">
+                <div className="font-display text-2xl font-semibold text-green">
+                  {ghs(amount)}
+                </div>
+                <dl className="mt-2 space-y-1 text-xs text-navy-3">
+                  <div className="flex gap-2">
+                    <dt className="w-16 shrink-0">From</dt>
+                    <dd className="font-medium text-navy-2">{payer}</dd>
+                  </div>
+                  <div className="flex gap-2">
+                    <dt className="w-16 shrink-0">For</dt>
+                    <dd className="font-medium text-navy-2">{studentName}</dd>
+                  </div>
+                  <div className="flex gap-2">
+                    <dt className="w-16 shrink-0">Receipt</dt>
+                    <dd className="font-mono text-navy-2">{receiptNumber}</dd>
+                  </div>
+                </dl>
+              </div>
+
+              {/* Decision tiles */}
+              <fieldset>
+                <legend className="mb-2 text-xs font-semibold uppercase tracking-wide text-navy-3">
+                  What are you doing?
+                </legend>
+                <div className="space-y-3">
+                  <DecisionTile
+                    label="Void"
+                    tone="terra"
+                    selected={decision === "void"}
+                    onSelect={() => setDecision("void")}
+                    description="This payment record is wrong — wrong amount, wrong student, or a duplicate. The receipt is voided."
+                  />
+                  <DecisionTile
+                    label="Refund"
+                    tone="gold"
+                    selected={decision === "refund"}
+                    onSelect={() => setDecision("refund")}
+                    description="The school is returning this money. The original receipt stays valid and the invoice balance is restored."
+                  />
+                </div>
+              </fieldset>
+
+              {/* Reason */}
+              <div>
+                <label className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-navy-3">
+                  Reason <span className="text-terra">·</span> audited
+                </label>
+                <textarea
+                  value={reason}
+                  onChange={(e) => setReason(e.target.value)}
+                  rows={3}
+                  maxLength={300}
+                  placeholder="Why is this being voided or refunded?"
+                  className="w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-navy outline-none focus:border-gold"
+                />
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  {PRESETS.map((p) => (
+                    <button
+                      key={p}
+                      type="button"
+                      onClick={() => setReason(p)}
+                      className="rounded-pill border border-border-2 px-2.5 py-1 text-[11px] font-medium text-navy-2 transition-colors hover:border-gold hover:text-navy"
+                    >
+                      {p}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Refund-only: amount + method */}
+              {isRefund && (
+                <div className="space-y-3 rounded-lg border border-gold-soft bg-gold-bg p-4">
+                  <div>
+                    <div className="text-[11px] font-bold uppercase tracking-wide text-navy-3">
+                      Refund amount
+                    </div>
+                    <div className="font-display text-lg font-semibold text-navy">
+                      {ghs(amount)}
+                    </div>
+                    <p className="mt-0.5 text-[11px] text-navy-3">
+                      Full refund; partial refunds aren&apos;t supported yet.
+                    </p>
+                  </div>
+                  <div>
+                    <label className="mb-1.5 block text-[11px] font-bold uppercase tracking-wide text-navy-3">
+                      Method
+                    </label>
+                    <input
+                      value={method}
+                      onChange={(e) => setMethod(e.target.value)}
+                      placeholder="How was the refund issued? e.g. MTN MoMo reversal · ref"
+                      className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-navy outline-none focus:border-gold"
+                    />
+                  </div>
+                </div>
+              )}
+
+              {/* Consequences */}
+              {decision && (
+                <div className="rounded-r-lg border-l-2 border-terra bg-terra-bg px-4 py-3">
+                  <div className="mb-1 text-[11px] font-bold uppercase tracking-wide text-terra">
+                    On confirm
+                  </div>
+                  <ul className="space-y-1 text-xs text-navy-2">
+                    <li>The invoice balance for this payment is restored.</li>
+                    <li>
+                      {isRefund
+                        ? "The original receipt stays valid (the money was returned)."
+                        : "The receipt is voided (the record was wrong)."}
+                    </li>
+                    <li>A permanent entry is written to the audit trail.</li>
+                  </ul>
+                </div>
+              )}
+
+              {/* Confirm checkbox */}
+              <label className="flex items-start gap-2.5 text-sm">
+                <input
+                  type="checkbox"
+                  checked={confirm}
+                  onChange={(e) => setConfirm(e.target.checked)}
+                  className="mt-0.5 h-4 w-4 rounded border-border accent-terra"
+                />
+                <span className="text-navy-2">
+                  I understand this cannot be undone from this screen.
+                </span>
+              </label>
+
+              {error && (
+                <p className="rounded-md bg-terra-bg px-3 py-2 text-sm text-terra">
+                  {error}
+                </p>
+              )}
+            </div>
+
+            {/* Footer */}
+            <div className="flex items-center justify-end gap-3 border-t border-border px-6 py-4">
+              <button
+                type="button"
+                onClick={close}
+                disabled={pending}
+                className="text-sm font-semibold text-navy-2 transition-colors hover:text-navy disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={submit}
+                disabled={!ready || pending}
+                className="text-bg rounded-md bg-terra px-4 py-2 text-sm font-semibold transition-opacity hover:opacity-90 disabled:opacity-50"
+              >
+                {pending
+                  ? "Working…"
+                  : `Confirm ${decision ?? "void"} of ${ghs(amount)} →`}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+function DecisionTile({
+  label,
+  tone,
+  description,
+  selected,
+  onSelect,
+}: {
+  label: string;
+  tone: "terra" | "gold";
+  description: string;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const ring =
+    selected && tone === "terra"
+      ? "border-terra bg-terra-bg"
+      : selected && tone === "gold"
+        ? "border-gold bg-gold-bg"
+        : "border-border-2 bg-surface hover:border-border";
+  const dot = tone === "terra" ? "text-terra" : "text-gold";
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={selected}
+      className={`block w-full rounded-lg border p-4 text-left transition-colors ${ring}`}
+    >
+      <div className="flex items-center gap-2">
+        <span className={`text-sm ${dot}`} aria-hidden>
+          ●
+        </span>
+        <span className="font-display text-base font-semibold text-navy">{label}</span>
+      </div>
+      <p className="mt-1 text-xs leading-relaxed text-navy-2">{description}</p>
+    </button>
+  );
+}

--- a/omnischools/lib/actions/fees.ts
+++ b/omnischools/lib/actions/fees.ts
@@ -464,10 +464,15 @@ export async function voidPayment(input: unknown): Promise<VoidPaymentResult> {
           voidIsRefund: d.isRefund,
         })
         .where(eq(payments.id, payment.id));
-      await tx
-        .update(receipts)
-        .set({ voidedAt: new Date() })
-        .where(eq(receipts.paymentId, payment.id));
+      // A void means the record was wrong → strike the receipt. A refund means the
+      // payment was correct but the money is being returned → the original receipt
+      // stays valid (a refund is recorded as a separate overlay). See schoolup-void-refund.
+      if (!d.isRefund) {
+        await tx
+          .update(receipts)
+          .set({ voidedAt: new Date() })
+          .where(eq(receipts.paymentId, payment.id));
+      }
 
       await tx.insert(paymentAuditLog).values({
         schoolId: school.id,
@@ -485,6 +490,8 @@ export async function voidPayment(input: unknown): Promise<VoidPaymentResult> {
     if (!out.ok) return out;
     safeRevalidate("/fees");
     safeRevalidate(`/fees/${out.studentId}`);
+    safeRevalidate(`/students/${out.studentId}/billing`);
+    safeRevalidate(`/billing/payments/${d.paymentId}`);
     return { ok: true };
   } catch {
     return { ok: false, error: "Could not void the payment. Please try again." };


### PR DESCRIPTION
## Student billing + payment void/refund (Students PR3 of 3)

Replicates `schoolup-void-refund` and gives the 360 profile's **Billing** card a real destination. Completes the Students series.

### Screens
- **`/students/[id]/billing`** — student billing detail (black & gold): Total billed / paid / **Outstanding** summary cards, the invoices table, and a payments table whose rows deep-link to the payment record. Record-payment / Issue-invoice kept.
- **`/billing/payments/[paymentId]`** — payment detail + audit history (**surface Screen 01**): payment record (amount · date · method · txn · received-from · for), "Applied to" allocations, the receipt card, and the `payment_audit_log` timeline. **"Void or refund…"** button (hidden once voided, replaced by a status note).
- **Void/refund drawer** (**surface Screen 02**): **Void** (terra — "the record was wrong") vs **Refund** (gold — "the money is being returned"), a required audited reason with preset chips, a refund Method field, a consequences strip, and a "cannot be undone" confirm gate. The amount-anchored terra button calls the existing `voidPayment` action.

### Money-logic note
- `voidPayment` refined so a **refund keeps the original receipt valid** (only a **void** strikes the receipt) — matching the surface's append-only correction model. Allocation reversal / balance restore unchanged.
- **Partial refunds aren't supported yet** — a refund returns the full payment amount (noted in the UI).
- Profile's Billing button repointed to `/students/[id]/billing`.

### Verification (money-sensitive — verified end-to-end)
- Live: billing page + payment detail render with real data; drawer opens (scrim token-safe via inline rgba), assembles **"Confirm refund of GHS 5,400.00 →"** with the validation gate.
- **Real refund round-trip executed + DB-confirmed**: payment marked refunded (`voidIsRefund=true`), **receipt RCT-1001 left VALID**, audit row written — then reverted to keep demo data clean.
- `pnpm typecheck` + `pnpm lint` + `pnpm build` clean; no slash-opacity on tokens.

> ⚠️ Touches the void/refund money action (the receipt-validity refinement). Worth a look before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)