### PR TITLE
feat(staff): black & gold list redesign — summary cards + filters (staff PR2)

### DIFF
--- a/omnischools/app/(app)/staff/page.tsx
+++ b/omnischools/app/(app)/staff/page.tsx
@@ -1,69 +1,97 @@
 import Link from "next/link";
 import { Users } from "lucide-react";
-import { and, asc, eq, notInArray } from "drizzle-orm";
+import { and, asc, eq, notInArray, sql } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
-import { users, roles, roleAssignments } from "@/db/schema";
+import { users, roles, roleAssignments, staffProfiles, students } from "@/db/schema";
 import { NON_STAFF_ROLE_CODES } from "@/lib/staff-roles";
 import { AddStaffForm } from "@/components/staff/add-staff-form";
-import { StaffTable } from "@/components/staff/staff-table";
+import { StaffBrowser, type StaffBrowserMember } from "@/components/staff/staff-browser";
 import { EmptyState } from "@/components/ui/empty-state";
 
 export const dynamic = "force-dynamic";
 
-type StaffMember = {
-  userId: string;
-  name: string | null;
-  phone: string;
-  email: string | null;
-  roles: { assignmentId: string; code: string; label: string | null }[];
-};
-
 export default async function StaffPage() {
   const { school } = await requireSchool();
 
-  const rows = await withSchool(school.id, (tx) =>
-    tx
-      .select({
-        assignmentId: roleAssignments.id,
-        userId: users.id,
-        name: users.fullName,
-        phone: users.phone,
-        email: users.email,
-        code: roles.code,
-        label: roles.label,
-      })
-      .from(roleAssignments)
-      .innerJoin(users, eq(roleAssignments.userId, users.id))
-      .innerJoin(roles, eq(roleAssignments.roleId, roles.id))
-      .where(
-        and(
-          eq(roleAssignments.schoolId, school.id),
-          notInArray(roles.code, NON_STAFF_ROLE_CODES),
-        ),
-      )
-      .orderBy(asc(users.fullName)),
-  );
+  const [rows, profileRows, [{ activeStudents }]] = await Promise.all([
+    withSchool(school.id, (tx) =>
+      tx
+        .select({
+          assignmentId: roleAssignments.id,
+          userId: users.id,
+          name: users.fullName,
+          phone: users.phone,
+          email: users.email,
+          code: roles.code,
+          label: roles.label,
+        })
+        .from(roleAssignments)
+        .innerJoin(users, eq(roleAssignments.userId, users.id))
+        .innerJoin(roles, eq(roleAssignments.roleId, roles.id))
+        .where(
+          and(
+            eq(roleAssignments.schoolId, school.id),
+            notInArray(roles.code, NON_STAFF_ROLE_CODES),
+          ),
+        )
+        .orderBy(asc(users.fullName)),
+    ),
+    withSchool(school.id, (tx) =>
+      tx
+        .select({ userId: staffProfiles.userId, level: staffProfiles.qualificationLevel })
+        .from(staffProfiles)
+        .where(eq(staffProfiles.schoolId, school.id)),
+    ),
+    withSchool(school.id, (tx) =>
+      tx
+        .select({ activeStudents: sql<number>`count(*)::int` })
+        .from(students)
+        .where(and(eq(students.schoolId, school.id), eq(students.status, "ACTIVE"))),
+    ),
+  ]);
 
-  const byUser = new Map<string, StaffMember>();
+  const qualByUser = new Map(profileRows.map((p) => [p.userId, p.level]));
+
+  const byUser = new Map<string, StaffBrowserMember>();
   for (const r of rows) {
     let g = byUser.get(r.userId);
     if (!g) {
-      g = { userId: r.userId, name: r.name, phone: r.phone, email: r.email, roles: [] };
+      g = {
+        userId: r.userId,
+        name: r.name,
+        phone: r.phone,
+        email: r.email,
+        roles: [],
+        qualificationLevel: qualByUser.get(r.userId) ?? null,
+      };
       byUser.set(r.userId, g);
     }
     g.roles.push({ assignmentId: r.assignmentId, code: r.code, label: r.label });
   }
   const staff = Array.from(byUser.values());
 
+  // Distinct roles present, for the filter dropdown.
+  const roleMap = new Map<string, string>();
+  for (const r of rows) roleMap.set(r.code, r.label ?? r.code);
+  const roleOptions = Array.from(roleMap.entries())
+    .map(([code, label]) => ({ code, label }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+
   return (
     <div className="mx-auto max-w-page">
-      <div className="mb-6 flex items-center justify-between gap-3">
+      <div className="mb-6 flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h1 className="font-display text-3xl font-semibold text-navy">Staff</h1>
-          <p className="text-sm text-navy-3">
-            {staff.length} {staff.length === 1 ? "person" : "people"} · teachers, bursars
-            and admins who can sign in.
+          <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gold">
+            Omnischools · Staff
+          </div>
+          <h1 className="mt-1 font-display text-3xl font-semibold text-navy">
+            The people who <em className="text-gold">run it</em>
+          </h1>
+          <div className="mb-3 mt-2 h-0.5 w-16 bg-gold" />
+          <p className="max-w-2xl text-sm text-navy-3">
+            Teaching strength, the pupil-teacher ratio and qualifications at a glance.
+            Filter by role or qualification, then open any record from the row.
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -84,7 +112,11 @@ export default async function StaffPage() {
           body="Add teachers and other staff so they can take attendance, enter scores and collect fees."
         />
       ) : (
-        <StaffTable staff={staff} />
+        <StaffBrowser
+          staff={staff}
+          activeStudents={activeStudents}
+          roleOptions={roleOptions}
+        />
       )}
     </div>
   );

--- a/omnischools/components/staff/staff-browser.tsx
+++ b/omnischools/components/staff/staff-browser.tsx
@@ -1,0 +1,167 @@
+"use client";
+import { useMemo, useState } from "react";
+import { StaffTable } from "./staff-table";
+import { isTeachingStaff } from "@/lib/staff-roles";
+import { QUALIFICATION_LEVELS, averageQualificationLabel } from "@/lib/staff-qualifications";
+
+export type StaffBrowserMember = {
+  userId: string;
+  name: string | null;
+  phone: string;
+  email: string | null;
+  roles: { assignmentId: string; code: string; label: string | null }[];
+  qualificationLevel: string | null;
+};
+
+const selectCls =
+  "rounded-lg border border-border-2 bg-surface px-3 py-2 text-sm text-navy outline-none transition-colors focus:border-gold";
+
+/**
+ * Staff list shell — owns the summary cards (# teachers · teacher : student ratio ·
+ * average qualification), the search + role/qualification filters, and the filtered
+ * table. The cards recompute with the filters; the ratio's student denominator is the
+ * school-wide active-student count (fixed). The table keeps its inline quick-actions.
+ */
+export function StaffBrowser({
+  staff,
+  activeStudents,
+  roleOptions,
+}: {
+  staff: StaffBrowserMember[];
+  activeStudents: number;
+  roleOptions: { code: string; label: string }[];
+}) {
+  const [search, setSearch] = useState("");
+  const [roleFilter, setRoleFilter] = useState("");
+  const [qualFilter, setQualFilter] = useState("");
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return staff.filter((m) => {
+      if (roleFilter && !m.roles.some((r) => r.code === roleFilter)) return false;
+      if (qualFilter && m.qualificationLevel !== qualFilter) return false;
+      if (q) {
+        const hay = `${m.name ?? ""} ${m.phone} ${m.email ?? ""}`.toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [staff, search, roleFilter, qualFilter]);
+
+  const stats = useMemo(() => {
+    const total = filtered.length;
+    const teachers = filtered.filter((m) => isTeachingStaff(m.roles.map((r) => r.code))).length;
+    const ratio = teachers > 0 ? activeStudents / teachers : null;
+    const qual = averageQualificationLabel(filtered.map((m) => m.qualificationLevel));
+    return { total, teachers, ratio, qual };
+  }, [filtered, activeStudents]);
+
+  const hasFilters = !!(search || roleFilter || qualFilter);
+  const clearAll = () => {
+    setSearch("");
+    setRoleFilter("");
+    setQualFilter("");
+  };
+
+  return (
+    <div>
+      {/* Summary cards */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <div className="rounded-xl border border-navy bg-navy p-5 text-bg">
+          <div className="text-[9px] font-bold uppercase tracking-[0.12em] text-gold-soft">
+            Teachers
+          </div>
+          <div className="mt-1 font-display text-4xl font-semibold">{stats.teachers}</div>
+          <div className="mt-0.5 text-[11px] text-gold-soft">
+            of {stats.total} staff
+            {stats.total - stats.teachers > 0
+              ? ` · ${stats.total - stats.teachers} non-teaching`
+              : ""}
+          </div>
+        </div>
+        <div className="rounded-xl border border-border bg-surface p-5">
+          <div className="text-[9px] font-bold uppercase tracking-[0.12em] text-navy-3">
+            Teacher : student ratio
+          </div>
+          <div className="mt-1 font-display text-4xl font-semibold text-navy">
+            {stats.ratio === null ? "—" : `1 : ${Math.round(stats.ratio)}`}
+          </div>
+          <div className="mt-0.5 text-[11px] text-navy-3">
+            {stats.teachers} {stats.teachers === 1 ? "teacher" : "teachers"} ·{" "}
+            {activeStudents} students
+          </div>
+        </div>
+        <div className="rounded-xl border border-border bg-surface p-5">
+          <div className="text-[9px] font-bold uppercase tracking-[0.12em] text-navy-3">
+            Average qualification
+          </div>
+          <div className="mt-1 font-display text-2xl font-semibold leading-tight text-navy">
+            {stats.qual.label}
+          </div>
+          <div className="mt-0.5 text-[11px] text-navy-3">
+            {stats.qual.captured} of {stats.total} captured
+          </div>
+        </div>
+      </div>
+
+      {/* Filter bar */}
+      <div className="mt-5 flex flex-wrap items-center gap-2">
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search by name, phone or email…"
+          className="min-w-[200px] flex-1 rounded-lg border border-border-2 bg-surface px-3 py-2 text-sm text-navy outline-none transition-colors focus:border-gold"
+          aria-label="Search staff"
+        />
+        <select
+          value={roleFilter}
+          onChange={(e) => setRoleFilter(e.target.value)}
+          className={selectCls}
+          aria-label="Filter by role"
+        >
+          <option value="">All roles</option>
+          {roleOptions.map((r) => (
+            <option key={r.code} value={r.code}>
+              {r.label}
+            </option>
+          ))}
+        </select>
+        <select
+          value={qualFilter}
+          onChange={(e) => setQualFilter(e.target.value)}
+          className={selectCls}
+          aria-label="Filter by qualification"
+        >
+          <option value="">All qualifications</option>
+          {QUALIFICATION_LEVELS.map((q) => (
+            <option key={q.code} value={q.code}>
+              {q.label}
+            </option>
+          ))}
+        </select>
+        {hasFilters && (
+          <button
+            type="button"
+            onClick={clearAll}
+            className="rounded-lg px-3 py-2 text-sm font-semibold text-navy-3 transition-colors hover:text-terra"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      <p className="mb-3 mt-3 text-xs text-navy-3">
+        Showing <span className="font-semibold text-navy">{filtered.length}</span> of{" "}
+        {staff.length} staff
+      </p>
+
+      {filtered.length === 0 ? (
+        <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
+          No staff match these filters.
+        </p>
+      ) : (
+        <StaffTable staff={filtered} />
+      )}
+    </div>
+  );
+}

--- a/omnischools/lib/staff-roles.ts
+++ b/omnischools/lib/staff-roles.ts
@@ -38,6 +38,21 @@ export const STAFF_ROLE_LABEL: Record<string, string> = Object.fromEntries(
 /** Roles that are NOT staff — used to include everyone else (incl. custom roles) as staff. */
 export const NON_STAFF_ROLE_CODES = ["STUDENT", "PARENT"] as [string, ...string[]];
 
+/** Academic/classroom roles — a staff member holding any of these counts as a teacher. */
+export const TEACHING_ROLE_CODES = [
+  "TEACHER",
+  "FORM_MASTER",
+  "HEAD_OF_DEPARTMENT",
+  "VICE_HEADMASTER_ACADEMIC",
+  "EXAMS_OFFICER",
+  "GUIDANCE_COUNSELLOR",
+  "SPORTS_MASTER",
+];
+
+/** True when a staff member's roles include a teaching role. */
+export const isTeachingStaff = (codes: string[]): boolean =>
+  codes.some((c) => TEACHING_ROLE_CODES.includes(c));
+
 /** Slug a custom role label to a stable code, e.g. "Sports Master" → "SPORTS_MASTER". */
 export function slugRole(label: string): string {
   return (


### PR DESCRIPTION
## Staff list redesign (Staff PR2)

Mirrors the Students list for Staff — the Reports/Attendance black & gold language + the summary cards and filters from the brief.

### What's here
- **Header** — gold eyebrow "Omnischools · Staff", Fraunces title "The people who *run it*", gold rule, subtext.
- **Summary cards** — **Teachers** (navy hero, teaching vs non-teaching) · **Teacher : student ratio** (teaching staff : active students, shown `1 : N`) · **Average qualification** (nearest level to the mean of captured levels, + "N of M captured").
- **Filters** — search by name/phone/email + **role** and **qualification level** dropdowns. Filtering recomputes the cards too, with a "Showing X of Y" count + no-match state.
- The `StaffTable` and its **inline quick-actions** (Edit / Invite / Delete) are unchanged — zooming into a full profile is the next slice.

### Notes
- "Teacher" = a staff member holding any academic/classroom role (new `TEACHING_ROLE_CODES` helper).
- Qualification levels come from the `staff_profile` table (Staff PR1). Seeded plausible demo qualifications so the card demonstrates.

### Verification
- Live: header + three cards render (**Teachers 15/17**, **ratio 1:4**, **avg Bachelor's**); filtering to **Master's** recomputes Teachers **2** / avg **Master's** / "Showing 3 of 17".
- `pnpm typecheck` + `pnpm lint` + `pnpm build` clean; no slash-opacity on tokens.

### Next
⑥ Staff profile 360 (`/staff/[id]` — header, roles, Personal & contact, Qualifications & licensure, class assignments + edit) and make the row open it; then ⑦ compensation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)