### PR TITLE
feat(staff): 360° staff profile + edit (staff PR3)

### DIFF
--- a/omnischools/app/(app)/staff/[id]/page.tsx
+++ b/omnischools/app/(app)/staff/[id]/page.tsx
@@ -1,0 +1,422 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { and, asc, count, eq, notInArray } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import { users, roles, roleAssignments, classes, students, staffProfiles } from "@/db/schema";
+import { NON_STAFF_ROLE_CODES, roleLabel } from "@/lib/staff-roles";
+import { qualificationLabel } from "@/lib/staff-qualifications";
+import { StaffProfileEdit } from "@/components/staff/staff-profile-edit";
+
+export const dynamic = "force-dynamic";
+
+const fmtDob = (iso: string) =>
+  new Date(iso + "T00:00:00Z").toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+
+const ageFrom = (dob: string, today: string) => {
+  const b = new Date(dob + "T00:00:00Z");
+  const t = new Date(today + "T00:00:00Z");
+  let a = t.getUTCFullYear() - b.getUTCFullYear();
+  if (
+    t.getUTCMonth() < b.getUTCMonth() ||
+    (t.getUTCMonth() === b.getUTCMonth() && t.getUTCDate() < b.getUTCDate())
+  )
+    a--;
+  return a;
+};
+
+/** Split a full name into "given" + surname for the gold-em hero treatment. */
+function splitName(full: string): { given: string; surname: string } {
+  const parts = full.trim().split(/\s+/);
+  if (parts.length <= 1) return { given: "", surname: full.trim() };
+  const surname = parts.pop() as string;
+  return { given: parts.join(" "), surname };
+}
+
+const initialsOf = (full: string) => {
+  const parts = full.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "—";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+};
+
+export default async function StaffDetailPage({ params }: { params: { id: string } }) {
+  const { school } = await requireSchool();
+  const today = new Date().toISOString().slice(0, 10);
+
+  const data = await withSchool(school.id, async (tx) => {
+    // The user must hold ≥1 non-student/parent role at this school to be staff here.
+    const [staffUser] = await tx
+      .select({
+        id: users.id,
+        fullName: users.fullName,
+        phone: users.phone,
+        email: users.email,
+      })
+      .from(users)
+      .innerJoin(roleAssignments, eq(roleAssignments.userId, users.id))
+      .innerJoin(roles, eq(roleAssignments.roleId, roles.id))
+      .where(
+        and(
+          eq(users.id, params.id),
+          eq(roleAssignments.schoolId, school.id),
+          notInArray(roles.code, NON_STAFF_ROLE_CODES),
+        ),
+      )
+      .limit(1);
+    if (!staffUser) return null;
+
+    const [roleRows, [profile], teacherClasses, classSizes] = await Promise.all([
+      tx
+        .select({
+          assignmentId: roleAssignments.id,
+          code: roles.code,
+          label: roles.label,
+          startDate: roleAssignments.startDate,
+          endDate: roleAssignments.endDate,
+        })
+        .from(roleAssignments)
+        .innerJoin(roles, eq(roleAssignments.roleId, roles.id))
+        .where(
+          and(
+            eq(roleAssignments.schoolId, school.id),
+            eq(roleAssignments.userId, staffUser.id),
+            notInArray(roles.code, NON_STAFF_ROLE_CODES),
+          ),
+        )
+        .orderBy(asc(roleAssignments.startDate)),
+      tx
+        .select()
+        .from(staffProfiles)
+        .where(
+          and(
+            eq(staffProfiles.schoolId, school.id),
+            eq(staffProfiles.userId, staffUser.id),
+          ),
+        )
+        .limit(1),
+      tx
+        .select({ id: classes.id, name: classes.name, level: classes.level })
+        .from(classes)
+        .where(
+          and(
+            eq(classes.schoolId, school.id),
+            eq(classes.classTeacherUserId, staffUser.id),
+          ),
+        )
+        .orderBy(asc(classes.name)),
+      tx
+        .select({ classId: students.classId, n: count() })
+        .from(students)
+        .where(eq(students.schoolId, school.id))
+        .groupBy(students.classId),
+    ]);
+
+    return { staffUser, roleRows, profile: profile ?? null, teacherClasses, classSizes };
+  });
+
+  if (!data) notFound();
+  const { staffUser, roleRows, profile, teacherClasses, classSizes } = data;
+
+  const fullName = staffUser.fullName ?? "—";
+  const { given, surname } = splitName(staffUser.fullName ?? "");
+
+  const activeRoles = roleRows.filter((r) => r.endDate === null);
+  const primaryRole = activeRoles[0] ?? roleRows[0] ?? null;
+  const primaryLabel = primaryRole
+    ? roleLabel(primaryRole.code, primaryRole.label)
+    : "No role";
+
+  const sizeOf = new Map(classSizes.map((r) => [r.classId, Number(r.n)]));
+
+  const dob = profile?.dateOfBirth ?? null;
+  const gender = profile?.gender ?? null;
+
+  return (
+    <div className="mx-auto max-w-page">
+      {/* ── Breadcrumb ─────────────────────────────────────────── */}
+      <div className="text-xs text-navy-3">
+        <Link href="/staff" className="text-gold hover:underline">
+          Staff
+        </Link>{" "}
+        / {fullName}
+      </div>
+
+      {/* ── Hero ───────────────────────────────────────────────── */}
+      <div className="mb-8 mt-2 flex flex-wrap items-start justify-between gap-4">
+        <div className="flex items-start gap-4">
+          <span className="flex h-[68px] w-[68px] shrink-0 items-center justify-center rounded-full bg-gold-bg font-display text-2xl font-semibold text-navy">
+            {initialsOf(fullName)}
+          </span>
+          <div>
+            <h1 className="font-display text-3xl font-semibold text-navy">
+              {given ? `${given} ` : ""}
+              <em className="not-italic text-gold">{surname}</em>
+            </h1>
+            <p className="mt-0.5 text-sm text-navy-3">
+              {activeRoles.length} active {activeRoles.length === 1 ? "role" : "roles"}
+              {" · "}
+              <b className="font-semibold text-navy-2">{primaryLabel}</b>
+            </p>
+            <div className="mt-2.5 flex flex-wrap gap-2">
+              <Chip glyph="☎">
+                <b className="font-mono font-semibold text-navy-2">{staffUser.phone || "—"}</b>
+              </Chip>
+              {staffUser.email && <Chip glyph="@">{staffUser.email}</Chip>}
+              {dob && (
+                <Chip glyph="◷">
+                  {fmtDob(dob)} · age {ageFrom(dob, today)}
+                </Chip>
+              )}
+              {gender && <Chip glyph="●">{gender}</Chip>}
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <StaffProfileEdit
+            userId={staffUser.id}
+            initial={{
+              fullName: staffUser.fullName ?? "",
+              phone: staffUser.phone ?? "",
+              email: staffUser.email ?? "",
+              dateOfBirth: profile?.dateOfBirth ?? "",
+              gender: profile?.gender ?? "",
+              address: profile?.address ?? "",
+              emergencyContact: profile?.emergencyContact ?? "",
+              qualificationLevel: profile?.qualificationLevel ?? "",
+              highestQualification: profile?.highestQualification ?? "",
+              undergraduate: profile?.undergraduate ?? "",
+              ntcLicenceNumber: profile?.ntcLicenceNumber ?? "",
+              ntcLicenceExpiry: profile?.ntcLicenceExpiry ?? "",
+              specialisations: profile?.specialisations ?? "",
+            }}
+          />
+          <Link
+            href="/classes"
+            className="rounded-md border border-border-2 px-3.5 py-2 text-sm font-semibold text-navy-2 transition-colors hover:bg-bg"
+          >
+            View classes
+          </Link>
+        </div>
+      </div>
+
+      {/* ── 01 · Active roles ──────────────────────────────────── */}
+      <Section num="01" title="Active roles">
+        {roleRows.length === 0 ? (
+          <Muted>No roles assigned at this school.</Muted>
+        ) : (
+          <div className="space-y-2">
+            {roleRows.map((r) => (
+              <div
+                key={r.assignmentId}
+                className="flex items-center justify-between rounded-lg border border-border bg-surface px-4 py-3"
+              >
+                <div>
+                  <div className="font-display text-base font-semibold text-gold">
+                    {roleLabel(r.code, r.label)}
+                  </div>
+                  <div className="text-xs text-navy-3">since {fmtDob(r.startDate)}</div>
+                </div>
+                {r.endDate === null ? (
+                  <span className="rounded-pill bg-green-bg px-2.5 py-0.5 text-[11px] font-bold uppercase tracking-wide text-green">
+                    Active
+                  </span>
+                ) : (
+                  <span className="rounded-pill bg-bg px-2.5 py-0.5 text-[11px] font-semibold text-navy-3">
+                    ended {fmtDob(r.endDate)}
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </Section>
+
+      {/* ── 02 · Personal & contact ────────────────────────────── */}
+      <Section num="02" title="Personal & contact">
+        <dl className="grid grid-cols-1 gap-x-8 gap-y-px overflow-hidden rounded-lg border border-border bg-border sm:grid-cols-2">
+          <Field label="Full name" value={staffUser.fullName} />
+          <Field
+            label="Date of birth"
+            value={dob ? `${fmtDob(dob)} · ${ageFrom(dob, today)} years` : null}
+          />
+          <Field label="Gender" value={gender} />
+          <Field label="Phone" value={staffUser.phone} mono />
+          <Field label="Email" value={staffUser.email} />
+          <Field label="Address" value={profile?.address ?? null} />
+          <Field label="Emergency contact" value={profile?.emergencyContact ?? null} />
+        </dl>
+      </Section>
+
+      {/* ── 03 · Qualifications & licensure ────────────────────── */}
+      <Section num="03" title="Qualifications & licensure">
+        {!profile ? (
+          <Muted>No profile details captured yet — use Edit profile to add them.</Muted>
+        ) : (
+          <dl className="grid grid-cols-1 gap-x-8 gap-y-px overflow-hidden rounded-lg border border-border bg-border sm:grid-cols-2">
+            <Field label="Highest qualification" value={profile.highestQualification} />
+            <Field label="Undergraduate" value={profile.undergraduate} />
+            <Field
+              label="NTC licence"
+              value={
+                profile.ntcLicenceNumber
+                  ? `${profile.ntcLicenceNumber}${
+                      profile.ntcLicenceExpiry
+                        ? ` · expires ${fmtDob(profile.ntcLicenceExpiry)}`
+                        : ""
+                    }`
+                  : null
+              }
+            />
+            <Field
+              label="Level"
+              value={
+                profile.qualificationLevel
+                  ? qualificationLabel(profile.qualificationLevel)
+                  : null
+              }
+            />
+            <div className="bg-surface p-4 sm:col-span-2">
+              <dt className="text-[9px] font-bold uppercase tracking-[0.1em] text-navy-3">
+                Specialisations
+              </dt>
+              <dd className="mt-1.5">
+                {specialisationChips(profile.specialisations)}
+              </dd>
+            </div>
+          </dl>
+        )}
+      </Section>
+
+      {/* ── 04 · Class assignments ─────────────────────────────── */}
+      <Section
+        num="04"
+        title="Class assignments"
+        right={<GoldLink href="/classes">View classes →</GoldLink>}
+      >
+        {teacherClasses.length === 0 ? (
+          <Muted>Not the class teacher of any class.</Muted>
+        ) : (
+          <div className="space-y-2">
+            {teacherClasses.map((c) => (
+              <div
+                key={c.id}
+                className="flex items-center justify-between rounded-lg border border-border bg-surface px-4 py-3"
+              >
+                <div>
+                  <div className="text-sm font-medium text-navy">{c.name}</div>
+                  {c.level && <div className="text-xs text-navy-3">{c.level}</div>}
+                </div>
+                <span className="text-xs text-navy-3">
+                  {sizeOf.get(c.id) ?? 0} students
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </Section>
+    </div>
+  );
+}
+
+// ── Presentational helpers (server components / pure) ───────────────────
+
+function specialisationChips(raw: string | null) {
+  const tags = (raw ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (tags.length === 0) return <span className="text-sm text-navy-3">—</span>;
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {tags.map((t, i) => (
+        <span
+          key={i}
+          className="rounded-pill bg-bg px-2.5 py-1 text-[11px] font-medium text-navy-2"
+        >
+          {t}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function Chip({ glyph, children }: { glyph: string; children: React.ReactNode }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-pill border border-border bg-bg px-2.5 py-1 text-[11px] text-navy-3">
+      <span className="font-display text-[10px] font-bold text-gold">{glyph}</span>
+      {children}
+    </span>
+  );
+}
+
+function SectionHead({ num, title }: { num: string; title: string }) {
+  return (
+    <div className="mb-3 flex flex-wrap items-baseline gap-3">
+      {num && <span className="font-display text-xl font-semibold italic text-gold">{num}</span>}
+      <h2 className="font-display text-lg font-semibold text-navy">{title}</h2>
+    </div>
+  );
+}
+
+function Section({
+  num,
+  title,
+  right,
+  children,
+}: {
+  num: string;
+  title: string;
+  right?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="mb-8">
+      <div className="mb-3 flex flex-wrap items-baseline justify-between gap-3">
+        <SectionHead num={num} title={title} />
+        {right && <div className="text-sm">{right}</div>}
+      </div>
+      <div className="rounded-xl border border-border bg-surface p-5">{children}</div>
+    </section>
+  );
+}
+
+function GoldLink({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <Link href={href} className="font-semibold text-gold hover:underline">
+      {children}
+    </Link>
+  );
+}
+
+function Muted({ children }: { children: React.ReactNode }) {
+  return <p className="text-sm text-navy-3">{children}</p>;
+}
+
+function Field({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string | null | undefined;
+  mono?: boolean;
+}) {
+  const has = value != null && value !== "";
+  return (
+    <div className="bg-surface p-4">
+      <dt className="text-[9px] font-bold uppercase tracking-[0.1em] text-navy-3">{label}</dt>
+      <dd
+        className={`mt-1 text-sm ${has ? "text-navy" : "text-navy-3"} ${
+          mono && has ? "font-mono" : ""
+        }`}
+      >
+        {has ? value : "—"}
+      </dd>
+    </div>
+  );
+}

--- a/omnischools/components/staff/staff-profile-edit.tsx
+++ b/omnischools/components/staff/staff-profile-edit.tsx
@@ -1,0 +1,278 @@
+"use client";
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { updateStaff, saveStaffProfile } from "@/lib/actions/staff";
+import { QUALIFICATION_LEVELS } from "@/lib/staff-qualifications";
+import { Modal } from "@/components/ui/modal";
+
+const fieldClass =
+  "w-full rounded-md border border-border-2 bg-bg px-3.5 py-2.5 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
+const labelClass = "mb-1 block text-xs font-semibold text-navy-2";
+
+export type StaffProfileInitial = {
+  fullName: string;
+  phone: string;
+  email: string;
+  dateOfBirth: string;
+  gender: string;
+  address: string;
+  emergencyContact: string;
+  qualificationLevel: string;
+  highestQualification: string;
+  undergraduate: string;
+  ntcLicenceNumber: string;
+  ntcLicenceExpiry: string;
+  specialisations: string;
+};
+
+export function StaffProfileEdit({
+  userId,
+  initial,
+}: {
+  userId: string;
+  initial: StaffProfileInitial;
+}) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState<StaffProfileInitial>(initial);
+
+  function set<K extends keyof StaffProfileInitial>(key: K, value: string) {
+    setForm((f) => ({ ...f, [key]: value }));
+  }
+
+  function close() {
+    setOpen(false);
+    setError(null);
+    setForm(initial);
+  }
+
+  function save() {
+    setError(null);
+    startTransition(async () => {
+      const identity = await updateStaff({
+        userId,
+        fullName: form.fullName,
+        phone: form.phone,
+        email: form.email,
+      });
+      if (!identity.ok) {
+        setError(identity.error ?? "Could not save the staff record.");
+        return;
+      }
+      const profile = await saveStaffProfile({
+        userId,
+        dateOfBirth: form.dateOfBirth,
+        gender: form.gender,
+        address: form.address,
+        emergencyContact: form.emergencyContact,
+        qualificationLevel: form.qualificationLevel,
+        highestQualification: form.highestQualification,
+        undergraduate: form.undergraduate,
+        ntcLicenceNumber: form.ntcLicenceNumber,
+        ntcLicenceExpiry: form.ntcLicenceExpiry,
+        specialisations: form.specialisations,
+      });
+      if (!profile.ok) {
+        setError(profile.error ?? "Could not save the staff profile.");
+        return;
+      }
+      setOpen(false);
+      router.refresh();
+    });
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="rounded-md bg-navy px-3.5 py-2 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep"
+      >
+        Edit profile
+      </button>
+
+      <Modal open={open} onClose={close} title="Edit staff profile">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            save();
+          }}
+          className="max-h-[70vh] space-y-5 overflow-y-auto pr-0.5"
+        >
+          {/* Identity */}
+          <fieldset className="space-y-3">
+            <legend className="text-[11px] font-bold uppercase tracking-[0.1em] text-navy-3">
+              Identity
+            </legend>
+            <div>
+              <label className={labelClass}>Full name</label>
+              <input
+                value={form.fullName}
+                onChange={(e) => set("fullName", e.target.value)}
+                required
+                className={fieldClass}
+              />
+            </div>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div>
+                <label className={labelClass}>Phone (login)</label>
+                <input
+                  value={form.phone}
+                  onChange={(e) => set("phone", e.target.value)}
+                  type="tel"
+                  required
+                  className={fieldClass}
+                />
+              </div>
+              <div>
+                <label className={labelClass}>
+                  Email <span className="font-medium text-navy-3">— optional</span>
+                </label>
+                <input
+                  value={form.email}
+                  onChange={(e) => set("email", e.target.value)}
+                  type="email"
+                  className={fieldClass}
+                />
+              </div>
+            </div>
+          </fieldset>
+
+          {/* Personal & contact */}
+          <fieldset className="space-y-3">
+            <legend className="text-[11px] font-bold uppercase tracking-[0.1em] text-navy-3">
+              Personal &amp; contact
+            </legend>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div>
+                <label className={labelClass}>Date of birth</label>
+                <input
+                  value={form.dateOfBirth}
+                  onChange={(e) => set("dateOfBirth", e.target.value)}
+                  type="date"
+                  className={fieldClass}
+                />
+              </div>
+              <div>
+                <label className={labelClass}>Gender</label>
+                <select
+                  value={form.gender}
+                  onChange={(e) => set("gender", e.target.value)}
+                  className={fieldClass}
+                >
+                  <option value="">—</option>
+                  <option value="Female">Female</option>
+                  <option value="Male">Male</option>
+                </select>
+              </div>
+            </div>
+            <div>
+              <label className={labelClass}>Address</label>
+              <input
+                value={form.address}
+                onChange={(e) => set("address", e.target.value)}
+                className={fieldClass}
+              />
+            </div>
+            <div>
+              <label className={labelClass}>Emergency contact</label>
+              <input
+                value={form.emergencyContact}
+                onChange={(e) => set("emergencyContact", e.target.value)}
+                placeholder="Name · relationship · phone"
+                className={fieldClass}
+              />
+            </div>
+          </fieldset>
+
+          {/* Qualifications & licensure */}
+          <fieldset className="space-y-3">
+            <legend className="text-[11px] font-bold uppercase tracking-[0.1em] text-navy-3">
+              Qualifications &amp; licensure
+            </legend>
+            <div>
+              <label className={labelClass}>Qualification level</label>
+              <select
+                value={form.qualificationLevel}
+                onChange={(e) => set("qualificationLevel", e.target.value)}
+                className={fieldClass}
+              >
+                <option value="">—</option>
+                {QUALIFICATION_LEVELS.map((q) => (
+                  <option key={q.code} value={q.code}>
+                    {q.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className={labelClass}>Highest qualification</label>
+              <input
+                value={form.highestQualification}
+                onChange={(e) => set("highestQualification", e.target.value)}
+                placeholder="e.g. MEd Mathematics · UCC · 2019"
+                className={fieldClass}
+              />
+            </div>
+            <div>
+              <label className={labelClass}>Undergraduate</label>
+              <input
+                value={form.undergraduate}
+                onChange={(e) => set("undergraduate", e.target.value)}
+                className={fieldClass}
+              />
+            </div>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div>
+                <label className={labelClass}>NTC licence no.</label>
+                <input
+                  value={form.ntcLicenceNumber}
+                  onChange={(e) => set("ntcLicenceNumber", e.target.value)}
+                  className={fieldClass}
+                />
+              </div>
+              <div>
+                <label className={labelClass}>NTC licence expiry</label>
+                <input
+                  value={form.ntcLicenceExpiry}
+                  onChange={(e) => set("ntcLicenceExpiry", e.target.value)}
+                  type="date"
+                  className={fieldClass}
+                />
+              </div>
+            </div>
+            <div>
+              <label className={labelClass}>Specialisations</label>
+              <input
+                value={form.specialisations}
+                onChange={(e) => set("specialisations", e.target.value)}
+                placeholder="Comma-separated, e.g. Mathematics, Science"
+                className={fieldClass}
+              />
+            </div>
+          </fieldset>
+
+          {error && <p className="text-sm text-terra">{error}</p>}
+
+          <div className="flex items-center gap-3 border-t border-border pt-4">
+            <button
+              type="submit"
+              disabled={pending}
+              className="rounded-md bg-navy px-5 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-60"
+            >
+              {pending ? "Saving…" : "Save changes"}
+            </button>
+            <button
+              type="button"
+              onClick={close}
+              className="text-sm font-semibold text-navy-2 hover:text-navy"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </Modal>
+    </>
+  );
+}

--- a/omnischools/components/staff/staff-row.tsx
+++ b/omnischools/components/staff/staff-row.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { updateStaff } from "@/lib/actions/staff";
 import { createInvite } from "@/lib/actions/invites";
@@ -93,7 +94,9 @@ export function StaffRow({
             className={inputClass}
           />
         ) : (
-          (member.name ?? "—")
+          <Link href={`/staff/${member.userId}`} className="hover:text-gold">
+            {member.name ?? "—"}
+          </Link>
         )}
       </td>
       <td className="px-4 py-3 font-mono text-xs text-navy-2">


### PR DESCRIPTION
## 360° staff profile (Staff PR3)

New `/staff/[id]` — the canonical staff record, adapting `schoolup-staff-record-multirole` §01 for the basic tier. (GES national rank ladder + CPD ledger deferred to SHS/MVP2, per scope.)

### Layout (mirrors the student-profile 360)
- **Hero** — gold initials avatar, name with a gold accent on the surname, "{n} active roles · {primary role}" meta, chips (phone · email · DOB+age · gender). Actions: **Edit profile** (primary) + **View classes**.
- **01 · Active roles** — the multi-role list (label + "since {date}" + ACTIVE/ended pill) — a teacher can hold several.
- **02 · Personal & contact** — full name, DOB (+age), gender, phone, email, address, emergency contact.
- **03 · Qualifications & licensure** — highest qualification, undergraduate, NTC licence (+ expiry), level, specialisations (chips); muted prompt when no profile yet.
- **04 · Class assignments** — classes this person teaches (name · level · size).

### Edit
- **`StaffProfileEdit`** modal wires `updateStaff` (name/phone/email) + `saveStaffProfile` (the optional fields; qualification level as a select). Saves both, refreshes.
- **Staff list rows now open the profile** (the name links to `/staff/[id]`); inline quick-actions (Edit/Invite/Delete) unchanged.

### Verification
- Live: all sections render; the edit modal opens with every field; an **Address edit saved + persisted** via `saveStaffProfile`; **17 staff rows link** to their profiles.
- `pnpm typecheck` + `pnpm lint` + `pnpm build` clean; no slash-opacity on tokens.

### Next (final staff slice)
⑦ Compensation (`schoolup-staff-compensation`) — monthly pay, method, status, deductions, tenure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)