### PR TITLE
fix(staff): modal focus loss while typing + Personal & contact layout

### DIFF
--- a/omnischools/app/(app)/staff/[id]/page.tsx
+++ b/omnischools/app/(app)/staff/[id]/page.tsx
@@ -306,8 +306,8 @@ export default async function StaffDetailPage({ params }: { params: { id: string
 
       {/* ── 02 · Personal & contact ────────────────────────────── */}
       <Section num="02" title="Personal & contact">
-        <dl className="grid grid-cols-1 gap-x-8 gap-y-px overflow-hidden rounded-lg border border-border bg-border sm:grid-cols-2">
-          <Field label="Full name" value={staffUser.fullName} />
+        <dl className="grid grid-cols-1 gap-px overflow-hidden rounded-lg border border-border bg-border sm:grid-cols-2">
+          <Field label="Full name" value={staffUser.fullName} wide />
           <Field
             label="Date of birth"
             value={dob ? `${fmtDob(dob)} · ${ageFrom(dob, today)} years` : null}
@@ -325,7 +325,7 @@ export default async function StaffDetailPage({ params }: { params: { id: string
         {!profile ? (
           <Muted>No profile details captured yet — use Edit profile to add them.</Muted>
         ) : (
-          <dl className="grid grid-cols-1 gap-x-8 gap-y-px overflow-hidden rounded-lg border border-border bg-border sm:grid-cols-2">
+          <dl className="grid grid-cols-1 gap-px overflow-hidden rounded-lg border border-border bg-border sm:grid-cols-2">
             <Field label="Highest qualification" value={profile.highestQualification} />
             <Field label="Undergraduate" value={profile.undergraduate} />
             <Field
@@ -417,7 +417,7 @@ export default async function StaffDetailPage({ params }: { params: { id: string
         {!compensation ? (
           <Muted>No compensation set — use Set compensation.</Muted>
         ) : (
-          <dl className="grid grid-cols-1 gap-x-8 gap-y-px overflow-hidden rounded-lg border border-border bg-border sm:grid-cols-2">
+          <dl className="grid grid-cols-1 gap-px overflow-hidden rounded-lg border border-border bg-border sm:grid-cols-2">
             <Field
               label="Salary status"
               value={COMP_STATUS_LABEL[compensation.salaryStatus] ?? compensation.salaryStatus}
@@ -539,14 +539,16 @@ function Field({
   label,
   value,
   mono,
+  wide,
 }: {
   label: string;
   value: string | null | undefined;
   mono?: boolean;
+  wide?: boolean;
 }) {
   const has = value != null && value !== "";
   return (
-    <div className="bg-surface p-4">
+    <div className={`bg-surface p-4 ${wide ? "sm:col-span-2" : ""}`}>
       <dt className="text-[9px] font-bold uppercase tracking-[0.1em] text-navy-3">{label}</dt>
       <dd
         className={`mt-1 text-sm ${has ? "text-navy" : "text-navy-3"} ${

--- a/omnischools/components/ui/modal.tsx
+++ b/omnischools/components/ui/modal.tsx
@@ -19,15 +19,20 @@ export function Modal({
   children: React.ReactNode;
 }) {
   const cardRef = useRef<HTMLDivElement>(null);
+  // Keep the latest onClose without making it a dependency of the open effect — else
+  // the effect re-runs on every parent render (e.g. each keystroke in a child input)
+  // and steals focus back to the first field.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
 
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") onCloseRef.current();
     };
     document.addEventListener("keydown", onKey);
     document.body.style.overflow = "hidden";
-    // focus the first focusable field
+    // focus the first focusable field — once, when the modal opens
     const first = cardRef.current?.querySelector<HTMLElement>(
       "input, select, textarea, button",
     );
@@ -36,7 +41,7 @@ export function Modal({
       document.removeEventListener("keydown", onKey);
       document.body.style.overflow = "";
     };
-  }, [open, onClose]);
+  }, [open]);
 
   if (!open) return null;
 


### PR DESCRIPTION
Fixes two issues reported on the staff profile.

### 1. Edit-profile modal kept losing focus while typing
The shared `Modal` open-effect depended on `[open, onClose]`. Callers pass an **inline** `onClose`, so its identity changed on every parent render — i.e. **every keystroke** in a child input — re-running the effect and re-focusing the first field. Typing in any field but the first kept jumping out.
**Fix:** focus the first field **once on open** (effect deps `[open]`); the Escape handler calls the latest `onClose` via a ref. This fixes focus retention for **every** Modal-based dialog with inputs (profile edit, compensation edit, etc.).

### 2. "Personal & contact" wide tan gap + empty tan block
The hairline-grid `<dl>`s used `gap-x-8 gap-y-px` over a `bg-border` background, so the **2rem horizontal gap exposed the tan border colour**, and the **7-field (odd)** grid left an empty `bg-border` cell (the tan block bottom-right).
**Fix:** uniform **`gap-px`** (matching the student profile's hairline grids) on sections 02 / 03 / 05, and **Full name spans both columns** so the grid is complete with no empty cell.

### Verification
Live on a staff profile: typing "Tamale" into Address → focus **kept on every keystroke** (`["kept"×6]`); section 02 renders Full name full-width, **0 empty cells**, hairline separators (no wide strip). `pnpm typecheck` + `pnpm lint` + `pnpm build` clean. No schema/prod changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)