### PR TITLE
feat(app): black & gold hero headers across remaining pages

### DIFF
--- a/omnischools/app/(app)/admissions/page.tsx
+++ b/omnischools/app/(app)/admissions/page.tsx
@@ -35,8 +35,14 @@ export default async function AdmissionsPage() {
   return (
     <div className="mx-auto max-w-page">
       <div className="mb-6">
-        <h1 className="font-display text-3xl font-semibold text-navy">Admissions</h1>
-        <p className="text-sm text-navy-3">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gold">
+          Omnischools · Admissions
+        </div>
+        <h1 className="mt-1 font-display text-3xl font-semibold text-navy">
+          Every applicant, <em className="text-gold">reviewed</em>
+        </h1>
+        <div className="mb-3 mt-2 h-0.5 w-16 bg-gold" />
+        <p className="max-w-2xl text-sm text-navy-3">
           {pending.length} awaiting review · {apps.length} total · public link:{" "}
           <Link
             href={`/apply/${encodeURIComponent(school.gesCode)}`}

--- a/omnischools/app/(app)/billing/page.tsx
+++ b/omnischools/app/(app)/billing/page.tsx
@@ -284,8 +284,14 @@ export default async function BillingPage() {
   return (
     <div className="mx-auto max-w-page space-y-10">
       <div>
-        <h1 className="font-display text-3xl font-semibold text-navy">Billing</h1>
-        <p className="text-sm text-navy-3">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gold">
+          Omnischools · Billing
+        </div>
+        <h1 className="mt-1 font-display text-3xl font-semibold text-navy">
+          What you bill, <em className="text-gold">before you collect</em>
+        </h1>
+        <div className="mb-3 mt-2 h-0.5 w-16 bg-gold" />
+        <p className="max-w-2xl text-sm text-navy-3">
           Set up fee structures, manage discounts, generate invoices for a class, and
           chase outstanding balances. (Collecting payments lives in Fees.)
         </p>

--- a/omnischools/app/(app)/classes/page.tsx
+++ b/omnischools/app/(app)/classes/page.tsx
@@ -53,8 +53,14 @@ export default async function ClassesPage() {
     <div className="mx-auto max-w-page">
       <div className="mb-6 flex items-center justify-between gap-3">
         <div>
-          <h1 className="font-display text-3xl font-semibold text-navy">Classes</h1>
-          <p className="text-sm text-navy-3">
+          <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gold">
+            Omnischools · Classes
+          </div>
+          <h1 className="mt-1 font-display text-3xl font-semibold text-navy">
+            Every form, <em className="text-gold">accounted for</em>
+          </h1>
+          <div className="mb-3 mt-2 h-0.5 w-16 bg-gold" />
+          <p className="max-w-2xl text-sm text-navy-3">
             {classRows.length} {classRows.length === 1 ? "class" : "classes"} · assign a
             class teacher and build the timetable.
           </p>

--- a/omnischools/app/(app)/communication/page.tsx
+++ b/omnischools/app/(app)/communication/page.tsx
@@ -60,10 +60,19 @@ export default async function CommunicationPage() {
 
   return (
     <div className="mx-auto max-w-page">
-      <h1 className="mb-1 font-display text-3xl font-semibold text-navy">
-        Communication
-      </h1>
-      <p className="mb-6 text-sm text-navy-3">Announcements and SMS to guardians.</p>
+      <div className="mb-6">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gold">
+          Omnischools · Communication
+        </div>
+        <h1 className="mt-1 font-display text-3xl font-semibold text-navy">
+          Reach every <em className="text-gold">guardian</em>
+        </h1>
+        <div className="mb-3 mt-2 h-0.5 w-16 bg-gold" />
+        <p className="max-w-2xl text-sm text-navy-3">
+          Post announcements and send SMS to guardians — with a reusable copy library and
+          a live delivery log.
+        </p>
+      </div>
 
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
         {/* Announcements */}

--- a/omnischools/app/(app)/fees/page.tsx
+++ b/omnischools/app/(app)/fees/page.tsx
@@ -54,11 +54,19 @@ export default async function FeesPage() {
 
   return (
     <div className="mx-auto max-w-page">
-      <h1 className="mb-1 font-display text-3xl font-semibold text-navy">Fees</h1>
-      <p className="mb-6 text-sm text-navy-3">
-        Collections for {school.name}. Open a student to issue an invoice or record a
-        payment.
-      </p>
+      <div className="mb-6">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gold">
+          Omnischools · Fees
+        </div>
+        <h1 className="mt-1 font-display text-3xl font-semibold text-navy">
+          Fees <em className="text-gold">collection</em>
+        </h1>
+        <div className="mb-3 mt-2 h-0.5 w-16 bg-gold" />
+        <p className="max-w-2xl text-sm text-navy-3">
+          Collections for {school.name}. Open a student with a balance to record a payment
+          or issue a receipt.
+        </p>
+      </div>
 
       <div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
         {cards.map((c) => (

--- a/omnischools/app/(app)/gradebook/page.tsx
+++ b/omnischools/app/(app)/gradebook/page.tsx
@@ -192,9 +192,16 @@ export default async function GradebookPage({
     <div className="mx-auto max-w-page">
       <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
         <div>
-          <h1 className="font-display text-3xl font-semibold text-navy">Gradebook</h1>
-          <p className="text-sm text-navy-3">
-            Enter class &amp; exam scores; totals are weighted.
+          <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gold">
+            Omnischools · Gradebook
+          </div>
+          <h1 className="mt-1 font-display text-3xl font-semibold text-navy">
+            Every score, <em className="text-gold">weighted right</em>
+          </h1>
+          <div className="mb-3 mt-2 h-0.5 w-16 bg-gold" />
+          <p className="max-w-2xl text-sm text-navy-3">
+            Enter class and exam scores by class, subject and term — totals weight
+            automatically.
           </p>
         </div>
         <div className="flex items-center gap-3">

--- a/omnischools/app/(app)/inbox/page.tsx
+++ b/omnischools/app/(app)/inbox/page.tsx
@@ -50,8 +50,14 @@ export default async function InboxPage() {
     <div className="mx-auto max-w-page">
       <div className="mb-6 flex items-center justify-between gap-3">
         <div>
-          <h1 className="font-display text-3xl font-semibold text-navy">Inbox</h1>
-          <p className="text-sm text-navy-3">
+          <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gold">
+            Omnischools · Inbox
+          </div>
+          <h1 className="mt-1 font-display text-3xl font-semibold text-navy">
+            When parents <em className="text-gold">reply</em>
+          </h1>
+          <div className="mb-3 mt-2 h-0.5 w-16 bg-gold" />
+          <p className="max-w-2xl text-sm text-navy-3">
             {open} open · two-way SMS conversations with parents.
           </p>
         </div>

--- a/omnischools/docs/senior-tier-backlog.md
+++ b/omnischools/docs/senior-tier-backlog.md
@@ -1,0 +1,68 @@
+# Senior-tier backlog (deferred from the Basic build)
+
+When auditing the planned `Surfaces/*.html` against the live Basic-tier (KG · Primary ·
+JHS) build, several surfaces turned out to be **Senior (SHS) / MVP2** designs. They are
+intentionally **not** built in the current Basic product. This file records what was
+deferred, page by page, so a future Senior MVP can pick them up. The Basic build keeps a
+clean black-&-gold hero header on every page; nothing below blocks Basic use.
+
+_Last updated: app hero-header sweep (classes · fees · admissions · billing · gradebook ·
+communication · inbox)._
+
+## Classes
+Related surfaces (`schoolup-shs-class-roster.html`, `schoolup-class-roster-shs-variant.html`)
+are **SHS**. Deferred:
+- House column + 6-colour House dots; right-rail House distribution bars.
+- Programme chips (General Arts / Science / Business / Agric).
+- Dual-axis "class × House" sort; Programmes / Houses nav.
+
+_Basic provision now: none needed — the Basic class list (name · level · class teacher ·
+size · timetable) is complete._
+
+## Admissions
+Related surfaces (`schoolup-shs-student-admission.html`, `schoolup-shs-bulk-admission.html`)
+are **SHS / CSSPS**. Deferred:
+- Bulk CSSPS intake (paste-from-portal / CSV / PDF, ~240 students in one atomic commit).
+- 17-day Free-SHS countdown card.
+- BECE index / CSSPS placement-number verification + auto pre-fill.
+- Programme picker (Science / Arts / Business / Agric) with capacity.
+- House + residency (boarding / day) assignment; placed-no-show reconciliation.
+- Horizontal stage progress.
+
+_Basic provision now: none — the Basic public-application-link → review → enrol flow is
+complete._
+
+## Gradebook
+Related surfaces (`schoolup-shs-score-ledger.html`, `schoolup-shs-score-ledger-pwa.html`)
+are **SHS**. Deferred:
+- 5-category NaCCA ledger grid (Basic uses the CA + Exam two-weight model).
+- WASSCE / aggregate performance-band chart + legend.
+- "Three ways" entry, incl. photograph paper book → OCR extract → verify cell-by-cell
+  (low-confidence "?" cells); category-as-you-go.
+- PWA phone frame + offline / online sync strip.
+- Semester (vs term) framing.
+
+_Basic provision now: none — the CA/Exam weighted grid + report cards cover Basic._
+
+## Communication
+Related surfaces are mostly covered in Basic (`schoolup-announcements.html`,
+`schoolup-sms-library.html` → announcements composer + SMS + reusable template library +
+delivery log all shipped). Deferred:
+- **WhatsApp channel** (`schoolup-whatsapp-template-authoring.html`): Meta Business
+  connection + template-approval workflow. Basic is SMS-only.
+- Announcement **read-receipts** (per-parent read tracking). Basic tracks SENT/FAILED only.
+
+## Inbox
+Basic two-way SMS inbox (list · open-count · last-message preview · assignee pill ·
+new-conversation · inbound webhook) is shipped. Deferred:
+- **WhatsApp channel** (`schoolup-whatsapp-inbox.html`): WhatsApp threads.
+- **Routing & assignment** (`schoolup-inbox-routing.html`): rules engine (top-to-bottom
+  evaluation + fallback), thread reassignment flow, team / unassigned / assigned-to-you
+  buckets. Basic has a single per-conversation assignee pill only.
+- Topic-tagging of conversations; read receipts.
+
+## Fees / Billing
+No Senior deferrals — `schoolup-record-payment-drawer.html`, `schoolup-receipt-pdf.html`,
+`schoolup-collection-trend.html` and `schoolup-discount-management.html` are all
+Basic-tier and already implemented (the per-student `/fees/[id]` route holds the
+record-payment drawer + receipt; `/billing` holds fee structures + discounts).


### PR DESCRIPTION
## Black & gold hero headers — Classes · Admissions · Gradebook · Fees · Billing · Communication · Inbox

Brings the seven remaining app pages onto the shipped Students/Staff/Reports/Attendance header language: gold eyebrow → Fraunces title with a gold `<em>` accent → gold rule → subtext. Each page's **dynamic subtext** (counts, public link, school name, open-count) and its **action buttons** are preserved exactly.

| Page | Title |
|---|---|
| Classes | Every form, *accounted for* |
| Admissions | Every applicant, *reviewed* |
| Gradebook | Every score, *weighted right* |
| Fees | Fees *collection* |
| Billing | What you bill, *before you collect* |
| Communication | Reach every *guardian* |
| Inbox | When parents *reply* |

### Surface audit + Senior-tier deferral
Each page's planned `Surfaces/*.html` were audited (focused cartographer passes) against prod. Most related surfaces are **Senior-tier** (SHS class roster with House/Programme axes, CSSPS bulk admissions, NaCCA 5-category score ledger) or **future channels** (WhatsApp inbox/templates, inbox routing rules) — **deferred, not built**. The full deferral list + basic-provision notes live in **[`docs/senior-tier-backlog.md`](docs/senior-tier-backlog.md)**. Fees/Billing surfaces are basic-tier and already implemented — no deferrals there.

### Verification
- Live: **Inbox** ("When parents *reply*" + open-count preserved) and **Fees** ("Fees *collection*" + school name preserved) render the gold eyebrow/title/rule correctly.
- `pnpm typecheck` + `pnpm lint` + `pnpm build` clean; no slash-opacity on tokens. No schema/prod changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)