### PR TITLE
feat(inbox): ownership buckets + reassign drawer (channels PR2)

### DIFF
--- a/omnischools/app/(app)/inbox/[id]/page.tsx
+++ b/omnischools/app/(app)/inbox/[id]/page.tsx
@@ -2,10 +2,12 @@ import { notFound } from "next/navigation";
 import { and, asc, eq } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
-import { conversations, inboxMessages, students } from "@/db/schema";
+import { conversations, inboxMessages, students, users } from "@/db/schema";
 import { loadStaffOptions } from "@/lib/data/staff-options";
+import { topicLabel } from "@/lib/inbox/topics";
 import { ReplyBox } from "@/components/inbox/reply-box";
 import { ConversationControls } from "@/components/inbox/conversation-controls";
+import { ReassignDrawer } from "@/components/inbox/reassign-drawer";
 import { BackLink } from "@/components/ui/back-link";
 
 export const dynamic = "force-dynamic";
@@ -18,8 +20,25 @@ const when = (d: Date) =>
     minute: "2-digit",
   });
 
+/** Topic chip colours — solid tokens / -bg tints / bordered neutrals only. */
+function topicChipClass(topic: string): string {
+  switch (topic) {
+    case "URGENT":
+      return "bg-terra text-bg";
+    case "BILLING":
+      return "bg-gold-bg text-gold";
+    case "ACADEMIC":
+      return "bg-green-bg text-green";
+    case "ATTENDANCE":
+    case "SCHEDULE":
+      return "bg-bg text-navy-2 border border-border-2";
+    default:
+      return "bg-bg text-navy-3";
+  }
+}
+
 export default async function ConversationPage({ params }: { params: { id: string } }) {
-  const { school } = await requireSchool();
+  const { user, school } = await requireSchool();
   const id = params.id;
 
   const [conv] = await withSchool(school.id, (tx) =>
@@ -31,12 +50,16 @@ export default async function ConversationPage({ params }: { params: { id: strin
         subject: conversations.subject,
         status: conversations.status,
         assignedToUserId: conversations.assignedToUserId,
+        assignedName: users.fullName,
+        topic: conversations.topic,
+        routedByRuleName: conversations.routedByRuleName,
         studentFirst: students.firstName,
         studentLast: students.lastName,
         studentClass: students.currentClassLabel,
       })
       .from(conversations)
       .leftJoin(students, eq(conversations.studentId, students.id))
+      .leftJoin(users, eq(conversations.assignedToUserId, users.id))
       .where(and(eq(conversations.id, id), eq(conversations.schoolId, school.id))),
   );
   if (!conv) notFound();
@@ -90,6 +113,47 @@ export default async function ConversationPage({ params }: { params: { id: strin
             staff={staff}
           />
         </div>
+      </div>
+
+      {/* Assignment bar — who owns the thread, auto-route provenance, topic, reassign */}
+      <div className="flex flex-wrap items-center gap-3 rounded-xl border border-gold-soft bg-gold-bg px-4 py-3">
+        <div className="min-w-0 flex-1">
+          <div className="text-[9px] font-bold uppercase tracking-[0.16em] text-gold">
+            Assigned to
+          </div>
+          <p className="mt-0.5 text-sm">
+            <span className="font-semibold text-navy">
+              {conv.assignedName ?? "Unassigned"}
+            </span>
+            {conv.assignedToUserId === user.id ? (
+              <span className="text-navy-3"> · you</span>
+            ) : null}
+            {conv.routedByRuleName ? (
+              <span className="italic text-navy-3">
+                {" "}
+                · auto-routed by{" "}
+                <span className="font-medium not-italic text-navy-2">
+                  {conv.routedByRuleName}
+                </span>
+              </span>
+            ) : null}
+          </p>
+        </div>
+        {conv.topic ? (
+          <span
+            className={`rounded-pill px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-[0.04em] ${topicChipClass(
+              conv.topic,
+            )}`}
+          >
+            {topicLabel(conv.topic)}
+          </span>
+        ) : null}
+        <ReassignDrawer
+          conversationId={conv.id}
+          currentAssigneeName={conv.assignedName}
+          staff={staff}
+          currentUserId={user.id}
+        />
       </div>
 
       <div className="space-y-3 rounded-xl border border-border bg-surface p-4">

--- a/omnischools/app/(app)/inbox/page.tsx
+++ b/omnischools/app/(app)/inbox/page.tsx
@@ -5,20 +5,13 @@ import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import { conversations, users } from "@/db/schema";
 import { NewConversationForm } from "@/components/inbox/new-conversation-form";
+import { InboxBrowser } from "@/components/inbox/inbox-browser";
 import { EmptyState } from "@/components/ui/empty-state";
 
 export const dynamic = "force-dynamic";
 
-const when = (d: Date) =>
-  new Date(d).toLocaleString("en-GB", {
-    day: "2-digit",
-    month: "short",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-
 export default async function InboxPage() {
-  const { school } = await requireSchool();
+  const { user, school } = await requireSchool();
 
   const rows = await withSchool(school.id, (tx) =>
     tx
@@ -30,6 +23,10 @@ export default async function InboxPage() {
         status: conversations.status,
         lastMessageAt: conversations.lastMessageAt,
         assignedName: users.fullName,
+        assignedToUserId: conversations.assignedToUserId,
+        channel: conversations.channel,
+        topic: conversations.topic,
+        routedByRuleName: conversations.routedByRuleName,
         lastBody: sql<
           string | null
         >`(select body from inbox_message m where m.conversation_id = ${conversations.id} order by m.created_at desc limit 1)`,
@@ -85,43 +82,7 @@ export default async function InboxPage() {
           }
         />
       ) : (
-        <div className="divide-y divide-border overflow-hidden rounded-xl border border-border bg-surface">
-          {rows.map((r) => (
-            <Link
-              key={r.id}
-              href={`/inbox/${r.id}`}
-              className="flex items-start gap-3 px-4 py-3.5 transition-colors hover:bg-bg"
-            >
-              <span
-                className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${
-                  r.status === "OPEN" ? "bg-green" : "bg-border-2"
-                }`}
-              />
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center justify-between gap-3">
-                  <span className="truncate font-medium text-navy">
-                    {r.contactName ?? r.contactPhone}
-                    {r.subject ? (
-                      <span className="font-normal text-navy-3"> · {r.subject}</span>
-                    ) : null}
-                  </span>
-                  <span className="shrink-0 text-xs text-navy-3">
-                    {when(r.lastMessageAt)}
-                  </span>
-                </div>
-                <p className="mt-0.5 truncate text-sm text-navy-3">
-                  {r.lastDir === "INBOUND" ? "↩ " : "→ "}
-                  {r.lastBody ?? "—"}
-                </p>
-              </div>
-              {r.assignedName && (
-                <span className="shrink-0 rounded-pill bg-gold-bg px-2 py-0.5 text-xs font-medium text-navy">
-                  {r.assignedName.split(" ")[0]}
-                </span>
-              )}
-            </Link>
-          ))}
-        </div>
+        <InboxBrowser rows={rows} currentUserId={user.id} />
       )}
     </div>
   );

--- a/omnischools/components/inbox/inbox-browser.tsx
+++ b/omnischools/components/inbox/inbox-browser.tsx
@@ -1,0 +1,220 @@
+"use client";
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { topicLabel } from "@/lib/inbox/topics";
+
+export type InboxRow = {
+  id: string;
+  contactName: string | null;
+  contactPhone: string;
+  subject: string | null;
+  status: "OPEN" | "CLOSED";
+  lastMessageAt: Date;
+  assignedName: string | null;
+  assignedToUserId: string | null;
+  channel: string;
+  topic: string | null;
+  routedByRuleName: string | null;
+  lastBody: string | null;
+  lastDir: string | null;
+};
+
+const when = (d: Date) =>
+  new Date(d).toLocaleString("en-GB", {
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+const firstName = (name: string) => name.trim().split(/\s+/)[0] ?? name;
+
+/** Topic chip colours — solid tokens / -bg tints / bordered neutrals only (no slash-opacity). */
+function topicChipClass(topic: string): string {
+  switch (topic) {
+    case "URGENT":
+      return "bg-terra text-bg";
+    case "BILLING":
+      return "bg-gold-bg text-gold";
+    case "ACADEMIC":
+      return "bg-green-bg text-green";
+    case "ATTENDANCE":
+    case "SCHEDULE":
+      return "bg-bg text-navy-2 border border-border-2";
+    default: // OTHER (or anything unmapped)
+      return "bg-bg text-navy-3";
+  }
+}
+
+type Bucket = "ALL" | "MINE" | "TEAM" | "UNASSIGNED" | "CLOSED";
+
+const TAB_LABELS: Record<Bucket, string> = {
+  ALL: "All",
+  MINE: "Mine",
+  TEAM: "Team",
+  UNASSIGNED: "Unassigned",
+  CLOSED: "Closed",
+};
+
+const TAB_ORDER: Bucket[] = ["ALL", "MINE", "TEAM", "UNASSIGNED", "CLOSED"];
+
+function bucketOf(r: InboxRow, currentUserId: string): Exclude<Bucket, "ALL"> {
+  if (r.status === "CLOSED") return "CLOSED";
+  if (r.assignedToUserId == null) return "UNASSIGNED";
+  return r.assignedToUserId === currentUserId ? "MINE" : "TEAM";
+}
+
+/**
+ * Inbox list with ownership buckets (surface §01). Bucket tabs mirror the students-browser
+ * tab pattern with live counts; each thread row carries a topic chip, a channel badge, an
+ * assignee chip, and an "auto-routed" hint when the thread was routed by a rule.
+ */
+export function InboxBrowser({
+  rows,
+  currentUserId,
+}: {
+  rows: InboxRow[];
+  currentUserId: string;
+}) {
+  const [active, setActive] = useState<Bucket>("ALL");
+
+  const counts = useMemo(() => {
+    const c: Record<Bucket, number> = {
+      ALL: rows.length,
+      MINE: 0,
+      TEAM: 0,
+      UNASSIGNED: 0,
+      CLOSED: 0,
+    };
+    for (const r of rows) c[bucketOf(r, currentUserId)]++;
+    return c;
+  }, [rows, currentUserId]);
+
+  const filtered = useMemo(() => {
+    if (active === "ALL") return rows;
+    return rows.filter((r) => bucketOf(r, currentUserId) === active);
+  }, [rows, active, currentUserId]);
+
+  return (
+    <div>
+      {/* Bucket tabs */}
+      <div className="mb-4 flex flex-wrap gap-2">
+        {TAB_ORDER.map((b) => {
+          const on = active === b;
+          const isUnassigned = b === "UNASSIGNED";
+          return (
+            <button
+              key={b}
+              type="button"
+              onClick={() => setActive(b)}
+              className={`inline-flex items-center gap-2 rounded-pill border px-3.5 py-1.5 text-sm font-semibold transition-colors ${
+                on
+                  ? "border-navy bg-navy text-bg"
+                  : "border-border-2 bg-surface text-navy-3 hover:bg-bg"
+              }`}
+            >
+              {b === "MINE" && on ? (
+                <em className="font-display not-italic text-gold [font-style:italic]">
+                  Mine
+                </em>
+              ) : (
+                TAB_LABELS[b]
+              )}
+              <span
+                className={`rounded-pill px-1.5 py-0.5 text-[10px] font-bold ${
+                  on
+                    ? "bg-gold text-navy"
+                    : isUnassigned && counts.UNASSIGNED > 0
+                      ? "bg-warn-bg text-warn"
+                      : "bg-bg text-navy-3"
+                }`}
+              >
+                {counts[b]}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      <p className="mb-3 text-xs text-navy-3">
+        Showing <span className="font-semibold text-navy">{filtered.length}</span>{" "}
+        {filtered.length === 1 ? "thread" : "threads"}
+      </p>
+
+      {filtered.length === 0 ? (
+        <p className="rounded-xl border border-dashed border-border-2 bg-surface p-8 text-center text-sm text-navy-3">
+          No threads in {TAB_LABELS[active]}.
+        </p>
+      ) : (
+        <div className="divide-y divide-border overflow-hidden rounded-xl border border-border bg-surface">
+          {filtered.map((r) => {
+            const mine =
+              r.assignedToUserId != null && r.assignedToUserId === currentUserId;
+            const colleague =
+              r.assignedToUserId != null && r.assignedToUserId !== currentUserId;
+            const topic = r.topic ?? "OTHER";
+            const channelLabel = r.channel === "WHATSAPP" ? "WhatsApp" : "SMS";
+            return (
+              <Link
+                key={r.id}
+                href={`/inbox/${r.id}`}
+                className="flex items-start gap-3 px-4 py-3.5 transition-colors hover:bg-bg"
+              >
+                <span
+                  className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${
+                    r.status === "OPEN" ? "bg-green" : "bg-border-2"
+                  }`}
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="truncate font-medium text-navy">
+                      {r.contactName ?? r.contactPhone}
+                      {r.subject ? (
+                        <span className="font-normal text-navy-3"> · {r.subject}</span>
+                      ) : null}
+                    </span>
+                    <span className="shrink-0 text-xs text-navy-3">
+                      {when(r.lastMessageAt)}
+                    </span>
+                  </div>
+                  <p className="mt-0.5 truncate text-sm text-navy-3">
+                    {r.lastDir === "INBOUND" ? "↩ " : "→ "}
+                    {r.lastBody ?? "—"}
+                  </p>
+                  <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+                    <span
+                      className={`rounded-pill px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.04em] ${topicChipClass(
+                        topic,
+                      )}`}
+                    >
+                      {topicLabel(topic)}
+                    </span>
+                    <span className="rounded-pill border border-border-2 bg-bg px-2 py-0.5 text-[10px] font-semibold text-navy-3">
+                      {channelLabel}
+                    </span>
+                    {mine ? (
+                      <span className="rounded-pill bg-green-bg px-2 py-0.5 text-[10px] font-bold text-green">
+                        You
+                      </span>
+                    ) : colleague ? (
+                      <span className="rounded-pill border border-border-2 bg-bg px-2 py-0.5 text-[10px] font-bold text-navy-2">
+                        {firstName(r.assignedName ?? "—")}
+                      </span>
+                    ) : (
+                      <span className="rounded-pill bg-terra-bg px-2 py-0.5 text-[10px] font-bold text-terra">
+                        Unassigned
+                      </span>
+                    )}
+                    {r.routedByRuleName ? (
+                      <span className="text-[10px] italic text-navy-3">· auto-routed</span>
+                    ) : null}
+                  </div>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/omnischools/components/inbox/reassign-drawer.tsx
+++ b/omnischools/components/inbox/reassign-drawer.tsx
@@ -1,0 +1,240 @@
+"use client";
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Modal } from "@/components/ui/modal";
+import { reassignConversation } from "@/lib/actions/inbox";
+import type { StaffOption } from "@/lib/data/staff-options";
+
+const firstName = (name: string) => name.trim().split(/\s+/)[0] ?? name;
+const initials = (name: string) =>
+  name
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((p) => p[0]?.toUpperCase() ?? "")
+    .join("") || "?";
+
+/**
+ * Reassign drawer (surface §02) — hand a thread off to a colleague with an optional
+ * handoff note. Renders inside the focus-safe Modal. On submit it calls
+ * reassignConversation (which reassigns, clears auto-route provenance, and audits the
+ * note), then refreshes and closes. The "notify by SMS" checkbox is a cosmetic stub.
+ */
+export function ReassignDrawer({
+  conversationId,
+  currentAssigneeName,
+  staff,
+  currentUserId,
+}: {
+  conversationId: string;
+  currentAssigneeName: string | null;
+  staff: StaffOption[];
+  currentUserId: string;
+}) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [toUserId, setToUserId] = useState<string>("");
+  const [note, setNote] = useState("");
+  const [notify, setNotify] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  // Exclude the current user from the pick list — reassigning to yourself is a no-op.
+  const colleagues = staff.filter((s) => s.id !== currentUserId);
+
+  const selected = staff.find((s) => s.id === toUserId) ?? null;
+  const fromLabel = currentAssigneeName ?? "Unassigned";
+  const toLabel = selected ? selected.name : "Unassigned";
+
+  function reset() {
+    setToUserId("");
+    setNote("");
+    setNotify(true);
+    setError(null);
+  }
+
+  function close() {
+    setOpen(false);
+    reset();
+  }
+
+  function submit() {
+    setError(null);
+    startTransition(async () => {
+      const res = await reassignConversation({
+        conversationId,
+        toUserId,
+        handoffNote: note,
+      });
+      if (!res.ok) {
+        setError(res.error ?? "Could not reassign.");
+        return;
+      }
+      router.refresh();
+      close();
+    });
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="rounded-pill border border-gold bg-surface px-3 py-1.5 text-sm font-semibold text-gold transition-colors hover:bg-gold-bg"
+      >
+        Reassign →
+      </button>
+
+      <Modal open={open} onClose={close} title="Reassign thread">
+        <div className="space-y-4">
+          <p className="text-xs text-navy-3">
+            Hand this thread off to a colleague. The new assignee owns it and Auto-route
+            provenance is cleared.
+          </p>
+
+          {/* From → To hint */}
+          <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-3 rounded-xl border border-border bg-bg px-3.5 py-3">
+            <div>
+              <div className="text-[9px] font-bold uppercase tracking-[0.12em] text-navy-3">
+                From
+              </div>
+              <div className="mt-1 flex items-center gap-2">
+                <span className="flex h-7 w-7 items-center justify-center rounded-full bg-gold-bg font-display text-[11px] font-bold text-navy">
+                  {currentAssigneeName ? initials(currentAssigneeName) : "?"}
+                </span>
+                <span className="truncate text-xs font-semibold text-navy">
+                  {fromLabel}
+                </span>
+              </div>
+            </div>
+            <div className="text-center font-display text-lg font-bold text-gold">→</div>
+            <div>
+              <div className="text-[9px] font-bold uppercase tracking-[0.12em] text-navy-3">
+                To
+              </div>
+              <div className="mt-1 flex items-center gap-2">
+                <span
+                  className={`flex h-7 w-7 items-center justify-center rounded-full font-display text-[11px] font-bold ${
+                    selected ? "bg-green text-bg" : "bg-gold-bg text-navy"
+                  }`}
+                >
+                  {selected ? initials(selected.name) : "?"}
+                </span>
+                <span className="truncate text-xs font-semibold text-navy">{toLabel}</span>
+              </div>
+            </div>
+          </div>
+
+          {/* Colleague picker */}
+          <div>
+            <div className="mb-2 text-[10px] font-bold uppercase tracking-[0.14em] text-navy-3">
+              Choose colleague
+            </div>
+            <div className="flex max-h-56 flex-col gap-1.5 overflow-y-auto">
+              <label
+                className={`flex cursor-pointer items-center gap-3 rounded-lg border px-3 py-2 transition-colors ${
+                  toUserId === ""
+                    ? "border-gold bg-gold-bg"
+                    : "border-border bg-surface hover:bg-bg"
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="reassign-to"
+                  value=""
+                  checked={toUserId === ""}
+                  onChange={() => setToUserId("")}
+                  className="accent-gold"
+                />
+                <span className="text-sm font-medium text-navy-3">
+                  — Leave unassigned —
+                </span>
+              </label>
+              {colleagues.map((s) => (
+                <label
+                  key={s.id}
+                  className={`flex cursor-pointer items-center gap-3 rounded-lg border px-3 py-2 transition-colors ${
+                    toUserId === s.id
+                      ? "border-gold bg-gold-bg"
+                      : "border-border bg-surface hover:bg-bg"
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="reassign-to"
+                    value={s.id}
+                    checked={toUserId === s.id}
+                    onChange={() => setToUserId(s.id)}
+                    className="accent-gold"
+                  />
+                  <span className="flex h-7 w-7 items-center justify-center rounded-full bg-gold-bg font-display text-[11px] font-bold text-navy">
+                    {initials(s.name)}
+                  </span>
+                  <span className="text-sm font-medium text-navy">{s.name}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {/* Handoff note */}
+          <div>
+            <label
+              htmlFor="handoff-note"
+              className="mb-2 block text-[10px] font-bold uppercase tracking-[0.14em] text-navy-3"
+            >
+              Handoff note · optional
+            </label>
+            <textarea
+              id="handoff-note"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              maxLength={600}
+              placeholder={`Brief context for ${
+                selected ? firstName(selected.name) : "the new assignee"
+              } — what's happened so far, what needs to happen next`}
+              className="min-h-[70px] w-full resize-none rounded-lg border border-border-2 bg-surface px-3 py-2 text-sm text-navy outline-none transition-colors focus:border-gold"
+            />
+          </div>
+
+          {/* Notify (cosmetic stub) */}
+          <label className="flex items-start gap-2.5">
+            <input
+              type="checkbox"
+              checked={notify}
+              onChange={(e) => setNotify(e.target.checked)}
+              className="mt-0.5 accent-green"
+            />
+            <span className="text-sm">
+              <span className="font-medium text-navy">Notify by SMS</span>
+              <span className="mt-0.5 block text-xs text-navy-3">
+                Notify the new assignee that this thread is now theirs.
+              </span>
+            </span>
+          </label>
+
+          {error ? <p className="text-sm font-medium text-terra">{error}</p> : null}
+
+          {/* Footer */}
+          <div className="flex items-center justify-between gap-3 border-t border-border pt-4">
+            <button
+              type="button"
+              onClick={close}
+              disabled={pending}
+              className="rounded-lg px-3 py-2 text-sm font-semibold text-navy-3 transition-colors hover:text-navy disabled:opacity-60"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={submit}
+              disabled={pending}
+              className="rounded-lg bg-gold px-4 py-2 text-sm font-bold text-navy transition-colors hover:opacity-90 disabled:opacity-60"
+            >
+              {pending ? "Reassigning…" : "Reassign →"}
+            </button>
+          </div>
+        </div>
+      </Modal>
+    </>
+  );
+}

--- a/omnischools/lib/actions/inbox.ts
+++ b/omnischools/lib/actions/inbox.ts
@@ -3,6 +3,7 @@ import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { withSchool } from "@/lib/db/rls";
 import { requireSchool, resolveActor } from "@/lib/auth/server";
+import { recordAudit } from "@/lib/db/audit";
 import { normalizeGhanaPhone } from "@/lib/auth";
 import { sendSms } from "@/lib/sms";
 import { safeRevalidate } from "@/lib/revalidate";
@@ -160,5 +161,54 @@ export async function setConversationStatus(input: unknown): Promise<Result> {
     return { ok: true };
   } catch {
     return { ok: false, error: "Could not update status." };
+  }
+}
+
+// ------------------------------------------------------- reassign (with handoff)
+const ReassignSchema = z.object({
+  conversationId: z.string().uuid(),
+  toUserId: z.string().uuid().optional().or(z.literal("")), // "" = leave unassigned
+  handoffNote: z.string().max(600).optional().or(z.literal("")),
+});
+
+/**
+ * Reassign a thread to a colleague with an optional handoff note. This is an explicit
+ * human hand-off, so it clears the auto-route provenance and is written to the audit
+ * log (the note is the reason). Never silently overwrites without a trail.
+ */
+export async function reassignConversation(input: unknown): Promise<Result> {
+  const { school } = await requireSchool();
+  const parsed = ReassignSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: "Invalid input" };
+  const toUserId = parsed.data.toUserId?.trim() || null;
+  const note = parsed.data.handoffNote?.trim() || null;
+  const actor = await resolveActor(school.id);
+  try {
+    await withSchool(school.id, async (tx) => {
+      await tx
+        .update(conversations)
+        .set({ assignedToUserId: toUserId, routedByRuleId: null, routedByRuleName: null })
+        .where(
+          and(
+            eq(conversations.id, parsed.data.conversationId),
+            eq(conversations.schoolId, school.id),
+          ),
+        );
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "reassigned",
+        entityType: "conversation",
+        entityId: parsed.data.conversationId,
+        after: { assignedToUserId: toUserId },
+        reason: note ?? "Thread reassigned",
+      });
+    });
+    safeRevalidate(`/inbox/${parsed.data.conversationId}`);
+    safeRevalidate("/inbox");
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Could not reassign." };
   }
 }


### PR DESCRIPTION
## Inbox buckets + reassign (Channels PR2)

Surfaces the thread ownership the routing engine (PR1) now sets — `schoolup-inbox-routing` §01–§02. No schema.

### Buckets + chips (`InboxBrowser`)
Bucket tabs with live counts: **All · Mine · Team · Unassigned · Closed**
- **Mine** = assigned to me & open · **Team** = assigned to someone else & open · **Unassigned** = open & unowned · **Closed** = status.

Each thread row now shows a **topic chip** (Billing/Attendance/Academic/Schedule/Urgent, colour-coded), a **channel badge** (SMS/WhatsApp), an **assignee chip** (You / colleague / Unassigned), and a muted **"· auto-routed"** hint when a rule assigned it.

### Reassign (`/inbox/[id]`)
An **assignment bar** (Assigned to … · auto-routed by {rule} · topic chip) + a **Reassign drawer** — from→to, a colleague picker (+ "leave unassigned"), an optional **handoff note**, and a notify checkbox. Wires **`reassignConversation`**, which clears the auto-route provenance (now human-owned) and **audits** the handoff note.

### Verification (seeded demo threads, removed after)
- Buckets + counts (**All 5 · Team 2 · Unassigned 2 · Closed 1**); the **Unassigned** filter → "Showing 2"; topic/channel/assignee chips + auto-routed hint.
- **Reassign round-trip**: Unassigned → colleague with a handoff note; the assignment bar updates.
- `pnpm typecheck` + `pnpm lint` + `pnpm build` clean; no slash-opacity. No schema/prod changes.

### Channels epic
- ✅ PR1 routing engine + admin · ✅ **PR2 buckets + reassign** · ⏭ **PR3 WhatsApp channel + templates** (data model + template authoring; live window-inbox deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)