### PR TITLE
feat(billing): receipt PDF engine + authenticated staff download

### DIFF
--- a/omnischools/app/(app)/billing/payments/[paymentId]/page.tsx
+++ b/omnischools/app/(app)/billing/payments/[paymentId]/page.tsx
@@ -156,14 +156,20 @@ export default async function PaymentDetailPage({
           Payment from <em className="not-italic text-gold">{payer}</em>
         </h1>
         <div className="flex flex-wrap items-center gap-2">
-          <button
-            type="button"
-            disabled
-            title="Coming soon"
-            className="cursor-not-allowed rounded-md border border-border-2 px-3.5 py-2 text-sm font-semibold text-navy-3 opacity-60"
-          >
-            Download receipt PDF
-          </button>
+          {receipt ? (
+            <a
+              href={`/api/receipts/${payment.id}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-md border border-navy bg-navy px-3.5 py-2 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep"
+            >
+              Download receipt PDF
+            </a>
+          ) : (
+            <span className="cursor-not-allowed rounded-md border border-border-2 px-3.5 py-2 text-sm font-semibold text-navy-3 opacity-60">
+              No receipt to download
+            </span>
+          )}
           {payment.voidedAt ? (
             <span
               className={`rounded-md px-3.5 py-2 text-sm font-semibold ${
@@ -280,17 +286,29 @@ export default async function PaymentDetailPage({
                     {receipt.receiptNumber}
                   </span>
                   <div className="flex flex-wrap gap-2">
-                    {["View", "Download", "Email"].map((l) => (
-                      <button
-                        key={l}
-                        type="button"
-                        disabled
-                        title="Coming soon"
-                        className="cursor-not-allowed rounded-md border border-border-2 px-2.5 py-1 text-xs font-semibold text-navy-3 opacity-60"
-                      >
-                        {l}
-                      </button>
-                    ))}
+                    <a
+                      href={`/api/receipts/${payment.id}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="rounded-md border border-border-2 px-2.5 py-1 text-xs font-semibold text-navy transition-colors hover:border-gold-soft"
+                    >
+                      View
+                    </a>
+                    <a
+                      href={`/api/receipts/${payment.id}`}
+                      download
+                      className="rounded-md border border-border-2 px-2.5 py-1 text-xs font-semibold text-navy transition-colors hover:border-gold-soft"
+                    >
+                      Download
+                    </a>
+                    <button
+                      type="button"
+                      disabled
+                      title="Emailing parents is coming soon"
+                      className="cursor-not-allowed rounded-md border border-border-2 px-2.5 py-1 text-xs font-semibold text-navy-3 opacity-60"
+                    >
+                      Email
+                    </button>
                   </div>
                 </div>
                 <p className="mt-3 text-xs text-navy-3">

--- a/omnischools/app/api/receipts/[paymentId]/route.ts
+++ b/omnischools/app/api/receipts/[paymentId]/route.ts
@@ -1,0 +1,221 @@
+import { and, asc, desc, eq } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import {
+  payments,
+  receipts,
+  paymentAllocations,
+  paymentAuditLog,
+  invoices,
+  students,
+  studentGuardians,
+  classes,
+  users,
+  schools,
+} from "@/db/schema";
+import { num } from "@/lib/fees-helpers";
+import { amountInWordsGhs } from "@/lib/number-to-words";
+import { renderReceiptPdf } from "@/lib/pdf/render-receipt";
+import type { ReceiptData } from "@/lib/pdf/receipt-document";
+
+// @react-pdf/renderer is Node-only (fontkit); never run this on the edge.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const METHOD_LABELS: Record<string, string> = {
+  MTN_MOMO: "MTN MoMo",
+  TELECEL_CASH: "Telecel Cash",
+  AIRTELTIGO_MONEY: "AirtelTigo Money",
+  BANK_TRANSFER: "Bank transfer",
+  CASH: "Cash",
+  CHEQUE: "Cheque",
+  OTHER: "Other",
+};
+const titleize = (s: string) =>
+  s.replaceAll("_", " ").toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase());
+const fmtDateTime = (d: Date | string) =>
+  (d instanceof Date ? d : new Date(d))
+    .toLocaleString("en-GB", {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    })
+    .replace(",", " ·");
+const initialsOf = (name: string) =>
+  name
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? "")
+    .join("") || "S";
+
+/**
+ * GET /api/receipts/[paymentId] — the authenticated staff receipt download. Renders the
+ * receipt for a payment to a PDF and streams it inline. Scoped to the caller's school via
+ * requireSchool + withSchool, so a staffer can only ever pull their own school's receipts.
+ * (The public, tokened parent-facing link is a separate slice.)
+ */
+export async function GET(
+  _req: Request,
+  { params }: { params: { paymentId: string } },
+) {
+  const { school } = await requireSchool();
+
+  const built = await withSchool(school.id, async (tx): Promise<ReceiptData | null> => {
+    const [p] = await tx
+      .select({
+        id: payments.id,
+        studentId: payments.studentId,
+        grossAmount: payments.grossAmount,
+        method: payments.method,
+        methodReference: payments.methodReference,
+        paidAt: payments.paidAt,
+        recordedAt: payments.recordedAt,
+        voidedAt: payments.voidedAt,
+        voidReason: payments.voidReason,
+        voidIsRefund: payments.voidIsRefund,
+        studentFirst: students.firstName,
+        studentLast: students.lastName,
+        studentCode: students.studentCode,
+        classLabel: students.currentClassLabel,
+        className: classes.name,
+      })
+      .from(payments)
+      .innerJoin(students, eq(payments.studentId, students.id))
+      .leftJoin(classes, eq(students.classId, classes.id))
+      .where(and(eq(payments.id, params.paymentId), eq(payments.schoolId, school.id)));
+    if (!p) return null;
+
+    const [receipt] = await tx
+      .select({
+        receiptNumber: receipts.receiptNumber,
+        generatedAt: receipts.generatedAt,
+      })
+      .from(receipts)
+      .where(eq(receipts.paymentId, p.id))
+      .limit(1);
+    if (!receipt) return null; // no receipt on record → nothing to render
+
+    const [sc] = await tx
+      .select({ name: schools.name, address: schools.address, gesCode: schools.gesCode })
+      .from(schools)
+      .where(eq(schools.id, school.id));
+
+    const [guardian] = await tx
+      .select({
+        name: studentGuardians.name,
+        phone: studentGuardians.phone,
+        relationship: studentGuardians.relationship,
+      })
+      .from(studentGuardians)
+      .where(eq(studentGuardians.studentId, p.studentId))
+      .orderBy(desc(studentGuardians.isPrimary))
+      .limit(1);
+
+    const allocs = await tx
+      .select({
+        amount: paymentAllocations.amount,
+        invoiceNumber: invoices.invoiceNumber,
+        academicYear: invoices.academicYear,
+      })
+      .from(paymentAllocations)
+      .innerJoin(invoices, eq(paymentAllocations.invoiceId, invoices.id))
+      .where(
+        and(
+          eq(paymentAllocations.paymentId, p.id),
+          eq(paymentAllocations.allocationType, "INVOICE"),
+        ),
+      )
+      .orderBy(asc(paymentAllocations.allocatedAt));
+
+    const auditRows = await tx
+      .select({
+        eventType: paymentAuditLog.eventType,
+        actorName: users.fullName,
+        createdAt: paymentAuditLog.createdAt,
+      })
+      .from(paymentAuditLog)
+      .leftJoin(users, eq(paymentAuditLog.actorUserId, users.id))
+      .where(eq(paymentAuditLog.paymentId, p.id))
+      .orderBy(asc(paymentAuditLog.createdAt));
+
+    const gross = num(p.grossAmount);
+    const recordedByName = auditRows[0]?.actorName ?? null;
+    const voidEvent = auditRows.find((e) => String(e.eventType).includes("VOID"));
+
+    const schoolName = sc?.name ?? school.name;
+    const classLabel = p.className ?? p.classLabel ?? null;
+
+    const lines: ReceiptData["lines"] =
+      allocs.length > 0
+        ? allocs.map((a) => ({
+            main: "Fees payment",
+            sub: `${a.academicYear ?? ""} · ${a.invoiceNumber}`.trim(),
+            period: a.academicYear ?? null,
+            amount: num(a.amount),
+          }))
+        : [{ main: "Payment on account", sub: null, period: null, amount: gross }];
+
+    return {
+      school: {
+        name: schoolName,
+        initials: initialsOf(schoolName),
+        addressLine: sc?.address ?? null,
+        idLine: sc?.gesCode ? `School ID: ${sc.gesCode}` : null,
+      },
+      receiptNumber: receipt.receiptNumber,
+      issuedAt: fmtDateTime(receipt.generatedAt ?? p.paidAt ?? p.recordedAt),
+      payer: {
+        name: guardian?.name ?? "—",
+        sub: guardian
+          ? `${guardian.phone} · ${titleize(guardian.relationship)}`
+          : null,
+      },
+      student: {
+        name: `${p.studentFirst} ${p.studentLast}`,
+        sub: [classLabel, p.studentCode].filter(Boolean).join(" · ") || null,
+      },
+      amount: gross,
+      amountInWords: amountInWordsGhs(gross),
+      lines,
+      allocations:
+        allocs.length > 1
+          ? allocs.map((a) => ({
+              invoiceNumber: a.invoiceNumber,
+              description: a.academicYear ?? "",
+              amount: num(a.amount),
+            }))
+          : null,
+      method: {
+        label: METHOD_LABELS[p.method] ?? titleize(p.method),
+        reference: p.methodReference,
+        sub: null,
+      },
+      recordedBy: recordedByName ? { name: recordedByName, role: null } : null,
+      context: null,
+      voided: p.voidedAt
+        ? {
+            at: fmtDateTime(p.voidedAt),
+            by: voidEvent?.actorName ?? null,
+            reason: p.voidReason,
+            replacement: null,
+          }
+        : null,
+    };
+  });
+
+  if (!built) {
+    return new Response("Receipt not found", { status: 404 });
+  }
+
+  const pdf = await renderReceiptPdf(built);
+  return new Response(new Uint8Array(pdf), {
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": `inline; filename="Receipt-${built.receiptNumber}.pdf"`,
+      "Cache-Control": "private, no-store",
+    },
+  });
+}

--- a/omnischools/lib/number-to-words.ts
+++ b/omnischools/lib/number-to-words.ts
@@ -1,0 +1,58 @@
+/**
+ * Spell a Ghana-cedi amount in words for receipts, e.g. 340 → "three hundred and forty
+ * Ghana cedis", 1204.5 → "one thousand, two hundred and four Ghana cedis and fifty
+ * pesewas". Lowercase, matching the receipt surface's in-words style.
+ */
+const ONES = [
+  "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+  "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen",
+  "eighteen", "nineteen",
+];
+const TENS = [
+  "", "", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety",
+];
+const SCALES: [number, string][] = [
+  [1_000_000_000, "billion"],
+  [1_000_000, "million"],
+  [1_000, "thousand"],
+];
+
+/** Spell a whole number below 1000 (no leading "and"). */
+function underThousand(n: number): string {
+  if (n < 20) return ONES[n];
+  if (n < 100) {
+    const t = TENS[Math.floor(n / 10)];
+    const r = n % 10;
+    return r ? `${t}-${ONES[r]}` : t;
+  }
+  const h = Math.floor(n / 100);
+  const r = n % 100;
+  return r ? `${ONES[h]} hundred and ${underThousand(r)}` : `${ONES[h]} hundred`;
+}
+
+/** Spell any non-negative integer. */
+function spellInteger(n: number): string {
+  if (n === 0) return "zero";
+  const parts: string[] = [];
+  let rest = n;
+  for (const [value, name] of SCALES) {
+    if (rest >= value) {
+      parts.push(`${underThousand(Math.floor(rest / value))} ${name}`);
+      rest %= value;
+    }
+  }
+  if (rest > 0) {
+    // Join a trailing hundreds/tens group with "and" when there's a higher group.
+    parts.push(parts.length > 0 && rest < 100 ? `and ${underThousand(rest)}` : underThousand(rest));
+  }
+  return parts.join(", ");
+}
+
+export function amountInWordsGhs(amount: number): string {
+  const safe = Number.isFinite(amount) ? Math.abs(amount) : 0;
+  const cedis = Math.floor(safe);
+  const pesewas = Math.round((safe - cedis) * 100);
+  const cedisWords = `${spellInteger(cedis)} Ghana ${cedis === 1 ? "cedi" : "cedis"}`;
+  if (pesewas === 0) return cedisWords;
+  return `${cedisWords} and ${spellInteger(pesewas)} ${pesewas === 1 ? "pesewa" : "pesewas"}`;
+}

--- a/omnischools/lib/pdf/fonts.ts
+++ b/omnischools/lib/pdf/fonts.ts
@@ -1,0 +1,18 @@
+/**
+ * PDF font roles for the document components.
+ *
+ * We use @react-pdf's built-in standard fonts (always present, zero bundling) as reliable
+ * stands-in for the brand faces, preserving the serif / sans / mono distinction the design
+ * relies on:
+ *   Fraunces (display serif)  → Times-Roman
+ *   Manrope  (body sans)      → Helvetica
+ *   JetBrains Mono            → Courier
+ *
+ * FOLLOW-UP (named in the PDF-engine PR): register the real brand TTFs via Font.register once
+ * serverless font-file bundling (outputFileTracingIncludes on Vercel) is deploy-tested — it
+ * can't be verified in this environment, and a failed font load would break rendering, so we
+ * ship on the guaranteed-present core fonts first. Swapping is a one-file change here.
+ */
+export const SERIF = "Times-Roman";
+export const SANS = "Helvetica";
+export const MONO = "Courier";

--- a/omnischools/lib/pdf/receipt-document.tsx
+++ b/omnischools/lib/pdf/receipt-document.tsx
@@ -1,0 +1,484 @@
+import React from "react";
+import { Document, Page, View, Text, StyleSheet } from "@react-pdf/renderer";
+import { SERIF, SANS, MONO } from "./fonts";
+
+/**
+ * Printable payment-receipt PDF — a 1:1 replication of Surfaces/schoolup-receipt-pdf.html
+ * (A5 portrait). Presentational only: all values arrive pre-formatted from the route so this
+ * component does no data access or locale work. Supports the standard, multi-invoice
+ * (allocation band) and voided states from the surface.
+ */
+
+// --- design tokens (hex; @react-pdf can't use CSS vars) ---
+const NAVY = "#1A2B47";
+const NAVY2 = "#2D3F5C";
+const NAVY3 = "#5C6675";
+const GOLD = "#C8975B";
+const GOLD_SOFT = "#E8D4B8";
+const GOLD_BG = "#F5EBDC";
+const BG = "#FAF7F2";
+const GREEN = "#2F6B47";
+const TERRA = "#B84A39";
+const TERRA_BG = "#F5E1DC";
+const BORDER = "#E5DFD3";
+
+const ghs = (v: number) =>
+  `GHS ${v.toLocaleString("en-GH", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+export type ReceiptLine = {
+  main: string;
+  sub?: string | null;
+  period?: string | null;
+  amount: number;
+};
+export type ReceiptAllocation = {
+  invoiceNumber: string;
+  description: string;
+  amount: number;
+};
+export type ReceiptData = {
+  school: {
+    name: string;
+    initials: string;
+    addressLine?: string | null;
+    idLine?: string | null;
+  };
+  receiptNumber: string;
+  issuedAt: string;
+  payer: { name: string; sub?: string | null };
+  student: { name: string; sub?: string | null };
+  amount: number;
+  amountInWords: string;
+  lines: ReceiptLine[];
+  allocations?: ReceiptAllocation[] | null;
+  method: { label: string; reference?: string | null; sub?: string | null };
+  recordedBy?: { name: string; role?: string | null } | null;
+  context?: string | null;
+  voided?: {
+    at: string;
+    by?: string | null;
+    reason?: string | null;
+    replacement?: string | null;
+  } | null;
+};
+
+const s = StyleSheet.create({
+  page: { backgroundColor: "#FFFFFF", fontFamily: SANS, fontSize: 10, color: NAVY },
+  strip: { height: 6, backgroundColor: GOLD },
+
+  // header
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    paddingHorizontal: 36,
+    paddingVertical: 20,
+    borderBottomWidth: 1,
+    borderBottomColor: BORDER,
+  },
+  schoolRow: { flexDirection: "row", gap: 12 },
+  mark: {
+    width: 44,
+    height: 44,
+    backgroundColor: NAVY,
+    borderRadius: 7,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  markText: { fontFamily: SERIF, fontWeight: "bold", fontSize: 16, color: GOLD },
+  schoolName: { fontFamily: SERIF, fontWeight: "bold", fontSize: 15, color: NAVY, marginBottom: 3 },
+  metaLine: { fontSize: 8.5, color: NAVY3, lineHeight: 1.5 },
+  anchor: { alignItems: "flex-end" },
+  docType: { fontSize: 8, color: GOLD, fontWeight: "bold", letterSpacing: 1, marginBottom: 3 },
+  receiptNo: { fontFamily: SERIF, fontWeight: "bold", fontSize: 15, color: NAVY, marginBottom: 2 },
+  issued: { fontSize: 8.5, color: NAVY3 },
+
+  // payer
+  payer: {
+    flexDirection: "row",
+    paddingHorizontal: 36,
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: BORDER,
+    borderStyle: "dashed",
+  },
+  cell: { flex: 1 },
+  lbl: { fontSize: 7.5, color: GOLD, fontWeight: "bold", letterSpacing: 1, marginBottom: 3 },
+  lblDark: { fontSize: 7.5, color: NAVY3, fontWeight: "bold", letterSpacing: 1, marginBottom: 3 },
+  val: { fontFamily: SERIF, fontWeight: "bold", fontSize: 12, color: NAVY, lineHeight: 1.3 },
+  sub: { fontSize: 8.5, color: NAVY3, marginTop: 2, lineHeight: 1.4 },
+
+  // body
+  body: { paddingHorizontal: 36, paddingTop: 16 },
+  banner: {
+    backgroundColor: BG,
+    borderLeftWidth: 3,
+    borderLeftColor: GOLD,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    borderTopRightRadius: 6,
+    borderBottomRightRadius: 6,
+    marginBottom: 14,
+  },
+  bannerLbl: { fontSize: 7.5, color: GOLD, fontWeight: "bold", letterSpacing: 1.2, marginBottom: 3 },
+  valRow: { flexDirection: "row", alignItems: "flex-end", gap: 12 },
+  amount: { fontFamily: SERIF, fontWeight: "bold", fontSize: 26, color: NAVY },
+  inWords: { fontSize: 9, color: NAVY3, fontStyle: "italic", flex: 1, lineHeight: 1.4, paddingBottom: 3 },
+
+  // allocation band
+  alloc: {
+    backgroundColor: GOLD_BG,
+    marginHorizontal: -36,
+    paddingHorizontal: 36,
+    paddingVertical: 12,
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    borderColor: GOLD_SOFT,
+    marginBottom: 12,
+  },
+  allocHead: { fontSize: 7.5, color: GOLD, fontWeight: "bold", letterSpacing: 1, marginBottom: 6 },
+  allocRow: { flexDirection: "row", gap: 12, paddingVertical: 5, alignItems: "center" },
+  invId: { fontFamily: MONO, fontSize: 8.5, color: GOLD, fontWeight: "bold", width: 90 },
+  invDesc: { fontFamily: SERIF, fontSize: 10, color: NAVY, flex: 1 },
+  invAmt: { fontFamily: SERIF, fontWeight: "bold", fontSize: 10, color: GREEN, width: 70, textAlign: "right" },
+
+  // table
+  table: { borderTopWidth: 1, borderTopColor: BORDER },
+  thead: {
+    flexDirection: "row",
+    paddingVertical: 6,
+    borderBottomWidth: 1,
+    borderBottomColor: BORDER,
+  },
+  th: { fontSize: 7.5, color: NAVY3, fontWeight: "bold", letterSpacing: 1 },
+  trow: {
+    flexDirection: "row",
+    paddingVertical: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: BORDER,
+    borderStyle: "dashed",
+  },
+  colDesc: { flex: 1 },
+  colPeriod: { width: 70, textAlign: "right" },
+  colAmt: { width: 80, textAlign: "right" },
+  tdMain: { fontFamily: SERIF, fontWeight: "bold", fontSize: 10.5, color: NAVY },
+  tdSub: { fontSize: 8, color: NAVY3, marginTop: 1 },
+  tdPeriod: { fontFamily: SERIF, fontSize: 10, color: NAVY3 },
+  tdAmt: { fontFamily: SERIF, fontWeight: "bold", fontSize: 10, color: NAVY },
+
+  totals: { flexDirection: "row", justifyContent: "flex-end", marginTop: 6 },
+  totalLbl: {
+    fontSize: 10.5,
+    fontWeight: "bold",
+    color: NAVY,
+    textAlign: "right",
+    borderTopWidth: 2,
+    borderTopColor: NAVY,
+    paddingTop: 8,
+    paddingRight: 16,
+  },
+  totalVal: {
+    fontFamily: SERIF,
+    fontWeight: "bold",
+    fontSize: 15,
+    color: NAVY,
+    width: 90,
+    textAlign: "right",
+    borderTopWidth: 2,
+    borderTopColor: NAVY,
+    paddingTop: 8,
+  },
+
+  contextBox: {
+    marginTop: 14,
+    padding: 12,
+    backgroundColor: BG,
+    borderRadius: 6,
+    fontSize: 9,
+    color: NAVY3,
+    lineHeight: 1.5,
+  },
+  bold: { color: NAVY, fontWeight: "bold" },
+
+  // payment method
+  method: {
+    flexDirection: "row",
+    paddingHorizontal: 36,
+    paddingVertical: 14,
+    marginTop: 16,
+    backgroundColor: BG,
+    borderTopWidth: 1,
+    borderTopColor: BORDER,
+  },
+  methodVal: { fontFamily: SERIF, fontWeight: "bold", fontSize: 11, color: NAVY },
+  methodMono: { fontFamily: MONO, fontSize: 10, color: NAVY, fontWeight: "bold" },
+
+  // footer
+  footer: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-end",
+    paddingHorizontal: 36,
+    paddingVertical: 14,
+    borderTopWidth: 1,
+    borderTopColor: BORDER,
+  },
+  stamp: {
+    width: 110,
+    height: 58,
+    borderWidth: 1.5,
+    borderColor: GOLD_SOFT,
+    borderStyle: "dashed",
+    borderRadius: 50,
+    alignItems: "center",
+    justifyContent: "center",
+    transform: "rotate(-4deg)",
+    marginBottom: 8,
+  },
+  stampText: { fontFamily: SERIF, fontStyle: "italic", fontSize: 8, color: GOLD, textAlign: "center", lineHeight: 1.2 },
+  sigLine: { width: 130, borderBottomWidth: 1, borderBottomColor: NAVY, paddingBottom: 1 },
+  sigName: { fontFamily: SERIF, fontWeight: "bold", fontSize: 9.5, color: NAVY, marginTop: 5 },
+  sigRole: { fontSize: 8.5, color: NAVY3 },
+  qrBlock: { alignItems: "center" },
+  qr: { width: 64, height: 64, backgroundColor: NAVY, borderRadius: 4, marginBottom: 4 },
+  qrLabel: { fontSize: 7.5, color: NAVY3, letterSpacing: 0.4 },
+
+  platform: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    paddingHorizontal: 36,
+    paddingTop: 12,
+    paddingBottom: 18,
+    borderTopWidth: 1,
+    borderTopColor: BORDER,
+  },
+  platformText: { fontSize: 7.5, color: NAVY3, letterSpacing: 0.4 },
+  goldEm: { color: GOLD, fontWeight: "bold" },
+  verifyUrl: { fontFamily: MONO, fontSize: 7.5, color: NAVY3, letterSpacing: 0.2 },
+
+  // void
+  voidBanner: {
+    flexDirection: "row",
+    gap: 12,
+    paddingHorizontal: 36,
+    paddingVertical: 12,
+    backgroundColor: TERRA_BG,
+    borderTopWidth: 2,
+    borderTopColor: TERRA,
+  },
+  voidIc: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    backgroundColor: TERRA,
+    color: "#FFFFFF",
+    fontFamily: SERIF,
+    fontWeight: "bold",
+    fontSize: 13,
+    textAlign: "center",
+    lineHeight: 1.5,
+  },
+  voidTitle: { fontFamily: SERIF, fontWeight: "bold", fontSize: 11, color: TERRA, marginBottom: 2 },
+  voidBody: { fontSize: 9, color: NAVY2, lineHeight: 1.5, flex: 1 },
+  voidStampWrap: {
+    position: "absolute",
+    top: 300,
+    left: 120,
+  },
+  voidStamp: {
+    borderWidth: 5,
+    borderColor: TERRA,
+    borderRadius: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 28,
+    transform: "rotate(-12deg)",
+  },
+  voidStampText: { fontFamily: SERIF, fontWeight: "bold", fontSize: 56, color: TERRA, letterSpacing: 4 },
+});
+
+export function ReceiptDocument({ data }: { data: ReceiptData }) {
+  const isVoid = !!data.voided;
+  const bodyOpacity = isVoid ? 0.55 : 1;
+  const allocations = data.allocations ?? [];
+
+  return (
+    <Document
+      title={`Receipt ${data.receiptNumber}`}
+      author="Omnischools"
+      subject={`Payment receipt for ${data.student.name}`}
+    >
+      <Page size="A5" style={s.page}>
+        <View style={s.strip} />
+
+        {isVoid && (
+          <View style={s.voidBanner}>
+            <Text style={s.voidIc}>!</Text>
+            <View style={s.voidBody}>
+              <Text style={s.voidTitle}>This receipt has been voided</Text>
+              <Text>
+                Voided {data.voided?.at}
+                {data.voided?.by ? ` by ${data.voided.by}` : ""}
+                {data.voided?.reason ? (
+                  <Text>
+                    {" · reason: "}
+                    <Text style={s.bold}>&ldquo;{data.voided.reason}&rdquo;</Text>
+                  </Text>
+                ) : null}
+                . The original payment was reversed; this receipt is no longer a valid record
+                of payment.
+                {data.voided?.replacement ? ` Replacement: ${data.voided.replacement}.` : ""}
+              </Text>
+            </View>
+          </View>
+        )}
+
+        <View style={{ opacity: bodyOpacity }}>
+          {/* Header */}
+          <View style={s.header}>
+            <View style={s.schoolRow}>
+              <View style={s.mark}>
+                <Text style={s.markText}>{data.school.initials}</Text>
+              </View>
+              <View>
+                <Text style={s.schoolName}>{data.school.name}</Text>
+                {data.school.addressLine ? (
+                  <Text style={s.metaLine}>{data.school.addressLine}</Text>
+                ) : null}
+                {data.school.idLine ? (
+                  <Text style={s.metaLine}>{data.school.idLine}</Text>
+                ) : null}
+              </View>
+            </View>
+            <View style={s.anchor}>
+              <Text style={s.docType}>OFFICIAL RECEIPT</Text>
+              <Text style={s.receiptNo}>{data.receiptNumber}</Text>
+              <Text style={s.issued}>Issued {data.issuedAt}</Text>
+            </View>
+          </View>
+
+          {/* Payer */}
+          <View style={s.payer}>
+            <View style={s.cell}>
+              <Text style={s.lbl}>RECEIVED FROM</Text>
+              <Text style={s.val}>{data.payer.name}</Text>
+              {data.payer.sub ? <Text style={s.sub}>{data.payer.sub}</Text> : null}
+            </View>
+            <View style={s.cell}>
+              <Text style={s.lbl}>FOR THE ACCOUNT OF</Text>
+              <Text style={s.val}>{data.student.name}</Text>
+              {data.student.sub ? <Text style={s.sub}>{data.student.sub}</Text> : null}
+            </View>
+          </View>
+
+          {/* Body */}
+          <View style={s.body}>
+            <View style={s.banner}>
+              <Text style={s.bannerLbl}>TOTAL RECEIVED</Text>
+              <View style={s.valRow}>
+                <Text style={s.amount}>{ghs(data.amount)}</Text>
+                <Text style={s.inWords}>{data.amountInWords}</Text>
+              </View>
+            </View>
+
+            {allocations.length > 1 && (
+              <View style={s.alloc}>
+                <Text style={s.allocHead}>
+                  SETTLED ACROSS {allocations.length} INVOICES
+                </Text>
+                {allocations.map((a, i) => (
+                  <View key={i} style={s.allocRow}>
+                    <Text style={s.invId}>{a.invoiceNumber}</Text>
+                    <Text style={s.invDesc}>{a.description}</Text>
+                    <Text style={s.invAmt}>{ghs(a.amount)}</Text>
+                  </View>
+                ))}
+              </View>
+            )}
+
+            <View style={s.table}>
+              <View style={s.thead}>
+                <Text style={[s.th, s.colDesc]}>Description</Text>
+                <Text style={[s.th, s.colPeriod]}>Period</Text>
+                <Text style={[s.th, s.colAmt]}>Amount</Text>
+              </View>
+              {data.lines.map((li, i) => (
+                <View key={i} style={s.trow}>
+                  <View style={s.colDesc}>
+                    <Text style={s.tdMain}>{li.main}</Text>
+                    {li.sub ? <Text style={s.tdSub}>{li.sub}</Text> : null}
+                  </View>
+                  <Text style={[s.tdPeriod, s.colPeriod]}>{li.period ?? ""}</Text>
+                  <Text style={[s.tdAmt, s.colAmt]}>{ghs(li.amount)}</Text>
+                </View>
+              ))}
+              <View style={s.totals}>
+                <Text style={s.totalLbl}>Paid this transaction</Text>
+                <Text style={s.totalVal}>{ghs(data.amount)}</Text>
+              </View>
+            </View>
+
+            {data.context ? (
+              <Text style={s.contextBox}>{data.context}</Text>
+            ) : null}
+          </View>
+
+          {/* Payment method */}
+          <View style={s.method}>
+            <View style={s.cell}>
+              <Text style={s.lblDark}>METHOD</Text>
+              <Text style={s.methodVal}>{data.method.label}</Text>
+              {data.method.sub ? <Text style={s.sub}>{data.method.sub}</Text> : null}
+            </View>
+            <View style={s.cell}>
+              <Text style={s.lblDark}>TRANSACTION ID</Text>
+              <Text style={s.methodMono}>{data.method.reference ?? "—"}</Text>
+            </View>
+            <View style={s.cell}>
+              <Text style={s.lblDark}>RECORDED BY</Text>
+              <Text style={s.methodVal}>{data.recordedBy?.name ?? "—"}</Text>
+              {data.recordedBy?.role ? (
+                <Text style={s.sub}>{data.recordedBy.role}</Text>
+              ) : null}
+            </View>
+          </View>
+
+          {/* Footer — signature + QR */}
+          <View style={s.footer}>
+            <View>
+              <View style={s.stamp}>
+                <Text style={s.stampText}>{data.school.name}</Text>
+                <Text style={s.stampText}>OFFICIAL</Text>
+              </View>
+              <View style={s.sigLine} />
+              <Text style={s.sigName}>{data.recordedBy?.name ?? data.school.name}</Text>
+              <Text style={s.sigRole}>Authorised officer</Text>
+            </View>
+            <View style={s.qrBlock}>
+              <View style={s.qr} />
+              <Text style={s.qrLabel}>Verify at omnischools.gh/r</Text>
+            </View>
+          </View>
+
+          {/* Platform footer */}
+          <View style={s.platform}>
+            <Text style={s.platformText}>
+              Issued on <Text style={s.goldEm}>Omnischools</Text> · the school management
+              platform
+            </Text>
+            <Text style={s.verifyUrl}>
+              omnischools.gh/r/{data.receiptNumber}
+              {isVoid ? " · VOIDED" : ""}
+            </Text>
+          </View>
+        </View>
+
+        {isVoid && (
+          <View style={s.voidStampWrap} fixed>
+            <View style={s.voidStamp}>
+              <Text style={s.voidStampText}>VOID</Text>
+            </View>
+          </View>
+        )}
+      </Page>
+    </Document>
+  );
+}

--- a/omnischools/lib/pdf/render-receipt.tsx
+++ b/omnischools/lib/pdf/render-receipt.tsx
@@ -1,0 +1,9 @@
+import "server-only";
+import React from "react";
+import { renderToBuffer } from "@react-pdf/renderer";
+import { ReceiptDocument, type ReceiptData } from "./receipt-document";
+
+/** Render a receipt to a PDF Buffer (Node runtime only). */
+export function renderReceiptPdf(data: ReceiptData): Promise<Buffer> {
+  return renderToBuffer(<ReceiptDocument data={data} />);
+}

--- a/omnischools/next.config.mjs
+++ b/omnischools/next.config.mjs
@@ -1,6 +1,11 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  // @react-pdf/renderer (receipt/report-card PDFs) is a Node-only lib pulling in fontkit;
+  // keep it out of the webpack bundle so the server route can require it at runtime.
+  experimental: {
+    serverComponentsExternalPackages: ["@react-pdf/renderer"],
+  },
   // Portability (BUILD_STACK): keep image optimisation host-agnostic.
   images: {
     remotePatterns: [

--- a/omnischools/package.json
+++ b/omnischools/package.json
@@ -28,6 +28,7 @@
     "db:setup": "drizzle-kit migrate && tsx scripts/apply-policies.ts && tsx db/seed/asankrangwa.ts"
   },
   "dependencies": {
+    "@react-pdf/renderer": "^4.5.1",
     "@supabase/ssr": "^0.10.3",
     "@supabase/supabase-js": "^2.107.0",
     "class-variance-authority": "^0.7.1",

--- a/omnischools/pnpm-lock.yaml
+++ b/omnischools/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@react-pdf/renderer':
+        specifier: ^4.5.1
+        version: 4.5.1(react@18.3.1)
       '@supabase/ssr':
         specifier: ^0.10.3
         version: 0.10.3(@supabase/supabase-js@2.107.0)
@@ -93,6 +96,10 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -676,6 +683,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -695,6 +710,49 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@react-pdf/fns@3.1.3':
+    resolution: {integrity: sha512-0I7pApDr1/RLAKbizuLy/IHTEa93LSPy/bEwYniboC3Xqnp6Od8xFJKbKEzGw2wh/5zKFFwl00g4t9RwgIMc3w==}
+
+  '@react-pdf/font@4.0.8':
+    resolution: {integrity: sha512-deNd+emtZAJho1IlzKL9bRoLAGv/6oXOIKO2oZfs4RuXUrK1onLHbJO7e2YoVLPFP/sQxisRTnzdJFtd35iKwA==}
+
+  '@react-pdf/image@3.1.0':
+    resolution: {integrity: sha512-ks7Ry8v711r8NvKWSELehj0BXBNPRihSnWsM09nDD8Ur175zbWBCK217LLwQMKDNYDVpkZaipdoJPom1LGaE9g==}
+
+  '@react-pdf/layout@4.6.1':
+    resolution: {integrity: sha512-gN6PmWoEffvlIkifLfEhMsVucRywVMyH3rnxdyOVOhGy0nWJKKGpHyPc4plbDdpP6EfZ0r8prHXujDSkIG2nSA==}
+
+  '@react-pdf/pdfkit@5.1.1':
+    resolution: {integrity: sha512-wNcdSsNlNYyGHGAgIdt453egBF7fiF9UxpRlklUfVvu8OWCrUppG9xiUrPLVoKiqWet5tMi0w6LmuFUJuYqjEg==}
+
+  '@react-pdf/primitives@4.3.0':
+    resolution: {integrity: sha512-nYXoZ36pvwNzbc54+DbL8RCn15jU7woJ9D/svnh5tpUXekJ+CbI4mZLo6boSv24CvJgychOu6h7gxX03B4ps0A==}
+
+  '@react-pdf/reconciler@2.0.0':
+    resolution: {integrity: sha512-7zaPRujpbHSmCpIrZ+b9HSTJHthcVZzX0Wx7RzvQGsGBUbHP4p6s5itXrAIOuQuPvDepoHGNOvf6xUuMVvdoyw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@react-pdf/render@4.5.1':
+    resolution: {integrity: sha512-IW/N4HWJWtioBXCf7n02IR24VJJ8gbdS3jGypf+vW/rSErEx3/URRzh9UK6Ma8Fpog9+T/W6GE2NHJ5AAKHhVA==}
+
+  '@react-pdf/renderer@4.5.1':
+    resolution: {integrity: sha512-5r1VQrE6FRLXX5wWUxwZzM24E2BJMo6g8AQWuS8WyPs9ugu5yMnb2g8/RpPYka/Z6J+RUEWc32wty2NoUJF42Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@react-pdf/stylesheet@6.2.1':
+    resolution: {integrity: sha512-2+UEk+7e+z8baaWi2l5kPLWmwtJeOI+T5wW9GGeN3iDH7vd3kbTqOpN1yt9mmfNVZFxQsnDHpznFb5v5UF983A==}
+
+  '@react-pdf/svg@1.1.0':
+    resolution: {integrity: sha512-cTIHXiz9x1HrbfqzfxfZP3FRdDwUXG77QWF6Fb5MP/lV3ONxR+g0Z3hwtBatCS9HeGBQCpxX/Lzb8wHE+co1PA==}
+
+  '@react-pdf/textkit@6.3.0':
+    resolution: {integrity: sha512-v6+V8nAcVwm7s2s1jIG2MD3Iw//x/k+XrH1foWOELBE4b32pyDgKyPXN/6KJE0dnX7+fVy27uctLNCLNMvzKzQ==}
+
+  '@react-pdf/types@2.11.1':
+    resolution: {integrity: sha512-i9xQgfaDU9QoeNnbp6rltXCWg1huEh195rpOuN8cE4BZ2FuLdQrsIcb2dhFF9aOxXf+XBA6LOSpIW051MDD/bw==}
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -736,6 +794,9 @@ packages:
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
   '@swc/helpers@0.5.5':
     resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
@@ -942,6 +1003,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  abs-svg-path@0.1.1:
+    resolution: {integrity: sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1046,6 +1110,16 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@0.0.8:
+    resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
+    engines: {node: '>= 0.4'}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
@@ -1063,6 +1137,12 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  brotli@1.3.3:
+    resolution: {integrity: sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==}
+
+  browserify-zlib@0.2.0:
+    resolution: {integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -1108,6 +1188,10 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  clone@2.1.2:
+    resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
+    engines: {node: '>=0.8'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -1118,6 +1202,14 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  color-name@2.1.0:
+    resolution: {integrity: sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==}
+    engines: {node: '>=12.20'}
+
+  color-string@2.1.4:
+    resolution: {integrity: sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==}
+    engines: {node: '>=18'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -1184,6 +1276,9 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  dfa@1.2.0:
+    resolution: {integrity: sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -1305,6 +1400,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  emoji-regex-xs@1.0.0:
+    resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -1475,6 +1573,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1500,6 +1602,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -1518,6 +1623,9 @@ packages:
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  fontkit@2.0.4:
+    resolution: {integrity: sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==}
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -1626,6 +1734,15 @@ packages:
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
+
+  hsl-to-hex@1.0.0:
+    resolution: {integrity: sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==}
+
+  hsl-to-rgb-for-reals@1.1.1:
+    resolution: {integrity: sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==}
+
+  hyphen@1.14.1:
+    resolution: {integrity: sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw==}
 
   iceberg-js@0.8.1:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
@@ -1761,6 +1878,9 @@ packages:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
 
+  is-url@1.2.4:
+    resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
+
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
     engines: {node: '>= 0.4'}
@@ -1787,9 +1907,15 @@ packages:
     resolution: {integrity: sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==}
     engines: {node: '>=14'}
 
+  jay-peg@1.1.1:
+    resolution: {integrity: sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==}
+
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
+
+  js-md5@0.8.3:
+    resolution: {integrity: sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1833,6 +1959,9 @@ packages:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
 
+  linebreak@1.1.0:
+    resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -1858,6 +1987,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  media-engine@1.0.3:
+    resolution: {integrity: sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -1930,6 +2062,9 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  normalize-svg-path@1.1.0:
+    resolution: {integrity: sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -1985,9 +2120,18 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-svg-path@0.1.2:
+    resolution: {integrity: sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -2026,6 +2170,9 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  png-js@2.0.0:
+    resolution: {integrity: sha512-GdzJuUMc6ZSpxFJWVxtOH1bzYHym+TOnveqUjb+VJIbZWbZzyiRGFiKhbiielfpYbgMlhHVhsJ0FTazfuRFkMA==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -2160,6 +2307,9 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  queue@6.0.2:
+    resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
+
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
@@ -2187,6 +2337,10 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2204,6 +2358,9 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  restructure@3.0.2:
+    resolution: {integrity: sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -2220,6 +2377,9 @@ packages:
     resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
     engines: {node: '>=0.4'}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
     engines: {node: '>= 0.4'}
@@ -2230,6 +2390,9 @@ packages:
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  scheduler@0.25.0-rc-603e6108-20241029:
+    resolution: {integrity: sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -2333,6 +2496,9 @@ packages:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -2375,6 +2541,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svg-arc-to-cubic-bezier@3.2.0:
+    resolution: {integrity: sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==}
+
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
@@ -2397,6 +2566,9 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -2462,6 +2634,12 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  unicode-properties@1.4.1:
+    resolution: {integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==}
+
+  unicode-trie@2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
+
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
 
@@ -2470,6 +2648,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vite-compatible-readable-stream@3.6.1:
+    resolution: {integrity: sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==}
+    engines: {node: '>= 6'}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -2511,12 +2693,17 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@babel/runtime@7.29.7': {}
 
   '@drizzle-team/brocli@0.10.2': {}
 
@@ -2866,6 +3053,10 @@ snapshots:
   '@next/swc-win32-x64-msvc@14.2.33':
     optional: true
 
+  '@noble/ciphers@1.3.0': {}
+
+  '@noble/hashes@1.8.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2882,6 +3073,110 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@react-pdf/fns@3.1.3': {}
+
+  '@react-pdf/font@4.0.8':
+    dependencies:
+      '@react-pdf/pdfkit': 5.1.1
+      '@react-pdf/types': 2.11.1
+      fontkit: 2.0.4
+      is-url: 1.2.4
+
+  '@react-pdf/image@3.1.0':
+    dependencies:
+      '@react-pdf/svg': 1.1.0
+      jay-peg: 1.1.1
+      png-js: 2.0.0
+
+  '@react-pdf/layout@4.6.1':
+    dependencies:
+      '@react-pdf/fns': 3.1.3
+      '@react-pdf/image': 3.1.0
+      '@react-pdf/primitives': 4.3.0
+      '@react-pdf/stylesheet': 6.2.1
+      '@react-pdf/textkit': 6.3.0
+      '@react-pdf/types': 2.11.1
+      emoji-regex-xs: 1.0.0
+      queue: 6.0.2
+      yoga-layout: 3.2.1
+
+  '@react-pdf/pdfkit@5.1.1':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@noble/ciphers': 1.3.0
+      '@noble/hashes': 1.8.0
+      browserify-zlib: 0.2.0
+      fontkit: 2.0.4
+      jay-peg: 1.1.1
+      js-md5: 0.8.3
+      linebreak: 1.1.0
+      png-js: 2.0.0
+      vite-compatible-readable-stream: 3.6.1
+
+  '@react-pdf/primitives@4.3.0': {}
+
+  '@react-pdf/reconciler@2.0.0(react@18.3.1)':
+    dependencies:
+      object-assign: 4.1.1
+      react: 18.3.1
+      scheduler: 0.25.0-rc-603e6108-20241029
+
+  '@react-pdf/render@4.5.1':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@react-pdf/fns': 3.1.3
+      '@react-pdf/primitives': 4.3.0
+      '@react-pdf/textkit': 6.3.0
+      '@react-pdf/types': 2.11.1
+      abs-svg-path: 0.1.1
+      color-string: 2.1.4
+      normalize-svg-path: 1.1.0
+      parse-svg-path: 0.1.2
+      svg-arc-to-cubic-bezier: 3.2.0
+
+  '@react-pdf/renderer@4.5.1(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@react-pdf/fns': 3.1.3
+      '@react-pdf/font': 4.0.8
+      '@react-pdf/layout': 4.6.1
+      '@react-pdf/pdfkit': 5.1.1
+      '@react-pdf/primitives': 4.3.0
+      '@react-pdf/reconciler': 2.0.0(react@18.3.1)
+      '@react-pdf/render': 4.5.1
+      '@react-pdf/types': 2.11.1
+      events: 3.3.0
+      object-assign: 4.1.1
+      prop-types: 15.8.1
+      queue: 6.0.2
+      react: 18.3.1
+
+  '@react-pdf/stylesheet@6.2.1':
+    dependencies:
+      '@react-pdf/fns': 3.1.3
+      '@react-pdf/types': 2.11.1
+      color-string: 2.1.4
+      hsl-to-hex: 1.0.0
+      media-engine: 1.0.3
+      postcss-value-parser: 4.2.0
+
+  '@react-pdf/svg@1.1.0':
+    dependencies:
+      '@react-pdf/primitives': 4.3.0
+
+  '@react-pdf/textkit@6.3.0':
+    dependencies:
+      '@react-pdf/fns': 3.1.3
+      bidi-js: 1.0.3
+      hyphen: 1.14.1
+      unicode-properties: 1.4.1
+
+  '@react-pdf/types@2.11.1':
+    dependencies:
+      '@react-pdf/font': 4.0.8
+      '@react-pdf/primitives': 4.3.0
+      '@react-pdf/stylesheet': 6.2.1
 
   '@rtsao/scc@1.1.0': {}
 
@@ -2925,6 +3220,10 @@ snapshots:
       '@supabase/storage-js': 2.107.0
 
   '@swc/counter@0.1.3': {}
+
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
 
   '@swc/helpers@0.5.5':
     dependencies:
@@ -3116,6 +3415,8 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
+  abs-svg-path@0.1.1: {}
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -3235,6 +3536,14 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@0.0.8: {}
+
+  base64-js@1.5.1: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   binary-extensions@2.3.0: {}
 
   brace-expansion@1.1.15:
@@ -3253,6 +3562,14 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  brotli@1.3.3:
+    dependencies:
+      base64-js: 1.5.1
+
+  browserify-zlib@0.2.0:
+    dependencies:
+      pako: 1.0.11
 
   buffer-from@1.1.2: {}
 
@@ -3306,6 +3623,8 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  clone@2.1.2: {}
+
   clsx@2.1.1: {}
 
   color-convert@2.0.1:
@@ -3313,6 +3632,12 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  color-name@2.1.0: {}
+
+  color-string@2.1.4:
+    dependencies:
+      color-name: 2.1.0
 
   commander@4.1.1: {}
 
@@ -3372,6 +3697,8 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  dfa@1.2.0: {}
+
   didyoumean@1.2.2: {}
 
   dlv@1.1.3: {}
@@ -3404,6 +3731,8 @@ snapshots:
       gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
+
+  emoji-regex-xs@1.0.0: {}
 
   emoji-regex@8.0.0: {}
 
@@ -3793,6 +4122,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  events@3.3.0: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -3815,6 +4146,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fflate@0.8.3: {}
+
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
@@ -3835,6 +4168,18 @@ snapshots:
       rimraf: 3.0.2
 
   flatted@3.4.2: {}
+
+  fontkit@2.0.4:
+    dependencies:
+      '@swc/helpers': 0.5.23
+      brotli: 1.3.3
+      clone: 2.1.2
+      dfa: 1.2.0
+      fast-deep-equal: 3.1.3
+      restructure: 3.0.2
+      tiny-inflate: 1.0.3
+      unicode-properties: 1.4.1
+      unicode-trie: 2.0.0
 
   for-each@0.3.5:
     dependencies:
@@ -3954,6 +4299,14 @@ snapshots:
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
+
+  hsl-to-hex@1.0.0:
+    dependencies:
+      hsl-to-rgb-for-reals: 1.1.1
+
+  hsl-to-rgb-for-reals@1.1.1: {}
+
+  hyphen@1.14.1: {}
 
   iceberg-js@0.8.1: {}
 
@@ -4090,6 +4443,8 @@ snapshots:
     dependencies:
       which-typed-array: 1.1.21
 
+  is-url@1.2.4: {}
+
   is-weakmap@2.0.2: {}
 
   is-weakref@1.1.1:
@@ -4120,7 +4475,13 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jay-peg@1.1.1:
+    dependencies:
+      restructure: 3.0.2
+
   jiti@1.21.7: {}
+
+  js-md5@0.8.3: {}
 
   js-tokens@4.0.0: {}
 
@@ -4162,6 +4523,11 @@ snapshots:
 
   lilconfig@3.1.3: {}
 
+  linebreak@1.1.0:
+    dependencies:
+      base64-js: 0.0.8
+      unicode-trie: 2.0.0
+
   lines-and-columns@1.2.4: {}
 
   locate-path@6.0.0:
@@ -4181,6 +4547,8 @@ snapshots:
       react: 18.3.1
 
   math-intrinsics@1.1.0: {}
+
+  media-engine@1.0.3: {}
 
   merge2@1.4.1: {}
 
@@ -4253,6 +4621,10 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  normalize-svg-path@1.1.0:
+    dependencies:
+      svg-arc-to-cubic-bezier: 3.2.0
+
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
@@ -4324,9 +4696,15 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  pako@0.2.9: {}
+
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-svg-path@0.1.2: {}
 
   path-exists@4.0.0: {}
 
@@ -4350,6 +4728,10 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  png-js@2.0.0:
+    dependencies:
+      fflate: 0.8.3
 
   possible-typed-array-names@1.1.0: {}
 
@@ -4417,6 +4799,10 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  queue@6.0.2:
+    dependencies:
+      inherits: 2.0.4
+
   react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
@@ -4457,6 +4843,8 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  require-from-string@2.0.2: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -4477,6 +4865,8 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  restructure@3.0.2: {}
+
   reusify@1.1.0: {}
 
   rimraf@3.0.2:
@@ -4495,6 +4885,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-buffer@5.2.1: {}
+
   safe-push-apply@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -4509,6 +4901,8 @@ snapshots:
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
+
+  scheduler@0.25.0-rc-603e6108-20241029: {}
 
   semver@6.3.1: {}
 
@@ -4652,6 +5046,10 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -4684,6 +5082,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svg-arc-to-cubic-bezier@3.2.0: {}
 
   tailwind-merge@3.6.0: {}
 
@@ -4728,6 +5128,8 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  tiny-inflate@1.0.3: {}
 
   tinyglobby@0.2.17:
     dependencies:
@@ -4809,6 +5211,16 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  unicode-properties@1.4.1:
+    dependencies:
+      base64-js: 1.5.1
+      unicode-trie: 2.0.0
+
+  unicode-trie@2.0.0:
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
+
   unrs-resolver@1.12.2:
     dependencies:
       napi-postinstall: 0.3.4
@@ -4841,6 +5253,12 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  vite-compatible-readable-stream@3.6.1:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -4904,5 +5322,7 @@ snapshots:
   wrappy@1.0.2: {}
 
   yocto-queue@0.1.0: {}
+
+  yoga-layout@3.2.1: {}
 
   zod@4.4.3: {}


### PR DESCRIPTION
## Summary
Recommended-sequence **①a** — server-side **receipt PDF generation** with an authenticated staff download, replicating `Surfaces/schoolup-receipt-pdf.html` 1:1.

## Approach
- **`@react-pdf/renderer`** (pure-JS, no headless chromium → serverless-portable). Added to `serverComponentsExternalPackages` so it stays out of the webpack bundle.
- **On-demand generation, not stored.** A receipt is small and immutable, so `GET /api/receipts/[paymentId]` renders it per request and streams it inline — no storage bucket, no upload step, no stale files, no migration. Fully portable.
- **Tenant-scoped**: the route runs `requireSchool` + `withSchool`, so a staffer can only ever pull their own school's receipts.

## What's included
- `lib/pdf/receipt-document.tsx` — the A5 receipt: gold accent strip, school-mark header, `RECEIVED FROM` / `FOR THE ACCOUNT OF`, `TOTAL RECEIVED` banner with amount-in-words, line-item table, multi-invoice **allocation band**, payment-method row, signature + QR footer, platform footer. Plus the **voided** state (terra banner + diagonal `VOID` overlay + dimmed body).
- `lib/number-to-words.ts` — GHS amount-in-words ("three hundred and forty Ghana cedis").
- `app/api/receipts/[paymentId]/route.ts` — the Node-runtime render+stream route.
- Payment detail page: the **Download receipt PDF** button and the receipt card's **View / Download** are now live links.

## Verification
- `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm build` ✅ (`@react-pdf` bundled cleanly).
- Rendered sample PDFs (standard + voided/multi-invoice) out-of-band and eyeballed — layout, tokens/colours, tables, allocation band, VOID overlay and amount-in-words all render correctly.

## Follow-ups (named, not silently dropped)
- **Brand fonts**: currently uses `@react-pdf` core fonts (Times/Helvetica/Courier) as serif/sans/mono stand-ins. Registering the real Fraunces/Manrope/JetBrains TTFs needs serverless font-file bundling (`outputFileTracingIncludes`) that can't be verified in a local session — swapping is a one-file change in `lib/pdf/fonts.ts`.
- **Parent-facing link**: the tokened public SMS receipt link is the next slice (its own security review — unauthenticated access to a PII document).
- School header shows address + `School ID` (GES code); the surface's phone/email line is omitted (no such columns on `ref_school` yet).

No schema change, no prod SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)