### PR TITLE
feat(gradebook): report-card PDF + authenticated staff download

### DIFF
--- a/omnischools/app/(app)/gradebook/report/[studentId]/page.tsx
+++ b/omnischools/app/(app)/gradebook/report/[studentId]/page.tsx
@@ -73,7 +73,17 @@ export default async function ReportCardPage({
     <div className="mx-auto max-w-3xl">
       <div className="mb-4 flex items-center justify-between print:hidden">
         <BackLink href="/gradebook/reports" label="Report cards" />
-        <PrintButton />
+        <div className="flex items-center gap-2">
+          <a
+            href={`/api/report-cards/${student.id}?periodId=${periodId}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded-md border border-navy bg-navy px-4 py-2 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep"
+          >
+            Download PDF
+          </a>
+          <PrintButton />
+        </div>
       </div>
 
       <div className="bg-surface rounded-xl border border-border p-8">

--- a/omnischools/app/api/report-cards/[studentId]/route.ts
+++ b/omnischools/app/api/report-cards/[studentId]/route.ts
@@ -1,0 +1,154 @@
+import { and, asc, eq } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import {
+  students,
+  academicPeriod,
+  subjects,
+  gradebookScores,
+  reportCards,
+  schools,
+} from "@/db/schema";
+import { renderReportCardPdf } from "@/lib/pdf/render-report-card";
+import type { ReportCardData } from "@/lib/pdf/report-card-document";
+
+// @react-pdf/renderer is Node-only (fontkit); never run this on the edge.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const toNum = (v: unknown): number | null =>
+  v == null || v === "" ? null : Number(v);
+const initialsOf = (name: string) =>
+  name
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? "")
+    .join("") || "S";
+const slug = (s: string) => s.replace(/[^A-Za-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+
+/**
+ * GET /api/report-cards/[studentId]?periodId=… — the authenticated staff report-card
+ * download. Renders the terminal report card for a student × period to a PDF and streams
+ * it inline. Tenant-scoped via requireSchool + withSchool. Mirrors the on-screen report
+ * card at app/(app)/gradebook/report/[studentId].
+ */
+export async function GET(
+  req: Request,
+  { params }: { params: { studentId: string } },
+) {
+  const { school } = await requireSchool();
+  const periodId = new URL(req.url).searchParams.get("periodId");
+  if (!periodId) return new Response("Missing periodId", { status: 400 });
+
+  const built = await withSchool(school.id, async (tx): Promise<ReportCardData | null> => {
+    const [student] = await tx
+      .select({
+        firstName: students.firstName,
+        otherNames: students.otherNames,
+        lastName: students.lastName,
+        studentCode: students.studentCode,
+        classLabel: students.currentClassLabel,
+      })
+      .from(students)
+      .where(and(eq(students.id, params.studentId), eq(students.schoolId, school.id)));
+    if (!student) return null;
+
+    const [period] = await tx
+      .select({
+        academicYear: academicPeriod.academicYear,
+        periodLabel: academicPeriod.periodLabel,
+      })
+      .from(academicPeriod)
+      .where(
+        and(eq(academicPeriod.periodId, periodId), eq(academicPeriod.schoolId, school.id)),
+      );
+
+    const lines = await tx
+      .select({
+        subject: subjects.name,
+        classScore: gradebookScores.classScore,
+        examScore: gradebookScores.examScore,
+        total: gradebookScores.total,
+        grade: gradebookScores.grade,
+      })
+      .from(gradebookScores)
+      .innerJoin(subjects, eq(gradebookScores.subjectId, subjects.id))
+      .where(
+        and(
+          eq(gradebookScores.schoolId, school.id),
+          eq(gradebookScores.studentId, params.studentId),
+          eq(gradebookScores.periodId, periodId),
+        ),
+      )
+      .orderBy(asc(subjects.name));
+
+    const [card] = await tx
+      .select({
+        remark: reportCards.remark,
+        overallTotal: reportCards.overallTotal,
+        overallGrade: reportCards.overallGrade,
+        generatedAt: reportCards.generatedAt,
+      })
+      .from(reportCards)
+      .where(
+        and(
+          eq(reportCards.studentId, params.studentId),
+          eq(reportCards.periodId, periodId),
+          eq(reportCards.schoolId, school.id),
+        ),
+      );
+
+    const [sc] = await tx
+      .select({ name: schools.name })
+      .from(schools)
+      .where(eq(schools.id, school.id));
+    const schoolName = sc?.name ?? school.name;
+
+    const fullName = `${student.firstName} ${student.otherNames ?? ""} ${student.lastName}`
+      .replace(/\s+/g, " ")
+      .trim();
+
+    return {
+      school: { name: schoolName, initials: initialsOf(schoolName) },
+      title: "Terminal Report",
+      periodLabel: period
+        ? `${period.academicYear} · ${period.periodLabel}`
+        : "—",
+      student: {
+        name: fullName,
+        code: student.studentCode,
+        classLabel: student.classLabel ?? "—",
+      },
+      lines: lines.map((l) => ({
+        subject: l.subject,
+        classScore: toNum(l.classScore),
+        examScore: toNum(l.examScore),
+        total: toNum(l.total),
+        grade: l.grade ?? null,
+      })),
+      overallTotal: toNum(card?.overallTotal),
+      overallGrade: card?.overallGrade ?? null,
+      remark: card?.remark ?? null,
+      generatedAt: card?.generatedAt
+        ? new Date(card.generatedAt).toLocaleDateString("en-GB", {
+            day: "numeric",
+            month: "short",
+            year: "numeric",
+          })
+        : null,
+    };
+  });
+
+  if (!built) return new Response("Student not found", { status: 404 });
+
+  const pdf = await renderReportCardPdf(built);
+  const filename = `Report-${slug(built.student.code)}-${slug(built.periodLabel)}.pdf`;
+  return new Response(new Uint8Array(pdf), {
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": `inline; filename="${filename}"`,
+      "Cache-Control": "private, no-store",
+    },
+  });
+}

--- a/omnischools/lib/pdf/render-report-card.tsx
+++ b/omnischools/lib/pdf/render-report-card.tsx
@@ -1,0 +1,9 @@
+import "server-only";
+import React from "react";
+import { renderToBuffer } from "@react-pdf/renderer";
+import { ReportCardDocument, type ReportCardData } from "./report-card-document";
+
+/** Render a terminal report card to a PDF Buffer (Node runtime only). */
+export function renderReportCardPdf(data: ReportCardData): Promise<Buffer> {
+  return renderToBuffer(<ReportCardDocument data={data} />);
+}

--- a/omnischools/lib/pdf/report-card-document.tsx
+++ b/omnischools/lib/pdf/report-card-document.tsx
@@ -1,0 +1,267 @@
+import React from "react";
+import { Document, Page, View, Text, StyleSheet } from "@react-pdf/renderer";
+import { SERIF, SANS, MONO } from "./fonts";
+
+/**
+ * Terminal report-card PDF (A4) — a faithful print rendering of the on-screen report card
+ * at app/(app)/gradebook/report/[studentId]. Presentational only; the route pre-loads and
+ * passes all values. Core PDF fonts (see ./fonts) stand in for the brand faces.
+ */
+
+const NAVY = "#1A2B47";
+const NAVY3 = "#5C6675";
+const GOLD = "#C8975B";
+const GOLD_BG = "#F5EBDC";
+const BG = "#FAF7F2";
+const BORDER = "#E5DFD3";
+
+const fmt0 = (n: number | null | undefined) => (n == null ? "—" : n.toFixed(0));
+const fmt2 = (n: number | null | undefined) => (n == null ? "—" : n.toFixed(2));
+
+export type ReportCardLine = {
+  subject: string;
+  classScore: number | null;
+  examScore: number | null;
+  total: number | null;
+  grade: string | null;
+};
+export type ReportCardData = {
+  school: { name: string; initials: string };
+  title: string; // "Terminal Report"
+  periodLabel: string; // "2025/26 · Term 1"
+  student: { name: string; code: string; classLabel: string };
+  lines: ReportCardLine[];
+  overallTotal: number | null;
+  overallGrade: string | null;
+  remark?: string | null;
+  generatedAt?: string | null; // preformatted date, or null
+};
+
+const s = StyleSheet.create({
+  page: { backgroundColor: "#FFFFFF", fontFamily: SANS, fontSize: 10, color: NAVY, padding: 0 },
+  strip: { height: 6, backgroundColor: GOLD },
+
+  header: { alignItems: "center", paddingHorizontal: 40, paddingTop: 22, paddingBottom: 16 },
+  mark: {
+    width: 46,
+    height: 46,
+    backgroundColor: NAVY,
+    borderRadius: 8,
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 10,
+  },
+  markText: { fontFamily: SERIF, fontWeight: "bold", fontSize: 18, color: GOLD },
+  schoolName: { fontFamily: SERIF, fontWeight: "bold", fontSize: 22, color: NAVY, textAlign: "center" },
+  eyebrow: {
+    fontSize: 8,
+    color: GOLD,
+    fontWeight: "bold",
+    letterSpacing: 1.6,
+    marginTop: 8,
+  },
+  periodLine: { fontSize: 10, color: NAVY3, marginTop: 3 },
+
+  // student meta
+  meta: {
+    marginHorizontal: 40,
+    marginBottom: 18,
+    flexDirection: "row",
+    flexWrap: "wrap",
+    borderWidth: 1,
+    borderColor: BORDER,
+    borderRadius: 8,
+    backgroundColor: BG,
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+  },
+  metaCell: { width: "50%", paddingVertical: 3 },
+  metaLbl: { fontSize: 8, color: NAVY3, fontWeight: "bold", letterSpacing: 0.6 },
+  metaVal: { fontSize: 11, color: NAVY, marginTop: 1 },
+  metaMono: { fontFamily: MONO, fontSize: 10, color: NAVY, marginTop: 1 },
+
+  // table
+  table: { marginHorizontal: 40 },
+  thead: {
+    flexDirection: "row",
+    borderBottomWidth: 1.5,
+    borderBottomColor: NAVY,
+    paddingBottom: 6,
+  },
+  th: { fontSize: 8, color: NAVY3, fontWeight: "bold", letterSpacing: 0.8, textTransform: "uppercase" },
+  trow: {
+    flexDirection: "row",
+    paddingVertical: 7,
+    borderBottomWidth: 1,
+    borderBottomColor: BORDER,
+    alignItems: "center",
+  },
+  colSubject: { flex: 1 },
+  colNum: { width: 64, textAlign: "right" },
+  colGrade: { width: 56, textAlign: "right" },
+  tdSubject: { fontSize: 10.5, color: NAVY },
+  tdNum: { fontSize: 10, color: "#2D3F5C" },
+  tdTotal: { fontFamily: SERIF, fontWeight: "bold", fontSize: 10.5, color: NAVY },
+  tdGrade: { fontFamily: SERIF, fontWeight: "bold", fontSize: 10.5, color: NAVY },
+  emptyRow: { paddingVertical: 20, textAlign: "center", fontSize: 10, color: NAVY3 },
+
+  // summary
+  summary: {
+    marginHorizontal: 40,
+    marginTop: 16,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
+    gap: 20,
+  },
+  remarkBox: { flex: 1 },
+  remarkLbl: { fontSize: 8, color: NAVY3, fontWeight: "bold", letterSpacing: 0.6, marginBottom: 3 },
+  remarkText: { fontSize: 10, color: "#2D3F5C", lineHeight: 1.5 },
+  overallBox: {
+    borderWidth: 1,
+    borderColor: GOLD,
+    backgroundColor: GOLD_BG,
+    borderRadius: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 18,
+    alignItems: "flex-end",
+    minWidth: 150,
+  },
+  overallLbl: { fontSize: 8, color: NAVY3, fontWeight: "bold", letterSpacing: 1 },
+  overallRow: { flexDirection: "row", alignItems: "baseline", marginTop: 3 },
+  overallTotal: { fontFamily: SERIF, fontWeight: "bold", fontSize: 26, color: NAVY },
+  overallGrade: { fontFamily: SERIF, fontWeight: "bold", fontSize: 18, color: GOLD, marginLeft: 8 },
+
+  // signatures
+  signatures: {
+    marginHorizontal: 40,
+    marginTop: 40,
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+  sigCol: { width: "42%" },
+  sigLine: { borderBottomWidth: 1, borderBottomColor: NAVY, marginBottom: 4 },
+  sigLbl: { fontSize: 8, color: NAVY3 },
+
+  // footer
+  footer: {
+    position: "absolute",
+    bottom: 24,
+    left: 40,
+    right: 40,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    borderTopWidth: 1,
+    borderTopColor: BORDER,
+    paddingTop: 8,
+  },
+  footerText: { fontSize: 8, color: NAVY3, letterSpacing: 0.3 },
+  goldEm: { color: GOLD, fontWeight: "bold" },
+});
+
+function MetaCell({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <View style={s.metaCell}>
+      <Text style={s.metaLbl}>{label}</Text>
+      <Text style={mono ? s.metaMono : s.metaVal}>{value}</Text>
+    </View>
+  );
+}
+
+export function ReportCardDocument({ data }: { data: ReportCardData }) {
+  return (
+    <Document
+      title={`${data.title} — ${data.student.name}`}
+      author="Omnischools"
+      subject={`${data.title} · ${data.periodLabel}`}
+    >
+      <Page size="A4" style={s.page}>
+        <View style={s.strip} />
+
+        {/* Header */}
+        <View style={s.header}>
+          <View style={s.mark}>
+            <Text style={s.markText}>{data.school.initials}</Text>
+          </View>
+          <Text style={s.schoolName}>{data.school.name}</Text>
+          <Text style={s.eyebrow}>{data.title.toUpperCase()}</Text>
+          <Text style={s.periodLine}>{data.periodLabel}</Text>
+        </View>
+
+        {/* Student meta */}
+        <View style={s.meta}>
+          <MetaCell label="STUDENT" value={data.student.name} />
+          <MetaCell label="STUDENT CODE" value={data.student.code} mono />
+          <MetaCell label="CLASS" value={data.student.classLabel} />
+        </View>
+
+        {/* Scores table */}
+        <View style={s.table}>
+          <View style={s.thead}>
+            <Text style={[s.th, s.colSubject]}>Subject</Text>
+            <Text style={[s.th, s.colNum]}>Class</Text>
+            <Text style={[s.th, s.colNum]}>Exam</Text>
+            <Text style={[s.th, s.colNum]}>Total</Text>
+            <Text style={[s.th, s.colGrade]}>Grade</Text>
+          </View>
+          {data.lines.length === 0 ? (
+            <Text style={s.emptyRow}>No scores entered for this period.</Text>
+          ) : (
+            data.lines.map((l, i) => (
+              <View key={i} style={s.trow}>
+                <Text style={[s.tdSubject, s.colSubject]}>{l.subject}</Text>
+                <Text style={[s.tdNum, s.colNum]}>{fmt0(l.classScore)}</Text>
+                <Text style={[s.tdNum, s.colNum]}>{fmt0(l.examScore)}</Text>
+                <Text style={[s.tdTotal, s.colNum]}>{fmt2(l.total)}</Text>
+                <Text style={[s.tdGrade, s.colGrade]}>{l.grade ?? "—"}</Text>
+              </View>
+            ))
+          )}
+        </View>
+
+        {/* Summary — remark + overall */}
+        <View style={s.summary}>
+          <View style={s.remarkBox}>
+            {data.remark ? (
+              <>
+                <Text style={s.remarkLbl}>REMARK</Text>
+                <Text style={s.remarkText}>{data.remark}</Text>
+              </>
+            ) : null}
+          </View>
+          <View style={s.overallBox}>
+            <Text style={s.overallLbl}>OVERALL</Text>
+            <View style={s.overallRow}>
+              <Text style={s.overallTotal}>{fmt2(data.overallTotal)}</Text>
+              {data.overallGrade ? (
+                <Text style={s.overallGrade}>{data.overallGrade}</Text>
+              ) : null}
+            </View>
+          </View>
+        </View>
+
+        {/* Signatures */}
+        <View style={s.signatures}>
+          <View style={s.sigCol}>
+            <View style={s.sigLine} />
+            <Text style={s.sigLbl}>Class teacher</Text>
+          </View>
+          <View style={s.sigCol}>
+            <View style={s.sigLine} />
+            <Text style={s.sigLbl}>Headteacher</Text>
+          </View>
+        </View>
+
+        {/* Footer */}
+        <View style={s.footer} fixed>
+          <Text style={s.footerText}>
+            {data.generatedAt ? `Generated ${data.generatedAt}` : "Draft — not yet generated"}
+          </Text>
+          <Text style={s.footerText}>
+            Issued on <Text style={s.goldEm}>Omnischools</Text>
+          </Text>
+        </View>
+      </Page>
+    </Document>
+  );
+}


### PR DESCRIPTION
## Summary
Recommended-sequence **① (other half)** — terminal **report-card PDFs**, reusing the receipt PDF engine.

> **Stacked on [#122](https://github.com/Omnischools/omnischools/pull/122)** (the receipt PDF engine, which introduces `lib/pdf/*` + `@react-pdf/renderer`). Base is `feat/receipt-pdf` so this diff shows only the report-card changes. Merge #122 first; GitHub will retarget this to `main`.

## What's included
- `lib/pdf/report-card-document.tsx` — an **A4 terminal report card**: gold accent strip, centred school masthead, student-meta box, `Subject / Class / Exam / Total / Grade` table, remark + gold **Overall** box, class-teacher & headteacher signature lines, platform footer. A faithful print rendering of the on-screen card at `gradebook/report/[studentId]` (there's no separate surface for it).
- `app/api/report-cards/[studentId]/route.ts` — `GET ?periodId=…`, Node runtime, renders on demand and streams inline; tenant-scoped via `requireSchool` + `withSchool`.
- Report card page: a live **Download PDF** button next to Print.

## Verification
- `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm build` ✅
- Rendered a sample (10-subject card) out-of-band — fits one A4 page; masthead, table, overall box, remark and signature lines all render correctly.

Shares `lib/pdf/fonts` (core PDF fonts) with the receipt engine. No schema change, no storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)