### PR TITLE
feat(gradebook): report-card PDF — term average, attendance summary & grade key

### DIFF
--- a/omnischools/app/(app)/gradebook/report/[studentId]/page.tsx
+++ b/omnischools/app/(app)/gradebook/report/[studentId]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, eq, gte, lte, sql } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import {
@@ -8,7 +8,15 @@ import {
   subjects,
   gradebookScores,
   reportCards,
+  gradeScale,
+  attendanceRecords,
 } from "@/db/schema";
+import {
+  averageOfTotals,
+  gradeForScore,
+  gradeLegend,
+  type GradeBand,
+} from "@/lib/gradebook/grade-scale";
 import { PrintButton } from "@/components/gradebook/print-button";
 import { BackLink } from "@/components/ui/back-link";
 
@@ -34,7 +42,9 @@ export default async function ReportCardPage({
     const [period] = await tx
       .select()
       .from(academicPeriod)
-      .where(eq(academicPeriod.periodId, periodId));
+      .where(
+        and(eq(academicPeriod.periodId, periodId), eq(academicPeriod.schoolId, school.id)),
+      );
     const lines = await tx
       .select({
         subject: subjects.name,
@@ -63,24 +73,75 @@ export default async function ReportCardPage({
           eq(reportCards.schoolId, school.id),
         ),
       );
-    return { student, period, lines, card };
+    const scaleRows = await tx
+      .select({
+        grade: gradeScale.grade,
+        label: gradeScale.label,
+        minScore: gradeScale.minScore,
+      })
+      .from(gradeScale)
+      .where(eq(gradeScale.schoolId, school.id))
+      .orderBy(asc(gradeScale.ordinal));
+
+    let attendance: { present: number; absent: number; excused: number } | null = null;
+    if (period?.startsOn && period?.endsOn) {
+      const attRows = await tx
+        .select({ status: attendanceRecords.status, n: sql<number>`count(*)::int` })
+        .from(attendanceRecords)
+        .where(
+          and(
+            eq(attendanceRecords.schoolId, school.id),
+            eq(attendanceRecords.studentId, student.id),
+            gte(attendanceRecords.date, period.startsOn),
+            lte(attendanceRecords.date, period.endsOn),
+          ),
+        )
+        .groupBy(attendanceRecords.status);
+      const by = (st: string) => attRows.find((r) => r.status === st)?.n ?? 0;
+      attendance = {
+        present: by("PRESENT") + by("LATE"),
+        absent: by("ABSENT"),
+        excused: by("EXCUSED") + by("MEDICAL"),
+      };
+    }
+
+    return { student, period, lines, card, scaleRows, attendance };
   });
 
   if (!data || !data.student) notFound();
-  const { student, period, lines, card } = data;
+  const { student, period, lines, card, scaleRows, attendance } = data;
+
+  const bands: GradeBand[] = scaleRows.map((g) => ({
+    grade: g.grade,
+    label: g.label,
+    minScore: Number(g.minScore),
+  }));
+  const average = averageOfTotals(
+    lines.map((l) => (l.total != null ? Number(l.total) : null)),
+  );
+  const overallGrade = average != null ? gradeForScore(bands, average) : null;
+  const legend = gradeLegend(bands);
 
   return (
     <div className="mx-auto max-w-3xl">
       <div className="mb-4 flex items-center justify-between print:hidden">
         <BackLink href="/gradebook/reports" label="Report cards" />
-        <PrintButton />
+        <div className="flex items-center gap-2">
+          <a
+            href={`/api/report-cards/${student.id}?periodId=${periodId}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded-md border border-navy bg-navy px-4 py-2 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep"
+          >
+            Download PDF
+          </a>
+          <PrintButton />
+        </div>
       </div>
 
       <div className="bg-surface rounded-xl border border-border p-8">
         <div className="mb-6 border-b border-border pb-4 text-center">
-          <div className="font-display text-2xl font-semibold text-navy">
-            {school.name}
-          </div>
+          <div className="font-display text-2xl font-semibold text-navy">{school.name}</div>
           <div className="mt-1 text-sm text-navy-3">
             Terminal Report ·{" "}
             {period ? `${period.academicYear} · ${period.periodLabel}` : "—"}
@@ -143,6 +204,32 @@ export default async function ReportCardPage({
           </tbody>
         </table>
 
+        {/* Attendance summary */}
+        {attendance && (
+          <div className="mt-6 grid grid-cols-3 gap-3">
+            {[
+              { label: "Present", n: attendance.present, tone: "text-green" },
+              { label: "Absent", n: attendance.absent, tone: "text-terra" },
+              { label: "Excused", n: attendance.excused, tone: "text-navy-2" },
+            ].map((a) => (
+              <div key={a.label} className="rounded-lg border border-border bg-bg p-3">
+                <div className="text-[10px] font-bold uppercase tracking-[0.08em] text-navy-3">
+                  {a.label}
+                </div>
+                <div className="mt-0.5">
+                  <span className={`font-display text-2xl font-semibold ${a.tone}`}>
+                    {a.n}
+                  </span>
+                  <span className="ml-1 text-xs text-navy-3">
+                    {a.n === 1 ? "day" : "days"}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Remark + term average */}
         <div className="mt-6 flex items-end justify-between border-t border-border pt-4">
           <div className="text-sm text-navy-2">
             {card?.remark && (
@@ -158,15 +245,37 @@ export default async function ReportCardPage({
             </p>
           </div>
           <div className="text-right">
-            <div className="text-xs uppercase tracking-wide text-navy-3">Overall</div>
+            <div className="text-xs uppercase tracking-wide text-navy-3">Term average</div>
             <div className="font-display text-3xl font-semibold text-navy">
-              {card?.overallTotal != null ? Number(card.overallTotal).toFixed(2) : "—"}
-              {card?.overallGrade && (
-                <span className="ml-2 text-xl text-gold">{card.overallGrade}</span>
-              )}
+              {average != null ? average.toFixed(2) : "—"}
+              <span className="ml-1 align-middle text-sm text-navy-3">/ 100</span>
+              {overallGrade && <span className="ml-2 text-xl text-gold">{overallGrade}</span>}
             </div>
           </div>
         </div>
+
+        {/* Grade key */}
+        {legend.length > 0 && (
+          <div className="mt-6 border-t border-border pt-4">
+            <div className="mb-2 text-[10px] font-bold uppercase tracking-[0.1em] text-navy-3">
+              Grade key
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {legend.map((g) => (
+                <span
+                  key={g.grade}
+                  className="inline-flex items-baseline gap-1.5 rounded border border-border px-2 py-1 text-xs"
+                >
+                  <span className="font-display font-semibold text-navy">{g.grade}</span>
+                  <span className="text-navy-3">
+                    {g.min}–{g.max}
+                    {g.label ? ` · ${g.label}` : ""}
+                  </span>
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/omnischools/app/api/report-cards/[studentId]/route.ts
+++ b/omnischools/app/api/report-cards/[studentId]/route.ts
@@ -1,0 +1,204 @@
+import { and, asc, eq, gte, lte, sql } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import {
+  students,
+  academicPeriod,
+  subjects,
+  gradebookScores,
+  reportCards,
+  gradeScale,
+  attendanceRecords,
+  schools,
+} from "@/db/schema";
+import {
+  averageOfTotals,
+  gradeForScore,
+  gradeLegend,
+  type GradeBand,
+} from "@/lib/gradebook/grade-scale";
+import { renderReportCardPdf } from "@/lib/pdf/render-report-card";
+import type { ReportCardData } from "@/lib/pdf/report-card-document";
+
+// @react-pdf/renderer is Node-only (fontkit); never run this on the edge.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const toNum = (v: unknown): number | null =>
+  v == null || v === "" ? null : Number(v);
+const initialsOf = (name: string) =>
+  name
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? "")
+    .join("") || "S";
+const slug = (s: string) => s.replace(/[^A-Za-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+
+/**
+ * GET /api/report-cards/[studentId]?periodId=… — the authenticated staff report-card
+ * download. Renders the terminal report card (term average, attendance summary, grade key)
+ * for a student × period to a PDF and streams it inline. Tenant-scoped via requireSchool +
+ * withSchool. Mirrors app/(app)/gradebook/report/[studentId].
+ */
+export async function GET(
+  req: Request,
+  { params }: { params: { studentId: string } },
+) {
+  const { school } = await requireSchool();
+  const periodId = new URL(req.url).searchParams.get("periodId");
+  if (!periodId) return new Response("Missing periodId", { status: 400 });
+
+  const built = await withSchool(school.id, async (tx): Promise<ReportCardData | null> => {
+    const [student] = await tx
+      .select({
+        firstName: students.firstName,
+        otherNames: students.otherNames,
+        lastName: students.lastName,
+        studentCode: students.studentCode,
+        classLabel: students.currentClassLabel,
+      })
+      .from(students)
+      .where(and(eq(students.id, params.studentId), eq(students.schoolId, school.id)));
+    if (!student) return null;
+
+    const [period] = await tx
+      .select({
+        academicYear: academicPeriod.academicYear,
+        periodLabel: academicPeriod.periodLabel,
+        startsOn: academicPeriod.startsOn,
+        endsOn: academicPeriod.endsOn,
+      })
+      .from(academicPeriod)
+      .where(
+        and(eq(academicPeriod.periodId, periodId), eq(academicPeriod.schoolId, school.id)),
+      );
+
+    const lines = await tx
+      .select({
+        subject: subjects.name,
+        classScore: gradebookScores.classScore,
+        examScore: gradebookScores.examScore,
+        total: gradebookScores.total,
+        grade: gradebookScores.grade,
+      })
+      .from(gradebookScores)
+      .innerJoin(subjects, eq(gradebookScores.subjectId, subjects.id))
+      .where(
+        and(
+          eq(gradebookScores.schoolId, school.id),
+          eq(gradebookScores.studentId, params.studentId),
+          eq(gradebookScores.periodId, periodId),
+        ),
+      )
+      .orderBy(asc(subjects.name));
+
+    const [card] = await tx
+      .select({ remark: reportCards.remark, generatedAt: reportCards.generatedAt })
+      .from(reportCards)
+      .where(
+        and(
+          eq(reportCards.studentId, params.studentId),
+          eq(reportCards.periodId, periodId),
+          eq(reportCards.schoolId, school.id),
+        ),
+      );
+
+    // Grade scale → average grade + legend.
+    const scaleRows = await tx
+      .select({
+        grade: gradeScale.grade,
+        label: gradeScale.label,
+        minScore: gradeScale.minScore,
+      })
+      .from(gradeScale)
+      .where(eq(gradeScale.schoolId, school.id))
+      .orderBy(asc(gradeScale.ordinal));
+    const bands: GradeBand[] = scaleRows.map((g) => ({
+      grade: g.grade,
+      label: g.label,
+      minScore: Number(g.minScore),
+    }));
+
+    // Attendance for the term (only when the period is dated).
+    let attendance: ReportCardData["attendance"] = null;
+    if (period?.startsOn && period?.endsOn) {
+      const attRows = await tx
+        .select({
+          status: attendanceRecords.status,
+          n: sql<number>`count(*)::int`,
+        })
+        .from(attendanceRecords)
+        .where(
+          and(
+            eq(attendanceRecords.schoolId, school.id),
+            eq(attendanceRecords.studentId, params.studentId),
+            gte(attendanceRecords.date, period.startsOn),
+            lte(attendanceRecords.date, period.endsOn),
+          ),
+        )
+        .groupBy(attendanceRecords.status);
+      const by = (st: string) => attRows.find((r) => r.status === st)?.n ?? 0;
+      attendance = {
+        present: by("PRESENT") + by("LATE"),
+        absent: by("ABSENT"),
+        excused: by("EXCUSED") + by("MEDICAL"),
+      };
+    }
+
+    const [sc] = await tx
+      .select({ name: schools.name })
+      .from(schools)
+      .where(eq(schools.id, school.id));
+    const schoolName = sc?.name ?? school.name;
+
+    const fullName = `${student.firstName} ${student.otherNames ?? ""} ${student.lastName}`
+      .replace(/\s+/g, " ")
+      .trim();
+
+    const average = averageOfTotals(lines.map((l) => toNum(l.total)));
+    const overallGrade = average != null ? gradeForScore(bands, average) : null;
+
+    return {
+      school: { name: schoolName, initials: initialsOf(schoolName) },
+      title: "Terminal Report",
+      periodLabel: period ? `${period.academicYear} · ${period.periodLabel}` : "—",
+      student: {
+        name: fullName,
+        code: student.studentCode,
+        classLabel: student.classLabel ?? "—",
+      },
+      lines: lines.map((l) => ({
+        subject: l.subject,
+        classScore: toNum(l.classScore),
+        examScore: toNum(l.examScore),
+        total: toNum(l.total),
+        grade: l.grade ?? null,
+      })),
+      overallAverage: average,
+      overallGrade,
+      attendance,
+      gradeLegend: gradeLegend(bands),
+      remark: card?.remark ?? null,
+      generatedAt: card?.generatedAt
+        ? new Date(card.generatedAt).toLocaleDateString("en-GB", {
+            day: "numeric",
+            month: "short",
+            year: "numeric",
+          })
+        : null,
+    };
+  });
+
+  if (!built) return new Response("Student not found", { status: 404 });
+
+  const pdf = await renderReportCardPdf(built);
+  const filename = `Report-${slug(built.student.code)}-${slug(built.periodLabel)}.pdf`;
+  return new Response(new Uint8Array(pdf), {
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": `inline; filename="${filename}"`,
+      "Cache-Control": "private, no-store",
+    },
+  });
+}

--- a/omnischools/lib/gradebook/grade-scale.ts
+++ b/omnischools/lib/gradebook/grade-scale.ts
@@ -1,0 +1,38 @@
+/**
+ * Grade-scale helpers shared by the on-screen report card and the report-card PDF.
+ * A grade applies for score >= minScore up to the next-higher grade's threshold; the
+ * top grade runs to 100 and the lowest usually starts at 0.
+ */
+export type GradeBand = { grade: string; label: string | null; minScore: number };
+
+export type GradeLegendRow = {
+  grade: string;
+  label: string | null;
+  min: number;
+  max: number;
+};
+
+/** The grade whose threshold a score falls into (highest minScore ≤ score). */
+export function gradeForScore(bands: GradeBand[], score: number): string | null {
+  if (bands.length === 0) return null;
+  const sorted = [...bands].sort((a, b) => b.minScore - a.minScore);
+  for (const b of sorted) if (score >= b.minScore) return b.grade;
+  return sorted[sorted.length - 1].grade;
+}
+
+/** Score ranges per grade, highest first: e.g. A 80–100, B2 70–79, … (top grade → 100). */
+export function gradeLegend(bands: GradeBand[]): GradeLegendRow[] {
+  const sorted = [...bands].sort((a, b) => b.minScore - a.minScore);
+  return sorted.map((b, i) => {
+    const min = Math.round(b.minScore);
+    const max = i === 0 ? 100 : Math.max(min, Math.round(sorted[i - 1].minScore) - 1);
+    return { grade: b.grade, label: b.label, min, max };
+  });
+}
+
+/** Parent-facing "average score" — simple mean of the non-null subject totals. */
+export function averageOfTotals(totals: (number | null)[]): number | null {
+  const vals = totals.filter((t): t is number => t != null);
+  if (vals.length === 0) return null;
+  return Math.round((vals.reduce((a, b) => a + b, 0) / vals.length) * 100) / 100;
+}

--- a/omnischools/lib/pdf/render-report-card.tsx
+++ b/omnischools/lib/pdf/render-report-card.tsx
@@ -1,0 +1,9 @@
+import "server-only";
+import React from "react";
+import { renderToBuffer } from "@react-pdf/renderer";
+import { ReportCardDocument, type ReportCardData } from "./report-card-document";
+
+/** Render a terminal report card to a PDF Buffer (Node runtime only). */
+export function renderReportCardPdf(data: ReportCardData): Promise<Buffer> {
+  return renderToBuffer(<ReportCardDocument data={data} />);
+}

--- a/omnischools/lib/pdf/report-card-document.tsx
+++ b/omnischools/lib/pdf/report-card-document.tsx
@@ -1,0 +1,362 @@
+import React from "react";
+import { Document, Page, View, Text, StyleSheet } from "@react-pdf/renderer";
+import { SERIF, SANS, MONO } from "./fonts";
+import type { GradeLegendRow } from "@/lib/gradebook/grade-scale";
+
+/**
+ * Terminal report-card PDF (A4) — a faithful print rendering of the on-screen report card
+ * at app/(app)/gradebook/report/[studentId]. Presentational only; the route pre-loads and
+ * passes all values. Core PDF fonts (see ./fonts) stand in for the brand faces.
+ *
+ * Shows the term average (not a sum), an attendance summary and a grade key/legend.
+ */
+
+const NAVY = "#1A2B47";
+const NAVY3 = "#5C6675";
+const GOLD = "#C8975B";
+const GOLD_BG = "#F5EBDC";
+const BG = "#FAF7F2";
+const GREEN = "#2F6B47";
+const TERRA = "#B84A39";
+const BORDER = "#E5DFD3";
+
+const fmt0 = (n: number | null | undefined) => (n == null ? "—" : n.toFixed(0));
+const fmt2 = (n: number | null | undefined) => (n == null ? "—" : n.toFixed(2));
+
+export type ReportCardLine = {
+  subject: string;
+  classScore: number | null;
+  examScore: number | null;
+  total: number | null;
+  grade: string | null;
+};
+export type ReportCardAttendance = {
+  present: number;
+  absent: number;
+  excused: number;
+};
+export type ReportCardData = {
+  school: { name: string; initials: string };
+  title: string; // "Terminal Report"
+  periodLabel: string; // "2025/26 · Term 1"
+  student: { name: string; code: string; classLabel: string };
+  lines: ReportCardLine[];
+  /** Term average (mean of subject totals), out of 100 — not a sum. */
+  overallAverage: number | null;
+  overallGrade: string | null;
+  attendance?: ReportCardAttendance | null;
+  gradeLegend?: GradeLegendRow[] | null;
+  remark?: string | null;
+  generatedAt?: string | null; // preformatted date, or null
+};
+
+const s = StyleSheet.create({
+  page: { backgroundColor: "#FFFFFF", fontFamily: SANS, fontSize: 10, color: NAVY, padding: 0 },
+  strip: { height: 6, backgroundColor: GOLD },
+
+  header: { alignItems: "center", paddingHorizontal: 40, paddingTop: 22, paddingBottom: 16 },
+  mark: {
+    width: 46,
+    height: 46,
+    backgroundColor: NAVY,
+    borderRadius: 8,
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 10,
+  },
+  markText: { fontFamily: SERIF, fontWeight: "bold", fontSize: 18, color: GOLD },
+  schoolName: { fontFamily: SERIF, fontWeight: "bold", fontSize: 22, color: NAVY, textAlign: "center" },
+  eyebrow: { fontSize: 8, color: GOLD, fontWeight: "bold", letterSpacing: 1.6, marginTop: 8 },
+  periodLine: { fontSize: 10, color: NAVY3, marginTop: 3 },
+
+  // student meta
+  meta: {
+    marginHorizontal: 40,
+    marginBottom: 18,
+    flexDirection: "row",
+    flexWrap: "wrap",
+    borderWidth: 1,
+    borderColor: BORDER,
+    borderRadius: 8,
+    backgroundColor: BG,
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+  },
+  metaCell: { width: "50%", paddingVertical: 3 },
+  metaLbl: { fontSize: 8, color: NAVY3, fontWeight: "bold", letterSpacing: 0.6 },
+  metaVal: { fontSize: 11, color: NAVY, marginTop: 1 },
+  metaMono: { fontFamily: MONO, fontSize: 10, color: NAVY, marginTop: 1 },
+
+  // table
+  table: { marginHorizontal: 40 },
+  thead: {
+    flexDirection: "row",
+    borderBottomWidth: 1.5,
+    borderBottomColor: NAVY,
+    paddingBottom: 6,
+  },
+  th: { fontSize: 8, color: NAVY3, fontWeight: "bold", letterSpacing: 0.8, textTransform: "uppercase" },
+  trow: {
+    flexDirection: "row",
+    paddingVertical: 7,
+    borderBottomWidth: 1,
+    borderBottomColor: BORDER,
+    alignItems: "center",
+  },
+  colSubject: { flex: 1 },
+  colNum: { width: 64, textAlign: "right" },
+  colGrade: { width: 56, textAlign: "right" },
+  tdSubject: { fontSize: 10.5, color: NAVY },
+  tdNum: { fontSize: 10, color: "#2D3F5C" },
+  tdTotal: { fontFamily: SERIF, fontWeight: "bold", fontSize: 10.5, color: NAVY },
+  tdGrade: { fontFamily: SERIF, fontWeight: "bold", fontSize: 10.5, color: NAVY },
+  emptyRow: { paddingVertical: 20, textAlign: "center", fontSize: 10, color: NAVY3 },
+
+  // attendance strip
+  attendance: {
+    marginHorizontal: 40,
+    marginTop: 16,
+    flexDirection: "row",
+    gap: 10,
+  },
+  attCell: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: BORDER,
+    borderRadius: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    backgroundColor: BG,
+  },
+  attLbl: { fontSize: 8, color: NAVY3, fontWeight: "bold", letterSpacing: 0.6 },
+  attNumRow: { flexDirection: "row", alignItems: "baseline", marginTop: 2 },
+  attNum: { fontFamily: SERIF, fontWeight: "bold", fontSize: 18 },
+  attUnit: { fontSize: 8, color: NAVY3, marginLeft: 4 },
+
+  // summary
+  summary: {
+    marginHorizontal: 40,
+    marginTop: 16,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
+    gap: 20,
+  },
+  remarkBox: { flex: 1 },
+  remarkLbl: { fontSize: 8, color: NAVY3, fontWeight: "bold", letterSpacing: 0.6, marginBottom: 3 },
+  remarkText: { fontSize: 10, color: "#2D3F5C", lineHeight: 1.5 },
+  overallBox: {
+    borderWidth: 1,
+    borderColor: GOLD,
+    backgroundColor: GOLD_BG,
+    borderRadius: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 18,
+    alignItems: "flex-end",
+    minWidth: 170,
+  },
+  overallLbl: { fontSize: 8, color: NAVY3, fontWeight: "bold", letterSpacing: 1 },
+  overallRow: { flexDirection: "row", alignItems: "baseline", marginTop: 3 },
+  overallVal: { fontFamily: SERIF, fontWeight: "bold", fontSize: 26, color: NAVY },
+  overallUnit: { fontSize: 9, color: NAVY3, marginLeft: 3 },
+  overallGrade: { fontFamily: SERIF, fontWeight: "bold", fontSize: 18, color: GOLD, marginLeft: 8 },
+
+  // grade legend
+  legend: {
+    marginHorizontal: 40,
+    marginTop: 18,
+    borderTopWidth: 1,
+    borderTopColor: BORDER,
+    paddingTop: 10,
+  },
+  legendLbl: { fontSize: 8, color: NAVY3, fontWeight: "bold", letterSpacing: 0.8, marginBottom: 6 },
+  legendRow: { flexDirection: "row", flexWrap: "wrap", gap: 6 },
+  legendItem: {
+    flexDirection: "row",
+    alignItems: "baseline",
+    borderWidth: 1,
+    borderColor: BORDER,
+    borderRadius: 4,
+    paddingVertical: 2,
+    paddingHorizontal: 6,
+    gap: 4,
+  },
+  legendGrade: { fontFamily: SERIF, fontWeight: "bold", fontSize: 9, color: NAVY },
+  legendRange: { fontSize: 8, color: NAVY3 },
+
+  // signatures
+  signatures: {
+    marginHorizontal: 40,
+    marginTop: 36,
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+  sigCol: { width: "42%" },
+  sigLine: { borderBottomWidth: 1, borderBottomColor: NAVY, marginBottom: 4 },
+  sigLbl: { fontSize: 8, color: NAVY3 },
+
+  // footer
+  footer: {
+    position: "absolute",
+    bottom: 24,
+    left: 40,
+    right: 40,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    borderTopWidth: 1,
+    borderTopColor: BORDER,
+    paddingTop: 8,
+  },
+  footerText: { fontSize: 8, color: NAVY3, letterSpacing: 0.3 },
+  goldEm: { color: GOLD, fontWeight: "bold" },
+});
+
+function MetaCell({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <View style={s.metaCell}>
+      <Text style={s.metaLbl}>{label}</Text>
+      <Text style={mono ? s.metaMono : s.metaVal}>{value}</Text>
+    </View>
+  );
+}
+
+function AttCell({ label, n, color }: { label: string; n: number; color: string }) {
+  return (
+    <View style={s.attCell}>
+      <Text style={s.attLbl}>{label}</Text>
+      <View style={s.attNumRow}>
+        <Text style={[s.attNum, { color }]}>{n}</Text>
+        <Text style={s.attUnit}>{n === 1 ? "day" : "days"}</Text>
+      </View>
+    </View>
+  );
+}
+
+export function ReportCardDocument({ data }: { data: ReportCardData }) {
+  const legend = data.gradeLegend ?? [];
+  const att = data.attendance;
+
+  return (
+    <Document
+      title={`${data.title} — ${data.student.name}`}
+      author="Omnischools"
+      subject={`${data.title} · ${data.periodLabel}`}
+    >
+      <Page size="A4" style={s.page}>
+        <View style={s.strip} />
+
+        {/* Header */}
+        <View style={s.header}>
+          <View style={s.mark}>
+            <Text style={s.markText}>{data.school.initials}</Text>
+          </View>
+          <Text style={s.schoolName}>{data.school.name}</Text>
+          <Text style={s.eyebrow}>{data.title.toUpperCase()}</Text>
+          <Text style={s.periodLine}>{data.periodLabel}</Text>
+        </View>
+
+        {/* Student meta */}
+        <View style={s.meta}>
+          <MetaCell label="STUDENT" value={data.student.name} />
+          <MetaCell label="STUDENT CODE" value={data.student.code} mono />
+          <MetaCell label="CLASS" value={data.student.classLabel} />
+        </View>
+
+        {/* Scores table */}
+        <View style={s.table}>
+          <View style={s.thead}>
+            <Text style={[s.th, s.colSubject]}>Subject</Text>
+            <Text style={[s.th, s.colNum]}>Class</Text>
+            <Text style={[s.th, s.colNum]}>Exam</Text>
+            <Text style={[s.th, s.colNum]}>Total</Text>
+            <Text style={[s.th, s.colGrade]}>Grade</Text>
+          </View>
+          {data.lines.length === 0 ? (
+            <Text style={s.emptyRow}>No scores entered for this period.</Text>
+          ) : (
+            data.lines.map((l, i) => (
+              <View key={i} style={s.trow}>
+                <Text style={[s.tdSubject, s.colSubject]}>{l.subject}</Text>
+                <Text style={[s.tdNum, s.colNum]}>{fmt0(l.classScore)}</Text>
+                <Text style={[s.tdNum, s.colNum]}>{fmt0(l.examScore)}</Text>
+                <Text style={[s.tdTotal, s.colNum]}>{fmt2(l.total)}</Text>
+                <Text style={[s.tdGrade, s.colGrade]}>{l.grade ?? "—"}</Text>
+              </View>
+            ))
+          )}
+        </View>
+
+        {/* Attendance summary */}
+        {att ? (
+          <View style={s.attendance}>
+            <AttCell label="PRESENT" n={att.present} color={GREEN} />
+            <AttCell label="ABSENT" n={att.absent} color={TERRA} />
+            <AttCell label="EXCUSED" n={att.excused} color={NAVY3} />
+          </View>
+        ) : null}
+
+        {/* Summary — remark + term average */}
+        <View style={s.summary}>
+          <View style={s.remarkBox}>
+            {data.remark ? (
+              <>
+                <Text style={s.remarkLbl}>REMARK</Text>
+                <Text style={s.remarkText}>{data.remark}</Text>
+              </>
+            ) : null}
+          </View>
+          <View style={s.overallBox}>
+            <Text style={s.overallLbl}>TERM AVERAGE</Text>
+            <View style={s.overallRow}>
+              <Text style={s.overallVal}>{fmt2(data.overallAverage)}</Text>
+              <Text style={s.overallUnit}>/ 100</Text>
+              {data.overallGrade ? (
+                <Text style={s.overallGrade}>{data.overallGrade}</Text>
+              ) : null}
+            </View>
+          </View>
+        </View>
+
+        {/* Grade legend / key */}
+        {legend.length > 0 ? (
+          <View style={s.legend}>
+            <Text style={s.legendLbl}>GRADE KEY</Text>
+            <View style={s.legendRow}>
+              {legend.map((g, i) => (
+                <View key={i} style={s.legendItem}>
+                  <Text style={s.legendGrade}>{g.grade}</Text>
+                  <Text style={s.legendRange}>
+                    {g.min}–{g.max}
+                    {g.label ? ` · ${g.label}` : ""}
+                  </Text>
+                </View>
+              ))}
+            </View>
+          </View>
+        ) : null}
+
+        {/* Signatures */}
+        <View style={s.signatures}>
+          <View style={s.sigCol}>
+            <View style={s.sigLine} />
+            <Text style={s.sigLbl}>Class teacher</Text>
+          </View>
+          <View style={s.sigCol}>
+            <View style={s.sigLine} />
+            <Text style={s.sigLbl}>Headteacher</Text>
+          </View>
+        </View>
+
+        {/* Footer */}
+        <View style={s.footer} fixed>
+          <Text style={s.footerText}>
+            {data.generatedAt ? `Generated ${data.generatedAt}` : "Draft — not yet generated"}
+          </Text>
+          <Text style={s.footerText}>
+            Issued on <Text style={s.goldEm}>Omnischools</Text>
+          </Text>
+        </View>
+      </Page>
+    </Document>
+  );
+}


### PR DESCRIPTION
## Summary
Adds the requested report-card improvements **and** carries the report-card PDF to `main`.

> ⚠️ **Why this re-adds the report-card PDF:** [#123](https://github.com/Omnischools/omnischools/pull/123) shows as "merged", but it merged into `feat/receipt-pdf` (its stacked base) *after* that branch had already merged to `main` — so its report-card commit was **orphaned on the dead branch and never reached `main`**. This PR brings the full report-card PDF (route + document + render) to `main`, superseding #123, and layers the new changes on top. **#123 can be closed.**

## What changed (the three requests)
1. **Overall → Term average.** The overall figure is now the **mean of the subject totals (out of 100)** with its grade derived from the school's grade scale — not a sum. Relabelled **"Term average"** (e.g. `72.80 / 100 · B`) so it reads clearly to parents. *(The stored value was already an average; the earlier sample just hard-coded a sum, which is what looked like `728`.)*
2. **Attendance summary** for the term: **Present** (Present + Late), **Absent**, and **Excused** (Excused + Medical) day counts, computed over the period's `starts_on…ends_on` range.
3. **Grade key / legend**: each grade with its **score range** (e.g. `A 80–100`, `B 70–79`) + label, from the per-school `grade_scale`.

## Consistency
Applies to **both** the PDF (`lib/pdf/report-card-document.tsx` + `/api/report-cards/[studentId]`) and the **on-screen** report card, kept in sync via new shared helpers in `lib/gradebook/grade-scale.ts` (`gradeForScore`, `gradeLegend`, `averageOfTotals`).

## Verification
- `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm build` ✅
- Rendered a sample (10-subject card) — fits one A4 page; average shows `72.80` (not `728`), attendance strip and grade key render correctly.

No schema change, no storage. Core PDF fonts retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)