### PR TITLE
feat(academic): year-end promotion — auto-ladder with preview & override

### DIFF
--- a/omnischools/app/(app)/settings/academic/page.tsx
+++ b/omnischools/app/(app)/settings/academic/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { asc, eq } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
@@ -86,6 +87,24 @@ export default async function AcademicSettingsPage() {
             How class (continuous assessment) and exam scores combine into the term total.
           </p>
           <WeightsForm initialClassWeight={data.classWeight} />
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-4 rounded-xl border border-border bg-surface p-6">
+          <div>
+            <h2 className="font-display text-lg font-semibold text-navy">
+              Year-end promotion
+            </h2>
+            <p className="mt-0.5 max-w-xl text-sm text-navy-3">
+              At the end of the year, move every student up a class and graduate the exit
+              year — with a preview you confirm before anything changes.
+            </p>
+          </div>
+          <Link
+            href="/settings/academic/promotion"
+            className="shrink-0 rounded-md border border-navy bg-navy px-4 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep"
+          >
+            Start promotion →
+          </Link>
         </div>
       </div>
     </div>

--- a/omnischools/app/(app)/settings/academic/promotion/page.tsx
+++ b/omnischools/app/(app)/settings/academic/promotion/page.tsx
@@ -1,0 +1,40 @@
+import { previewPromotion } from "@/lib/actions/promotion";
+import { PromotionRunner } from "@/components/settings/promotion-runner";
+import { BackLink } from "@/components/ui/back-link";
+import { EmptyState } from "@/components/ui/empty-state";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Year-end promotion" };
+
+export default async function PromotionPage() {
+  const res = await previewPromotion();
+
+  return (
+    <div className="mx-auto max-w-page">
+      <BackLink href="/settings/academic" label="Academic structure" />
+      <div className="mb-6 mt-2">
+        <h1 className="font-display text-3xl font-semibold text-navy">
+          Year-end{" "}
+          <em className="not-italic text-gold [font-style:italic]">promotion.</em>
+        </h1>
+        <p className="text-sm text-navy-3">
+          Move every active student up one class for the new academic year and graduate the
+          exit year. Follows the KG → Primary → JHS ladder; review and hold back anyone
+          repeating before you commit.
+        </p>
+      </div>
+
+      {!res.ok ? (
+        <p className="rounded-md bg-terra-bg px-3 py-2 text-sm text-terra">{res.error}</p>
+      ) : res.preview.rows.length === 0 ? (
+        <EmptyState
+          title="No active students to promote."
+          body="Add students from the Students module first."
+          primary={{ label: "Open Students →", href: "/students" }}
+        />
+      ) : (
+        <PromotionRunner preview={res.preview} />
+      )}
+    </div>
+  );
+}

--- a/omnischools/components/settings/promotion-runner.tsx
+++ b/omnischools/components/settings/promotion-runner.tsx
@@ -1,0 +1,223 @@
+"use client";
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { runPromotion, type PromotionPreview } from "@/lib/actions/promotion";
+import { Modal } from "@/components/ui/modal";
+
+const ACTION_BADGE: Record<string, string> = {
+  PROMOTE: "bg-green-bg text-green",
+  GRADUATE: "bg-gold-bg text-gold",
+  NO_TARGET: "bg-warn-bg text-warn",
+  UNMATCHED: "bg-bg text-navy-3 border border-border-2",
+};
+const ACTION_LABEL: Record<string, string> = {
+  PROMOTE: "Promote",
+  GRADUATE: "Graduate",
+  NO_TARGET: "No next class",
+  UNMATCHED: "Not on ladder",
+};
+
+export function PromotionRunner({ preview }: { preview: PromotionPreview }) {
+  const router = useRouter();
+  const [hold, setHold] = useState<Set<string>>(new Set());
+  const [confirm, setConfirm] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState<null | {
+    promoted: number;
+    graduated: number;
+    heldBack: number;
+    skipped: number;
+    nextYearCreated: boolean;
+  }>(null);
+
+  const toggle = (id: string) =>
+    setHold((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  // Live counts reflecting hold-backs.
+  const live = useMemo(() => {
+    let promote = 0;
+    let graduate = 0;
+    for (const r of preview.rows) {
+      if (hold.has(r.studentId)) continue;
+      if (r.action === "PROMOTE") promote++;
+      else if (r.action === "GRADUATE") graduate++;
+    }
+    return { promote, graduate, heldBack: hold.size };
+  }, [preview.rows, hold]);
+
+  const needsAttention = preview.counts.noTarget + preview.counts.unmatched;
+
+  async function run() {
+    setBusy(true);
+    setError(null);
+    const res = await runPromotion({ holdBackIds: Array.from(hold) });
+    setBusy(false);
+    setConfirm(false);
+    if (res.ok) {
+      setDone(res);
+      router.refresh();
+    } else setError(res.error ?? "Could not run the promotion.");
+  }
+
+  if (done) {
+    return (
+      <div className="rounded-xl border border-green-bg bg-green-bg p-6">
+        <h2 className="font-display text-lg font-semibold text-navy">Promotion complete</h2>
+        <p className="mt-1 text-sm text-navy-2">
+          Promoted <b className="text-navy">{done.promoted}</b>, graduated{" "}
+          <b className="text-navy">{done.graduated}</b>, held back{" "}
+          <b className="text-navy">{done.heldBack}</b>
+          {done.skipped ? (
+            <>
+              , left <b className="text-navy">{done.skipped}</b> for manual handling
+            </>
+          ) : null}
+          .{" "}
+          {done.nextYearCreated
+            ? `${preview.nextYear}'s terms were created.`
+            : `${preview.nextYear}'s terms already existed.`}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl border border-warn-bg bg-warn-bg p-5">
+        <div className="font-display text-base font-semibold text-navy">
+          {preview.currentYear} → {preview.nextYear}
+        </div>
+        <p className="mt-1 text-sm text-navy-2">
+          This moves every active student up one class and graduates the exit year. Review
+          below and tick <b className="text-navy">Hold back</b> for anyone repeating.
+          It can&apos;t be easily undone, so nothing changes until you confirm.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-2 text-sm">
+        <Chip tone="bg-green-bg text-green" label={`${live.promote} to promote`} />
+        <Chip tone="bg-gold-bg text-gold" label={`${live.graduate} to graduate`} />
+        <Chip tone="bg-bg text-navy-3" label={`${live.heldBack} held back`} />
+        {needsAttention > 0 && (
+          <Chip tone="bg-warn-bg text-warn" label={`${needsAttention} need attention`} />
+        )}
+      </div>
+
+      {error && (
+        <p className="rounded-md bg-terra-bg px-3 py-2 text-sm text-terra">{error}</p>
+      )}
+
+      <div className="overflow-hidden rounded-xl border border-border bg-surface">
+        <table className="w-full text-sm">
+          <thead className="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-navy-3">
+            <tr>
+              <th className="px-4 py-3 font-semibold">Student</th>
+              <th className="px-4 py-3 font-semibold">From</th>
+              <th className="px-4 py-3 font-semibold">Next</th>
+              <th className="px-4 py-3 text-right font-semibold">Hold back</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {preview.rows.map((r) => {
+              const held = hold.has(r.studentId);
+              const canHold = r.action === "PROMOTE" || r.action === "GRADUATE";
+              return (
+                <tr key={r.studentId} className={held ? "bg-bg" : ""}>
+                  <td className="px-4 py-2.5">
+                    <div className={`font-medium ${held ? "text-navy-3" : "text-navy"}`}>
+                      {r.name}
+                    </div>
+                    <div className="font-mono text-[11px] text-navy-3">{r.code}</div>
+                  </td>
+                  <td className="px-4 py-2.5 text-navy-2">{r.fromClass}</td>
+                  <td className="px-4 py-2.5">
+                    <span
+                      className={`rounded-pill px-2 py-0.5 text-[11px] font-semibold ${ACTION_BADGE[r.action]}`}
+                    >
+                      {r.action === "PROMOTE"
+                        ? `→ ${r.toClass}`
+                        : ACTION_LABEL[r.action]}
+                    </span>
+                  </td>
+                  <td className="px-4 py-2.5 text-right">
+                    {canHold ? (
+                      <input
+                        type="checkbox"
+                        checked={held}
+                        onChange={() => toggle(r.studentId)}
+                        className="h-4 w-4 accent-navy"
+                        aria-label={`Hold back ${r.name}`}
+                      />
+                    ) : (
+                      <span className="text-xs text-navy-3">—</span>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-end gap-3">
+        <button
+          type="button"
+          onClick={() => setConfirm(true)}
+          disabled={live.promote + live.graduate === 0}
+          className="rounded-md bg-navy px-5 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-50"
+        >
+          Run promotion
+        </button>
+      </div>
+
+      <Modal
+        open={confirm}
+        onClose={busy ? () => {} : () => setConfirm(false)}
+        title={`Promote to ${preview.nextYear}?`}
+      >
+        <div className="space-y-4">
+          <p className="text-sm leading-relaxed text-navy-2">
+            You&apos;re about to promote <b className="text-navy">{live.promote}</b>{" "}
+            student{live.promote === 1 ? "" : "s"}, graduate{" "}
+            <b className="text-navy">{live.graduate}</b>, and hold back{" "}
+            <b className="text-navy">{live.heldBack}</b>.
+            {!preview.nextYearExists
+              ? ` ${preview.nextYear}'s terms will be created from this year's dates.`
+              : ""}{" "}
+            This can&apos;t be easily undone.
+          </p>
+          <div className="flex items-center justify-end gap-3">
+            <button
+              type="button"
+              onClick={() => setConfirm(false)}
+              disabled={busy}
+              className="text-sm font-semibold text-navy-2 transition-colors hover:text-navy disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={run}
+              disabled={busy}
+              className="rounded-md bg-navy px-4 py-2 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-60"
+            >
+              {busy ? "Promoting…" : "Yes, promote"}
+            </button>
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+}
+
+function Chip({ tone, label }: { tone: string; label: string }) {
+  return (
+    <span className={`rounded-pill px-3 py-1 text-xs font-semibold ${tone}`}>{label}</span>
+  );
+}

--- a/omnischools/lib/academic/promotion.ts
+++ b/omnischools/lib/academic/promotion.ts
@@ -1,0 +1,52 @@
+import { GES_BASIC_CLASSES } from "@/lib/onboarding";
+
+/**
+ * Year-end promotion ladder — pure helpers shared by the promotion action and UI.
+ * Progression follows the GES basic ladder (KG 1 → KG 2 → Primary 1–6 → JHS 1–3);
+ * the terminal level graduates.
+ */
+
+export const GRADUATE = "GRADUATE" as const;
+
+/**
+ * The next rung for a class level: the next level label, GRADUATE for the terminal level
+ * (JHS 3), or null when the level isn't on the standard ladder (custom naming → handled
+ * manually).
+ */
+export function nextLevel(
+  level: string | null | undefined,
+): string | typeof GRADUATE | null {
+  if (!level) return null;
+  const i = GES_BASIC_CLASSES.indexOf(level.trim());
+  if (i < 0) return null;
+  return i === GES_BASIC_CLASSES.length - 1 ? GRADUATE : GES_BASIC_CLASSES[i + 1];
+}
+
+/** Next academic-year label: "2025/26" → "2026/27". Falls back to the input if unparsable. */
+export function nextAcademicYear(label: string): string {
+  const m = label.match(/^(\d{4})\s*\/\s*\d{2,4}$/);
+  if (!m) return label;
+  const start = Number(m[1]) + 1;
+  return `${start}/${String((start + 1) % 100).padStart(2, "0")}`;
+}
+
+/** Shift an ISO date (YYYY-MM-DD) forward one year; Feb 29 → Feb 28. */
+export function shiftYearIso(iso: string): string {
+  const d = new Date(`${iso.slice(0, 10)}T00:00:00Z`);
+  if (Number.isNaN(d.getTime())) return iso;
+  const month = d.getUTCMonth();
+  d.setUTCFullYear(d.getUTCFullYear() + 1);
+  if (d.getUTCMonth() !== month) d.setUTCDate(0); // overflowed (Feb 29) → last day of Feb
+  return d.toISOString().slice(0, 10);
+}
+
+/** The section suffix of a class name relative to its level, e.g. ("JHS 1 A","JHS 1") → "A". */
+export function sectionSuffix(className: string, level: string | null): string {
+  if (!level) return "";
+  const n = className.trim();
+  const l = level.trim();
+  if (n.toLowerCase().startsWith(l.toLowerCase())) {
+    return n.slice(l.length).trim();
+  }
+  return "";
+}

--- a/omnischools/lib/actions/promotion.ts
+++ b/omnischools/lib/actions/promotion.ts
@@ -1,0 +1,256 @@
+"use server";
+import { and, asc, eq } from "drizzle-orm";
+import { z } from "zod";
+import { withSchool } from "@/lib/db/rls";
+import { requireSchool, resolveActor, assertWriteAccess } from "@/lib/auth/server";
+import { recordAudit } from "@/lib/db/audit";
+import { safeRevalidate } from "@/lib/revalidate";
+import { currentAcademicYearLabel } from "@/lib/onboarding";
+import {
+  GRADUATE,
+  nextLevel,
+  nextAcademicYear,
+  shiftYearIso,
+  sectionSuffix,
+} from "@/lib/academic/promotion";
+import type { Tx } from "@/lib/db";
+import { students, classes, academicPeriod, academicPeriodConfig } from "@/db/schema";
+
+export type PromotionAction = "PROMOTE" | "GRADUATE" | "NO_TARGET" | "UNMATCHED";
+export type PromotionRow = {
+  studentId: string;
+  name: string;
+  code: string;
+  fromClass: string;
+  fromLevel: string | null;
+  action: PromotionAction;
+  toClassId: string | null;
+  toClass: string | null;
+};
+export type PromotionPreview = {
+  rows: PromotionRow[];
+  currentYear: string;
+  nextYear: string;
+  nextYearExists: boolean;
+  counts: { promote: number; graduate: number; noTarget: number; unmatched: number };
+};
+
+/** Build the promotion plan for every active student from the class ladder. */
+async function buildPlan(tx: Tx, schoolId: string): Promise<PromotionRow[]> {
+  const cls = await tx
+    .select({ id: classes.id, name: classes.name, level: classes.level })
+    .from(classes)
+    .where(and(eq(classes.schoolId, schoolId), eq(classes.active, true)));
+  const clsById = new Map(cls.map((c) => [c.id, c]));
+  const byLevel = new Map<string, typeof cls>();
+  for (const c of cls) {
+    if (!c.level) continue;
+    const arr = byLevel.get(c.level) ?? [];
+    arr.push(c);
+    byLevel.set(c.level, arr);
+  }
+
+  const studs = await tx
+    .select({
+      id: students.id,
+      firstName: students.firstName,
+      lastName: students.lastName,
+      code: students.studentCode,
+      classId: students.classId,
+    })
+    .from(students)
+    .where(and(eq(students.schoolId, schoolId), eq(students.status, "ACTIVE")))
+    .orderBy(asc(students.currentClassLabel), asc(students.lastName));
+
+  return studs.map((s): PromotionRow => {
+    const name = `${s.firstName} ${s.lastName}`.trim();
+    const from = s.classId ? clsById.get(s.classId) : undefined;
+    const base = {
+      studentId: s.id,
+      name,
+      code: s.code,
+      fromClass: from?.name ?? "—",
+      fromLevel: from?.level ?? null,
+      toClassId: null as string | null,
+      toClass: null as string | null,
+    };
+    const nl = nextLevel(from?.level);
+    if (!from || nl === null) return { ...base, action: "UNMATCHED" };
+    if (nl === GRADUATE) return { ...base, action: "GRADUATE" };
+    const targets = byLevel.get(nl) ?? [];
+    if (targets.length === 0) return { ...base, action: "NO_TARGET" };
+    const suffix = sectionSuffix(from.name, from.level);
+    const target =
+      (suffix ? targets.find((t) => sectionSuffix(t.name, nl) === suffix) : undefined) ??
+      targets[0];
+    return { ...base, action: "PROMOTE", toClassId: target.id, toClass: target.name };
+  });
+}
+
+/** Resolve the school's current academic year and whether the next year already exists. */
+async function resolveYears(
+  tx: Tx,
+  schoolId: string,
+): Promise<{ currentYear: string; nextYear: string; nextYearExists: boolean }> {
+  const configs = await tx
+    .select({ academicYear: academicPeriodConfig.academicYear })
+    .from(academicPeriodConfig)
+    .where(eq(academicPeriodConfig.schoolId, schoolId));
+  const years = configs.map((c) => c.academicYear);
+  const label = currentAcademicYearLabel();
+  const currentYear =
+    years.find((y) => y === label) ??
+    years.slice().sort().reverse()[0] ??
+    label;
+  const nextYear = nextAcademicYear(currentYear);
+  return { currentYear, nextYear, nextYearExists: years.includes(nextYear) };
+}
+
+export async function previewPromotion(): Promise<
+  { ok: true; preview: PromotionPreview } | { ok: false; error: string }
+> {
+  const { school } = await requireSchool();
+  try {
+    const preview = await withSchool(school.id, async (tx): Promise<PromotionPreview> => {
+      const rows = await buildPlan(tx, school.id);
+      const { currentYear, nextYear, nextYearExists } = await resolveYears(tx, school.id);
+      const counts = {
+        promote: rows.filter((r) => r.action === "PROMOTE").length,
+        graduate: rows.filter((r) => r.action === "GRADUATE").length,
+        noTarget: rows.filter((r) => r.action === "NO_TARGET").length,
+        unmatched: rows.filter((r) => r.action === "UNMATCHED").length,
+      };
+      return { rows, currentYear, nextYear, nextYearExists, counts };
+    });
+    return { ok: true, preview };
+  } catch {
+    return { ok: false, error: "Could not build the promotion preview." };
+  }
+}
+
+export type RunPromotionResult =
+  | {
+      ok: true;
+      promoted: number;
+      graduated: number;
+      heldBack: number;
+      skipped: number;
+      nextYearCreated: boolean;
+    }
+  | { ok: false; error: string };
+
+const RunSchema = z.object({
+  holdBackIds: z.array(z.string().uuid()).default([]),
+});
+
+/**
+ * Commit the year-end promotion. Recomputes the plan server-side (the client only supplies
+ * the hold-back list), promotes each student up a class, graduates the exit year and creates
+ * next year's period calendar (this year's dates shifted +1 year). Audited.
+ */
+export async function runPromotion(input: unknown): Promise<RunPromotionResult> {
+  const { school } = await requireSchool();
+  await assertWriteAccess();
+  const parsed = RunSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: "Invalid input." };
+  const hold = new Set(parsed.data.holdBackIds);
+  const actor = await resolveActor(school.id);
+
+  try {
+    const out = await withSchool(school.id, async (tx) => {
+      const rows = await buildPlan(tx, school.id);
+      const { currentYear, nextYear, nextYearExists } = await resolveYears(tx, school.id);
+
+      let promoted = 0;
+      let graduated = 0;
+      let heldBack = 0;
+      let skipped = 0;
+
+      for (const r of rows) {
+        if (hold.has(r.studentId)) {
+          heldBack++;
+          continue;
+        }
+        if (r.action === "PROMOTE" && r.toClassId) {
+          await tx
+            .update(students)
+            .set({ classId: r.toClassId, currentClassLabel: r.toClass })
+            .where(and(eq(students.id, r.studentId), eq(students.schoolId, school.id)));
+          promoted++;
+        } else if (r.action === "GRADUATE") {
+          await tx
+            .update(students)
+            .set({ status: "GRADUATED" })
+            .where(and(eq(students.id, r.studentId), eq(students.schoolId, school.id)));
+          graduated++;
+        } else {
+          skipped++; // NO_TARGET / UNMATCHED — left as-is for manual handling
+        }
+      }
+
+      // Create next year's calendar from this year's periods (dates shifted +1 year).
+      let nextYearCreated = false;
+      if (!nextYearExists) {
+        const [cfg] = await tx
+          .select()
+          .from(academicPeriodConfig)
+          .where(
+            and(
+              eq(academicPeriodConfig.schoolId, school.id),
+              eq(academicPeriodConfig.academicYear, currentYear),
+            ),
+          );
+        const curPeriods = await tx
+          .select()
+          .from(academicPeriod)
+          .where(
+            and(
+              eq(academicPeriod.schoolId, school.id),
+              eq(academicPeriod.academicYear, currentYear),
+            ),
+          )
+          .orderBy(asc(academicPeriod.periodNumber));
+        if (cfg && curPeriods.length > 0) {
+          await tx.insert(academicPeriodConfig).values({
+            schoolId: school.id,
+            academicYear: nextYear,
+            periodType: cfg.periodType,
+            periodCount: cfg.periodCount,
+            source: "SCHOOL_OVERRIDE",
+            configuredBy: actor.id ?? undefined,
+          });
+          await tx.insert(academicPeriod).values(
+            curPeriods.map((p) => ({
+              schoolId: school.id,
+              academicYear: nextYear,
+              periodNumber: p.periodNumber,
+              periodLabel: p.periodLabel,
+              startsOn: shiftYearIso(String(p.startsOn)),
+              endsOn: shiftYearIso(String(p.endsOn)),
+            })),
+          );
+          nextYearCreated = true;
+        }
+      }
+
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "promoted",
+        entityType: "school_year",
+        entityId: school.id,
+        after: { currentYear, nextYear, promoted, graduated, heldBack, skipped, nextYearCreated },
+        reason: `Year-end promotion ${currentYear} → ${nextYear}`,
+      });
+
+      return { promoted, graduated, heldBack, skipped, nextYearCreated };
+    });
+
+    safeRevalidate("/students");
+    safeRevalidate("/settings/academic");
+    return { ok: true, ...out };
+  } catch {
+    return { ok: false, error: "Could not run the promotion. No changes were made." };
+  }
+}


### PR DESCRIPTION
## Summary
Recommended-sequence **② (year-end)** — the second half of term rollover. Promotes every active student up a class for the new academic year, graduates the exit year, and creates next year's calendar — all behind a **preview the admin confirms**.

Uses the **auto-ladder + preview/override** model you chose.

## How it works
- **Ladder** (`lib/academic/promotion.ts`, pure): `GES_BASIC_CLASSES` (KG 1 → KG 2 → Primary 1–6 → JHS 1–3). Each student's next class is the class at the next level; **JHS 3 → graduate**. Section suffixes are respected (JHS 1A → JHS 2A, not merged). Levels not on the ladder / with no next class are flagged **"need attention"** and left untouched.
- **Preview** (`previewPromotion`): a per-student plan — `PROMOTE` (→ target class) / `GRADUATE` / `NO_TARGET` / `UNMATCHED` — plus current→next academic-year labels.
- **Commit** (`runPromotion`): **recomputes the plan server-side** (the client only sends the hold-back list), then moves each student up a class, sets the exit year to `GRADUATED`, and **creates next year's period config + terms** by shifting this year's dates +1 year. Admin-gated (`assertWriteAccess`) and **audited**.
- **UI** — **Settings → Academic → Year-end promotion**: a preview table with live counts and per-student **Hold back** toggles (for repeats), behind a **confirm** modal — nothing mutates until the admin commits.

## Safety
- Nothing changes until the admin reviews the full preview and confirms.
- Hold-back per student for repeats/retention.
- All mutation recomputed server-side (client can't forge targets).
- Single audit entry summarising promoted / graduated / held-back / skipped.

## Verification
- `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm build` ✅
- **Schema-free** — reuses `class` / `student` / `academic_period`. **No migration, no prod SQL.**
- Live run needs auth + a seeded roster (not exercised this session); the logic is pure/unit-friendly and recomputed server-side.

This completes the term-rollover sequence: **term-to-term** (#125) + **year-end promotion** (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)