### PR TITLE
feat(billing): fuse §03 admin-billing — KPI strip + invoices table

### DIFF
--- a/omnischools/app/(app)/billing/page.tsx
+++ b/omnischools/app/(app)/billing/page.tsx
@@ -1,5 +1,5 @@
 import { Receipt } from "lucide-react";
-import { and, asc, eq, inArray, isNotNull, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNotNull, sql } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import {
@@ -14,7 +14,8 @@ import {
   households,
   students,
 } from "@/db/schema";
-import { num } from "@/lib/fees-helpers";
+import { num, daysOverdue } from "@/lib/fees-helpers";
+import { InvoicesTable, type InvoiceRow } from "@/components/billing/invoices-table";
 import { CreateFeeStructureForm } from "@/components/billing/create-fee-structure-form";
 import { FeeStructureCard } from "@/components/billing/fee-structure-card";
 import { IssueInvoicesCard } from "@/components/billing/issue-invoices-card";
@@ -30,6 +31,10 @@ function currentAcademicYear() {
   const start = now.getMonth() >= 8 ? now.getFullYear() : now.getFullYear() - 1;
   return `${start}/${String((start + 1) % 100).padStart(2, "0")}`;
 }
+
+const ghs = (v: number) =>
+  `GHS ${v.toLocaleString("en-GH", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const plural = (n: number, w: string) => `${n} ${w}${n === 1 ? "" : "s"}`;
 
 export default async function BillingPage() {
   const { school } = await requireSchool();
@@ -50,6 +55,9 @@ export default async function BillingPage() {
     [activeCount],
     [unInvoicedCount],
     periodRows,
+    [kpi],
+    [overdue],
+    invoiceListRows,
   ] = await Promise.all([
     withSchool(school.id, (tx) =>
       tx
@@ -187,6 +195,71 @@ export default async function BillingPage() {
         .where(eq(academicPeriod.schoolId, school.id))
         .orderBy(asc(academicPeriod.startsOn)),
     ),
+    // KPI aggregates for the year (non-voided invoices).
+    withSchool(school.id, (tx) =>
+      tx
+        .select({
+          billed: sql<string>`coalesce(sum(${invoices.billedAmount}), 0)`,
+          collected: sql<string>`coalesce(sum(${invoices.paidAmount}), 0)`,
+          outstanding: sql<string>`coalesce(sum(case when ${invoices.status} in ('ISSUED','PARTIAL','OVERDUE') then ${invoices.balanceAmount} else 0 end), 0)`,
+          count: sql<number>`count(*)::int`,
+        })
+        .from(invoices)
+        .where(
+          and(
+            eq(invoices.schoolId, school.id),
+            eq(invoices.academicYear, year),
+            sql`${invoices.status} <> 'VOIDED'`,
+          ),
+        ),
+    ),
+    // Overdue > 30 days.
+    withSchool(school.id, (tx) =>
+      tx
+        .select({
+          amount: sql<string>`coalesce(sum(${invoices.balanceAmount}), 0)`,
+          students: sql<number>`count(distinct ${invoices.studentId})::int`,
+        })
+        .from(invoices)
+        .where(
+          and(
+            eq(invoices.schoolId, school.id),
+            eq(invoices.academicYear, year),
+            sql`${invoices.balanceAmount} > 0`,
+            sql`${invoices.dueAt} is not null and ${invoices.dueAt} < now() - interval '30 days'`,
+          ),
+        ),
+    ),
+    // School-wide invoice list for the year (non-voided), newest first.
+    withSchool(school.id, (tx) =>
+      tx
+        .select({
+          invoiceId: invoices.id,
+          studentId: invoices.studentId,
+          firstName: students.firstName,
+          lastName: students.lastName,
+          className: students.currentClassLabel,
+          invoiceNumber: invoices.invoiceNumber,
+          subtotal: invoices.subtotalAmount,
+          discount: invoices.discountAmount,
+          billed: invoices.billedAmount,
+          paid: invoices.paidAmount,
+          balance: invoices.balanceAmount,
+          status: invoices.status,
+          dueAt: invoices.dueAt,
+        })
+        .from(invoices)
+        .innerJoin(students, eq(invoices.studentId, students.id))
+        .where(
+          and(
+            eq(invoices.schoolId, school.id),
+            eq(invoices.academicYear, year),
+            sql`${invoices.status} <> 'VOIDED'`,
+          ),
+        )
+        .orderBy(desc(invoices.issuedAt))
+        .limit(300),
+    ),
   ]);
 
   const itemsByStructure = new Map<string, { description: string; amount: number }[]>();
@@ -281,6 +354,50 @@ export default async function BillingPage() {
     }))
     .filter((f) => f.members.length > 0);
 
+  // ── §03 admin-billing: KPI strip + school-wide invoices ──────────────
+  const kpiBilled = num(kpi?.billed);
+  const kpiCollected = num(kpi?.collected);
+  const kpiOutstanding = num(kpi?.outstanding);
+  const kpiCount = num(kpi?.count);
+  const collectedPct = kpiBilled > 0 ? Math.round((kpiCollected / kpiBilled) * 100) : 0;
+  const overdueAmount = num(overdue?.amount);
+  const overdueStudents = num(overdue?.students);
+  const outstandingStudents = num(summary?.families);
+
+  const invoiceRows: InvoiceRow[] = invoiceListRows.map((r) => {
+    const billed = num(r.billed);
+    const paid = num(r.paid);
+    const balance = num(r.balance);
+    const subtotal = num(r.subtotal);
+    const discount = num(r.discount);
+    const exempt = r.status === "EXEMPT" || (billed === 0 && subtotal > 0);
+    const discountPct =
+      !exempt && discount > 0 && subtotal > 0
+        ? Math.round((discount / subtotal) * 100)
+        : null;
+    const od = balance > 0 ? daysOverdue(r.dueAt) : 0;
+    let status: InvoiceRow["status"];
+    if (exempt) status = "EXEMPT";
+    else if (balance <= 0) status = "PAID";
+    else if (od > 0 || r.status === "OVERDUE") status = "OVERDUE";
+    else if (paid > 0) status = "PARTIAL";
+    else status = "UNPAID";
+    return {
+      invoiceId: r.invoiceId,
+      studentId: r.studentId,
+      student: `${r.firstName} ${r.lastName}`,
+      className: r.className,
+      invoiceNumber: r.invoiceNumber,
+      billed,
+      paid,
+      balance,
+      discountPct,
+      exempt,
+      status,
+      overdueDays: od,
+    };
+  });
+
   return (
     <div className="mx-auto max-w-page space-y-10">
       <div>
@@ -296,6 +413,36 @@ export default async function BillingPage() {
           chase outstanding balances. (Collecting payments lives in Fees.)
         </p>
       </div>
+
+      {kpiCount > 0 && (
+        <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+          <Kpi
+            label="Total billed"
+            value={ghs(kpiBilled)}
+            sub={plural(kpiCount, "invoice")}
+            tone="text-navy"
+          />
+          <Kpi
+            label="Collected"
+            value={ghs(kpiCollected)}
+            sub={`${collectedPct}% collected`}
+            tone="text-green"
+            subTone="text-green"
+          />
+          <Kpi
+            label="Outstanding"
+            value={ghs(kpiOutstanding)}
+            sub={plural(outstandingStudents, "student")}
+            tone="text-terra"
+          />
+          <Kpi
+            label="Overdue > 30d"
+            value={ghs(overdueAmount)}
+            sub={plural(overdueStudents, "student")}
+            tone="text-gold"
+          />
+        </div>
+      )}
 
       <RemindersCard families={num(summary?.families)} total={num(summary?.total)} />
 
@@ -326,6 +473,17 @@ export default async function BillingPage() {
             classesWithoutStructure={classesWithoutStructure}
           />
         )
+      )}
+
+      {/* Invoices — school-wide, this year (sms-mvp1 §03) */}
+      {invoiceRows.length > 0 && (
+        <section>
+          <div className="mb-4 flex items-baseline justify-between gap-3">
+            <h2 className="font-display text-xl font-semibold text-navy">Invoices</h2>
+            <span className="text-xs text-navy-3">{termLabel}</span>
+          </div>
+          <InvoicesTable rows={invoiceRows} />
+        </section>
       )}
 
       {/* Fee structures */}
@@ -372,6 +530,30 @@ export default async function BillingPage() {
         </h2>
         <FamiliesCard families={families} />
       </section>
+    </div>
+  );
+}
+
+function Kpi({
+  label,
+  value,
+  sub,
+  tone,
+  subTone,
+}: {
+  label: string;
+  value: string;
+  sub: string;
+  tone: string;
+  subTone?: string;
+}) {
+  return (
+    <div className="rounded-xl border border-border bg-surface p-[18px]">
+      <div className="text-[10px] font-semibold uppercase tracking-[0.12em] text-navy-3">
+        {label}
+      </div>
+      <div className={`mt-2.5 font-display text-2xl font-semibold ${tone}`}>{value}</div>
+      <div className={`mt-1 text-[11px] ${subTone ?? "text-navy-3"}`}>{sub}</div>
     </div>
   );
 }

--- a/omnischools/components/billing/invoices-table.tsx
+++ b/omnischools/components/billing/invoices-table.tsx
@@ -1,0 +1,160 @@
+"use client";
+import { useMemo, useState } from "react";
+import Link from "next/link";
+
+export type InvoiceRow = {
+  invoiceId: string;
+  studentId: string;
+  student: string;
+  className: string | null;
+  invoiceNumber: string;
+  billed: number;
+  paid: number;
+  balance: number;
+  discountPct: number | null; // for the tag; null when no discount
+  exempt: boolean;
+  status: "PAID" | "PARTIAL" | "OVERDUE" | "UNPAID" | "EXEMPT";
+  overdueDays: number;
+};
+
+type Filter = "ALL" | "UNPAID" | "PARTIAL" | "OVERDUE";
+const FILTERS: { key: Filter; label: string }[] = [
+  { key: "ALL", label: "All" },
+  { key: "UNPAID", label: "Unpaid" },
+  { key: "PARTIAL", label: "Partial" },
+  { key: "OVERDUE", label: "Overdue" },
+];
+
+const ghs = (v: number) =>
+  `GHS ${v.toLocaleString("en-GH", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+const STATUS: Record<InvoiceRow["status"], { label: (r: InvoiceRow) => string; cls: string }> = {
+  PAID: { label: () => "Paid", cls: "bg-green-bg text-green" },
+  EXEMPT: { label: () => "Exempted", cls: "bg-green-bg text-green" },
+  PARTIAL: { label: () => "Partial", cls: "bg-gold-bg text-gold" },
+  OVERDUE: { label: (r) => `Overdue ${r.overdueDays}d`, cls: "bg-terra-bg text-terra" },
+  UNPAID: { label: () => "Unpaid", cls: "bg-bg text-navy-3" },
+};
+
+/**
+ * School-wide invoices table (sms-mvp1 §03 "admin billing"): filter pills, per-student
+ * rows with billed/paid/balance, discount tags and status badges. Rows link to the
+ * student's billing statement where a payment can be recorded.
+ */
+export function InvoicesTable({ rows }: { rows: InvoiceRow[] }) {
+  const [filter, setFilter] = useState<Filter>("ALL");
+
+  const shown = useMemo(() => {
+    switch (filter) {
+      case "UNPAID":
+        return rows.filter((r) => r.status === "UNPAID");
+      case "PARTIAL":
+        return rows.filter((r) => r.status === "PARTIAL");
+      case "OVERDUE":
+        return rows.filter((r) => r.status === "OVERDUE");
+      default:
+        return rows;
+    }
+  }, [rows, filter]);
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-border bg-surface">
+      {/* Filter toolbar */}
+      <div className="flex flex-wrap items-center gap-2 border-b border-border px-5 py-3.5">
+        {FILTERS.map((f) => {
+          const on = filter === f.key;
+          return (
+            <button
+              key={f.key}
+              type="button"
+              onClick={() => setFilter(f.key)}
+              className={`rounded-pill border px-3 py-1 text-xs font-semibold transition-colors ${
+                on
+                  ? "border-navy bg-navy text-bg"
+                  : "border-border-2 bg-bg text-navy-3 hover:bg-gold-bg"
+              }`}
+            >
+              {f.label}
+            </button>
+          );
+        })}
+        <span className="ml-auto text-xs text-navy-3">
+          Showing <span className="font-semibold text-navy">{shown.length}</span> of{" "}
+          {rows.length}
+        </span>
+      </div>
+
+      {shown.length === 0 ? (
+        <p className="px-5 py-10 text-center text-sm text-navy-3">
+          No invoices in this filter.
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="border-b border-border bg-bg text-left text-[10px] uppercase tracking-[0.08em] text-navy-3">
+              <tr>
+                <th className="px-4 py-3 font-bold">Student</th>
+                <th className="px-4 py-3 font-bold">Class</th>
+                <th className="px-4 py-3 font-bold">Invoice</th>
+                <th className="px-4 py-3 text-right font-bold">Billed</th>
+                <th className="px-4 py-3 text-right font-bold">Paid</th>
+                <th className="px-4 py-3 text-right font-bold">Balance</th>
+                <th className="px-4 py-3 font-bold">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {shown.map((r) => {
+                const st = STATUS[r.status];
+                return (
+                  <tr key={r.invoiceId} className="transition-colors hover:bg-gold-bg">
+                    <td className="px-4 py-2.5">
+                      <Link
+                        href={`/students/${r.studentId}/billing`}
+                        className="font-semibold text-navy hover:text-gold hover:underline"
+                      >
+                        {r.student}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-2.5 text-navy-2">{r.className ?? "—"}</td>
+                    <td className="px-4 py-2.5 font-mono text-xs text-navy-2">
+                      {r.invoiceNumber}
+                    </td>
+                    <td className="px-4 py-2.5 text-right">
+                      <span className="font-medium text-navy">{ghs(r.billed)}</span>
+                      {r.exempt ? (
+                        <span className="ml-1.5 rounded-[3px] bg-green-bg px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.06em] text-green">
+                          Exempt
+                        </span>
+                      ) : r.discountPct != null ? (
+                        <span className="ml-1.5 rounded-[3px] bg-gold-bg px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.06em] text-gold">
+                          −{r.discountPct}%
+                        </span>
+                      ) : null}
+                    </td>
+                    <td className="px-4 py-2.5 text-right text-navy-2">
+                      {r.paid > 0 ? ghs(r.paid) : "—"}
+                    </td>
+                    <td
+                      className={`px-4 py-2.5 text-right font-medium ${
+                        r.balance > 0 ? "text-terra" : "text-navy-3"
+                      }`}
+                    >
+                      {r.balance > 0 ? ghs(r.balance) : "—"}
+                    </td>
+                    <td className="px-4 py-2.5">
+                      <span
+                        className={`rounded-pill px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.04em] ${st.cls}`}
+                      >
+                        {st.label(r)}
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Audited **Billing** against `sms-mvp1-wireframes.html › 03 Desktop — admin billing` with the design cartographer, then **fused** the surface's collection-overview elements into the current setup-focused page.

## Gap the surface had that the build lacked
§03 is a "Fees collection" admin view: a **4-KPI strip**, a **school-wide invoices table** (with filters, status badges, discount tags) and a sticky invoice-detail panel. The current Billing page had none of these — only fee-structure/discount/family setup.

## What I fused in (keeping all the existing setup sections)
- **4-KPI strip** — Total billed / **Collected** (green, % collected) / **Outstanding** (terra, N students) / **Overdue >30d** (gold, N students), coloured per the surface. Shows once any invoice exists for the year.
- **Invoices table** — `Student · Class · Invoice · Billed · Paid · Balance · Status`, with **filter pills** (All / Unpaid / Partial / Overdue), **status badges** (Paid / Partial / Overdue Nd / Unpaid / Exempted), **discount tags** (`−N%` / `Exempt`) and a "Showing X of Y" count — 1:1 with §03. Rows link to the student's billing statement (where a payment is recorded), instead of duplicating the surface's sticky panel (that data already lives on `/students/[id]/billing` + `/billing/payments/[id]`).

## Kept from the current build
Reminders card, school-wide issue-invoices, fee structures, discounts, families & siblings.

## Verification
- `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm build` ✅ · token-safe classes (solid tokens / -bg tints, no slash-opacity).
- Live render needs auth + seeded invoices (not run this session).

No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)