### PR TITLE
feat(settings): audit-log — Today's activity feed (§01) above the table (§02)

### DIFF
--- a/omnischools/app/(app)/settings/audit/page.tsx
+++ b/omnischools/app/(app)/settings/audit/page.tsx
@@ -1,11 +1,12 @@
 import Link from "next/link";
-import { and, desc, eq, sql } from "drizzle-orm";
+import { and, desc, eq, gte, sql } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
 import { withSchool } from "@/lib/db/rls";
 import { ScrollText } from "lucide-react";
 import { auditLog, users } from "@/db/schema";
 import { BackLink } from "@/components/ui/back-link";
 import { EmptyState } from "@/components/ui/empty-state";
+import { AuditActivityFeed } from "@/components/settings/audit-activity-feed";
 
 export const dynamic = "force-dynamic";
 export const metadata = { title: "Audit log" };
@@ -37,7 +38,27 @@ export default async function AuditLogPage({
   const { school } = await requireSchool();
   const entity = searchParams.entity;
 
+  const startOfToday = new Date();
+  startOfToday.setHours(0, 0, 0, 0);
+
   const data = await withSchool(school.id, async (tx) => {
+    // §01 feed — today's events, newest first.
+    const todayEvents = await tx
+      .select({
+        id: auditLog.auditId,
+        occurredAt: auditLog.occurredAt,
+        actorName: users.fullName,
+        actorRole: auditLog.actorRole,
+        actionType: auditLog.actionType,
+        entityType: auditLog.entityType,
+        entityId: auditLog.entityId,
+        reason: auditLog.reason,
+      })
+      .from(auditLog)
+      .leftJoin(users, eq(auditLog.actorUserId, users.id))
+      .where(and(eq(auditLog.schoolId, school.id), gte(auditLog.occurredAt, startOfToday)))
+      .orderBy(desc(auditLog.occurredAt))
+      .limit(60);
     const kinds = await tx
       .select({ entityType: auditLog.entityType, n: sql<number>`count(*)` })
       .from(auditLog)
@@ -64,8 +85,14 @@ export default async function AuditLogPage({
       )
       .orderBy(desc(auditLog.occurredAt))
       .limit(200);
-    return { kinds, rows };
+    return { kinds, rows, todayEvents };
   });
+
+  const dayLabel = `Today · ${startOfToday.toLocaleDateString("en-GB", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+  })}`;
 
   const chip = (label: string, value: string | null, count?: number) => {
     const active = (value ?? undefined) === entity || (!value && !entity);
@@ -92,10 +119,37 @@ export default async function AuditLogPage({
           Audit <em className="not-italic text-gold [font-style:italic]">log.</em>
         </h1>
         <p className="text-sm text-navy-3">
-          An append-only record of who changed what. Showing the latest {data.rows.length}{" "}
-          {entity ? `${title(entity)} ` : ""}events.
+          Every action by every user, recorded as it happens — append-only: entries
+          can&apos;t be edited or deleted.
         </p>
       </div>
+
+      {/* Section 01 — Today's activity feed (surface §01) */}
+      <section className="mb-8">
+        <div className="mb-3 flex flex-wrap items-baseline gap-3">
+          <span className="font-display text-xl font-semibold italic text-gold">01</span>
+          <h2 className="font-display text-lg font-semibold text-navy">
+            Today&apos;s{" "}
+            <em className="not-italic text-gold [font-style:italic]">activity</em> · most
+            recent first
+          </h2>
+          <span className="ml-auto text-[11px] uppercase tracking-wide text-navy-3">
+            {data.todayEvents.length} today
+          </span>
+        </div>
+        <AuditActivityFeed events={data.todayEvents} dayLabel={dayLabel} />
+      </section>
+
+      {/* Section 02 — Full log (the existing table) */}
+      <section>
+        <div className="mb-3 flex flex-wrap items-baseline gap-3">
+          <span className="font-display text-xl font-semibold italic text-gold">02</span>
+          <h2 className="font-display text-lg font-semibold text-navy">Full log</h2>
+          <span className="ml-auto text-[11px] uppercase tracking-wide text-navy-3">
+            latest {data.rows.length}
+            {entity ? ` · ${title(entity)}` : ""}
+          </span>
+        </div>
 
       <div className="mb-4 flex flex-wrap gap-1.5">
         {chip("All", null)}
@@ -155,6 +209,7 @@ export default async function AuditLogPage({
           </table>
         </div>
       )}
+      </section>
     </div>
   );
 }

--- a/omnischools/app/(app)/settings/audit/page.tsx
+++ b/omnischools/app/(app)/settings/audit/page.tsx
@@ -53,6 +53,8 @@ export default async function AuditLogPage({
         entityType: auditLog.entityType,
         entityId: auditLog.entityId,
         reason: auditLog.reason,
+        before: auditLog.beforeState,
+        after: auditLog.afterState,
       })
       .from(auditLog)
       .leftJoin(users, eq(auditLog.actorUserId, users.id))

--- a/omnischools/components/settings/audit-activity-feed.tsx
+++ b/omnischools/components/settings/audit-activity-feed.tsx
@@ -17,7 +17,41 @@ export type AuditEvent = {
   entityType: string | null;
   entityId: string | null;
   reason: string | null;
+  before: unknown;
+  after: unknown;
 };
+
+type DiffRow = { field: string; old: string; new: string };
+
+const fieldLabel = (k: string) =>
+  k
+    .replace(/([A-Z])/g, " $1")
+    .replace(/[_-]+/g, " ")
+    .trim()
+    .toLowerCase();
+
+function fmtVal(v: unknown): string {
+  if (v == null) return "—";
+  const s = typeof v === "object" ? JSON.stringify(v) : String(v);
+  return s.length > 44 ? `${s.slice(0, 44)}…` : s;
+}
+
+/** Field-level before→after changes (only fields that actually differ). Empty for creates. */
+function computeDiff(before: unknown, after: unknown): DiffRow[] {
+  if (!before || !after || typeof before !== "object" || typeof after !== "object") {
+    return [];
+  }
+  const b = before as Record<string, unknown>;
+  const a = after as Record<string, unknown>;
+  const keys = Array.from(new Set([...Object.keys(b), ...Object.keys(a)]));
+  const rows: DiffRow[] = [];
+  for (const k of keys) {
+    const oldV = fmtVal(b[k]);
+    const newV = fmtVal(a[k]);
+    if (oldV !== newV) rows.push({ field: fieldLabel(k), old: oldV, new: newV });
+  }
+  return rows.slice(0, 6);
+}
 
 // Money / role / structural changes are "sensitive"; the rest are routine.
 const SENSITIVE = new Set([
@@ -90,6 +124,7 @@ export function AuditActivityFeed({
             const bulk = e.entityType ? BULK_ENTITIES.has(e.entityType) : false;
             const actor = e.actorName ?? title(e.actorRole) ?? "System";
             const moduleLabel = e.entityType ? title(e.entityType) : "System";
+            const diff = computeDiff(e.before, e.after);
             return (
               <div
                 key={e.id}
@@ -132,6 +167,27 @@ export function AuditActivityFeed({
                       </span>
                     ) : null}
                   </div>
+
+                  {/* Per-event diff (before → after) — surface §01 diff block */}
+                  {diff.length > 0 ? (
+                    <div className="mt-2 rounded-md border border-dashed border-border bg-bg p-2.5 font-mono text-[11px] leading-relaxed">
+                      {diff.map((d) => (
+                        <div
+                          key={d.field}
+                          className="grid grid-cols-[92px_1fr] gap-2.5 py-0.5"
+                        >
+                          <span className="pt-px text-[9px] font-semibold uppercase tracking-[0.06em] text-navy-3">
+                            {d.field}
+                          </span>
+                          <span className="break-words text-navy-2">
+                            <span className="text-terra line-through">{d.old}</span>
+                            <span className="mx-1.5 text-navy-3">→</span>
+                            <span className="font-bold text-green">{d.new}</span>
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
                 </div>
               </div>
             );

--- a/omnischools/components/settings/audit-activity-feed.tsx
+++ b/omnischools/components/settings/audit-activity-feed.tsx
@@ -1,0 +1,143 @@
+import "server-only";
+
+/**
+ * §01 "Today's activity · most recent first" — the activity-feed section of
+ * Surfaces/schoolup-audit-log-viewer.html, fused above the existing audit table.
+ * Server-rendered from the same audit_log rows; newest first, grouped under a day marker.
+ * Entry cards carry a mono timestamp + relative "ago", a prose headline, module + severity
+ * pills, and a severity tint (sensitive = warn, bulk = gold left-border).
+ */
+
+export type AuditEvent = {
+  id: string;
+  occurredAt: Date | string;
+  actorName: string | null;
+  actorRole: string | null;
+  actionType: string;
+  entityType: string | null;
+  entityId: string | null;
+  reason: string | null;
+};
+
+// Money / role / structural changes are "sensitive"; the rest are routine.
+const SENSITIVE = new Set([
+  "voided",
+  "refunded",
+  "deleted",
+  "reassigned",
+  "approved",
+  "promoted",
+  "closed",
+  "reopened",
+]);
+// Actions that touch many records at once.
+const BULK_ENTITIES = new Set(["invoice_batch", "school_year"]);
+
+const title = (s?: string | null) =>
+  s ? s.charAt(0) + s.slice(1).toLowerCase().replaceAll("_", " ") : "—";
+
+function timeParts(occurredAt: Date | string, now: Date) {
+  const d = occurredAt instanceof Date ? occurredAt : new Date(occurredAt);
+  const time = d.toLocaleTimeString("en-GB", {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  });
+  const min = Math.max(0, Math.floor((now.getTime() - d.getTime()) / 60000));
+  const ago =
+    min < 1
+      ? "just now"
+      : min < 60
+        ? `${min} min ago`
+        : min < 1440
+          ? `${Math.floor(min / 60)}h ago`
+          : `${Math.floor(min / 1440)}d ago`;
+  return { time, ago };
+}
+
+export function AuditActivityFeed({
+  events,
+  dayLabel,
+}: {
+  events: AuditEvent[];
+  dayLabel: string;
+}) {
+  const now = new Date();
+
+  return (
+    <div>
+      {/* Day marker */}
+      <div className="mb-3 mt-1 flex items-center gap-3.5">
+        <span className="h-px flex-1 bg-border" />
+        <span className="shrink-0 px-1 font-display text-[13px] italic text-gold">
+          {dayLabel}
+        </span>
+        <span className="shrink-0 font-mono text-[10px] text-navy-2">
+          {events.length} {events.length === 1 ? "event" : "events"}
+        </span>
+        <span className="h-px flex-1 bg-border" />
+      </div>
+
+      {events.length === 0 ? (
+        <p className="rounded-[10px] border border-dashed border-border-2 bg-surface px-4 py-8 text-center text-sm text-navy-3">
+          No activity recorded yet today.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {events.map((e) => {
+            const { time, ago } = timeParts(e.occurredAt, now);
+            const sensitive = SENSITIVE.has(e.actionType);
+            const bulk = e.entityType ? BULK_ENTITIES.has(e.entityType) : false;
+            const actor = e.actorName ?? title(e.actorRole) ?? "System";
+            const moduleLabel = e.entityType ? title(e.entityType) : "System";
+            return (
+              <div
+                key={e.id}
+                className={`grid grid-cols-[auto_1fr] gap-4 rounded-[10px] border p-3.5 ${
+                  sensitive ? "border-warn-bg bg-warn-bg" : "border-border bg-surface"
+                } ${bulk ? "border-l-[3px] border-l-gold" : ""}`}
+              >
+                <div className="min-w-[58px] pt-0.5 font-mono text-[11px] font-semibold text-navy-2">
+                  <div>{time}</div>
+                  <div className="mt-0.5 text-[9px] font-medium text-navy-3">{ago}</div>
+                </div>
+                <div className="min-w-0">
+                  <p className="text-[13px] leading-relaxed text-navy">
+                    <span className="font-bold">{actor}</span>{" "}
+                    <span className="text-navy-2">{title(e.actionType)}</span>{" "}
+                    <span className="font-semibold">{moduleLabel}</span>
+                    {e.reason ? (
+                      <span className="text-navy-2"> — {e.reason}</span>
+                    ) : null}
+                  </p>
+                  <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+                    <span className="rounded-pill border border-border bg-bg px-2 py-0.5 text-[10px] font-semibold text-navy-2">
+                      {moduleLabel}
+                    </span>
+                    <span
+                      className={`rounded-pill px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.04em] ${
+                        sensitive ? "bg-warn text-white" : "bg-bg text-navy-3"
+                      }`}
+                    >
+                      {sensitive ? "Sensitive" : "Routine"}
+                    </span>
+                    {bulk ? (
+                      <span className="rounded-pill bg-gold px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.04em] text-navy">
+                        Bulk
+                      </span>
+                    ) : null}
+                    {e.entityId ? (
+                      <span className="font-mono text-[10px] text-navy-3">
+                        {e.entityId.slice(0, 8)}
+                      </span>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Cartographed `schoolup-audit-log-viewer.html` and fused its **§01 "Today's activity · most recent first"** feed into the current Audit log: the surface's feed is **section 01**, the existing table is kept as **section 02**.

## What changed
- **New `AuditActivityFeed`** (server component) — **today's** `audit_log` events, newest first, under a **"Today · {date}"** day marker. Each entry card has a mono timestamp + relative "ago", a prose headline (*actor · action · module — reason*), **module + severity pills**, and a severity tint (sensitive = warn, **bulk** = gold left-border).
- **Per-event before→after diff** — surfaces the `before_jsonb`/`after_jsonb` we already store. Events that changed state (admission decisions, renames, role/status changes, term close/reopen…) render a git-style **`field | old → new`** block — old struck-through terra, new bold green — in a dashed mono panel, per the surface. Creates (no before-state) show none.
- **Audit page restructured** into two gold-italic numbered sections:
  - **01 · Today's activity · most recent first** → the feed (empty-state when nothing today).
  - **02 · Full log** → the existing entity-filter chips + table, **unchanged**.

## Notes
- Reads existing `audit_log` columns — **no schema change**.
- Remaining surface extras still deferred (need data we don't yet capture): cryptographic **day-seal** and **PII tombstones**. The feed degrades gracefully.

## Verification
- `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm build` ✅ · token-safe classes.
- Confirmed real events carry before+after (e.g. `decideApplication` → `status: pending → accepted`), so diffs render on live data. Full live render needs auth (not run this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)