### PR TITLE
feat(billing): generate a student's receipt from the invoices table

### DIFF
--- a/omnischools/app/(app)/billing/page.tsx
+++ b/omnischools/app/(app)/billing/page.tsx
@@ -10,6 +10,7 @@ import {
   discountTiers,
   classes,
   invoices,
+  paymentAllocations,
   academicPeriod,
   households,
   students,
@@ -247,6 +248,16 @@ export default async function BillingPage() {
           balance: invoices.balanceAmount,
           status: invoices.status,
           dueAt: invoices.dueAt,
+          // Latest live payment that settled this invoice → its receipt.
+          receiptPaymentId: sql<string | null>`(
+            select pa.payment_id from ${paymentAllocations} pa
+            where pa.invoice_id = ${invoices.id}
+              and pa.school_id = ${school.id}
+              and pa.allocation_type = 'INVOICE'
+              and pa.voided_at is null
+            order by pa.allocated_at desc
+            limit 1
+          )`,
         })
         .from(invoices)
         .innerJoin(students, eq(invoices.studentId, students.id))
@@ -395,6 +406,7 @@ export default async function BillingPage() {
       exempt,
       status,
       overdueDays: od,
+      receiptPaymentId: r.receiptPaymentId,
     };
   });
 

--- a/omnischools/components/billing/invoices-table.tsx
+++ b/omnischools/components/billing/invoices-table.tsx
@@ -15,6 +15,7 @@ export type InvoiceRow = {
   exempt: boolean;
   status: "PAID" | "PARTIAL" | "OVERDUE" | "UNPAID" | "EXEMPT";
   overdueDays: number;
+  receiptPaymentId: string | null; // latest payment that settled this invoice → its receipt
 };
 
 type Filter = "ALL" | "UNPAID" | "PARTIAL" | "OVERDUE";
@@ -100,6 +101,7 @@ export function InvoicesTable({ rows }: { rows: InvoiceRow[] }) {
                 <th className="px-4 py-3 text-right font-bold">Paid</th>
                 <th className="px-4 py-3 text-right font-bold">Balance</th>
                 <th className="px-4 py-3 font-bold">Status</th>
+                <th className="px-4 py-3 text-right font-bold">Receipt</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-border">
@@ -147,6 +149,20 @@ export function InvoicesTable({ rows }: { rows: InvoiceRow[] }) {
                       >
                         {st.label(r)}
                       </span>
+                    </td>
+                    <td className="px-4 py-2.5 text-right">
+                      {r.receiptPaymentId ? (
+                        <a
+                          href={`/api/receipts/${r.receiptPaymentId}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-block rounded-md border border-border-2 px-2.5 py-1 text-xs font-semibold text-navy transition-colors hover:border-gold-soft hover:bg-gold-bg"
+                        >
+                          Receipt
+                        </a>
+                      ) : (
+                        <span className="text-xs text-navy-3">—</span>
+                      )}
                     </td>
                   </tr>
                 );


### PR DESCRIPTION
## Summary
Adds a staff-facing **"Receipt"** button to the Billing invoices table — a second way to produce a student's receipt, alongside the parent-facing SMS link.

## How it works
- The Billing invoices query resolves, per invoice, the **latest non-voided payment** that settled it (via `payment_allocation`).
- The invoices table gains a **Receipt** column: for a paid invoice it's a link that opens the **receipt PDF** for that payment (the existing on-demand `/api/receipts/[paymentId]` route — authenticated, tenant-scoped); for unpaid / exempt invoices (no payment → no receipt) it shows `—`.

Clicking it generates and opens the receipt inline, so an admin can print/hand a receipt to a parent directly from Billing without opening the payment detail page.

## Notes
- **No schema change** — reuses the receipt renderer and the allocation data already recorded.
- A receipt is per **payment**; the row's button points at the payment that paid that invoice (a payment spanning multiple invoices shows its full allocation in the PDF).

## Verification
- `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm build` ✅ · token-safe classes.
- Live render needs auth + a paid invoice (not run this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)