### PR TITLE
fix(gradebook): 'Add your first column' card clips on short rosters

### DIFF
--- a/omnischools/components/gradebook/empty-columns.tsx
+++ b/omnischools/components/gradebook/empty-columns.tsx
@@ -79,9 +79,11 @@ export function GradebookEmptyColumns({
         </div>
       </div>
 
-      {/* Faded preview grid with a floating CTA over it */}
-      <div className="relative bg-surface overflow-hidden rounded-xl border border-border">
-        <div className="opacity-45 pointer-events-none">
+      {/* Faded preview grid with the CTA stacked over it. A grid stack (both children in
+          the same cell) sizes the box to the TALLER of {grid, card}, so the card never gets
+          clipped by overflow-hidden on a short roster. */}
+      <div className="grid bg-surface overflow-hidden rounded-xl border border-border">
+        <div className="[grid-area:1/1] opacity-45 pointer-events-none">
           <table className="w-full text-xs">
             <thead>
               <tr className="border-b border-border">
@@ -130,8 +132,9 @@ export function GradebookEmptyColumns({
           </table>
         </div>
 
-        {/* Floating CTA card, centered over the faded grid */}
-        <div className="absolute left-1/2 top-1/2 z-10 w-[360px] max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-gold bg-surface px-7 pb-5 pt-6 text-center shadow-[0_30px_70px_-20px_rgba(26,43,71,0.22)]">
+        {/* CTA stacked over the faded grid (same grid cell, centered) */}
+        <div className="z-10 flex items-center justify-center p-4 [grid-area:1/1]">
+          <div className="w-[360px] max-w-full rounded-2xl border border-gold bg-surface px-7 pb-5 pt-6 text-center shadow-[0_30px_70px_-20px_rgba(26,43,71,0.22)]">
           <div className="mx-auto mb-3.5 flex h-11 w-11 items-center justify-center rounded-full bg-gold-bg font-display text-lg font-bold text-gold">
             +
           </div>
@@ -172,6 +175,7 @@ export function GradebookEmptyColumns({
           )}
 
           {error && <p className="mt-2 text-xs text-terra">{error}</p>}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Bug
On the Gradebook grid, when a class×subject×term has **no columns yet**, the "Add your first column" CTA is shown as an **absolutely-centered overlay** on top of a faded preview grid, inside an `overflow-hidden` box. With a small roster (e.g. 2 students) the faded grid is shorter than the CTA card, so the card — and its buttons / expanded add-column form — **overflow the box and get clipped** (see the reported screenshot: the "+" is cut at the top and the input/button are cut at the bottom).

## Fix
Switch the container to a **grid stack**: the faded grid and the CTA both occupy the *same* grid cell (`[grid-area:1/1]`), so the box auto-sizes to the **taller** of the two. The CTA is centered with flex instead of absolute translate. Result: the card is always fully visible — any roster size, and whether or not the add-column form is expanded. No magic heights.

## Verification
- `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm build` ✅ (after a `pnpm install` to pick up `vitest`, which #131 added to package.json — my local node_modules was just stale; nothing to change here).
- Pure structural CSS change; live render needs auth + the exact "no columns yet" state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)