### PR TITLE
feat(senior): Score Ledger Item 3 — Vice Headmaster progress view

### DIFF
--- a/omnischools/app/(app)/senior/academic-progress/page.tsx
+++ b/omnischools/app/(app)/senior/academic-progress/page.tsx
@@ -96,7 +96,7 @@ export default async function AcademicProgressPage({
         <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-gold font-display text-sm italic text-navy">
           i
         </span>
-        <p className="text-xs leading-relaxed text-bg/90">
+        <p className="text-xs leading-relaxed text-bg">
           This view shows{" "}
           <em className="font-display italic text-gold">completion progress</em>, not the
           score values themselves. You see which categories each teacher has entered; the

--- a/omnischools/app/(app)/senior/academic-progress/page.tsx
+++ b/omnischools/app/(app)/senior/academic-progress/page.tsx
@@ -45,9 +45,13 @@ export default async function AcademicProgressPage({
   // At-risk flags (§2), computed on-the-fly from the same completion data.
   const inactiveFlags = rows.filter((r) => r.flags.length > 0);
   const notReady = rows.filter((r) => r.status !== "ready");
-  const behindTeachers = Array.from(
+  const behindNames = Array.from(
     new Set(notReady.map((r) => r.teacherName ?? "Unassigned")),
   );
+  const behindLabel =
+    behindNames.length <= 6
+      ? behindNames.join(", ")
+      : `${behindNames.slice(0, 6).join(", ")}, and ${behindNames.length - 6} more`;
 
   return (
     <div className="mx-auto max-w-page">
@@ -163,8 +167,7 @@ export default async function AcademicProgressPage({
                     <strong className="text-navy">
                       {notReady.length} of {total} class-subject combinations
                     </strong>{" "}
-                    are not yet STPSHS-ready. Teachers behind:{" "}
-                    {behindTeachers.join(", ")}.
+                    are not yet STPSHS-ready. Teachers behind: {behindLabel}.
                   </p>
                   <p className="mt-0.5 text-[9.5px] font-bold uppercase tracking-[0.04em] text-navy-3">
                     Rule: STPSHS window approaching with incomplete entries · severity high

--- a/omnischools/app/(app)/senior/academic-progress/page.tsx
+++ b/omnischools/app/(app)/senior/academic-progress/page.tsx
@@ -1,0 +1,180 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { asc, eq } from "drizzle-orm";
+import { requireSchool } from "@/lib/auth/server";
+import { withSchool } from "@/lib/db/rls";
+import { academicPeriod } from "@/db/schema";
+import { loadVhmProgress, type VhmProgressRow } from "@/lib/score-ledger/vhm-progress";
+import { VhmProgressTable } from "@/components/senior/vhm-progress-table";
+
+export const dynamic = "force-dynamic";
+
+export default async function AcademicProgressPage({
+  searchParams,
+}: {
+  searchParams: { periodId?: string };
+}) {
+  const { school } = await requireSchool();
+  // Senior-only management surface.
+  if (school.schoolType === "BASIC") redirect("/gradebook");
+
+  const periods = await withSchool(school.id, (tx) =>
+    tx
+      .select()
+      .from(academicPeriod)
+      .where(eq(academicPeriod.schoolId, school.id))
+      .orderBy(asc(academicPeriod.periodNumber)),
+  );
+  const activePeriod =
+    periods.find((p) => p.periodId === searchParams.periodId) ??
+    periods[periods.length - 1];
+
+  let rows: VhmProgressRow[] = [];
+  if (activePeriod) {
+    rows = await withSchool(school.id, (tx) =>
+      loadVhmProgress(tx, school.id, activePeriod.periodId, new Date()),
+    );
+  }
+
+  const total = rows.length;
+  const ready = rows.filter((r) => r.status === "ready").length;
+  const behind = rows.filter((r) => r.status === "behind").length;
+  const atRisk = rows.filter((r) => r.status === "at_risk").length;
+  const termLabel = activePeriod?.periodLabel ?? "this semester";
+
+  // At-risk flags (§2), computed on-the-fly from the same completion data.
+  const inactiveFlags = rows.filter((r) => r.flags.length > 0);
+  const notReady = rows.filter((r) => r.status !== "ready");
+  const behindTeachers = Array.from(
+    new Set(notReady.map((r) => r.teacherName ?? "Unassigned")),
+  );
+
+  return (
+    <div className="mx-auto max-w-page">
+      {/* Hero (§1.2) */}
+      <div className="mb-5">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gold">
+          Senior · Vice Headmaster · Academic progress
+          {activePeriod ? ` · ${activePeriod.academicYear} ${activePeriod.periodLabel}` : ""}
+        </div>
+        <h1 className="mt-1 font-display text-3xl font-semibold text-navy">
+          Score ledger <em className="italic text-gold">progress.</em>
+        </h1>
+        <div className="mb-3 mt-2 h-0.5 w-16 bg-gold" />
+        <p className="max-w-2xl text-sm text-navy-3">
+          {total} class-subject {total === 1 ? "combination" : "combinations"} ·{" "}
+          <span className="font-semibold text-green">{ready} ready</span> ·{" "}
+          <span className="font-semibold text-gold">{behind} behind</span> ·{" "}
+          <span className="font-semibold text-terra">{atRisk} at risk</span> for {termLabel}.
+        </p>
+      </div>
+
+      {/* Period tabs (only when more than one). */}
+      {periods.length > 1 && (
+        <div className="mb-5 flex flex-wrap gap-2">
+          {periods.map((p) => {
+            const active = p.periodId === activePeriod?.periodId;
+            return (
+              <Link
+                key={p.periodId}
+                href={`/senior/academic-progress?periodId=${p.periodId}`}
+                className={
+                  active
+                    ? "rounded-md border border-gold bg-gold-bg px-3 py-1.5 text-sm font-semibold text-navy"
+                    : "rounded-md border border-border-2 bg-surface px-3 py-1.5 text-sm text-navy-3 hover:bg-gold-bg"
+                }
+              >
+                {p.periodLabel}
+              </Link>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Discipline banner (§1.3) — the completion-not-scores contract, made visible. Non-negotiable. */}
+      <div className="mb-5 flex items-start gap-3 rounded-xl bg-navy px-5 py-4 text-bg">
+        <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-gold font-display text-sm italic text-navy">
+          i
+        </span>
+        <p className="text-xs leading-relaxed text-bg/90">
+          This view shows{" "}
+          <em className="font-display italic text-gold">completion progress</em>, not the
+          score values themselves. You see which categories each teacher has entered; the
+          marks remain the teacher&apos;s domain until the semester is closed. To inspect
+          actual scores, open the gradebook — that access is audit-logged.
+        </p>
+      </div>
+
+      {/* Completion table (§1.4) */}
+      <section className="mb-6">
+        <div className="mb-3 flex flex-wrap items-baseline justify-between gap-2">
+          <h2 className="font-display text-lg font-semibold text-navy">
+            Teacher × class ·{" "}
+            <em className="italic text-gold">
+              {total} {total === 1 ? "combination" : "combinations"}
+            </em>
+          </h2>
+          <span className="text-[10px] uppercase tracking-wide text-navy-3">
+            Sorted by STPSHS readiness · most behind first
+          </span>
+        </div>
+        <VhmProgressTable rows={rows} />
+      </section>
+
+      {/* At-risk flags (§2) — computed from the completion data. */}
+      <section>
+        <h2 className="mb-3 font-display text-lg font-semibold text-navy">
+          Risks <em className="italic text-gold">this week.</em>
+        </h2>
+        {inactiveFlags.length === 0 && notReady.length === 0 ? (
+          <div className="rounded-[11px] border border-border bg-bg px-[18px] py-4 text-[11px] text-navy-3">
+            <span className="font-display text-[13px] italic text-navy">No flags.</span>{" "}
+            Every class-subject is tracking on schedule.
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {inactiveFlags.map((r) => (
+              <div
+                key={`inactive-${r.classId}:${r.subjectId}`}
+                className="flex items-start gap-3 rounded-[11px] border border-terra bg-terra-bg px-[18px] py-3.5"
+              >
+                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-terra font-display italic text-bg">
+                  !
+                </span>
+                <div>
+                  <p className="text-sm text-navy-2">
+                    <strong className="text-navy">{r.teacherName ?? "A teacher"}</strong> has
+                    not touched the ledger for {r.className} · {r.subjectName} in{" "}
+                    {r.daysInactive} days.
+                  </p>
+                  <p className="mt-0.5 text-[9.5px] font-bold uppercase tracking-[0.04em] text-navy-3">
+                    Rule: teacher inactivity 14+ days during semester · severity high
+                  </p>
+                </div>
+              </div>
+            ))}
+            {notReady.length > 0 && (
+              <div className="flex items-start gap-3 rounded-[11px] border border-gold bg-gold-bg px-[18px] py-3.5">
+                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gold font-display italic text-navy">
+                  !
+                </span>
+                <div>
+                  <p className="text-sm text-navy-2">
+                    <strong className="text-navy">
+                      {notReady.length} of {total} class-subject combinations
+                    </strong>{" "}
+                    are not yet STPSHS-ready. Teachers behind:{" "}
+                    {behindTeachers.join(", ")}.
+                  </p>
+                  <p className="mt-0.5 text-[9.5px] font-bold uppercase tracking-[0.04em] text-navy-3">
+                    Rule: STPSHS window approaching with incomplete entries · severity high
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/omnischools/components/app/sidebar.tsx
+++ b/omnischools/components/app/sidebar.tsx
@@ -17,6 +17,7 @@ import {
   MessageSquare,
   Settings,
   NotebookText,
+  Gauge,
   type LucideIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -45,12 +46,12 @@ const TIER: Record<string, string> = {
   COMBINED: "Combined",
 };
 
-/** Senior (SHS) tier only — the five-category score ledger. Inserted after Gradebook. */
-const SENIOR_ITEM = {
-  href: "/senior/score-ledger",
-  label: "Score ledger",
-  Icon: NotebookText,
-};
+/** Senior (SHS) tier only — inserted after Gradebook. The teacher's score ledger and the
+ * Vice Headmaster's completion view. */
+const SENIOR_ITEMS = [
+  { href: "/senior/score-ledger", label: "Score ledger", Icon: NotebookText },
+  { href: "/senior/academic-progress", label: "Ledger progress", Icon: Gauge },
+];
 
 /** Finance-only (Accountant/Bursar) nav — billing first, then read-only students/classes. */
 const FINANCE_NAV_ORDER = ["/billing", "/fees", "/reports", "/books", "/students", "/classes"];
@@ -89,7 +90,7 @@ export function AppSidebar({
   const isSenior =
     school.schoolType === "SENIOR" || school.schoolType === "COMBINED";
   const fullNav = isSenior
-    ? NAV.flatMap((n) => (n.href === "/gradebook" ? [n, SENIOR_ITEM] : [n]))
+    ? NAV.flatMap((n) => (n.href === "/gradebook" ? [n, ...SENIOR_ITEMS] : [n]))
     : NAV;
   // Finance-only staff see a billing-focused nav; everyone else sees the full set.
   const nav = isFinanceOnly(user.roles)

--- a/omnischools/components/senior/vhm-progress-table.tsx
+++ b/omnischools/components/senior/vhm-progress-table.tsx
@@ -1,0 +1,163 @@
+import type { VhmProgressRow, CapturePath, VhmStatus } from "@/lib/score-ledger/vhm-progress";
+
+/**
+ * The Vice Headmaster completion table (surface §1). COMPLETION STATES ONLY — every cell is
+ * a path letter, a category dot (entered / partial / pending), an n/5 tier, or a relative
+ * date. No score value is ever rendered (spec §6.2). Server component — purely presentational.
+ */
+
+const PATH_PILL: Record<CapturePath, { letter: string; cls: string }> = {
+  AUTO_COMPILE: { letter: "A", cls: "bg-green-bg text-green" },
+  SCAN_EXTRACT: { letter: "B", cls: "bg-gold-bg text-gold" },
+  DIRECT_ENTRY: { letter: "C", cls: "bg-terra-bg text-terra" },
+};
+
+const STPSHS: Record<VhmStatus, { label: string; cls: string }> = {
+  ready: { label: "Ready", cls: "bg-green-bg text-green" },
+  behind: { label: "Behind", cls: "bg-gold-bg text-gold" },
+  at_risk: { label: "At risk", cls: "bg-terra-bg text-terra" },
+};
+
+const CATS: { key: keyof VhmProgressRow["filled"]; label: string; cls: string }[] = [
+  { key: "asgn", label: "Asg", cls: "text-green" },
+  { key: "midSem", label: "MS", cls: "text-navy-2" },
+  { key: "endSem", label: "ES", cls: "text-navy-2" },
+  { key: "project", label: "Proj", cls: "text-green" },
+  { key: "portfolio", label: "Port", cls: "text-terra" },
+];
+
+/** A category dot: ✓ (all entered) / ◐ (some) / — (none). Never a score — the state only. */
+function CatDot({ filled, roster }: { filled: number; roster: number }) {
+  const done = roster > 0 && filled === roster;
+  const partial = filled > 0 && !done;
+  const cls = done
+    ? "bg-green text-bg"
+    : partial
+      ? "bg-gold text-navy"
+      : "bg-border-2 text-navy-3";
+  const glyph = done ? "✓" : partial ? "◐" : "—";
+  return (
+    <span
+      title={roster > 0 ? `${filled} of ${roster} entered` : "no students"}
+      className={`inline-flex h-[22px] w-[22px] items-center justify-center rounded-md font-mono text-[11px] font-bold ${cls}`}
+    >
+      {glyph}
+    </span>
+  );
+}
+
+function lastActivityLabel(daysInactive: number | null): string {
+  if (daysInactive == null) return "never";
+  if (daysInactive <= 0) return "today";
+  if (daysInactive === 1) return "yesterday";
+  return `${daysInactive} days ago`;
+}
+
+export function VhmProgressTable({ rows }: { rows: VhmProgressRow[] }) {
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-border-2 bg-surface p-12 text-center text-sm text-navy-3">
+        No class-subject combinations for this semester yet. Set up teaching assignments in
+        Classes &amp; subjects to track ledger progress.
+      </div>
+    );
+  }
+  return (
+    <div>
+      <div className="overflow-x-auto rounded-xl border border-border bg-surface">
+        <table className="w-full text-sm">
+          <thead className="border-b border-border bg-bg text-[9px] font-bold uppercase tracking-[0.1em] text-navy-3">
+            <tr>
+              <th className="px-4 py-3 text-left">Teacher</th>
+              <th className="px-3 py-3 text-left">Class · subject</th>
+              <th className="px-2 py-3 text-center">Path</th>
+              {CATS.map((c) => (
+                <th key={c.key} className={`px-2 py-3 text-center ${c.cls}`}>
+                  {c.label}
+                </th>
+              ))}
+              <th className="px-3 py-3 text-center">STPSHS</th>
+              <th className="px-4 py-3 text-right">Last activity</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {rows.map((r) => {
+              const pill = PATH_PILL[r.path];
+              const s = STPSHS[r.status];
+              const stale = r.daysInactive != null && r.daysInactive >= 14;
+              return (
+                <tr key={`${r.classId}:${r.subjectId}`} className="hover:bg-gold-bg">
+                  <td className="px-4 py-3 text-left">
+                    <div className="font-semibold text-navy">{r.teacherName ?? "—"}</div>
+                    <div className="text-[9.5px] text-navy-3">{r.subjectName}</div>
+                  </td>
+                  <td className="px-3 py-3 text-left font-semibold text-navy-2">
+                    {r.className}
+                  </td>
+                  <td className="px-2 py-3 text-center">
+                    <span
+                      className={`rounded-full px-[7px] py-[3px] font-mono text-[9px] font-bold tracking-[0.04em] ${pill.cls}`}
+                    >
+                      {pill.letter}
+                    </span>
+                  </td>
+                  {CATS.map((c) => (
+                    <td key={c.key} className="px-2 py-3 text-center">
+                      <CatDot filled={r.filled[c.key]} roster={r.rosterSize} />
+                    </td>
+                  ))}
+                  <td className="px-3 py-3 text-center">
+                    <span
+                      className={`inline-block rounded-full px-2.5 py-1 font-mono text-[10px] font-bold uppercase tracking-[0.04em] ${s.cls}`}
+                    >
+                      {s.label} · {r.categoriesDone}/5
+                    </span>
+                  </td>
+                  <td
+                    className={`px-4 py-3 text-right font-mono text-[10px] ${
+                      stale ? "font-bold text-terra" : "text-navy-3"
+                    }`}
+                  >
+                    {lastActivityLabel(r.daysInactive)}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Legends (§1.5 path · §1.6 cat-dot). */}
+      <div className="mt-3 flex flex-wrap gap-x-5 gap-y-2 text-[10.5px] text-navy-3">
+        <span className="flex items-center gap-2">
+          <span className="rounded-full bg-green-bg px-[6px] py-[2px] font-mono text-[9px] font-bold text-green">
+            A
+          </span>
+          Auto-compile
+          <span className="rounded-full bg-gold-bg px-[6px] py-[2px] font-mono text-[9px] font-bold text-gold">
+            B
+          </span>
+          Scan paper
+          <span className="rounded-full bg-terra-bg px-[6px] py-[2px] font-mono text-[9px] font-bold text-terra">
+            C
+          </span>
+          Direct digital
+        </span>
+        <span className="flex items-center gap-2">
+          <span className="inline-flex h-4 w-4 items-center justify-center rounded bg-green text-[9px] text-bg">
+            ✓
+          </span>
+          Entered
+          <span className="inline-flex h-4 w-4 items-center justify-center rounded bg-gold text-[9px] text-navy">
+            ◐
+          </span>
+          Partial
+          <span className="inline-flex h-4 w-4 items-center justify-center rounded bg-border-2 text-[9px] text-navy-3">
+            —
+          </span>
+          Pending
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/omnischools/db/migrations/0040_green_captain_stacy.sql
+++ b/omnischools/db/migrations/0040_green_captain_stacy.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "senior_subject_teacher" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"school_id" uuid NOT NULL,
+	"class_id" uuid NOT NULL,
+	"subject_id" uuid NOT NULL,
+	"teacher_user_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "uniq_subject_teacher_context" UNIQUE("school_id","class_id","subject_id")
+);
+--> statement-breakpoint
+ALTER TABLE "senior_subject_teacher" ADD CONSTRAINT "senior_subject_teacher_school_id_ref_school_id_fk" FOREIGN KEY ("school_id") REFERENCES "public"."ref_school"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "senior_subject_teacher" ADD CONSTRAINT "senior_subject_teacher_teacher_user_id_ref_user_id_fk" FOREIGN KEY ("teacher_user_id") REFERENCES "public"."ref_user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "senior_subject_teacher" ADD CONSTRAINT "senior_subject_teacher_school_id_class_id_class_school_id_id_fk" FOREIGN KEY ("school_id","class_id") REFERENCES "public"."class"("school_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "senior_subject_teacher" ADD CONSTRAINT "senior_subject_teacher_school_id_subject_id_subject_school_id_id_fk" FOREIGN KEY ("school_id","subject_id") REFERENCES "public"."subject"("school_id","id") ON DELETE cascade ON UPDATE no action;

--- a/omnischools/db/migrations/meta/0040_snapshot.json
+++ b/omnischools/db/migrations/meta/0040_snapshot.json
@@ -1,0 +1,8696 @@
+{
+  "id": "fea2b143-77f8-41db-ada5-a5f1be060c3a",
+  "prevId": "e523c240-b886-4dd2-bfd4-c11dbd8e8dc0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ref_district": {
+      "name": "ref_district",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_district_region_id_ref_region_id_fk": {
+          "name": "ref_district_region_id_ref_region_id_fk",
+          "tableFrom": "ref_district",
+          "tableTo": "ref_region",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_district_code_unique": {
+          "name": "ref_district_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_region": {
+      "name": "ref_region",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_region_code_unique": {
+          "name": "ref_region_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_school_product": {
+      "name": "ref_school_product",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product": {
+          "name": "product",
+          "type": "product",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_school_product_school_id_ref_school_id_fk": {
+          "name": "ref_school_product_school_id_ref_school_id_fk",
+          "tableFrom": "ref_school_product",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_school_product": {
+          "name": "uniq_school_product",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "product"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_school": {
+      "name": "ref_school",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ges_code": {
+          "name": "ges_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cssps_code": {
+          "name": "cssps_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_type": {
+          "name": "school_type",
+          "type": "school_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'BASIC'"
+        },
+        "subtype": {
+          "name": "subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shs_category": {
+          "name": "shs_category",
+          "type": "shs_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownership_type": {
+          "name": "ownership_type",
+          "type": "ownership_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRIVATE'"
+        },
+        "year_founded": {
+          "name": "year_founded",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stamp_url": {
+          "name": "stamp_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_color": {
+          "name": "brand_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cadence": {
+          "name": "billing_cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_methods": {
+          "name": "payment_methods",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residency_model": {
+          "name": "residency_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "house_count": {
+          "name": "house_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visiting_day": {
+          "name": "visiting_day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waec_centre_code": {
+          "name": "waec_centre_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waec_office": {
+          "name": "waec_office",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_wassce_year": {
+          "name": "first_wassce_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_retention_months": {
+          "name": "record_retention_months",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audit_retention_months": {
+          "name": "audit_retention_months",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_2fa": {
+          "name": "require_2fa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_hours": {
+          "name": "session_hours",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "district_id": {
+          "name": "district_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_school_district_id_ref_district_id_fk": {
+          "name": "ref_school_district_id_ref_district_id_fk",
+          "tableFrom": "ref_school",
+          "tableTo": "ref_district",
+          "columnsFrom": [
+            "district_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ref_school_region_id_ref_region_id_fk": {
+          "name": "ref_school_region_id_ref_region_id_fk",
+          "tableFrom": "ref_school",
+          "tableTo": "ref_region",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_school_ges_code_unique": {
+          "name": "ref_school_ges_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "ges_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_assignment": {
+      "name": "role_assignment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_ref": {
+          "name": "scope_ref",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_assignment_user_id_ref_user_id_fk": {
+          "name": "role_assignment_user_id_ref_user_id_fk",
+          "tableFrom": "role_assignment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_assignment_school_id_ref_school_id_fk": {
+          "name": "role_assignment_school_id_ref_school_id_fk",
+          "tableFrom": "role_assignment",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_assignment_role_id_ref_role_id_fk": {
+          "name": "role_assignment_role_id_ref_role_id_fk",
+          "tableFrom": "role_assignment",
+          "tableTo": "ref_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_role": {
+      "name": "ref_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_role_code_unique": {
+          "name": "ref_role_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_user": {
+      "name": "ref_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_user_phone_unique": {
+          "name": "ref_user_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_compensation": {
+      "name": "staff_compensation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "salary_status": {
+          "name": "salary_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SCHOOL_PAID'"
+        },
+        "monthly_amount": {
+          "name": "monthly_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "pay_method": {
+          "name": "pay_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'BANK'"
+        },
+        "pay_cadence": {
+          "name": "pay_cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MONTHLY'"
+        },
+        "ssnit_deduction": {
+          "name": "ssnit_deduction",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "paye_deduction": {
+          "name": "paye_deduction",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "staff_compensation_school_idx": {
+          "name": "staff_compensation_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_compensation_school_id_ref_school_id_fk": {
+          "name": "staff_compensation_school_id_ref_school_id_fk",
+          "tableFrom": "staff_compensation",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "staff_compensation_user_id_ref_user_id_fk": {
+          "name": "staff_compensation_user_id_ref_user_id_fk",
+          "tableFrom": "staff_compensation",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_staff_compensation_per_school": {
+          "name": "uniq_staff_compensation_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_profile": {
+      "name": "staff_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qualification_level": {
+          "name": "qualification_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highest_qualification": {
+          "name": "highest_qualification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "undergraduate": {
+          "name": "undergraduate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ntc_licence_number": {
+          "name": "ntc_licence_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ntc_licence_expiry": {
+          "name": "ntc_licence_expiry",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialisations": {
+          "name": "specialisations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "staff_profile_school_idx": {
+          "name": "staff_profile_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_profile_school_id_ref_school_id_fk": {
+          "name": "staff_profile_school_id_ref_school_id_fk",
+          "tableFrom": "staff_profile",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "staff_profile_user_id_ref_user_id_fk": {
+          "name": "staff_profile_user_id_ref_user_id_fk",
+          "tableFrom": "staff_profile",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_staff_profile_per_school": {
+          "name": "uniq_staff_profile_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.academic_period": {
+      "name": "academic_period",
+      "schema": "",
+      "columns": {
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_number": {
+          "name": "period_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_label": {
+          "name": "period_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_on": {
+          "name": "ends_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by_user_id": {
+          "name": "closed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "academic_period_closed_by_user_id_ref_user_id_fk": {
+          "name": "academic_period_closed_by_user_id_ref_user_id_fk",
+          "tableFrom": "academic_period",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "closed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "academic_period_school_id_academic_year_ref_academic_period_config_school_id_academic_year_fk": {
+          "name": "academic_period_school_id_academic_year_ref_academic_period_config_school_id_academic_year_fk",
+          "tableFrom": "academic_period",
+          "tableTo": "ref_academic_period_config",
+          "columnsFrom": [
+            "school_id",
+            "academic_year"
+          ],
+          "columnsTo": [
+            "school_id",
+            "academic_year"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "academic_period_tenant_uk": {
+          "name": "academic_period_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_academic_period_config": {
+      "name": "ref_academic_period_config",
+      "schema": "",
+      "columns": {
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_type": {
+          "name": "period_type",
+          "type": "period_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_count": {
+          "name": "period_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "period_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured_at": {
+          "name": "configured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "configured_by": {
+          "name": "configured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_academic_period_config_school_id_ref_school_id_fk": {
+          "name": "ref_academic_period_config_school_id_ref_school_id_fk",
+          "tableFrom": "ref_academic_period_config",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ref_academic_period_config_configured_by_ref_user_id_fk": {
+          "name": "ref_academic_period_config_configured_by_ref_user_id_fk",
+          "tableFrom": "ref_academic_period_config",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "configured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ref_academic_period_config_school_id_academic_year_pk": {
+          "name": "ref_academic_period_config_school_id_academic_year_pk",
+          "columns": [
+            "school_id",
+            "academic_year"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gen_period_defaults": {
+      "name": "gen_period_defaults",
+      "schema": "",
+      "columns": {
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_line": {
+          "name": "product_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_number": {
+          "name": "period_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_label": {
+          "name": "period_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_on": {
+          "name": "ends_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_at": {
+          "name": "extracted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gen_period_defaults_reviewed_by_ref_user_id_fk": {
+          "name": "gen_period_defaults_reviewed_by_ref_user_id_fk",
+          "tableFrom": "gen_period_defaults",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gen_period_defaults_academic_year_product_line_period_number_pk": {
+          "name": "gen_period_defaults_academic_year_product_line_period_number_pk",
+          "columns": [
+            "academic_year",
+            "product_line",
+            "period_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.school_holiday": {
+      "name": "school_holiday",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_on": {
+          "name": "ends_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PUBLIC'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "school_holiday_school_idx": {
+          "name": "school_holiday_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "school_holiday_school_id_ref_school_id_fk": {
+          "name": "school_holiday_school_id_ref_school_id_fk",
+          "tableFrom": "school_holiday",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "audit_id": {
+          "name": "audit_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_role": {
+          "name": "actor_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before_jsonb": {
+          "name": "before_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_jsonb": {
+          "name": "after_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_school_time_idx": {
+          "name": "audit_school_time_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_entity_idx": {
+          "name": "audit_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_school_id_ref_school_id_fk": {
+          "name": "audit_log_school_id_ref_school_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_log_actor_user_id_ref_user_id_fk": {
+          "name": "audit_log_actor_user_id_ref_user_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_anomaly_rule": {
+      "name": "ref_anomaly_rule",
+      "schema": "",
+      "columns": {
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_code": {
+          "name": "rule_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "anomaly_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applies_to": {
+          "name": "applies_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold_jsonb": {
+          "name": "threshold_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_anomaly_rule_rule_code_unique": {
+          "name": "ref_anomaly_rule_rule_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rule_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.marketing_lead": {
+      "name": "marketing_lead",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organisation": {
+          "name": "organisation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'demo_form'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.class": {
+      "name": "class",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "programme": {
+          "name": "programme",
+          "type": "programme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_teacher_user_id": {
+          "name": "class_teacher_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_capacity": {
+          "name": "target_capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "class_school_id_ref_school_id_fk": {
+          "name": "class_school_id_ref_school_id_fk",
+          "tableFrom": "class",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "class_class_teacher_user_id_ref_user_id_fk": {
+          "name": "class_class_teacher_user_id_ref_user_id_fk",
+          "tableFrom": "class",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "class_teacher_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_class_per_school": {
+          "name": "uniq_class_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        },
+        "class_tenant_uk": {
+          "name": "class_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.household": {
+      "name": "household",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "household_school_idx": {
+          "name": "household_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "household_school_id_ref_school_id_fk": {
+          "name": "household_school_id_ref_school_id_fk",
+          "tableFrom": "household",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.house": {
+      "name": "house",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "colour": {
+          "name": "colour",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "house_school_id_ref_school_id_fk": {
+          "name": "house_school_id_ref_school_id_fk",
+          "tableFrom": "house",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_house_per_school": {
+          "name": "uniq_house_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        },
+        "house_tenant_uk": {
+          "name": "house_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_guardian": {
+      "name": "student_guardian",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "guardian_relation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GUARDIAN'"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "guardian_student_idx": {
+          "name": "guardian_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_guardian_school_id_ref_school_id_fk": {
+          "name": "student_guardian_school_id_ref_school_id_fk",
+          "tableFrom": "student_guardian",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_guardian_school_id_student_id_students_school_id_id_fk": {
+          "name": "student_guardian_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "student_guardian",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_health_record": {
+      "name": "student_health_record",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blood_group": {
+          "name": "blood_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medications": {
+          "name": "medications",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_relation": {
+          "name": "emergency_contact_relation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "health_student_idx": {
+          "name": "health_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_health_record_school_id_ref_school_id_fk": {
+          "name": "student_health_record_school_id_ref_school_id_fk",
+          "tableFrom": "student_health_record",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_health_record_updated_by_user_id_ref_user_id_fk": {
+          "name": "student_health_record_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "student_health_record",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "student_health_record_school_id_student_id_students_school_id_id_fk": {
+          "name": "student_health_record_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "student_health_record",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "student_health_record_student_id_unique": {
+          "name": "student_health_record_student_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.students": {
+      "name": "students",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_code": {
+          "name": "student_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "other_names": {
+          "name": "other_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "student_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "current_class_label": {
+          "name": "current_class_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "programme": {
+          "name": "programme",
+          "type": "programme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residency": {
+          "name": "residency",
+          "type": "residency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "house_id": {
+          "name": "house_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrolled_on": {
+          "name": "enrolled_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admission_application_id": {
+          "name": "admission_application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "students_school_idx": {
+          "name": "students_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "students_school_id_ref_school_id_fk": {
+          "name": "students_school_id_ref_school_id_fk",
+          "tableFrom": "students",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "students_household_id_household_id_fk": {
+          "name": "students_household_id_household_id_fk",
+          "tableFrom": "students",
+          "tableTo": "household",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "students_school_id_class_id_class_school_id_id_fk": {
+          "name": "students_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "students",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "students_school_id_house_id_house_school_id_id_fk": {
+          "name": "students_school_id_house_id_house_school_id_id_fk",
+          "tableFrom": "students",
+          "tableTo": "house",
+          "columnsFrom": [
+            "school_id",
+            "house_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_student_code_per_school": {
+          "name": "uniq_student_code_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_code"
+          ]
+        },
+        "students_tenant_uk": {
+          "name": "students_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admission_application": {
+      "name": "admission_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_first_name": {
+          "name": "applicant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_last_name": {
+          "name": "applicant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_other_names": {
+          "name": "applicant_other_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desired_class_label": {
+          "name": "desired_class_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guardian_name": {
+          "name": "guardian_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guardian_phone": {
+          "name": "guardian_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guardian_email": {
+          "name": "guardian_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "admission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SUBMITTED'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admission_school_status_idx": {
+          "name": "admission_school_status_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admission_application_school_id_ref_school_id_fk": {
+          "name": "admission_application_school_id_ref_school_id_fk",
+          "tableFrom": "admission_application",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admission_application_decided_by_user_id_ref_user_id_fk": {
+          "name": "admission_application_decided_by_user_id_ref_user_id_fk",
+          "tableFrom": "admission_application",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "admission_application_school_id_student_id_students_school_id_id_fk": {
+          "name": "admission_application_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "admission_application",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admission_application_tenant_uk": {
+          "name": "admission_application_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admission_document": {
+      "name": "admission_document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admission_document_school_id_ref_school_id_fk": {
+          "name": "admission_document_school_id_ref_school_id_fk",
+          "tableFrom": "admission_document",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admission_document_school_id_application_id_admission_application_school_id_id_fk": {
+          "name": "admission_document_school_id_application_id_admission_application_school_id_id_fk",
+          "tableFrom": "admission_document",
+          "tableTo": "admission_application",
+          "columnsFrom": [
+            "school_id",
+            "application_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_category": {
+      "name": "fee_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_category_school_id_ref_school_id_fk": {
+          "name": "fee_category_school_id_ref_school_id_fk",
+          "tableFrom": "fee_category",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_fee_category_per_school": {
+          "name": "uniq_fee_category_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        },
+        "fee_category_tenant_uk": {
+          "name": "fee_category_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_line_item": {
+      "name": "invoice_line_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_category_id": {
+          "name": "fee_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_optional": {
+          "name": "is_optional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_line_item_school_id_ref_school_id_fk": {
+          "name": "invoice_line_item_school_id_ref_school_id_fk",
+          "tableFrom": "invoice_line_item",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_line_item_school_id_invoice_id_invoice_school_id_id_fk": {
+          "name": "invoice_line_item_school_id_invoice_id_invoice_school_id_id_fk",
+          "tableFrom": "invoice_line_item",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "school_id",
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_line_item_school_id_fee_category_id_fee_category_school_id_id_fk": {
+          "name": "invoice_line_item_school_id_fee_category_id_fee_category_school_id_id_fk",
+          "tableFrom": "invoice_line_item",
+          "tableTo": "fee_category",
+          "columnsFrom": [
+            "school_id",
+            "fee_category_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice": {
+      "name": "invoice",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal_amount": {
+          "name": "subtotal_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "billed_amount": {
+          "name": "billed_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "balance_amount": {
+          "name": "balance_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ISSUED'"
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_student_idx": {
+          "name": "invoice_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_school_id_ref_school_id_fk": {
+          "name": "invoice_school_id_ref_school_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_school_id_student_id_students_school_id_id_fk": {
+          "name": "invoice_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "invoice_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_invoice_number_per_school": {
+          "name": "uniq_invoice_number_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "invoice_number"
+          ]
+        },
+        "invoice_tenant_uk": {
+          "name": "invoice_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_allocation": {
+      "name": "payment_allocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allocation_type": {
+          "name": "allocation_type",
+          "type": "allocation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INVOICE'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allocation_method": {
+          "name": "allocation_method",
+          "type": "allocation_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MANUAL'"
+        },
+        "allocated_by_user_id": {
+          "name": "allocated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allocated_at": {
+          "name": "allocated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payment_allocation_school_id_ref_school_id_fk": {
+          "name": "payment_allocation_school_id_ref_school_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_allocation_allocated_by_user_id_ref_user_id_fk": {
+          "name": "payment_allocation_allocated_by_user_id_ref_user_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "allocated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_allocation_school_id_payment_id_payment_school_id_id_fk": {
+          "name": "payment_allocation_school_id_payment_id_payment_school_id_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "payment",
+          "columnsFrom": [
+            "school_id",
+            "payment_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_allocation_school_id_invoice_id_invoice_school_id_id_fk": {
+          "name": "payment_allocation_school_id_invoice_id_invoice_school_id_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "school_id",
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_audit_log": {
+      "name": "payment_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "payment_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "payment_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ADMIN'"
+        },
+        "before_state": {
+          "name": "before_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_state": {
+          "name": "after_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_audit_school_time_idx": {
+          "name": "payment_audit_school_time_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_audit_log_school_id_ref_school_id_fk": {
+          "name": "payment_audit_log_school_id_ref_school_id_fk",
+          "tableFrom": "payment_audit_log",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_audit_log_actor_user_id_ref_user_id_fk": {
+          "name": "payment_audit_log_actor_user_id_ref_user_id_fk",
+          "tableFrom": "payment_audit_log",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment": {
+      "name": "payment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gross_amount": {
+          "name": "gross_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_amount": {
+          "name": "fee_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "net_amount": {
+          "name": "net_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GHS'"
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method_reference": {
+          "name": "method_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregator": {
+          "name": "aggregator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settlement_status": {
+          "name": "settlement_status",
+          "type": "settlement_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_by_user_id": {
+          "name": "voided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_is_refund": {
+          "name": "void_is_refund",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "payment_student_idx": {
+          "name": "payment_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_school_id_ref_school_id_fk": {
+          "name": "payment_school_id_ref_school_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_recorded_by_user_id_ref_user_id_fk": {
+          "name": "payment_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_voided_by_user_id_ref_user_id_fk": {
+          "name": "payment_voided_by_user_id_ref_user_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "voided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_school_id_student_id_students_school_id_id_fk": {
+          "name": "payment_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "payment_tenant_uk": {
+          "name": "payment_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.receipt": {
+      "name": "receipt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receipt_number": {
+          "name": "receipt_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_token": {
+          "name": "public_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_replacement_id": {
+          "name": "void_replacement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "receipt_school_id_ref_school_id_fk": {
+          "name": "receipt_school_id_ref_school_id_fk",
+          "tableFrom": "receipt",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "receipt_school_id_payment_id_payment_school_id_id_fk": {
+          "name": "receipt_school_id_payment_id_payment_school_id_id_fk",
+          "tableFrom": "receipt",
+          "tableTo": "payment",
+          "columnsFrom": [
+            "school_id",
+            "payment_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "receipt_school_id_student_id_students_school_id_id_fk": {
+          "name": "receipt_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "receipt",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "receipt_payment_id_unique": {
+          "name": "receipt_payment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "payment_id"
+          ]
+        },
+        "receipt_public_token_unique": {
+          "name": "receipt_public_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_token"
+          ]
+        },
+        "uniq_receipt_number_per_school": {
+          "name": "uniq_receipt_number_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "receipt_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discount_tier": {
+      "name": "discount_tier",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_id": {
+          "name": "discount_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "discount_tier_school_id_ref_school_id_fk": {
+          "name": "discount_tier_school_id_ref_school_id_fk",
+          "tableFrom": "discount_tier",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discount_tier_school_id_discount_id_discount_school_id_id_fk": {
+          "name": "discount_tier_school_id_discount_id_discount_school_id_id_fk",
+          "tableFrom": "discount_tier",
+          "tableTo": "discount",
+          "columnsFrom": [
+            "school_id",
+            "discount_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_discount_tier_rank": {
+          "name": "uniq_discount_tier_rank",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discount_id",
+            "rank"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discount": {
+      "name": "discount",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "discount_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'FIXED'"
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applies_to_category_id": {
+          "name": "applies_to_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_label": {
+          "name": "duration_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_approval": {
+          "name": "requires_approval",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stackable": {
+          "name": "stackable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_tiered": {
+          "name": "is_tiered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "applied_count": {
+          "name": "applied_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "discount_school_id_ref_school_id_fk": {
+          "name": "discount_school_id_ref_school_id_fk",
+          "tableFrom": "discount",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discount_applies_to_category_id_fee_category_id_fk": {
+          "name": "discount_applies_to_category_id_fee_category_id_fk",
+          "tableFrom": "discount",
+          "tableTo": "fee_category",
+          "columnsFrom": [
+            "applies_to_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "discount_approved_by_user_id_ref_user_id_fk": {
+          "name": "discount_approved_by_user_id_ref_user_id_fk",
+          "tableFrom": "discount",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_discount_per_school": {
+          "name": "uniq_discount_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        },
+        "discount_tenant_uk": {
+          "name": "discount_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_structure_item": {
+      "name": "fee_structure_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_structure_id": {
+          "name": "fee_structure_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_category_id": {
+          "name": "fee_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_structure_item_school_id_ref_school_id_fk": {
+          "name": "fee_structure_item_school_id_ref_school_id_fk",
+          "tableFrom": "fee_structure_item",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fee_structure_item_fee_category_id_fee_category_id_fk": {
+          "name": "fee_structure_item_fee_category_id_fee_category_id_fk",
+          "tableFrom": "fee_structure_item",
+          "tableTo": "fee_category",
+          "columnsFrom": [
+            "fee_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "fee_structure_item_school_id_fee_structure_id_fee_structure_school_id_id_fk": {
+          "name": "fee_structure_item_school_id_fee_structure_id_fee_structure_school_id_id_fk",
+          "tableFrom": "fee_structure_item",
+          "tableTo": "fee_structure",
+          "columnsFrom": [
+            "school_id",
+            "fee_structure_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_structure": {
+      "name": "fee_structure",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_structure_school_id_ref_school_id_fk": {
+          "name": "fee_structure_school_id_ref_school_id_fk",
+          "tableFrom": "fee_structure",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_fee_structure_per_school": {
+          "name": "uniq_fee_structure_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        },
+        "fee_structure_tenant_uk": {
+          "name": "fee_structure_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_discount_application": {
+      "name": "invoice_discount_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_id": {
+          "name": "discount_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind_snapshot": {
+          "name": "kind_snapshot",
+          "type": "discount_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "applied_by_user_id": {
+          "name": "applied_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_discount_app_school_idx": {
+          "name": "invoice_discount_app_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_discount_app_invoice_idx": {
+          "name": "invoice_discount_app_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_discount_app_discount_idx": {
+          "name": "invoice_discount_app_discount_idx",
+          "columns": [
+            {
+              "expression": "discount_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_discount_application_school_id_ref_school_id_fk": {
+          "name": "invoice_discount_application_school_id_ref_school_id_fk",
+          "tableFrom": "invoice_discount_application",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_discount_application_applied_by_user_id_ref_user_id_fk": {
+          "name": "invoice_discount_application_applied_by_user_id_ref_user_id_fk",
+          "tableFrom": "invoice_discount_application",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "applied_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_discount_application_school_id_invoice_id_invoice_school_id_id_fk": {
+          "name": "invoice_discount_application_school_id_invoice_id_invoice_school_id_id_fk",
+          "tableFrom": "invoice_discount_application",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "school_id",
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_discount_application_school_id_student_id_students_school_id_id_fk": {
+          "name": "invoice_discount_application_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "invoice_discount_application",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_discount_application_school_id_discount_id_discount_school_id_id_fk": {
+          "name": "invoice_discount_application_school_id_discount_id_discount_school_id_id_fk",
+          "tableFrom": "invoice_discount_application",
+          "tableTo": "discount",
+          "columnsFrom": [
+            "school_id",
+            "discount_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attendance_correction": {
+      "name": "attendance_correction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_record_id": {
+          "name": "attendance_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_status": {
+          "name": "requested_status",
+          "type": "attendance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "correction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "decision_note": {
+          "name": "decision_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attendance_correction_school_id_ref_school_id_fk": {
+          "name": "attendance_correction_school_id_ref_school_id_fk",
+          "tableFrom": "attendance_correction",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_correction_requested_by_user_id_ref_user_id_fk": {
+          "name": "attendance_correction_requested_by_user_id_ref_user_id_fk",
+          "tableFrom": "attendance_correction",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attendance_correction_decided_by_user_id_ref_user_id_fk": {
+          "name": "attendance_correction_decided_by_user_id_ref_user_id_fk",
+          "tableFrom": "attendance_correction",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attendance_correction_school_id_attendance_record_id_attendance_record_school_id_id_fk": {
+          "name": "attendance_correction_school_id_attendance_record_id_attendance_record_school_id_id_fk",
+          "tableFrom": "attendance_correction",
+          "tableTo": "attendance_record",
+          "columnsFrom": [
+            "school_id",
+            "attendance_record_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attendance_record": {
+      "name": "attendance_record",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "attendance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marked_by_user_id": {
+          "name": "marked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marked_at": {
+          "name": "marked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attendance_class_date_idx": {
+          "name": "attendance_class_date_idx",
+          "columns": [
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attendance_record_school_id_ref_school_id_fk": {
+          "name": "attendance_record_school_id_ref_school_id_fk",
+          "tableFrom": "attendance_record",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_record_marked_by_user_id_ref_user_id_fk": {
+          "name": "attendance_record_marked_by_user_id_ref_user_id_fk",
+          "tableFrom": "attendance_record",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "marked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attendance_record_school_id_student_id_students_school_id_id_fk": {
+          "name": "attendance_record_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "attendance_record",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_record_school_id_class_id_class_school_id_id_fk": {
+          "name": "attendance_record_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "attendance_record",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_attendance_student_day": {
+          "name": "uniq_attendance_student_day",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "date"
+          ]
+        },
+        "attendance_record_tenant_uk": {
+          "name": "attendance_record_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attendance_settings": {
+      "name": "attendance_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_start": {
+          "name": "day_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'08:00'"
+        },
+        "late_threshold": {
+          "name": "late_threshold",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'08:15'"
+        },
+        "day_end": {
+          "name": "day_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'15:00'"
+        },
+        "edit_window_hours": {
+          "name": "edit_window_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 24
+        },
+        "absence_sms": {
+          "name": "absence_sms",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "abs_watch_days": {
+          "name": "abs_watch_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "abs_critical_days": {
+          "name": "abs_critical_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "pct_watch": {
+          "name": "pct_watch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 70
+        },
+        "pct_critical": {
+          "name": "pct_critical",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attendance_settings_school_id_ref_school_id_fk": {
+          "name": "attendance_settings_school_id_ref_school_id_fk",
+          "tableFrom": "attendance_settings",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "attendance_settings_school_id_unique": {
+          "name": "attendance_settings_school_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.grade_scale": {
+      "name": "grade_scale",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_score": {
+          "name": "min_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grade_scale_school_idx": {
+          "name": "grade_scale_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grade_scale_school_id_ref_school_id_fk": {
+          "name": "grade_scale_school_id_ref_school_id_fk",
+          "tableFrom": "grade_scale",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_grade_per_school": {
+          "name": "uniq_grade_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "grade"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gradebook_column_score": {
+      "name": "gradebook_column_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_score": {
+          "name": "raw_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gradebook_column_score_column_idx": {
+          "name": "gradebook_column_score_column_idx",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gradebook_column_score_school_id_ref_school_id_fk": {
+          "name": "gradebook_column_score_school_id_ref_school_id_fk",
+          "tableFrom": "gradebook_column_score",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_score_updated_by_user_id_ref_user_id_fk": {
+          "name": "gradebook_column_score_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "gradebook_column_score",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_score_school_id_column_id_gradebook_column_school_id_id_fk": {
+          "name": "gradebook_column_score_school_id_column_id_gradebook_column_school_id_id_fk",
+          "tableFrom": "gradebook_column_score",
+          "tableTo": "gradebook_column",
+          "columnsFrom": [
+            "school_id",
+            "column_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_score_school_id_student_id_students_school_id_id_fk": {
+          "name": "gradebook_column_score_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "gradebook_column_score",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_column_score_per_student": {
+          "name": "uniq_column_score_per_student",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "column_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gradebook_column": {
+      "name": "gradebook_column",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CA'"
+        },
+        "max_score": {
+          "name": "max_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gradebook_column_context_idx": {
+          "name": "gradebook_column_context_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gradebook_column_school_id_ref_school_id_fk": {
+          "name": "gradebook_column_school_id_ref_school_id_fk",
+          "tableFrom": "gradebook_column",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_created_by_user_id_ref_user_id_fk": {
+          "name": "gradebook_column_created_by_user_id_ref_user_id_fk",
+          "tableFrom": "gradebook_column",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_school_id_class_id_class_school_id_id_fk": {
+          "name": "gradebook_column_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "gradebook_column",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "gradebook_column_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "gradebook_column",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "gradebook_column_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "gradebook_column",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_column_per_class_subject_period": {
+          "name": "uniq_column_per_class_subject_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "class_id",
+            "subject_id",
+            "period_id",
+            "name"
+          ]
+        },
+        "gradebook_column_tenant_uk": {
+          "name": "gradebook_column_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gradebook_config": {
+      "name": "gradebook_config",
+      "schema": "",
+      "columns": {
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "class_weight": {
+          "name": "class_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "exam_weight": {
+          "name": "exam_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gradebook_config_school_id_ref_school_id_fk": {
+          "name": "gradebook_config_school_id_ref_school_id_fk",
+          "tableFrom": "gradebook_config",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gradebook_score": {
+      "name": "gradebook_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_score": {
+          "name": "class_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exam_score": {
+          "name": "exam_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "score_period_subject_idx": {
+          "name": "score_period_subject_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gradebook_score_school_id_ref_school_id_fk": {
+          "name": "gradebook_score_school_id_ref_school_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_score_updated_by_user_id_ref_user_id_fk": {
+          "name": "gradebook_score_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gradebook_score_school_id_student_id_students_school_id_id_fk": {
+          "name": "gradebook_score_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_score_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "gradebook_score_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_score_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "gradebook_score_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_score_student_subject_period": {
+          "name": "uniq_score_student_subject_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "subject_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_card": {
+      "name": "report_card",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overall_total": {
+          "name": "overall_total",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overall_grade": {
+          "name": "overall_grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_count": {
+          "name": "subject_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "report_card_school_id_ref_school_id_fk": {
+          "name": "report_card_school_id_ref_school_id_fk",
+          "tableFrom": "report_card",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "report_card_generated_by_user_id_ref_user_id_fk": {
+          "name": "report_card_generated_by_user_id_ref_user_id_fk",
+          "tableFrom": "report_card",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "report_card_school_id_student_id_students_school_id_id_fk": {
+          "name": "report_card_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "report_card",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "report_card_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "report_card_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "report_card",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_report_student_period": {
+          "name": "uniq_report_student_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subject": {
+      "name": "subject",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subject_school_id_ref_school_id_fk": {
+          "name": "subject_school_id_ref_school_id_fk",
+          "tableFrom": "subject",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_subject_per_school": {
+          "name": "uniq_subject_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        },
+        "subject_tenant_uk": {
+          "name": "subject_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_assessment_weights": {
+      "name": "ref_assessment_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asgn_weight": {
+          "name": "asgn_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "mid_sem_weight": {
+          "name": "mid_sem_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "end_sem_weight": {
+          "name": "end_sem_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 40
+        },
+        "project_weight": {
+          "name": "project_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "portfolio_weight": {
+          "name": "portfolio_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_school_default_weights": {
+          "name": "uniq_school_default_weights",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"ref_assessment_weights\".\"subject_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ref_assessment_weights_school_id_ref_school_id_fk": {
+          "name": "ref_assessment_weights_school_id_ref_school_id_fk",
+          "tableFrom": "ref_assessment_weights",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ref_assessment_weights_updated_by_user_id_ref_user_id_fk": {
+          "name": "ref_assessment_weights_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "ref_assessment_weights",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ref_assessment_weights_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "ref_assessment_weights_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "ref_assessment_weights",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_weights_per_school_subject": {
+          "name": "uniq_weights_per_school_subject",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "subject_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "assessment_weights_sum_100": {
+          "name": "assessment_weights_sum_100",
+          "value": "\"ref_assessment_weights\".\"asgn_weight\" + \"ref_assessment_weights\".\"mid_sem_weight\" + \"ref_assessment_weights\".\"end_sem_weight\" + \"ref_assessment_weights\".\"project_weight\" + \"ref_assessment_weights\".\"portfolio_weight\" = 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.senior_assessment_score": {
+      "name": "senior_assessment_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assessment_id": {
+          "name": "assessment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_mark": {
+          "name": "raw_mark",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "senior_assessment_score_assessment_idx": {
+          "name": "senior_assessment_score_assessment_idx",
+          "columns": [
+            {
+              "expression": "assessment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "senior_assessment_score_school_id_ref_school_id_fk": {
+          "name": "senior_assessment_score_school_id_ref_school_id_fk",
+          "tableFrom": "senior_assessment_score",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_score_updated_by_user_id_ref_user_id_fk": {
+          "name": "senior_assessment_score_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "senior_assessment_score",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_score_school_id_assessment_id_senior_assessment_school_id_id_fk": {
+          "name": "senior_assessment_score_school_id_assessment_id_senior_assessment_school_id_id_fk",
+          "tableFrom": "senior_assessment_score",
+          "tableTo": "senior_assessment",
+          "columnsFrom": [
+            "school_id",
+            "assessment_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_score_school_id_student_id_students_school_id_id_fk": {
+          "name": "senior_assessment_score_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "senior_assessment_score",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_assessment_score_per_student": {
+          "name": "uniq_assessment_score_per_student",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "assessment_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.senior_assessment": {
+      "name": "senior_assessment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "assessment_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_mark": {
+          "name": "max_mark",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assessed_on": {
+          "name": "assessed_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_one_mid_sem_per_context": {
+          "name": "uniq_one_mid_sem_per_context",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"senior_assessment\".\"category\" = 'MID_SEM_EXAM'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_one_end_sem_per_context": {
+          "name": "uniq_one_end_sem_per_context",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"senior_assessment\".\"category\" = 'END_SEM_EXAM'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "senior_assessment_context_idx": {
+          "name": "senior_assessment_context_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "senior_assessment_school_id_ref_school_id_fk": {
+          "name": "senior_assessment_school_id_ref_school_id_fk",
+          "tableFrom": "senior_assessment",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_created_by_user_id_ref_user_id_fk": {
+          "name": "senior_assessment_created_by_user_id_ref_user_id_fk",
+          "tableFrom": "senior_assessment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_school_id_class_id_class_school_id_id_fk": {
+          "name": "senior_assessment_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "senior_assessment",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "senior_assessment_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "senior_assessment",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "senior_assessment_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "senior_assessment",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_assessment_per_context": {
+          "name": "uniq_assessment_per_context",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "class_id",
+            "subject_id",
+            "period_id",
+            "category",
+            "title"
+          ]
+        },
+        "senior_assessment_tenant_uk": {
+          "name": "senior_assessment_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.senior_ledger_path": {
+      "name": "senior_ledger_path",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "capture_path",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AUTO_COMPILE'"
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "senior_ledger_path_school_id_ref_school_id_fk": {
+          "name": "senior_ledger_path_school_id_ref_school_id_fk",
+          "tableFrom": "senior_ledger_path",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_ledger_path_updated_by_user_id_ref_user_id_fk": {
+          "name": "senior_ledger_path_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "senior_ledger_path",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "senior_ledger_path_school_id_class_id_class_school_id_id_fk": {
+          "name": "senior_ledger_path_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "senior_ledger_path",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_ledger_path_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "senior_ledger_path_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "senior_ledger_path",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_ledger_path_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "senior_ledger_path_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "senior_ledger_path",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_ledger_path_context": {
+          "name": "uniq_ledger_path_context",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "class_id",
+            "subject_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.senior_score_ledger": {
+      "name": "senior_score_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asgn_score": {
+          "name": "asgn_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mid_sem_score": {
+          "name": "mid_sem_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_sem_score": {
+          "name": "end_sem_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_score": {
+          "name": "project_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "portfolio_score": {
+          "name": "portfolio_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weighted_total": {
+          "name": "weighted_total",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asgn_weight_used": {
+          "name": "asgn_weight_used",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mid_sem_weight_used": {
+          "name": "mid_sem_weight_used",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_sem_weight_used": {
+          "name": "end_sem_weight_used",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_weight_used": {
+          "name": "project_weight_used",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "portfolio_weight_used": {
+          "name": "portfolio_weight_used",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "portfolio_manual": {
+          "name": "portfolio_manual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ledger_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "compiled_by_user_id": {
+          "name": "compiled_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compiled_at": {
+          "name": "compiled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "senior_ledger_period_subject_idx": {
+          "name": "senior_ledger_period_subject_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "senior_score_ledger_school_id_ref_school_id_fk": {
+          "name": "senior_score_ledger_school_id_ref_school_id_fk",
+          "tableFrom": "senior_score_ledger",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_compiled_by_user_id_ref_user_id_fk": {
+          "name": "senior_score_ledger_compiled_by_user_id_ref_user_id_fk",
+          "tableFrom": "senior_score_ledger",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "compiled_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_school_id_student_id_students_school_id_id_fk": {
+          "name": "senior_score_ledger_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "senior_score_ledger",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "senior_score_ledger_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "senior_score_ledger",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "senior_score_ledger_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "senior_score_ledger",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_ledger_student_subject_period": {
+          "name": "uniq_ledger_student_subject_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "subject_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.senior_subject_teacher": {
+      "name": "senior_subject_teacher",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teacher_user_id": {
+          "name": "teacher_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "senior_subject_teacher_school_id_ref_school_id_fk": {
+          "name": "senior_subject_teacher_school_id_ref_school_id_fk",
+          "tableFrom": "senior_subject_teacher",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_subject_teacher_teacher_user_id_ref_user_id_fk": {
+          "name": "senior_subject_teacher_teacher_user_id_ref_user_id_fk",
+          "tableFrom": "senior_subject_teacher",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "teacher_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "senior_subject_teacher_school_id_class_id_class_school_id_id_fk": {
+          "name": "senior_subject_teacher_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "senior_subject_teacher",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_subject_teacher_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "senior_subject_teacher_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "senior_subject_teacher",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_subject_teacher_context": {
+          "name": "uniq_subject_teacher_context",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "class_id",
+            "subject_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.timetable_slot": {
+      "name": "timetable_slot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_index": {
+          "name": "period_index",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teacher_user_id": {
+          "name": "teacher_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "timetable_teacher_slot_idx": {
+          "name": "timetable_teacher_slot_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "teacher_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "timetable_slot_school_id_ref_school_id_fk": {
+          "name": "timetable_slot_school_id_ref_school_id_fk",
+          "tableFrom": "timetable_slot",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "timetable_slot_subject_id_subject_id_fk": {
+          "name": "timetable_slot_subject_id_subject_id_fk",
+          "tableFrom": "timetable_slot",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "timetable_slot_teacher_user_id_ref_user_id_fk": {
+          "name": "timetable_slot_teacher_user_id_ref_user_id_fk",
+          "tableFrom": "timetable_slot",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "teacher_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "timetable_slot_school_id_class_id_class_school_id_id_fk": {
+          "name": "timetable_slot_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "timetable_slot",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_timetable_class_slot": {
+          "name": "uniq_timetable_class_slot",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "class_id",
+            "day_of_week",
+            "period_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.announcement": {
+      "name": "announcement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "audience",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'WHOLE_SCHOOL'"
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_by_user_id": {
+          "name": "posted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "announcement_school_id_ref_school_id_fk": {
+          "name": "announcement_school_id_ref_school_id_fk",
+          "tableFrom": "announcement",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "announcement_class_id_class_id_fk": {
+          "name": "announcement_class_id_class_id_fk",
+          "tableFrom": "announcement",
+          "tableTo": "class",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "announcement_posted_by_user_id_ref_user_id_fk": {
+          "name": "announcement_posted_by_user_id_ref_user_id_fk",
+          "tableFrom": "announcement",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "posted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "notif_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'QUEUED'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_ref": {
+          "name": "provider_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_by_user_id": {
+          "name": "sent_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notif_school_time_idx": {
+          "name": "notif_school_time_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_log_school_id_ref_school_id_fk": {
+          "name": "notification_log_school_id_ref_school_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_log_student_id_students_id_fk": {
+          "name": "notification_log_student_id_students_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_log_template_id_sms_template_id_fk": {
+          "name": "notification_log_template_id_sms_template_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "sms_template",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_log_sent_by_user_id_ref_user_id_fk": {
+          "name": "notification_log_sent_by_user_id_ref_user_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "sent_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_template": {
+      "name": "sms_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sms_template_school_id_ref_school_id_fk": {
+          "name": "sms_template_school_id_ref_school_id_fk",
+          "tableFrom": "sms_template",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_template_per_school": {
+          "name": "uniq_template_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "conversation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "assigned_to_user_id": {
+          "name": "assigned_to_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SMS'"
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "routed_by_rule_id": {
+          "name": "routed_by_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "routed_by_rule_name": {
+          "name": "routed_by_rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_school_activity_idx": {
+          "name": "conversation_school_activity_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_phone_idx": {
+          "name": "conversation_phone_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_school_id_ref_school_id_fk": {
+          "name": "conversation_school_id_ref_school_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_student_id_students_id_fk": {
+          "name": "conversation_student_id_students_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "conversation_assigned_to_user_id_ref_user_id_fk": {
+          "name": "conversation_assigned_to_user_id_ref_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "assigned_to_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_tenant_uk": {
+          "name": "conversation_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbox_message": {
+      "name": "inbox_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "message_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_by_user_id": {
+          "name": "sent_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inbox_message_conversation_idx": {
+          "name": "inbox_message_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbox_message_school_id_ref_school_id_fk": {
+          "name": "inbox_message_school_id_ref_school_id_fk",
+          "tableFrom": "inbox_message",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbox_message_sent_by_user_id_ref_user_id_fk": {
+          "name": "inbox_message_sent_by_user_id_ref_user_id_fk",
+          "tableFrom": "inbox_message",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "sent_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbox_message_school_id_conversation_id_conversation_school_id_id_fk": {
+          "name": "inbox_message_school_id_conversation_id_conversation_school_id_id_fk",
+          "tableFrom": "inbox_message",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "school_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbox_routing_rule": {
+      "name": "inbox_routing_rule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_fallback": {
+          "name": "is_fallback",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "match_topic": {
+          "name": "match_topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_class": {
+          "name": "match_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_keywords": {
+          "name": "match_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assign_to_user_id": {
+          "name": "assign_to_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_all_admins": {
+          "name": "notify_all_admins",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inbox_routing_rule_school_pos_idx": {
+          "name": "inbox_routing_rule_school_pos_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbox_routing_rule_school_id_ref_school_id_fk": {
+          "name": "inbox_routing_rule_school_id_ref_school_id_fk",
+          "tableFrom": "inbox_routing_rule",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbox_routing_rule_assign_to_user_id_ref_user_id_fk": {
+          "name": "inbox_routing_rule_assign_to_user_id_ref_user_id_fk",
+          "tableFrom": "inbox_routing_rule",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "assign_to_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite": {
+      "name": "invite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignments": {
+          "name": "assignments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_user_id": {
+          "name": "accepted_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invite_school_status_idx": {
+          "name": "invite_school_status_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_school_id_ref_school_id_fk": {
+          "name": "invite_school_id_ref_school_id_fk",
+          "tableFrom": "invite",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_invited_by_user_id_ref_user_id_fk": {
+          "name": "invite_invited_by_user_id_ref_user_id_fk",
+          "tableFrom": "invite",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invite_accepted_user_id_ref_user_id_fk": {
+          "name": "invite_accepted_user_id_ref_user_id_fk",
+          "tableFrom": "invite",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "accepted_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_token_unique": {
+          "name": "invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_category": {
+      "name": "book_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "book_entry_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_category_school_idx": {
+          "name": "book_category_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_category_school_id_ref_school_id_fk": {
+          "name": "book_category_school_id_ref_school_id_fk",
+          "tableFrom": "book_category",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_book_category_per_school": {
+          "name": "uniq_book_category_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "kind",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_entry": {
+      "name": "book_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "book_entry_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_date": {
+          "name": "entry_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "party": {
+          "name": "party",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_entry_school_date_idx": {
+          "name": "book_entry_school_date_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entry_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_entry_school_id_ref_school_id_fk": {
+          "name": "book_entry_school_id_ref_school_id_fk",
+          "tableFrom": "book_entry",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_entry_category_id_book_category_id_fk": {
+          "name": "book_entry_category_id_book_category_id_fk",
+          "tableFrom": "book_entry",
+          "tableTo": "book_category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "book_entry_created_by_user_id_ref_user_id_fk": {
+          "name": "book_entry_created_by_user_id_ref_user_id_fk",
+          "tableFrom": "book_entry",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fixed_asset": {
+      "name": "fixed_asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acquired_on": {
+          "name": "acquired_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_cost": {
+          "name": "original_cost",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accumulated_depreciation": {
+          "name": "accumulated_depreciation",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "useful_life_years": {
+          "name": "useful_life_years",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fixed_asset_school_idx": {
+          "name": "fixed_asset_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fixed_asset_school_id_ref_school_id_fk": {
+          "name": "fixed_asset_school_id_ref_school_id_fk",
+          "tableFrom": "fixed_asset",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.whatsapp_template": {
+      "name": "whatsapp_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTILITY'"
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en_GH'"
+        },
+        "header_type": {
+          "name": "header_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NONE'"
+        },
+        "header_text": {
+          "name": "header_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_filename": {
+          "name": "header_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footer": {
+          "name": "footer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buttons": {
+          "name": "buttons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sample_values": {
+          "name": "sample_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "whatsapp_template_school_idx": {
+          "name": "whatsapp_template_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "whatsapp_template_school_id_ref_school_id_fk": {
+          "name": "whatsapp_template_school_id_ref_school_id_fk",
+          "tableFrom": "whatsapp_template",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "whatsapp_template_created_by_user_id_ref_user_id_fk": {
+          "name": "whatsapp_template_created_by_user_id_ref_user_id_fk",
+          "tableFrom": "whatsapp_template",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_whatsapp_template_name_per_school": {
+          "name": "uniq_whatsapp_template_name_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.admission_status": {
+      "name": "admission_status",
+      "schema": "public",
+      "values": [
+        "SUBMITTED",
+        "UNDER_REVIEW",
+        "ACCEPTED",
+        "REJECTED",
+        "WAITLISTED"
+      ]
+    },
+    "public.allocation_method": {
+      "name": "allocation_method",
+      "schema": "public",
+      "values": [
+        "MANUAL",
+        "AUTO_OLDEST_FIRST",
+        "AUTO_NEWEST_FIRST"
+      ]
+    },
+    "public.allocation_type": {
+      "name": "allocation_type",
+      "schema": "public",
+      "values": [
+        "INVOICE",
+        "CREDIT",
+        "REFUND"
+      ]
+    },
+    "public.anomaly_severity": {
+      "name": "anomaly_severity",
+      "schema": "public",
+      "values": [
+        "LOW",
+        "MEDIUM",
+        "HIGH"
+      ]
+    },
+    "public.app_role": {
+      "name": "app_role",
+      "schema": "public",
+      "values": [
+        "ADMIN",
+        "HEADMASTER",
+        "VICE_HEADMASTER_ACADEMIC",
+        "TEACHER",
+        "FORM_MASTER",
+        "HOUSEMASTER",
+        "STUDENT",
+        "PARENT",
+        "BURSAR",
+        "DEAN_OF_BOARDING",
+        "MATRON"
+      ]
+    },
+    "public.assessment_category": {
+      "name": "assessment_category",
+      "schema": "public",
+      "values": [
+        "ASSIGNMENT",
+        "MID_SEM_EXAM",
+        "END_SEM_EXAM",
+        "PROJECT"
+      ]
+    },
+    "public.attendance_status": {
+      "name": "attendance_status",
+      "schema": "public",
+      "values": [
+        "PRESENT",
+        "ABSENT",
+        "LATE",
+        "EXCUSED",
+        "MEDICAL"
+      ]
+    },
+    "public.audience": {
+      "name": "audience",
+      "schema": "public",
+      "values": [
+        "WHOLE_SCHOOL",
+        "CLASS"
+      ]
+    },
+    "public.book_entry_kind": {
+      "name": "book_entry_kind",
+      "schema": "public",
+      "values": [
+        "INCOME",
+        "EXPENSE"
+      ]
+    },
+    "public.capture_path": {
+      "name": "capture_path",
+      "schema": "public",
+      "values": [
+        "AUTO_COMPILE",
+        "SCAN_EXTRACT",
+        "DIRECT_ENTRY"
+      ]
+    },
+    "public.conversation_status": {
+      "name": "conversation_status",
+      "schema": "public",
+      "values": [
+        "OPEN",
+        "CLOSED"
+      ]
+    },
+    "public.correction_status": {
+      "name": "correction_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPROVED",
+        "REJECTED"
+      ]
+    },
+    "public.discount_kind": {
+      "name": "discount_kind",
+      "schema": "public",
+      "values": [
+        "PERCENT",
+        "FIXED"
+      ]
+    },
+    "public.guardian_relation": {
+      "name": "guardian_relation",
+      "schema": "public",
+      "values": [
+        "MOTHER",
+        "FATHER",
+        "GUARDIAN",
+        "OTHER"
+      ]
+    },
+    "public.invite_status": {
+      "name": "invite_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "REVOKED",
+        "EXPIRED"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "ISSUED",
+        "PARTIAL",
+        "PAID",
+        "OVERDUE",
+        "EXEMPT",
+        "VOIDED"
+      ]
+    },
+    "public.ledger_status": {
+      "name": "ledger_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "COMPLETE",
+        "STPSHS_READY"
+      ]
+    },
+    "public.message_direction": {
+      "name": "message_direction",
+      "schema": "public",
+      "values": [
+        "INBOUND",
+        "OUTBOUND"
+      ]
+    },
+    "public.notif_status": {
+      "name": "notif_status",
+      "schema": "public",
+      "values": [
+        "QUEUED",
+        "SENT",
+        "FAILED"
+      ]
+    },
+    "public.ownership_type": {
+      "name": "ownership_type",
+      "schema": "public",
+      "values": [
+        "PUBLIC",
+        "PRIVATE",
+        "MISSION",
+        "INTERNATIONAL"
+      ]
+    },
+    "public.payment_actor_type": {
+      "name": "payment_actor_type",
+      "schema": "public",
+      "values": [
+        "ADMIN",
+        "SYSTEM",
+        "WEBHOOK",
+        "RECONCILIATION_JOB"
+      ]
+    },
+    "public.payment_event_type": {
+      "name": "payment_event_type",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "ALLOCATION_ADDED",
+        "ALLOCATION_VOIDED",
+        "SETTLED",
+        "VOIDED",
+        "SMS_SENT",
+        "SMS_FAILED",
+        "REFUNDED",
+        "DISCOUNT_OVERRIDDEN"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "MTN_MOMO",
+        "TELECEL_CASH",
+        "AIRTELTIGO_MONEY",
+        "BANK_TRANSFER",
+        "CASH",
+        "CHEQUE",
+        "OTHER"
+      ]
+    },
+    "public.period_source": {
+      "name": "period_source",
+      "schema": "public",
+      "values": [
+        "GES_DEFAULT",
+        "SCHOOL_OVERRIDE"
+      ]
+    },
+    "public.period_type": {
+      "name": "period_type",
+      "schema": "public",
+      "values": [
+        "TERM",
+        "SEMESTER"
+      ]
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "public",
+      "values": [
+        "BASIC",
+        "SENIOR",
+        "OVERSIGHT"
+      ]
+    },
+    "public.programme": {
+      "name": "programme",
+      "schema": "public",
+      "values": [
+        "GENERAL_ARTS",
+        "GENERAL_SCIENCE",
+        "BUSINESS",
+        "AGRICULTURE",
+        "VISUAL_ARTS",
+        "HOME_ECONOMICS",
+        "TECHNICAL"
+      ]
+    },
+    "public.residency": {
+      "name": "residency",
+      "schema": "public",
+      "values": [
+        "BOARDER",
+        "DAY",
+        "DEBOARDINIZED"
+      ]
+    },
+    "public.school_type": {
+      "name": "school_type",
+      "schema": "public",
+      "values": [
+        "BASIC",
+        "SENIOR",
+        "COMBINED"
+      ]
+    },
+    "public.settlement_status": {
+      "name": "settlement_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "CONFIRMED",
+        "SETTLED",
+        "RECONCILED",
+        "DISPUTED"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "MALE",
+        "FEMALE"
+      ]
+    },
+    "public.shs_category": {
+      "name": "shs_category",
+      "schema": "public",
+      "values": [
+        "A",
+        "B",
+        "C",
+        "D",
+        "E",
+        "F"
+      ]
+    },
+    "public.student_status": {
+      "name": "student_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "INACTIVE",
+        "GRADUATED",
+        "WITHDRAWN",
+        "TRANSFERRED"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/omnischools/db/migrations/meta/_journal.json
+++ b/omnischools/db/migrations/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1783282710814,
       "tag": "0039_late_magdalene",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1783286276085,
+      "tag": "0040_green_captain_stacy",
+      "breakpoints": true
     }
   ]
 }

--- a/omnischools/db/schema/score-ledger.ts
+++ b/omnischools/db/schema/score-ledger.ts
@@ -283,3 +283,37 @@ export const seniorLedgerPath = pgTable(
     }).onDelete("cascade"),
   }),
 );
+
+/**
+ * Which teacher teaches a subject to a class — the authoritative assignment (spec §6.1).
+ * This is the ENUMERATION SOURCE for the Vice Headmaster progress view: rows are driven by
+ * the assignments (what's expected), LEFT JOINed to ledger progress (what's started), so a
+ * teacher who has done nothing still appears as an at-risk 0/5 row rather than vanishing.
+ * Period-agnostic (a teacher owns a class-subject for the year). Populated at setup/onboarding.
+ */
+export const seniorSubjectTeacher = pgTable(
+  "senior_subject_teacher",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    schoolId: uuid("school_id")
+      .notNull()
+      .references(() => schools.id, { onDelete: "cascade" }),
+    classId: uuid("class_id").notNull(),
+    subjectId: uuid("subject_id").notNull(),
+    teacherUserId: uuid("teacher_user_id")
+      .notNull()
+      .references(() => users.id),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    uniq: unique("uniq_subject_teacher_context").on(t.schoolId, t.classId, t.subjectId),
+    classFk: foreignKey({
+      columns: [t.schoolId, t.classId],
+      foreignColumns: [classes.schoolId, classes.id],
+    }).onDelete("cascade"),
+    subjectFk: foreignKey({
+      columns: [t.schoolId, t.subjectId],
+      foreignColumns: [subjects.schoolId, subjects.id],
+    }).onDelete("cascade"),
+  }),
+);

--- a/omnischools/db/seed/asankrangwa.ts
+++ b/omnischools/db/seed/asankrangwa.ts
@@ -23,6 +23,7 @@ import {
   seniorAssessmentScores,
   seniorScoreLedger,
   seniorLedgerPath,
+  seniorSubjectTeacher,
   type appRoleEnum,
 } from "@/db/schema";
 import {
@@ -482,6 +483,39 @@ async function main() {
     path: "DIRECT_ENTRY",
     updatedByUserId: userByPhone.get("+233244000003"),
   });
+
+  // Subject-teacher assignments — the enumeration source for the VHM progress view.
+  // A mix so the view shows every state: Owusu's Maths (Path A, 4/5 behind — portfolio
+  // pending), Owusu's English (Path C, nothing entered → at risk), and two Mensah
+  // assignments never touched → at-risk 0/5 rows (the "never started" case must be visible).
+  const socialStudies = subjectRows.find((s) => s.name === "Social Studies")!;
+  const science = subjectRows.find((s) => s.name === "Integrated Science")!;
+  await db.insert(seniorSubjectTeacher).values([
+    {
+      schoolId: school.id,
+      classId: form2Science.id,
+      subjectId: maths.id,
+      teacherUserId: userByPhone.get("+233244000003")!, // Mr K. Owusu
+    },
+    {
+      schoolId: school.id,
+      classId: form2Science.id,
+      subjectId: english.id,
+      teacherUserId: userByPhone.get("+233244000003")!,
+    },
+    {
+      schoolId: school.id,
+      classId: form2GA.id,
+      subjectId: socialStudies.id,
+      teacherUserId: userByPhone.get("+233244000004")!, // Mr A. Mensah
+    },
+    {
+      schoolId: school.id,
+      classId: form3GA.id,
+      subjectId: science.id,
+      teacherUserId: userByPhone.get("+233244000004")!,
+    },
+  ]);
 
   // --- audit: record the seed itself (append-only) ---
   await db.insert(auditLog).values({

--- a/omnischools/db/sql/policies.sql
+++ b/omnischools/db/sql/policies.sql
@@ -97,6 +97,7 @@ BEGIN
     'senior_assessment_score',
     'senior_score_ledger',
     'senior_ledger_path',
+    'senior_subject_teacher',
     'announcement',
     'sms_template',
     'notification_log',

--- a/omnischools/db/sql/prod-paste-0040-senior-subject-teacher.sql
+++ b/omnischools/db/sql/prod-paste-0040-senior-subject-teacher.sql
@@ -1,0 +1,47 @@
+-- Omnischools — migration 0040: senior_subject_teacher (Item 3, VHM progress view).
+-- The authoritative "teacher teaches subject to class" assignment — the enumeration source
+-- for the Vice Headmaster progress view (so a never-started teacher still appears) + its RLS.
+-- Idempotent — safe to run more than once. Paste into the Supabase SQL editor on PROD after
+-- merging. (db:policies only configures local dev; a new tenant table needs its RLS pasted
+-- on prod by hand, or it leaks across schools.)
+
+CREATE TABLE IF NOT EXISTS "senior_subject_teacher" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "school_id" uuid NOT NULL,
+  "class_id" uuid NOT NULL,
+  "subject_id" uuid NOT NULL,
+  "teacher_user_id" uuid NOT NULL,
+  "created_at" timestamptz DEFAULT now() NOT NULL,
+  CONSTRAINT "uniq_subject_teacher_context" UNIQUE("school_id","class_id","subject_id")
+);
+
+DO $$ BEGIN
+  ALTER TABLE "senior_subject_teacher" ADD CONSTRAINT "senior_subject_teacher_school_id_ref_school_id_fk"
+    FOREIGN KEY ("school_id") REFERENCES "public"."ref_school"("id") ON DELETE cascade;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE "senior_subject_teacher" ADD CONSTRAINT "senior_subject_teacher_teacher_user_id_ref_user_id_fk"
+    FOREIGN KEY ("teacher_user_id") REFERENCES "public"."ref_user"("id");
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE "senior_subject_teacher" ADD CONSTRAINT "senior_subject_teacher_school_id_class_id_class_school_id_id_fk"
+    FOREIGN KEY ("school_id","class_id") REFERENCES "public"."class"("school_id","id") ON DELETE cascade;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE "senior_subject_teacher" ADD CONSTRAINT "senior_subject_teacher_school_id_subject_id_subject_school_id_id_fk"
+    FOREIGN KEY ("school_id","subject_id") REFERENCES "public"."subject"("school_id","id") ON DELETE cascade;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- ---- RLS — the same tenant_isolation policy every other tenant table uses ----
+ALTER TABLE "senior_subject_teacher" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "senior_subject_teacher" FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation ON "senior_subject_teacher";
+CREATE POLICY tenant_isolation ON "senior_subject_teacher" FOR ALL TO public
+  USING (
+    current_setting('app.bypass_rls', true) = 'on'
+    OR school_id = NULLIF(current_setting('app.current_school', true), '')::uuid
+  )
+  WITH CHECK (
+    current_setting('app.bypass_rls', true) = 'on'
+    OR school_id = NULLIF(current_setting('app.current_school', true), '')::uuid
+  );

--- a/omnischools/docs/senior-build-plan.md
+++ b/omnischools/docs/senior-build-plan.md
@@ -19,8 +19,8 @@
 - Item 0 — period config ✅ shipped in Basic.
 - Item 1 — 5-category model + Path A auto-compile ✅ merged (PR #131, migration 0038)
 - Item 2 — Path C direct entry ✅ gates green (PR #134, migration 0039)
-- **Item 3 — VHM progress view** ← _in progress_ · Item 4 — Path B OCR
-  - Read-only dashboard: per (class×subject×period) context — completion counts per category, STPSHS-ready count, path pill, derived teacher, last activity, ready/behind/at-risk status. **Counts only, NEVER score values (§6.2).** Teacher derived (path.updatedBy → class teacher), no new schema. At-risk flags reuse seeded `ref_anomaly_rule` (inactive 14+ days). Optional Headmaster roll-up (§6.4).
+- Item 3 — VHM progress view ✅ gates green (PR pending, migration 0040) · **Item 4 — Path B OCR** ← _next_
+  - Read-only dashboard `/senior/academic-progress`: per (class×subject) — completion counts per category, STPSHS `n/5` tier, path pill, teacher, last activity, ready/behind/at-risk. **Counts only, NEVER score values (§6.2).** Rows enumerate from the new `senior_subject_teacher` assignment table (LEFT JOIN progress) so never-started teachers appear. At-risk flags computed on-the-fly (inactive 14+ days, N-not-ready). Headmaster roll-up (§6.4) + full filter bar + role gating deferred.
 - Item 5 — PWA phase 1 · Item 6 — paper ledger book · Item 7 — versioned diff · Item 8 — STPSHS sheet
 
 ## Current increment — INCR-1: F0 + Score Ledger Item 1

--- a/omnischools/docs/senior-build-plan.md
+++ b/omnischools/docs/senior-build-plan.md
@@ -19,7 +19,8 @@
 - Item 0 — period config ✅ shipped in Basic.
 - Item 1 — 5-category model + Path A auto-compile ✅ merged (PR #131, migration 0038)
 - Item 2 — Path C direct entry ✅ gates green (PR #134, migration 0039)
-- **Item 3 — VHM progress view** ← _next_ · Item 4 — Path B OCR
+- **Item 3 — VHM progress view** ← _in progress_ · Item 4 — Path B OCR
+  - Read-only dashboard: per (class×subject×period) context — completion counts per category, STPSHS-ready count, path pill, derived teacher, last activity, ready/behind/at-risk status. **Counts only, NEVER score values (§6.2).** Teacher derived (path.updatedBy → class teacher), no new schema. At-risk flags reuse seeded `ref_anomaly_rule` (inactive 14+ days). Optional Headmaster roll-up (§6.4).
 - Item 5 — PWA phase 1 · Item 6 — paper ledger book · Item 7 — versioned diff · Item 8 — STPSHS sheet
 
 ## Current increment — INCR-1: F0 + Score Ledger Item 1

--- a/omnischools/docs/senior/vhm-progress-surface-map.md
+++ b/omnischools/docs/senior/vhm-progress-surface-map.md
@@ -1,0 +1,390 @@
+# SHS Score Ledger — Surface Map (Item 3: Vice Headmaster Academic progress view)
+
+**Author:** Lucy (design cartographer) · **Status:** design spec, ready for the implementation engineer.
+**Scope of this map:** Score Ledger **Item 3** — the Vice Headmaster Academic progress view (spec `md files/SHS_SCORE_LEDGER_SPEC.md` §6). This is the **management/oversight read** of ledger completion: three cascading surfaces (per-teacher table · at-risk flags · Headmaster roll-up), all reading the same per-teacher completion data.
+
+This is an exhaustive 1:1 map of the source surface onto the existing Next.js Senior idioms. Where surface and spec disagree, the rule is **spec wins on logic, surface wins on visual presentation** — every drift is called out inline and collected in the **Open questions / drift log** at the end.
+
+The **single most important thing this surface is _not_**: it is not the ledger grid. Item 1 (`senior-ledger-grid.tsx`) shows *score values* to the teacher who owns them. This surface shows *completion states only* to a manager who must never see the values (spec §6.2). Everything below serves that discipline.
+
+## Source surfaces (visual source of truth — replicate 1:1)
+
+| Surface file | Role in this map |
+|---|---|
+| `Surfaces/schoolup-shs-vice-headmaster-progress.html` | **PRIMARY.** Three sections, three routed screens: §1 per-teacher progress table (VHM), §2 at-risk flags (VHM), §3 Headmaster roll-up. Each wrapped in the editorial browser-frame chrome that the implementer strips (build the in-app `.main` only). |
+
+## Canonical inputs
+
+- **Tokens:** `md files/design-tokens.json` (v1.0.0) + live `omnischools/styles/tokens.css`. Runtime uses **Tailwind token classes** (`text-navy`, `bg-gold-bg`, `border-border`, `font-display`, `max-w-page`), **never inline `var(--x)` in JSX**. The surface is hand-written HTML with `var(--x)`; translate each to the Tailwind class of the same token. **The token table from the Item-1 map (`ledger-surface-map.md` §0) applies verbatim** and is reproduced condensed in §0 below.
+- **Spec:** `SHS_SCORE_LEDGER_SPEC.md` §6 — §6.1 (ten columns + filters + default sort), §6.2 (completion-not-score discipline), §6.3 (three at-risk rules), §6.4 (Headmaster subject-level cascade).
+- **Item-1 map:** `omnischools/docs/senior/ledger-surface-map.md` — the VHM vocabulary noted there (path pills A/B/C, `stpshs-cell` ready/behind/at-risk, ✓/¾/— category dots) is authoritative and must stay consistent; this map is its downstream consumer.
+- **Shipped idioms to match:** `omnischools/app/(app)/senior/score-ledger/page.tsx` (hero header block, `withSchool`/`requireSchool` server fetch, `?classId&subjectId&periodId` query params, `academic_period.period_label`), `omnischools/components/senior/senior-ledger-grid.tsx` (sticky-left table, token cell classes), `omnischools/components/gradebook/selectors.tsx` (query-param filter precedent).
+- **Schema already present:** `omnischools/db/schema/score-ledger.ts` (`seniorScoreLedger`, `seniorAssessments`, `assessmentWeights`), `omnischools/db/schema/anomaly.ts` (`ref_anomaly_rule` — the flag engine), `omnischools/db/schema/timetable.ts` (`timetable_slot.teacherUserId` — the *only* teacher↔class×subject link that exists; see the drift log, this is the central data-model gap).
+
+---
+
+## 0. Token & type reference (condensed — full table in `ledger-surface-map.md` §0)
+
+| Surface `var(--x)` | Tailwind class | Used for on THIS surface |
+|---|---|---|
+| `--navy` `#1A2B47` | `text-navy` / `bg-navy` | primary text, discipline banner bg, primary buttons, deep-navy sidebar override note |
+| `--navy-2` `#2D3F5C` | `text-navy-2` | secondary text, MS/ES header labels, risk-card body |
+| `--navy-3` `#5C6675` | `text-navy-3` | muted meta, crumbs, `.last-active`, pending-dot colour |
+| `--navy-deep` `#13203A` | `bg-navy-deep` | **Oversight** app-shell sidebar (the surface's default `.sidebar` = `#13203A`); **but Senior override forces `bg-navy`** — see §1.1 |
+| `--gold` `#C8975B` | `text-gold` / `bg-gold` | accents, italic `<em>`, path-pill B text, `stpshs-cell.behind` text, med-risk icon |
+| `--gold-soft` `#E8D4B8` | `border-gold-soft` | gold-tinted borders |
+| `--gold-bg` `#F5EBDC` | `bg-gold-bg` | row hover, path-pill B bg, `stpshs-cell.behind` bg, `cat-dot.partial`… no wait: partial = solid gold; `behind` pills = gold-bg |
+| `--bg` `#FAF7F2` | `bg-bg` | page bg, table-head bg, low-risk card bg |
+| `--surface` `#FFFFFF` | `bg-surface` | cards, panels, table body |
+| `--green` `#2F6B47` | `text-green` / `bg-green` | path-pill A, `cat-dot.done`, `stpshs-cell.ready`, "complete" roll-up accent |
+| `--green-bg` `#E5EFE8` | `bg-green-bg` | path-pill A bg, `stpshs-cell.ready` bg |
+| `--terra` `#B84A39` | `text-terra` / `bg-terra` | path-pill C, `cat-dot.late`, `stpshs-cell.at-risk`, `.last-active.stale`, high-risk card, "at risk" roll-up |
+| `--terra-bg` `#F5E1DC` | `bg-terra-bg` | path-pill C bg, `stpshs-cell.at-risk` bg, high-risk card bg |
+| `--warn` `#C58A2E` | `text-warn` | (defined; used on other ledger surfaces for low-conf — **unused on this surface**) |
+| `--warn-bg` `#F5E9D0` | `bg-warn-bg` | (Item-1 `behind` variant uses this; **this surface uses `gold-bg` for `behind` instead** — drift note §1.4) |
+| `--border` `#E5DFD3` | `border-border` | dividers, card borders |
+| `--border-2` `#D4CCBA` | `border-border-2` | stronger borders, buttons, `cat-dot.pending` bg |
+
+**Type families:** `font-display` = Fraunces (headings, section numerals, stat numbers, italic gold `<em>`); `font-body`/Manrope (body, labels, teacher names); `font-mono` = JetBrains Mono (**path pills, cat-dots, stpshs-cell counts, last-activity, all counts**). Every count ("0/5", "4 of 6"), every path letter, every last-activity string is `font-mono`.
+
+**Convention:** an unentered category renders the em-dash `—` in `cat-dot.pending`, never `0` / `N/A`. (The dot is the state; the surface deliberately shows no numeric score anywhere — see §1.3.)
+
+---
+
+## Which surface renders where — the three screens
+
+The one HTML file is three routed screens sharing the Senior app-shell. Recommended routes (extending the `/senior/score-ledger` precedent):
+
+| Section | Screen | URL in surface | Suggested route | Role viewing |
+|---|---|---|---|---|
+| §1 | Per-teacher progress table | `…/senior/academic-progress/semester-2-2025-26` | `/senior/academic-progress` | Vice Headmaster Academic |
+| §2 | At-risk flags | `…/senior/academic-progress/risks` | `/senior/academic-progress/risks` | Vice Headmaster Academic |
+| §3 | Headmaster roll-up | `…/senior/headmaster-summary/semester-2-2025-26` | `/senior/headmaster-summary` | Headmaster |
+
+§1 and §2 are the same role's two tabs; §3 is a **different role's** landing. The roll-up (§3) **is on a separate surface**, not embedded in the VHM view (spec §6.4 confirmed by the surface: distinct sidebar scope-chip `Mr. V. Yanney · Headmaster`, distinct nav, distinct URL). See §3.
+
+---
+
+# SECTION 1 — Per-teacher progress table (the core)
+
+Source: surface §1. Demo: **Asankrangwa SHS · Mrs. P. Anim (Vice Headmaster Academic) · Semester 2 of 2025/26 · 14 teachers · 23 class-subject combinations · STPSHS window opens 14 July 2026.**
+
+## 1.0 Editorial page-header (design-doc chrome — DO NOT build)
+
+The outer `.page-header` (mvp-tag `Omnischools Senior · Vice Headmaster Academic · Progress view`, `<h1>Who's done, <em>who's not.</em></h1>`, gold rule, lede paragraph) is the design-doc framing above the browser mock. **Build the in-app `.page-head` inside the app-shell (§1.2), not this.** The lede's content, however, is the spec source for §6.2's discipline and should inform the in-app discipline banner copy.
+
+## 1.1 App shell — sidebar + main
+
+- **Sidebar** — the surface's base `.sidebar` is Oversight deep-navy `#13203A`, **but the Senior override at CSS line 254 forces `.app-shell .sidebar { background: var(--navy) }`.** Build the sidebar `bg-navy` (regular Senior operational navy, matching the Item-1 ledger sidebar), **not** `bg-navy-deep`. Width 230px.
+  - **Brand crest** (`.gov-mark`): gold rounded square badge `A` (`bg-gold text-navy font-display`) + `Omnischools Senior` (`.l1`, `font-display 14px`) / `Asankrangwa SHS` (`.l2`, `text-gold-soft 9px uppercase tracking-[0.14em]`).
+  - **Scope chip** (`.scope-chip`, `bg-[rgba(200,151,91,0.10)] border-[rgba(200,151,91,0.25)] rounded-md`): label `Role` (`.sc-label`, gold `8.5px uppercase`), name `Mrs. P. Anim` (`.sc-name`, `font-display 14px`), meta `Vice Headmaster Academic` (`.sc-meta`, `text-gold-soft 10px`). **Note this is a `Role` chip, not the Item-1 `Teaching` chip** — the VHM's scope is school-wide, not a class-subject.
+  - **Nav groups + items (verbatim, §1 & §2 identical):** group `Academic management` → **Ledger progress (active)** · Teachers · Classes & subjects · Timetable. group `Term cycle` → Assessment calendar · Report cards · STPSHS submissions. group `School` → All students · Parents. Active item = `bg-[rgba(200,151,91,0.10)] text-bg border-l-2 border-gold`; inactive `text-[rgba(250,247,242,0.7)]`.
+  - **Footer:** avatar `PA` (`bg-gold-soft text-navy font-display`) / `P. Anim` / `Vice Headmaster Academic`. `Powered by <em class="text-gold">Omnischools</em>`.
+- **Main** `bg-bg`.
+
+## 1.2 `.page-head` (in-app header — BUILD THIS)
+
+Reuse the shipped hero idiom (`score-ledger/page.tsx` lines 320–343: eyebrow/crumb → `font-display` h1 with italic gold `<em>` → lede → right-aligned actions).
+
+- **Crumb** (`.crumb`, `text-navy-3 11px uppercase tracking-[0.12em]`): `Senior · Vice Headmaster · Academic progress · Semester 2 of 2025/26`.
+- **h1** (`font-display 28px 500`): `Score ledger <em class="text-gold italic">progress.</em>`
+- **Lede** (`.lede`, `text-navy-3 13px`): `14 teachers · 23 class-subject combinations · STPSHS window opens 14 July 2026 — 17 days from now`. The "17 days from now" is **computed** from `academic_period` / the STPSHS window date, not literal.
+- **Actions** (right): `Filter` (`.btn.ghost` = `bg-transparent border-border-2 text-navy-3`) · `Export PDF` (`.btn.ghost`) · **`Message behind teachers →`** (`.btn.primary` = `bg-navy text-bg`). The primary action is a **bulk comms** action scoped to the currently-behind set (ties to `Message all flagged teachers` in §2).
+
+## 1.3 The discipline banner (`.discipline-banner`) — the completion-not-scores contract, made visible
+
+**This is the §6.2 discipline rendered as a first-class UI element and must not be dropped.** Full-width navy gradient card above the table.
+
+- Container: `bg-[linear-gradient(135deg,navy,navy-2)] text-bg rounded-xl px-[22px] py-4 mb-[18px]`, grid `auto 1fr`.
+- Icon (`.db-icon`): gold rounded square `bg-gold text-navy font-display italic`, glyph `i`.
+- Text (`.db-text`, `12px`, `<b>` accents in `font-display italic text-gold`): verbatim —
+  > This view shows **completion progress**, not the score values themselves. The Vice Headmaster sees which categories each teacher has entered; the marks themselves remain the teacher's domain until the semester is closed. To inspect actual scores, navigate to the gradebook — that access is audit-logged, the same way Oversight's compliance record view is.
+
+**Discipline audit (brief requirement — CONFIRMED CLEAN):** I traced every cell rendered on this surface. **No score value appears anywhere.** The columns render category *states* (✓ / ¾ / ⅔ / —), path letters, aggregate counts (`0/5`, `2/5`), status pills, and relative dates. The one place a number-that-looks-like-a-mark could leak is the cat-dot — but `¾` and `⅔` are **completion fractions** (assignments 3-of-4 entered), not scores. The implementer must preserve this: the cat-dot's value is derived from *how many category-entries exist*, never from `weighted_total` or any `*_score` column. **Any future addition of a mean/average/total column to this table breaks the §6.2 contract and must be rejected.** The banner's promise ("navigate to the gradebook, audit-logged") is the sanctioned escape hatch — a per-teacher link to the audit-logged ledger view, not an inline reveal.
+
+## 1.4 The completion table (`.vha-table`) — spec §6.1, ten logical columns
+
+Wrapped in a `.panel` (`bg-surface border border-border rounded-[14px]`). Panel-head: title `Teacher × class · <em class="text-gold">23 combinations</em>` (`font-display 17px`) + meta `Sorted by STPSHS readiness · most behind first` (`.ph-meta`, `10px uppercase text-navy-3`).
+
+Reuse `senior-ledger-grid.tsx`'s table mechanics: `overflow-x-auto rounded-xl border`, `thead` = `bg-bg text-[9px] uppercase tracking-[0.1em] font-bold text-navy-3`, `tbody` rows `divide-y divide-border`, `tr:hover td → bg-gold-bg`. **The header is `position: sticky; top: 0`** (`.vha-table thead th` — sticky on vertical scroll, since this table is long; the teacher column is NOT sticky-left here, unlike the ledger grid, because the surface doesn't declare it — see drift §D3).
+
+### The columns — surface headers vs spec §6.1, exhaustive
+
+The surface **compresses** the spec's ten columns into **eight rendered columns**. The mapping (this reconciliation is the heart of the map):
+
+| # | Spec §6.1 column | Surface header | Cell render (verbatim from surface) | Token/class |
+|---|---|---|---|---|
+| 1 | Teacher (name + subject) | **Teacher** | `<div class="teacher-name">B. Akoto</div>` + `<span class="teacher-subjects">Government</span>` | name `font-bold text-navy`; subject `9.5px text-navy-3` block |
+| 2 | Class (form + programme) | **Class · subject** | `<div class="class-name">Form 3 Arts A</div>` | `font-semibold text-navy-2` |
+| 3 | Path (A/B/C) | **Path** (center) | `<span class="path-pill b">B</span>` | see §1.5 |
+| 4 | Assignments (count/expected + bar) | **Asg** (cat-col, `text-green`) | `<span class="cat-dot done">✓</span>` | see §1.6 · **DRIFT §D1: surface shows a dot, NOT a "count/expected + progress bar"** |
+| 5 | Mid-semester exam (entered+date) | **MS** (cat-col, `text-navy-2`) | `cat-dot` (✓/¾/—) | §1.6 · **DRIFT §D1: no date shown** |
+| 6 | End-of-semester exam (entered+date) | **ES** (cat-col, `text-navy-2`) | `cat-dot` | §1.6 · no date |
+| 7 | Project work (entered+date) | **Proj** (cat-col, `text-green`) | `cat-dot` | §1.6 · no date |
+| 8 | Portfolio (entered+date) | **Port** (cat-col, `text-terra`) | `cat-dot` | §1.6 · no date. **Portfolio header is `text-terra`** — the same "one category Omnischools can't compute" colour as Item 1 |
+| 9 | STPSHS export ready (Yes/No missing X) | **STPSHS** (center) | `<span class="stpshs-cell at-risk">At risk · 0/5</span>` | see §1.7 |
+| 10 | Last activity | **Last activity** (right) | `<span class="last-active stale">19 days ago</span>` | see §1.8 |
+
+**Header colour coding (must preserve, matches Item-1 §3.4 semantic key):** Asg + Proj = `text-green` (auto-computable "safe" categories); MS + ES = `text-navy-2` (the two exams); **Port = `text-terra`** (the one manual-only category). This is the same five-category colour vocabulary as the ledger grid — a VHM glancing across knows terra = portfolio without a legend.
+
+## 1.5 The path pill (`.path-pill`) — A/B/C, spec/Item-1 colour vocabulary
+
+`font-mono 9px font-bold rounded-full px-[7px] py-[3px] tracking-[0.04em]`, one letter:
+
+| Path | Class | Colour | Tailwind |
+|---|---|---|---|
+| **A** — Auto-compile | `.path-pill.a` | green | `bg-green-bg text-green` |
+| **B** — Scan paper | `.path-pill.b` | gold | `bg-gold-bg text-gold` |
+| **C** — Direct digital | `.path-pill.c` | terra | `bg-terra-bg text-terra` |
+
+**These are exactly the colours the Item-1 map (§6) pinned for the VHM `.path-pill`.** Keep them. The path is per `(teacher × subject × class × semester)` and affects what "complete" looks like (a Path C teacher shows progress cell-by-cell early; a Path B teacher shows nothing until the semester-end scan) — the pill tells the VHM which reading applies. **In-table legend footer** (`.legend`-style, below the table) spells them out: `A Auto-compile · B Scan paper · C Direct digital`.
+
+## 1.6 The category dot (`.cat-dot`) — the completion state, NOT a score
+
+`inline-flex 22×22px rounded-md font-mono 11px font-bold`, four states:
+
+| State | Class | Glyph | Colour | Meaning |
+|---|---|---|---|---|
+| Entered / complete | `.cat-dot.done` | `✓` | `bg-green text-bg` | category fully entered |
+| Partial | `.cat-dot.partial` | `¾` or `⅔` | `bg-gold text-navy` | some but not all entries in (e.g. 3 of 4 assignments) — the glyph is a **completion fraction**, surface uses `¾` and `⅔` literally |
+| Pending | `.cat-dot.pending` | `—` | `bg-border-2 text-navy-3` | nothing entered |
+| Late | `.cat-dot.late` | (n/a in demo rows) | `bg-terra text-bg` | **defined in CSS, unused in demo** — reserved for "entry expected by calendar but overdue" |
+
+**Table-foot legend** (below `.vha-table`, `10.5px text-navy-3`): three 16px dots — `✓ Entered · ¾ Partial · — Pending`. The `.late` state has no legend entry (unused). **DRIFT §D2:** the `.cat-dot.late` (terra) state exists but no demo row triggers it and there is no legend for it — the implementer must decide the trigger (spec is silent; likely "a single-event category — MS/ES/Proj — whose assessment date has passed with no entry"). This is where the spec §6.1 "entered (date)" data would surface as a *state* rather than a *date*.
+
+## 1.7 The STPSHS-ready cell (`.stpshs-cell`) — spec §6.1 col 9, the three-tier readiness
+
+`inline-block font-mono 10px font-bold rounded-full px-2.5 py-1 uppercase tracking-[0.04em]`. **Format: `<Tier> · <n>/5`** — tier word + categories-entered-of-five:
+
+| Tier | Class | Colour | Demo values | Meaning (spec §6.1 / §6.5-note) |
+|---|---|---|---|---|
+| **Ready** | `.stpshs-cell.ready` | `bg-green-bg text-green` | `Ready · 5/5` | all five categories in — STPSHS-exportable |
+| **Behind** | `.stpshs-cell.behind` | `bg-gold-bg text-gold` | `Behind · 2/5`, `Behind · 3/5`, `Behind · 4/5` | window approaching, teacher still has categories outstanding |
+| **At risk** | `.stpshs-cell.at-risk` | `bg-terra-bg text-terra` | `At risk · 0/5` | window has effectively arrived and the teacher hasn't moved |
+
+**These are the exact three tiers the Item-1 map (§3.7) said the teacher's grid completion summary must map onto** — teacher view and VHM view share `ready / behind / at-risk` vocabulary so a conversation between them needs no translation (spec §6.1). The `n/5` is the count of the five categories in a `done`-or-better state.
+
+> **DRIFT §D4 — `behind` colour differs from Item-1.** The Item-1 map's class-tab status pill used `behind = bg-warn-bg text-warn` (§3.3). **This surface uses `behind = bg-gold-bg text-gold`.** Same semantic, different token. Since the two live on different surfaces the visual clash is invisible to any one user, but the implementer should pick one and note it. **Recommendation: follow THIS surface (`gold-bg`/`gold`) for the VHM `stpshs-cell`**, since it's the surface being built; leave the Item-1 class-tab as-is or reconcile later. The tier→calendar calibration (Ready/Behind/At risk are calibrated against the *window date*, not an arbitrary %) is spec §6.1 and identical either way.
+
+## 1.8 Last activity (`.last-active`) — spec §6.1 col 10
+
+`font-mono 10px text-navy-3`, right-aligned. Renders a **relative** string: `today`, `yesterday`, `2 days ago`, `3 days ago`, `4 days ago`, `19 days ago`. **`.stale` variant** = `text-terra font-bold` — applied when the teacher is inactive past the 14-day threshold (the demo's "19 days ago" rows are `.stale`). This column is the visual seed of the §6.3 "inactive 14+ days" flag; the flag engine (§2) reads the same underlying `last_touched_at`.
+
+## 1.9 Default sort & the overflow row
+
+- **Default sort = STPSHS readiness, most-behind first** (spec §6.1, panel-head meta confirms "Sorted by STPSHS readiness · most behind first"). Demo order: the two `At risk · 0/5` rows (B. Akoto ×2, `19 days ago` stale) first, then `Behind · 2/5`, `3/5`, `4/5` ascending, then `Ready · 5/5` last. **Sort key = (tier rank: at-risk<behind<ready) then (n ascending) then (last-activity descending staleness).** The most consequential cases are visually loudest at the top.
+- **Overflow row** (`opacity:0.4`, `colspan=10`, `font-style:italic text-navy-3 center`): `… 14 more class-subject combinations · 5 ready, 8 behind, 1 at risk`. This is the truncation affordance (demo shows 9 of 23 rows) — build as a "show all / paginate" footer, or virtualise. The tally string (`5 ready, 8 behind, 1 at risk`) is a live aggregate.
+
+## 1.10 Filters (spec §6.1) — reuse the `GradebookSelectors` query-param precedent
+
+Spec §6.1: **filter by teacher, subject, form, programme, and submission status.** The surface renders a `Filter` ghost button (unexpanded); the mechanism is the shipped `GradebookSelectors` pattern (`components/gradebook/selectors.tsx`) — linked `<select>`s that push to the route via `URLSearchParams`. For this surface the params are `?teacherId&subjectId&form&programme&status` on `/senior/academic-progress`. Default (no params) = the STPSHS-readiness sort above, all rows. The `status` filter values map to the three `stpshs-cell` tiers (`ready|behind|at-risk`). **DRIFT §D5:** the surface does not render an expanded filter bar — only the button. The implementer builds the filter row from the spec's five dimensions using the `selectors.tsx` idiom; the surface gives colour/placement precedent only via the `Filter` button in `.actions`.
+
+## 1.11 Demo rows (verbatim — the data contract)
+
+The exact eight visible rows (each is one `(teacher × class-subject)` combination), so the implementer can seed/verify:
+
+| Teacher (subject) | Class | Path | Asg | MS | ES | Proj | Port | STPSHS | Last activity |
+|---|---|---|---|---|---|---|---|---|---|
+| B. Akoto (Government) | Form 3 Arts A | B | — | — | — | — | — | At risk · 0/5 | 19 days ago (stale) |
+| B. Akoto (Government) | Form 3 Arts B | B | — | — | — | — | — | At risk · 0/5 | 19 days ago (stale) |
+| J. Asare (Chemistry) | Form 2 Science | A | ✓ | ✓ | ¾ | — | — | Behind · 2/5 | 2 days ago |
+| M. Boateng (English) | Form 1 General | C | ✓ | ✓ | ✓ | ⅔ | — | Behind · 3/5 | today |
+| A. Nkrumah (Biology) | Form 2 Science | B | ✓ | ✓ | ✓ | ✓ | — | Behind · 4/5 | yesterday |
+| K. Owusu (Mathematics) | Form 2 Science | A | ✓ | ✓ | ✓ | ✓ | — | Behind · 4/5 | today |
+| K. Owusu (Mathematics) | Form 2 General | A | ✓ | ✓ | ✓ | ✓ | — | Behind · 4/5 | today |
+| F. Sarpong (Physics) | Form 2 Science | C | ✓ | ✓ | ✓ | ✓ | ✓ | Ready · 5/5 | 4 days ago |
+| G. Mensah (Elective Maths) | Form 3 Science | A | ✓ | ✓ | ✓ | ✓ | ✓ | Ready · 5/5 | 3 days ago |
+
+Note: **`Behind · 2/5` (Asare) counts ✓✓ = 2** and treats the `¾` partial ES as not-yet-done for the count — so `n/5` counts only `done` categories, partials don't increment. Confirm this rule (a partial category is "started, not complete" → excluded from `n`).
+
+---
+
+# SECTION 2 — At-risk flags (spec §6.3)
+
+Source: surface §2 (route `…/risks`). Same VHM sidebar/scope as §1. Demo: **3 flags raised · sorted by severity · STPSHS window opens in 17 days.**
+
+## 2.1 `.page-head`
+
+- Crumb: `Senior · Vice Headmaster · Academic progress · At-risk flags`.
+- h1: `Risks <em class="text-gold italic">this week.</em>`
+- Lede: `3 flags raised by the engine · sorted by severity · STPSHS window opens in 17 days`.
+- Actions: `Configure rules` (`.btn.ghost` → opens the `ref_anomaly_rule` editor) · **`Message all flagged teachers →`** (`.btn.primary`) — the bulk-comms action (spec §2 note: one templated message per flagged teacher with their specific gap referenced).
+
+## 2.2 The risk stack (`.risk-stack`) — three severity tiers
+
+Vertical stack of `.risk-card`s. Each card: grid `auto 1fr auto`, `rounded-[11px] border px-[18px] py-[14px]`. Icon (`.rc-icon`, 34px rounded, `font-display italic`, glyph `!`). Body (`.rc-text`, `12px text-navy-2`, `<b>` in `text-navy`) + a meta line (`.rc-meta`, `9.5px uppercase tracking-[0.04em] text-navy-3 font-bold`) that **names the rule that fired**. Right: action button (`.rc-action`).
+
+| Severity | Card class | bg / border | Icon bg | Action button |
+|---|---|---|---|---|
+| **High** | `.risk-card.high` | `bg-terra-bg border-terra` | `bg-terra text-bg` | `.rc-action` on high = `bg-navy text-bg border-navy` (filled) |
+| **Medium** | `.risk-card.med` | `bg-gold-bg border-gold` | `bg-gold text-navy` | `bg-surface border-border-2` (outline) |
+| **Low** | `.risk-card.low` | `bg-bg border-border-2` | `bg-navy-3 text-bg` | (no demo low card; outline) |
+
+## 2.3 The three flags — exact copy, mapped to the three spec §6.3 rules
+
+**Flag 1 (high) — the inactivity rule (spec §6.3 bullet 2, "14+ days"):**
+- Title `<b>`: `Mr. B. Akoto has not touched the ledger in 19 days.`
+- Body: `Two Form 3 Arts Government classes — 82 students between them — have zero categories entered for Semester 2. STPSHS window opens in 17 days. Mid-sem and end-of-sem exam dates have already passed; scores exist on paper somewhere but not in Omnischools.`
+- Meta: `Rule: teacher inactivity 14+ days during semester · severity high`
+- Action: `Message Mr. Akoto →`
+
+**Flag 2 (high) — the STPSHS-window rule (spec §6.3 bullet 1, "window opens in <7 days, teachers not complete"):**
+- Title: `STPSHS window opens in 17 days · 9 of 23 class-subject combinations not yet ready.`
+- Body: `If trajectory holds, 4 of those will not be complete by 14 July. The teachers behind are: J. Asare (1 class), M. Boateng (1), A. Nkrumah (1), K. Owusu (2), and B. Akoto (2 — flagged separately above).`
+- Meta: `Rule: STPSHS window < 7 days with incomplete entries · severity high`
+- Action: `See behind list →` (deep-links back to §1's table filtered to `status=behind|at-risk`)
+
+> **DRIFT §D6 — the window-rule threshold is inconsistent within the surface.** The rule meta says "STPSHS window **< 7 days**" (matching spec §6.3), but the flag fires at **17 days** out and the lede says "opens in 17 days." Either the demo fires the rule early for illustration, or the rule's real threshold is wider than 7 days (a trajectory projection: "won't be complete *by* the window even though the window is >7 days away"). The body's "If trajectory holds, 4 … will not be complete by 14 July" implies the latter — a **projection**, not a simple countdown. Implementer: the rule is likely two-part (`days_to_window < 7` OR `projected_incomplete_at_window`), and the `ref_anomaly_rule.threshold_jsonb` should encode both. Confirm with the spec author.
+
+**Flag 3 (medium) — the entry-rate rule (spec §6.3 bullet 3, "Path C anomalous rate"):**
+- Title: `Mrs. E. Coleman entered 38 scores in 4 minutes on Path C.`
+- Body: `Possible data-quality concern — that pace is significantly faster than the class median (38 students entered in ~22 minutes). Could be a teacher with all marks ready in front of them typing fast; could also be guessing. Worth a brief conversation before STPSHS submission.`
+- Meta: `Rule: entry rate > 3σ from median · severity medium`
+- Action: `Review with Mrs. Coleman →` (note: **"Review with", not "Confront"** — the action framing is a conversation prompt, spec §2/§6.3 posture)
+
+> Note the entry-rate flag names **Mrs. E. Coleman**, a teacher NOT in §1's eight visible rows (she's among the "14 more"). The flags read the full 23-combination set, not just the visible page.
+
+## 2.4 The "no more flags" footer (`.risk-stack` sibling)
+
+Below the stack, a reassurance panel (`bg-bg border border-border rounded-[11px] px-[18px] py-[14px] 11px text-navy-3`, flex):
+- Lead (`font-display italic 13px text-navy`): `No more flags.`
+- Body: `The engine evaluated 23 class-subject combinations against five active rules. Three triggered. The remainder are tracking on schedule. Rules are configurable — the Headmaster or Vice Headmaster Academic can add a school-specific rule (e.g. "no class incomplete by week 9") and the engine picks it up the next night.`
+
+**Note "five active rules" but only three §6.3 rules are specced.** The surface notes (§2 notes list) name the five: (1) teacher inactivity, (2) STPSHS window approach, (3) entry-rate outlier, (4) **score-down between uploads** (from the Item-2/ledger diff logic, spec §7.2 — a cell populated-then-blanked or changed), (5) **portfolio-only-pending** (all four computable done, portfolio the sole gap). **DRIFT §D7:** spec §6.3 lists three rules; the surface's engine runs five. Rules 4 and 5 come from spec §7 (diff) and the portfolio-manual discipline. Model all five in `ref_anomaly_rule` (`applies_to = 'SCORE_LEDGER'`), each with `severity` + `threshold_jsonb` + `enabled`. "The engine picks it up the next night" implies a **nightly batch evaluator**, not live (contrast the roll-up's "live" refresh in §3.5 — see drift §D8).
+
+## 2.5 Rule engine → schema (already present)
+
+`ref_anomaly_rule` (`omnischools/db/schema/anomaly.ts`) exists and is explicitly "consumed by the Vice-Headmaster Academic progress view." Columns: `rule_code`, `severity` (enum), `description`, `applies_to`, `threshold_jsonb`, `enabled`. The five rules seed as rows here. The **flag instances** (which teacher tripped which rule, when, the computed detail) need a **flag-instances table that does not yet exist** — `ref_anomaly_rule` is the catalogue, not the log. **DRIFT §D9 (data-model gap):** there is no `anomaly_flag` / `ledger_risk_flag` table to hold a fired flag's `(rule_id, teacher_user_id, class_id, subject_id, period_id, detail_json, raised_at, resolved_at)`. The implementer must add one, or compute flags on-the-fly from the ledger state each render (cheaper for v1, but then "Configure rules … picks it up the next night" and resolved-state tracking don't fit). Recommend a lightweight `senior_ledger_flag` instance table.
+
+---
+
+# SECTION 3 — Headmaster roll-up (spec §6.4)
+
+Source: surface §3 (route `…/headmaster-summary`). **This is a SEPARATE surface for a SEPARATE role** — not embedded in the VHM view. Demo: **Mr. V. Yanney (Headmaster) · Semester 2 of 2025/26.**
+
+## 3.1 App shell — the Headmaster's different sidebar
+
+Same `bg-navy` Senior shell, but **different scope-chip and nav** (the surface makes the role switch explicit):
+- **Scope chip:** `Role` / `Mr. V. Yanney` / `Headmaster`.
+- **Nav (verbatim, differs from VHM):** group `School overview` → **Headmaster summary (active)** · Enrolment · WASSCE readiness. group `Academic` → Ledger progress (full) · Teachers · STPSHS submissions. group `School operations` → Boarding · Finance · Parents & PTA.
+- Footer: `VY` / `V. Yanney` / `Headmaster`.
+
+The nav difference encodes the hierarchy: the Headmaster's landing is `Headmaster summary`; `Ledger progress (full)` is a drill-down into the VHM's §1 view (spec §6.4: "a Headmaster who wants to see Mr. Akoto's row clicks 'Open full progress view' and lands in the Vice Headmaster's view").
+
+## 3.2 `.page-head`
+
+- Crumb: `Senior · Headmaster · Semester-end summary`.
+- h1: `Where the school <em class="text-gold italic">stands.</em>`
+- Lede: `Semester 2 of 2025/26 · 23 class-subject combinations · STPSHS window opens 14 July 2026`.
+- Actions: `Open full progress view` (`.btn.ghost` → deep-links to §1) · **`Brief the board →`** (`.btn.primary` — exports the three figures + action note for a Board of Governors briefing).
+
+## 3.3 The roll-up grid (`.rollup-grid`) — spec §6.4 subject-level "all / partial / behind complete"
+
+Section label above the grid (`11px uppercase tracking-[0.08em] font-bold text-navy-3`): `Subject-level readiness · cascaded from per-teacher progress`.
+
+Three `.rollup-card`s (`grid-cols-3 gap-3.5`, each `bg-surface border rounded-[11px] px-5 py-[18px]`). Structure: label (`.rc-label`, `10px uppercase text-navy-3`) → big number (`.rc-num`, `font-display 36px 600`, gold italic `<em>`) → suffix (`.rc-suffix`, `12px text-navy-3`) → subject list (`.subject-list`, `10.5px text-navy-2`, `border-top`, `<b>` accents).
+
+| Card | Border | `<em>` colour | Label | Number | Suffix | Subject list (verbatim) |
+|---|---|---|---|---|---|---|
+| **Complete** | `.complete` → `border-green` | `text-green` | `Subjects fully ready` | `3` | `of 9 subjects · all teachers complete` | `<b>Physics</b> · Elective Maths · Geography` |
+| **Partial** | `.partial` → `border-gold` | (default gold) | `Subjects partially ready` | `5` | `of 9 subjects · 1 or more teachers behind` | `<b>Mathematics</b> (4 of 6 teachers complete) · <b>English</b> (3 of 5) · <b>Chemistry</b> (1 of 2) · <b>Biology</b> (2 of 3) · <b>Integrated Science</b> (3 of 4)` |
+| **At risk** | `.behind` → `border-terra` | `text-terra` | `Subjects at risk` | `1` | `of 9 subjects · zero teachers ready` | `<b>Government</b> (Form 3 Arts) — Mr. B. Akoto's two classes flagged; 19 days inactive` |
+
+**This is the §6.4 "subjects with all teachers complete / partial / behind" aggregation** — the same per-teacher data (§1) grouped by subject. The subject-list line with per-subject teacher counts (`4 of 6 teachers complete`) is the deliberate design choice (surface note §3): "9 ready / 8 behind / 1 at risk" would be the right total but wrong framing — the Headmaster needs to know *which* subjects, because Government-at-risk (1 teacher) is a different problem from Mathematics-at-risk (6 teachers).
+
+**Aggregation rule:** a subject is `complete` if all its teachers are `Ready`; `at risk` if zero are `Ready`; `partial` otherwise. Grain: subject × (all classes/teachers teaching it). Counts (`3 + 5 + 1 = 9 subjects`) are subject-level, distinct from §1's 23 class-subject combinations.
+
+## 3.4 The action-item card (gold callout) — the surfaced escalation
+
+Below the roll-up, a gold-bordered callout (`bg-[linear-gradient(135deg,gold-bg,surface_70%)] border-[1.5px] border-gold rounded-xl`, grid `auto 1fr auto`):
+- Icon: gold rounded square `!` (`bg-gold text-navy font-display italic`).
+- Text (`12px text-navy-2`): `The Vice Headmaster Academic has flagged Mr. B. Akoto's classes as the most urgent action item — 19 days inactive, no scores entered, two classes affected. Mrs. P. Anim has been in touch; Mr. Akoto cited illness, returning next week. Mrs. Anim is preparing to support score entry on Mr. Akoto's return. <b>You may want to confirm the support plan with her before the STPSHS window opens.</b>`
+- Action: `Message Mrs. Anim` (`.btn.primary` small).
+
+**Design discipline (surface note §3, must preserve):** the action button is **"Message Mrs. Anim" (the line manager), NOT "Message Mr. Akoto"** — escalating past the line manager is the wrong move and the system reflects the hierarchy. The Headmaster's escalation routes through the VHM.
+
+## 3.5 Provenance footer (`.provenance`)
+
+Three items (`10.5px text-navy-3`, `<b>` in `text-navy-2`): `Source data · per-teacher ledger progress, same as Vice Headmaster view` · `Aggregation · grouped by subject across all classes` · `Refresh · live as teachers enter`.
+
+> **DRIFT §D8 — "live" here vs "next night" in §2.** The roll-up claims `Refresh · live as teachers enter`, while §2's flag engine "picks it up the next night." Reconcile: the **completion states** (§1 table, §3 roll-up) are live-derived from `senior_score_ledger` on each request (cheap aggregate query, matches the shipped `page.tsx` server-fetch model). The **anomaly flags** (§2) run as a nightly batch (rate-outlier and trajectory projection are expensive / need historical entry-timing). So both statements are true of different data. The implementer should make §1/§3 request-time server aggregates and §2 a batched evaluator writing flag instances.
+
+---
+
+## Interaction-state inventory (every state, per region)
+
+| Region | State | Visual |
+|---|---|---|
+| Table row (`.vha-table tr`) | default / hover | `bg-surface` / `bg-gold-bg` |
+| Path pill | A / B / C | `bg-green-bg text-green` / `bg-gold-bg text-gold` / `bg-terra-bg text-terra` |
+| Category dot | done / partial / pending / late | `bg-green text-bg ✓` / `bg-gold text-navy ¾` / `bg-border-2 text-navy-3 —` / `bg-terra text-bg` (unused in demo) |
+| STPSHS cell | ready / behind / at-risk | `bg-green-bg text-green` / `bg-gold-bg text-gold` / `bg-terra-bg text-terra` |
+| Last activity | normal / stale | `text-navy-3` / `text-terra font-bold` (>14 days) |
+| Risk card | high / med / low | `bg-terra-bg border-terra` / `bg-gold-bg border-gold` / `bg-bg border-border-2` |
+| Risk-card action | high / med-low | `bg-navy text-bg` (filled) / `bg-surface border-border-2` (outline) |
+| Roll-up card | complete / partial / at-risk | `border-green` + green `<em>` / `border-gold` / `border-terra` + terra `<em>` |
+| `.btn` | ghost / primary | `bg-transparent border-border-2 text-navy-3` / `bg-navy text-bg` |
+| Filter (spec §6.1) | via query param | `GradebookSelectors` `<select>` idiom, `focus:border-gold` |
+| Empty state (no ledger activity) | — | see below |
+
+## The empty state (no ledger activity yet — brief requirement)
+
+The surface shows **no explicit empty state** (the demo is mid-semester with data). The implementer must build one, reusing the shipped dashed-card idiom (`score-ledger/page.tsx` lines 76–80, and `components/ui/empty-state.tsx` `tone="muted"`):
+- **No teachers/combinations configured** (semester just opened, no class-subjects set up): `rounded-xl border border-dashed border-border-2 bg-surface p-12 text-center text-sm text-navy-3` → e.g. *"No class-subject combinations for this semester yet. Set up teaching assignments in Classes & subjects."* — **and this copy exposes the data-model gap in §D10 below** (there must be a "teaching assignment" source to enumerate rows).
+- **All combinations at 0/5, no activity** (semester open, no teacher has touched a ledger): show the full table with every row `At risk · 0/5` / `— never` last-activity, plus a lede note. Do **not** show the dashed empty card here — zero-progress is data, not absence.
+- **§2 flags, none raised:** the "No more flags." panel (§2.4) *is* the empty-of-flags state — reuse it verbatim.
+- **§3 roll-up, no subjects ready:** all three cards render with `0` — again, data not absence.
+
+---
+
+## Component mapping summary (surface region → build target)
+
+| Surface region | Existing idiom to reuse | New work for Item 3 |
+|---|---|---|
+| `.page-head` hero (all 3 screens) | `score-ledger/page.tsx` hero block | copy structure; swap crumb/h1/lede/actions per screen |
+| App-shell sidebar | Item-1 Senior `bg-navy` sidebar | swap scope-chip to `Role`; VHM vs Headmaster nav lists |
+| Discipline banner (§1.3) | — (new) | navy-gradient card; **non-negotiable, encodes §6.2** |
+| `.vha-table` (§1.4) | `senior-ledger-grid.tsx` table mechanics (overflow-x, thead/tbody classes, hover) | **sticky-top** thead (not sticky-left); 8 columns; NO score values |
+| Path pill (§1.5) | — (Item-1 map §6 pinned colours) | 3-variant `font-mono` pill |
+| Category dot (§1.6) | — (new) | 4-state dot (done/partial/pending/late); value = completion fraction, never a score |
+| STPSHS cell (§1.7) | — (Item-1 §3.7 tiers) | 3-tier `Tier · n/5` pill |
+| Filters (§1.10) | `components/gradebook/selectors.tsx` | 5-dimension query-param filter row |
+| Default sort (§1.9) | — | tier→n→staleness sort; overflow/paginate footer |
+| Risk stack (§2.2–2.3) | — (new) | 3-severity card; rule-meta line; conversation-framed actions |
+| Rule engine (§2.5) | `ref_anomaly_rule` (schema exists) | seed 5 rule rows; **add flag-instance table (§D9)** |
+| Roll-up cards (§3.3) | — (new) | 3 subject-level aggregate cards; subject-list with teacher counts |
+| Action-item callout (§3.4) | — (new) | gold callout; action routes to line-manager, not teacher |
+| Empty states | `components/ui/empty-state.tsx` + dashed card | per §"empty state" above |
+| Data fetch (all) | `withSchool`/`requireSchool` + `academic_period.period_label` (from `page.tsx`) | server aggregates over `senior_score_ledger`; **teacher attribution unresolved (§D10)** |
+
+---
+
+## Open questions / drift log
+
+**The central data-model question (brief-flagged): how does the surface know which teacher owns each class × subject?**
+
+- **§D10 — There is NO subject-teacher assignment table.** This is the load-bearing gap. The surface's atomic row is `(teacher × class × subject)`, and every aggregate (§1 rows, §2 flags, §3 subject roll-up) depends on knowing *which teacher owns each class-subject*. **The schema has no such table.** The only teacher↔(class×subject) links that exist are:
+  1. `timetable_slot.teacherUserId` (`timetable.ts`) — but this is `onDelete: set null`, **per weekday-slot** (a teacher appears in many slots for one class-subject), `subjectId` is nullable, and it models *scheduling*, not *authoritative assignment*. Deriving "B. Akoto owns Form 3 Arts A Government" from timetable slots is possible but fragile (a class-subject with no timetable rows would vanish from the VHM view entirely).
+  2. `senior_assessment.createdByUserId` (`score-ledger.ts`) — who created an assessment event. But **Path B and Path C teachers may never create `senior_assessment` rows** (Path B scans, Path C types straight into the ledger), so this attributes nothing for them — and `senior_score_ledger` itself has **no `teacher_user_id` column at all** (grain is `student × subject × period`, teacher-free).
+  - **Consequence:** the VHM view cannot be built on current schema without either (a) a new **`class_subject_teacher`** assignment table — grain `(school, class_id, subject_id, teacher_user_id, period_id?)`, composite tenant FKs per the memory `composite-tenant-fks` convention — which becomes the enumeration source for the rows and the join target for `last_activity`; or (b) treating `timetable_slot` (distinct teacher×class×subject tuples) as the assignment source, accepting its fragility. **Recommend (a): a dedicated `class_subject_teacher` table.** The Item-1 onboarding-cascade memory (`onboarding-inputs-cascade`) applies — teaching assignments should be created when the admin sets up classes/subjects, not re-entered. **Confirm with the spec author before building §1.**
+
+- **§D11 — "Expected / not-started" contexts (brief-flagged).** Related to §D10: a class-subject where the teacher has done *nothing* still must appear as a row (`At risk · 0/5`, `— never` activity) — the B. Akoto rows are exactly this. That means the row set is driven by **assignments (what's expected)**, not by **ledger rows that exist (what's started)**. A pure `senior_score_ledger` scan would **omit** a teacher who never touched anything (no ledger rows → no row → the most at-risk teacher is invisible). So the enumeration MUST come from the expected set (the `class_subject_teacher` table of §D10), left-joined to `senior_score_ledger`/`senior_assessment` for progress. This is the single most important correctness point for the implementer: **enumerate from expected assignments, LEFT JOIN progress — never enumerate from progress.** `last_activity` for a never-started row is `—`/`never`, not absent.
+
+**Other drifts (collected from inline notes above):**
+
+- **§D1 — Category columns are dots, not "count/bar + date".** Spec §6.1 specifies Assignments as "count entered / expected, progress bar" and MS/ES/Proj/Port as "entered (date) / not entered." The surface renders all five as a single `cat-dot` (✓/¾/⅔/—) with **no count, no bar, no date**. Surface wins on presentation (the dot is cleaner and the `¾`/`⅔` partial glyph carries the count-ish signal for assignments/project). **But the "entered (date)" data is lost** — the VHM can't see *when* mid-sem was entered from this table. Decide: keep the surface's dot-only rendering (recommended, matches the completion-not-detail posture) and expose dates on row-expand/hover, or add a date tooltip. Confirm.
+- **§D2 — `.cat-dot.late` (terra) is defined but unused, and has no legend.** Trigger unspecified. Likely "single-event category (MS/ES/Proj) whose assessment date has passed with no entry" — this is where §6.1's date data becomes a *state*. Implementer must define the trigger; add a legend entry if used.
+- **§D3 — Table thead is sticky-top, not sticky-left.** Unlike `senior-ledger-grid.tsx` (sticky-left student column), `.vha-table` declares `thead th { position: sticky; top: 0 }` only. On narrow screens the Teacher column will scroll away under horizontal overflow. Consider adding sticky-left to the Teacher column for parity with the ledger grid (minor enhancement, not in surface).
+- **§D4 — `behind` status colour drifts from Item-1.** This surface: `stpshs-cell.behind = gold-bg/gold`. Item-1 class-tab: `behind = warn-bg/warn`. Pick one; recommend following this surface for the VHM view. Same three-tier semantic either way.
+- **§D5 — Filter bar is a button only.** Surface renders `Filter` unexpanded; build the 5-dimension filter (teacher/subject/form/programme/status) from the `selectors.tsx` query-param idiom.
+- **§D6 — STPSHS-window rule threshold is inconsistent (7 days vs firing at 17).** The rule meta says "< 7 days" but fires at 17 days with a *trajectory projection* ("won't be complete by 14 July"). The real rule is likely two-part: `days_to_window < 7` OR `projected_incomplete_at_window`. Encode both in `threshold_jsonb`. Confirm with spec author.
+- **§D7 — Five rules run, spec §6.3 lists three.** Surface engine adds (4) score-changed-between-uploads (from spec §7 diff) and (5) portfolio-only-pending. Model all five as `ref_anomaly_rule` rows; spec §6.3 is a subset.
+- **§D8 — "Live" (§3 roll-up) vs "next night" (§2 flags).** Completion states are request-time server aggregates; anomaly flags are a nightly batch. Both statements true of different data — split accordingly.
+- **§D9 — No flag-instance table.** `ref_anomaly_rule` is the catalogue; there's no table for a *fired* flag (`rule_id, teacher, class, subject, period, detail, raised_at, resolved_at`). Add `senior_ledger_flag` (or compute on-the-fly for v1, accepting no resolved-state tracking). The `Configure rules` and "picks it up the next night" copy implies a persisted, batch-populated instance store.
+- **§D12 — Roll-up subject count (9) vs combination count (23).** §3 counts 9 subjects; §1 counts 23 class-subject combinations; §2 counts 23. The roll-up aggregates combinations→subjects (many classes per subject). Keep both grains straight: §1/§2 are per-combination, §3 is per-subject.
+- **§D13 — `Message …` / `Export PDF` / `Brief the board` / `Configure rules` actions are downstream.** All buttons must render; their targets (bulk comms compose, PDF export, board-brief export, rule editor) are later work. For Item 3, wire the navigation/deep-links (`See behind list →` → §1 filtered; `Open full progress view` → §1; `Message Mrs. Anim` → comms) and stub the export/compose actions. Confirm scope.
+- **§D14 — Role/permission gating.** §1/§2 are Vice-Headmaster-Academic-scoped; §3 is Headmaster-scoped. The `ref_user`/role model (`TEACHER` role seen in seed; VHM/Headmaster roles) must gate route access and — critically for §6.2 — **deny the score values** to these roles (only the audit-logged gradebook link reveals them). Confirm the role codes for `VICE_HEADMASTER_ACADEMIC` / `HEADMASTER` exist or need seeding.
+
+---
+
+*Map produced against: `schoolup-shs-vice-headmaster-progress.html` (§1/§2/§3); `SHS_SCORE_LEDGER_SPEC.md` §6 (§6.1–§6.4) + §7 (diff rules) + §2/§4.1 (portfolio-manual, path model); `omnischools/docs/senior/ledger-surface-map.md` §0/§3.7/§6 (token table + VHM vocabulary); shipped `app/(app)/senior/score-ledger/page.tsx`, `components/senior/senior-ledger-grid.tsx`, `components/gradebook/selectors.tsx`; schema `db/schema/score-ledger.ts`, `anomaly.ts`, `timetable.ts`, `staff.ts`; `design-tokens.json` v1.0.0.*

--- a/omnischools/lib/score-ledger/vhm-progress.test.ts
+++ b/omnischools/lib/score-ledger/vhm-progress.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { computeVhmTier } from "./vhm-progress";
+
+const filled = (
+  asgn: number,
+  midSem: number,
+  endSem: number,
+  project: number,
+  portfolio: number,
+) => ({ asgn, midSem, endSem, project, portfolio });
+
+describe("computeVhmTier — the STPSHS n/5 tier (completion, never scores)", () => {
+  const roster = 37;
+
+  it("all five categories entered by every student → Ready 5/5", () => {
+    expect(computeVhmTier(filled(37, 37, 37, 37, 37), roster)).toEqual({
+      categoriesDone: 5,
+      status: "ready",
+    });
+  });
+
+  it("no category fully entered → At risk 0/5 (the never-started case)", () => {
+    expect(computeVhmTier(filled(0, 0, 0, 0, 0), roster)).toEqual({
+      categoriesDone: 0,
+      status: "at_risk",
+    });
+  });
+
+  it("four of five categories fully entered → Behind 4/5 (portfolio pending)", () => {
+    expect(computeVhmTier(filled(37, 37, 37, 37, 0), roster)).toEqual({
+      categoriesDone: 4,
+      status: "behind",
+    });
+  });
+
+  it("a partially-entered category does NOT count toward n (§1.11)", () => {
+    // asgn fully in (37), mid-sem only 30 of 37 → mid-sem is 'partial', not done.
+    expect(computeVhmTier(filled(37, 30, 0, 0, 0), roster)).toEqual({
+      categoriesDone: 1,
+      status: "behind",
+    });
+  });
+
+  it("a category counts only when EVERY student has it, not just some", () => {
+    // Every category has 36 of 37 — none is fully done → 0/5, at risk.
+    expect(computeVhmTier(filled(36, 36, 36, 36, 36), roster)).toEqual({
+      categoriesDone: 0,
+      status: "at_risk",
+    });
+  });
+
+  it("an empty roster is at_risk 0/5, never divides or reads a phantom 'all done'", () => {
+    expect(computeVhmTier(filled(0, 0, 0, 0, 0), 0)).toEqual({
+      categoriesDone: 0,
+      status: "at_risk",
+    });
+  });
+});

--- a/omnischools/lib/score-ledger/vhm-progress.ts
+++ b/omnischools/lib/score-ledger/vhm-progress.ts
@@ -1,0 +1,254 @@
+import { and, eq, isNotNull, sql } from "drizzle-orm";
+import type { Tx } from "@/lib/db";
+import {
+  students,
+  classes,
+  subjects,
+  users,
+  seniorScoreLedger,
+  seniorLedgerPath,
+  seniorSubjectTeacher,
+} from "@/db/schema";
+
+export type CapturePath = "AUTO_COMPILE" | "SCAN_EXTRACT" | "DIRECT_ENTRY";
+/** STPSHS readiness tier (spec §6.1 / surface §1.7). Never-started folds into at_risk. */
+export type VhmStatus = "ready" | "behind" | "at_risk";
+
+/**
+ * One (class × subject) row of the Vice Headmaster Academic progress view.
+ * COMPLETION ONLY — the number of students who have each category *entered*, never the
+ * score values themselves (spec §6.2). The Vice Headmaster sees whether work is done,
+ * not what the marks are.
+ */
+export type VhmProgressRow = {
+  classId: string;
+  className: string;
+  subjectId: string;
+  subjectName: string;
+  path: CapturePath;
+  teacherName: string | null;
+  rosterSize: number;
+  filled: {
+    asgn: number;
+    midSem: number;
+    endSem: number;
+    project: number;
+    portfolio: number;
+  };
+  categoriesDone: number; // of 5 — categories where EVERY student has an entry (the "n/5")
+  lastActivityAt: Date | null;
+  daysInactive: number | null;
+  status: VhmStatus;
+  flags: string[];
+};
+
+/** ref_anomaly_rule LEDGER-INACTIVE-14 threshold (spec §6.3). */
+const INACTIVE_DAYS = 14;
+
+const DAY_MS = 86_400_000;
+
+/**
+ * Aggregate ledger completion for the Vice Headmaster progress view (spec §6). One row per
+ * teaching assignment (senior_subject_teacher) for the period, LEFT JOINed to progress — so a
+ * teacher who has started nothing still appears (§6.1). Per-category counts are computed with
+ * SQL `count(*) filter (…)` so raw scores never leave the DB (§6.2). The STPSHS "n/5" tier is
+ * the number of categories EVERY student has entered; never-started folds into at_risk.
+ */
+export async function loadVhmProgress(
+  tx: Tx,
+  schoolId: string,
+  periodId: string,
+  now: Date,
+): Promise<VhmProgressRow[]> {
+  // Enumeration source: the teaching assignments (spec §6.1). A teacher who has started
+  // nothing still gets a row — enumerate from what's EXPECTED, LEFT JOIN progress, never
+  // from what's started, or the most at-risk (never-started) teachers become invisible.
+  const assignments = await tx
+    .select({
+      classId: seniorSubjectTeacher.classId,
+      subjectId: seniorSubjectTeacher.subjectId,
+      teacherUserId: seniorSubjectTeacher.teacherUserId,
+    })
+    .from(seniorSubjectTeacher)
+    .where(eq(seniorSubjectTeacher.schoolId, schoolId));
+  if (assignments.length === 0) return [];
+
+  // Per (class, subject) completion counts — join students to resolve the class; count in
+  // SQL so no score value is ever selected into app memory (§6.2 discipline).
+  const agg = await tx
+    .select({
+      classId: students.classId,
+      subjectId: seniorScoreLedger.subjectId,
+      asgn: sql<number>`count(*) filter (where ${seniorScoreLedger.asgnScore} is not null)`.mapWith(
+        Number,
+      ),
+      midSem:
+        sql<number>`count(*) filter (where ${seniorScoreLedger.midSemScore} is not null)`.mapWith(
+          Number,
+        ),
+      endSem:
+        sql<number>`count(*) filter (where ${seniorScoreLedger.endSemScore} is not null)`.mapWith(
+          Number,
+        ),
+      project:
+        sql<number>`count(*) filter (where ${seniorScoreLedger.projectScore} is not null)`.mapWith(
+          Number,
+        ),
+      portfolio:
+        sql<number>`count(*) filter (where ${seniorScoreLedger.portfolioScore} is not null)`.mapWith(
+          Number,
+        ),
+      lastActivityAt: sql<Date | null>`max(${seniorScoreLedger.updatedAt})`,
+    })
+    .from(seniorScoreLedger)
+    .innerJoin(
+      students,
+      and(
+        eq(students.schoolId, seniorScoreLedger.schoolId),
+        eq(students.id, seniorScoreLedger.studentId),
+      ),
+    )
+    .where(
+      and(
+        eq(seniorScoreLedger.schoolId, schoolId),
+        eq(seniorScoreLedger.periodId, periodId),
+        eq(students.status, "ACTIVE"),
+        isNotNull(students.classId),
+      ),
+    )
+    .groupBy(students.classId, seniorScoreLedger.subjectId);
+
+  // Chosen capture paths for the period (a context may have a path but no entries yet).
+  const paths = await tx
+    .select({
+      classId: seniorLedgerPath.classId,
+      subjectId: seniorLedgerPath.subjectId,
+      path: seniorLedgerPath.path,
+      updatedByUserId: seniorLedgerPath.updatedByUserId,
+      updatedAt: seniorLedgerPath.updatedAt,
+    })
+    .from(seniorLedgerPath)
+    .where(
+      and(
+        eq(seniorLedgerPath.schoolId, schoolId),
+        eq(seniorLedgerPath.periodId, periodId),
+      ),
+    );
+
+  // Active roster size per class.
+  const rosters = await tx
+    .select({
+      classId: students.classId,
+      size: sql<number>`count(*)`.mapWith(Number),
+    })
+    .from(students)
+    .where(
+      and(
+        eq(students.schoolId, schoolId),
+        eq(students.status, "ACTIVE"),
+        isNotNull(students.classId),
+      ),
+    )
+    .groupBy(students.classId);
+  const rosterByClass = new Map(rosters.map((r) => [r.classId as string, r.size]));
+
+  const cls = await tx
+    .select({ id: classes.id, name: classes.name })
+    .from(classes)
+    .where(eq(classes.schoolId, schoolId));
+  const classById = new Map(cls.map((c) => [c.id, c]));
+  const subs = await tx
+    .select({ id: subjects.id, name: subjects.name })
+    .from(subjects)
+    .where(eq(subjects.schoolId, schoolId));
+  const subjectById = new Map(subs.map((s) => [s.id, s.name]));
+
+  const pathByCtx = new Map(paths.map((p) => [`${p.classId}:${p.subjectId}`, p]));
+
+  // Resolve teacher names for the assigned teachers.
+  const userIds = new Set(assignments.map((a) => a.teacherUserId));
+  const nameById = new Map<string, string | null>();
+  {
+    const rows = await tx.select({ id: users.id, name: users.fullName }).from(users);
+    for (const u of rows) if (userIds.has(u.id)) nameById.set(u.id, u.name);
+  }
+
+  const aggByCtx = new Map(
+    agg.filter((a) => a.classId).map((a) => [`${a.classId}:${a.subjectId}`, a]),
+  );
+
+  const out: VhmProgressRow[] = [];
+  for (const asn of assignments) {
+    const classId = asn.classId;
+    const subjectId = asn.subjectId;
+    const key = `${classId}:${subjectId}`;
+    const a = aggByCtx.get(key);
+    const p = pathByCtx.get(key);
+    const cl = classById.get(classId);
+    const rosterSize = rosterByClass.get(classId) ?? 0;
+    const teacherId: string | null = asn.teacherUserId;
+    const filled = {
+      asgn: a?.asgn ?? 0,
+      midSem: a?.midSem ?? 0,
+      endSem: a?.endSem ?? 0,
+      project: a?.project ?? 0,
+      portfolio: a?.portfolio ?? 0,
+    };
+    // "n/5" = categories every active student has entered (partials don't count — §1.11).
+    const categoriesDone =
+      rosterSize > 0
+        ? [filled.asgn, filled.midSem, filled.endSem, filled.project, filled.portfolio].filter(
+            (c) => c === rosterSize,
+          ).length
+        : 0;
+
+    // Last activity across the ledger and the path row.
+    const stamps: Date[] = [];
+    if (a?.lastActivityAt) stamps.push(new Date(a.lastActivityAt));
+    if (p?.updatedAt) stamps.push(new Date(p.updatedAt));
+    const lastActivityAt = stamps.length
+      ? new Date(Math.max(...stamps.map((d) => d.getTime())))
+      : null;
+    const daysInactive = lastActivityAt
+      ? Math.floor((now.getTime() - lastActivityAt.getTime()) / DAY_MS)
+      : null;
+
+    // STPSHS tier (§1.7): all five done = ready; none done = at_risk (incl. never-started);
+    // in between = behind. Inactivity is a separate flag (§2) + stale styling, not the tier.
+    const status: VhmStatus =
+      categoriesDone === 5 ? "ready" : categoriesDone === 0 ? "at_risk" : "behind";
+
+    const flags: string[] = [];
+    if (daysInactive != null && daysInactive >= INACTIVE_DAYS && status !== "ready") {
+      flags.push(`Teacher inactive ${daysInactive} days`);
+    }
+
+    out.push({
+      classId,
+      className: cl?.name ?? "—",
+      subjectId,
+      subjectName: subjectById.get(subjectId) ?? "—",
+      path: (p?.path ?? "AUTO_COMPILE") as CapturePath,
+      teacherName: teacherId ? (nameById.get(teacherId) ?? null) : null,
+      rosterSize,
+      filled,
+      categoriesDone,
+      lastActivityAt,
+      daysInactive,
+      status,
+      flags,
+    });
+  }
+
+  // Default sort (§6.1): most-behind first (so the VHM sees who's at risk), then by name.
+  const rank: Record<VhmStatus, number> = { at_risk: 0, behind: 1, ready: 2 };
+  out.sort(
+    (x, y) =>
+      rank[x.status] - rank[y.status] ||
+      x.categoriesDone - y.categoriesDone ||
+      (y.daysInactive ?? -1) - (x.daysInactive ?? -1) ||
+      x.className.localeCompare(y.className) ||
+      x.subjectName.localeCompare(y.subjectName),
+  );
+  return out;
+}

--- a/omnischools/lib/score-ledger/vhm-progress.ts
+++ b/omnischools/lib/score-ledger/vhm-progress.ts
@@ -48,6 +48,27 @@ const INACTIVE_DAYS = 14;
 const DAY_MS = 86_400_000;
 
 /**
+ * The STPSHS "n/5" and tier from the per-category filled counts (surface §1.7 / §1.11).
+ * `categoriesDone` = categories EVERY active student has entered (partials don't count).
+ * Tier: 5/5 = ready · 0/5 = at_risk (incl. never-started) · in between = behind. Pure &
+ * side-effect-free so it is unit-tested directly.
+ */
+export function computeVhmTier(
+  filled: { asgn: number; midSem: number; endSem: number; project: number; portfolio: number },
+  rosterSize: number,
+): { categoriesDone: number; status: VhmStatus } {
+  const categoriesDone =
+    rosterSize > 0
+      ? [filled.asgn, filled.midSem, filled.endSem, filled.project, filled.portfolio].filter(
+          (c) => c === rosterSize,
+        ).length
+      : 0;
+  const status: VhmStatus =
+    categoriesDone === 5 ? "ready" : categoriesDone === 0 ? "at_risk" : "behind";
+  return { categoriesDone, status };
+}
+
+/**
  * Aggregate ledger completion for the Vice Headmaster progress view (spec §6). One row per
  * teaching assignment (senior_subject_teacher) for the period, LEFT JOINed to progress — so a
  * teacher who has started nothing still appears (§6.1). Per-category counts are computed with
@@ -194,13 +215,8 @@ export async function loadVhmProgress(
       project: a?.project ?? 0,
       portfolio: a?.portfolio ?? 0,
     };
-    // "n/5" = categories every active student has entered (partials don't count — §1.11).
-    const categoriesDone =
-      rosterSize > 0
-        ? [filled.asgn, filled.midSem, filled.endSem, filled.project, filled.portfolio].filter(
-            (c) => c === rosterSize,
-          ).length
-        : 0;
+    // "n/5" and STPSHS tier (§1.7 / §1.11) — the same pure function unit tests exercise.
+    const { categoriesDone, status } = computeVhmTier(filled, rosterSize);
 
     // Last activity across the ledger and the path row.
     const stamps: Date[] = [];
@@ -212,11 +228,6 @@ export async function loadVhmProgress(
     const daysInactive = lastActivityAt
       ? Math.floor((now.getTime() - lastActivityAt.getTime()) / DAY_MS)
       : null;
-
-    // STPSHS tier (§1.7): all five done = ready; none done = at_risk (incl. never-started);
-    // in between = behind. Inactivity is a separate flag (§2) + stale styling, not the tier.
-    const status: VhmStatus =
-      categoriesDone === 5 ? "ready" : categoriesDone === 0 ? "at_risk" : "behind";
 
     const flags: string[] = [];
     if (daysInactive != null && daysInactive >= INACTIVE_DAYS && status !== "ready") {

--- a/omnischools/lib/score-ledger/vhm-progress.ts
+++ b/omnischools/lib/score-ledger/vhm-progress.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNotNull, sql } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, sql } from "drizzle-orm";
 import type { Tx } from "@/lib/db";
 import {
   students,
@@ -52,6 +52,11 @@ const DAY_MS = 86_400_000;
  * `categoriesDone` = categories EVERY active student has entered (partials don't count).
  * Tier: 5/5 = ready · 0/5 = at_risk (incl. never-started) · in between = behind. Pure &
  * side-effect-free so it is unit-tested directly.
+ *
+ * LIMITATION (roster vs enrolment): `rosterSize` is the whole active class. Once elective
+ * subjects exist (only some of a class take a subject), a category could read "partial"
+ * forever because not every class member is enrolled in it. All current subjects are
+ * class-wide; revisit with a per-subject enrolment model (see the follow-up task).
  */
 export function computeVhmTier(
   filled: { asgn: number; midSem: number; endSem: number; project: number; portfolio: number },
@@ -186,12 +191,15 @@ export async function loadVhmProgress(
 
   const pathByCtx = new Map(paths.map((p) => [`${p.classId}:${p.subjectId}`, p]));
 
-  // Resolve teacher names for the assigned teachers.
-  const userIds = new Set(assignments.map((a) => a.teacherUserId));
+  // Resolve teacher names — bounded to the referenced ids (ref_user is a global table).
+  const userIds = Array.from(new Set(assignments.map((a) => a.teacherUserId)));
   const nameById = new Map<string, string | null>();
-  {
-    const rows = await tx.select({ id: users.id, name: users.fullName }).from(users);
-    for (const u of rows) if (userIds.has(u.id)) nameById.set(u.id, u.name);
+  if (userIds.length > 0) {
+    const rows = await tx
+      .select({ id: users.id, name: users.fullName })
+      .from(users)
+      .where(inArray(users.id, userIds));
+    for (const u of rows) nameById.set(u.id, u.name);
   }
 
   const aggByCtx = new Map(
@@ -253,11 +261,14 @@ export async function loadVhmProgress(
 
   // Default sort (§6.1): most-behind first (so the VHM sees who's at risk), then by name.
   const rank: Record<VhmStatus, number> = { at_risk: 0, behind: 1, ready: 2 };
+  // Staleness tiebreak: a never-touched row (null) is the MOST stale — it sorts first among
+  // equals, so a never-started teacher isn't buried under one merely touched today (Quinn).
+  const staleness = (d: number | null) => d ?? Number.MAX_SAFE_INTEGER;
   out.sort(
     (x, y) =>
       rank[x.status] - rank[y.status] ||
       x.categoriesDone - y.categoriesDone ||
-      (y.daysInactive ?? -1) - (x.daysInactive ?? -1) ||
+      staleness(y.daysInactive) - staleness(x.daysInactive) ||
       x.className.localeCompare(y.className) ||
       x.subjectName.localeCompare(y.subjectName),
   );

--- a/omnischools/scripts/verify-score-ledger.ts
+++ b/omnischools/scripts/verify-score-ledger.ts
@@ -11,12 +11,16 @@ import {
   saveDirectLedgerScores,
 } from "@/lib/actions/score-ledger";
 import { db } from "@/lib/db";
+import { withSchool } from "@/lib/db/rls";
+import { loadVhmProgress } from "@/lib/score-ledger/vhm-progress";
 import {
   students,
   subjects,
   classes,
+  users,
   academicPeriod,
   seniorScoreLedger,
+  seniorSubjectTeacher,
   schools,
 } from "@/db/schema";
 
@@ -206,13 +210,54 @@ async function main() {
     `${rA2?.weightedTotal}/${rA2?.status}`,
   );
 
+  // ---------- Item 3: VHM progress (enumerate from assignments) ----------
+  // A fresh assignment with NO ledger activity must still surface as at-risk 0/5 "never" —
+  // the load-bearing correctness point (enumerate from expected, LEFT JOIN progress).
+  const [anyUser] = await db.select({ id: users.id }).from(users).limit(1);
+  const vClass = await createClass({ name: `VHM-${tag}` });
+  const vSub = await createSubject({ name: `VHMsub-${tag}` });
+  const vStu = await createStudent({ firstName: "Vera", lastName: "Vhm", sex: "FEMALE" });
+  if (!vClass.ok || !vSub.ok || !vSub.id || !vStu.ok || !anyUser) {
+    console.error("vhm setup failed");
+    process.exit(1);
+  }
+  await setStudentClass({ studentId: vStu.studentId, classId: vClass.classId });
+  await db.insert(seniorSubjectTeacher).values({
+    schoolId: school.id,
+    classId: vClass.classId,
+    subjectId: vSub.id,
+    teacherUserId: anyUser.id,
+  });
+  const progress = await withSchool(school.id, (tx) =>
+    loadVhmProgress(tx, school.id, periodId, new Date()),
+  );
+  const vhmRow = progress.find(
+    (r) => r.classId === vClass.classId && r.subjectId === vSub.id,
+  );
+  check("VHM: never-started assignment still appears (enumerate from assignments)", !!vhmRow);
+  check(
+    "VHM: never-started → at_risk, 0/5, last activity 'never'",
+    vhmRow?.status === "at_risk" &&
+      vhmRow?.categoriesDone === 0 &&
+      vhmRow?.lastActivityAt == null,
+    `${vhmRow?.status}/${vhmRow?.categoriesDone}/${vhmRow?.lastActivityAt}`,
+  );
+  check(
+    "VHM: row exposes NO score value (completion only, §6.2)",
+    vhmRow != null && !Object.keys(vhmRow).some((k) => /score|weighted|total/i.test(k)),
+    Object.keys(vhmRow ?? {}).join(","),
+  );
+
   // cleanup — students cascade ledger/assessments/scores; then subject, class, path.
   await db.delete(students).where(eq(students.id, s1.studentId));
   await db.delete(students).where(eq(students.id, s2.studentId));
   await db.delete(students).where(eq(students.id, s3.studentId));
   await db.delete(students).where(eq(students.id, stranger.studentId));
+  await db.delete(students).where(eq(students.id, vStu.studentId));
   await db.delete(subjects).where(eq(subjects.id, subjectId));
+  await db.delete(subjects).where(eq(subjects.id, vSub.id));
   await db.delete(classes).where(eq(classes.id, classId));
+  await db.delete(classes).where(eq(classes.id, vClass.classId));
 
   console.log(
     failures === 0


### PR DESCRIPTION
## Senior tier — Score Ledger Item 3: Vice Headmaster Academic progress view

The management read of ledger completion (spec §6), on top of merged Items 1+2. It shows **whether** each teacher has entered each category — **never the score values themselves** (§6.2). Route: **`/senior/academic-progress`**.

### The load-bearing design decision
The view is per *(teacher × class × subject)*, but no subject-teacher assignment existed. Per Lucy's surface map (§D10/§D11) and spec §6.1, the rows must enumerate from **expected assignments LEFT JOINed to progress** — otherwise the most at-risk teachers (never-started) are invisible. So this adds a **`senior_subject_teacher`** assignment table and enumerates from it; a teacher who has done nothing appears as an **at-risk 0/5** row instead of vanishing.

### What's in it
- **Schema:** `senior_subject_teacher` (per school × class × subject → teacher; composite `(school_id,id)` tenant FKs; RLS). Migration **0040**; prod-paste-0040.
- **Aggregation** (`lib/score-ledger/vhm-progress.ts`): per (class×subject) completion is counted with SQL `count(*) filter(…)` so **no `*_score` value is ever selected into app memory** (§6.2). The STPSHS `n/5` = categories every student has entered → tier ready (5/5) / behind / at-risk (0/5, incl. never-started); teacher-inactivity (14+ days) flag; most-behind-first sort (never-started sorts first among at-risk). Pure `computeVhmTier` extracted + unit-tested.
- **UI** (server components): hero, the **§6.2 discipline banner** (non-negotiable), the completion table (path pills A/B/C, cat-dots ✓/◐/—, `Tier · n/5` pill, stale last-activity) reusing the ledger table idioms, and a computed at-risk section. Sidebar gains "Ledger progress" for SENIOR/COMBINED.
- **Seed:** 4 assignments including two never-started ones (to demo the at-risk rows).

### Review gates — all green
- **Quinn (QA):** PASS — confirmed both acceptance criteria (never-started appears as at-risk 0/5; no score value ever shown). MINORs (never-started sort, bounded users query, integration coverage) **fixed** — added `loadVhmProgress` integration assertions incl. an automated §6.2 no-score-field check.
- **Dex (architecture):** APPROVE — "textbook" `senior_subject_teacher`, airtight SQL-count privacy, pure `computeVhmTier`, clean server/client boundary, zero slash-opacity, faithful to the surface map.
- **Sarah (security):** APPROVE — **Score-value exposure to the VHM: NONE**; **Prod RLS parity: PASS**; **Cross-tenant read: BLOCKED**.

### Verification
`pnpm typecheck` ✓ · `pnpm test` (**32 unit**) ✓ · `pnpm build` ✓ · RLS isolation across all **55 tenant tables** ✓ · **`pnpm db:verify-score-ledger` 18/18** ✓ · live preview — 4 combinations render, the two never-started rows visible, `hasScoreValues: "no score values"`, at-risk flags fire.

### ⚠️ Deploy step (required)
After merge, paste **`omnischools/db/sql/prod-paste-0040-senior-subject-teacher.sql`** on prod, or the new tenant table leaks across schools.

### Scope & follow-ups (spawned as tasks)
Deferred, per the surface map: the **Headmaster roll-up** (§6.4 — separate role/surface), the full 5-dimension **filter bar**, and a persisted anomaly-flag-instance table. Two follow-up tasks flagged by the gates: **tier-wide role gating** (the surfaces gate BASIC schools but not roles — inherited from Items 1–3) and **per-subject enrolment for electives** (completion currently assumes whole-class enrolment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
