### PR TITLE
feat(senior): role-gate the SHS surfaces (RBAC)

### DIFF
--- a/omnischools/app/(app)/senior/academic-progress/page.tsx
+++ b/omnischools/app/(app)/senior/academic-progress/page.tsx
@@ -1,7 +1,8 @@
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { asc, eq } from "drizzle-orm";
-import { requireSchool } from "@/lib/auth/server";
+import { requireSchoolRole } from "@/lib/auth/server";
+import { SENIOR_MANAGEMENT_ROLES } from "@/lib/access";
 import { withSchool } from "@/lib/db/rls";
 import { academicPeriod } from "@/db/schema";
 import { loadVhmProgress, type VhmProgressRow } from "@/lib/score-ledger/vhm-progress";
@@ -14,8 +15,9 @@ export default async function AcademicProgressPage({
 }: {
   searchParams: { periodId?: string };
 }) {
-  const { school } = await requireSchool();
-  // Senior-only management surface.
+  // Management-only surface (§6.2 / §D14): Vice Headmaster, Headmaster, Admin.
+  const { school } = await requireSchoolRole(SENIOR_MANAGEMENT_ROLES);
+  // Senior-only.
   if (school.schoolType === "BASIC") redirect("/gradebook");
 
   const periods = await withSchool(school.id, (tx) =>

--- a/omnischools/app/(app)/senior/score-ledger/page.tsx
+++ b/omnischools/app/(app)/senior/score-ledger/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { and, asc, eq, inArray } from "drizzle-orm";
-import { requireSchool } from "@/lib/auth/server";
+import { requireSchoolRole } from "@/lib/auth/server";
+import { SENIOR_LEDGER_ROLES } from "@/lib/access";
 import { withSchool } from "@/lib/db/rls";
 import {
   classes,
@@ -31,7 +32,7 @@ export default async function ScoreLedgerPage({
 }: {
   searchParams: { classId?: string; subjectId?: string; periodId?: string };
 }) {
-  const { school } = await requireSchool();
+  const { school } = await requireSchoolRole(SENIOR_LEDGER_ROLES);
   // Senior-only surface — a Basic (KG · Primary · JHS) school has no score ledger.
   if (school.schoolType === "BASIC") redirect("/gradebook");
 

--- a/omnischools/components/app/sidebar.tsx
+++ b/omnischools/components/app/sidebar.tsx
@@ -21,7 +21,12 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { isFinanceOnly } from "@/lib/access";
+import {
+  isFinanceOnly,
+  hasAnyRole,
+  SENIOR_LEDGER_ROLES,
+  SENIOR_MANAGEMENT_ROLES,
+} from "@/lib/access";
 
 const NAV: { href: string; label: string; Icon: LucideIcon }[] = [
   { href: "/dashboard", label: "Dashboard", Icon: LayoutDashboard },
@@ -49,8 +54,18 @@ const TIER: Record<string, string> = {
 /** Senior (SHS) tier only — inserted after Gradebook. The teacher's score ledger and the
  * Vice Headmaster's completion view. */
 const SENIOR_ITEMS = [
-  { href: "/senior/score-ledger", label: "Score ledger", Icon: NotebookText },
-  { href: "/senior/academic-progress", label: "Ledger progress", Icon: Gauge },
+  {
+    href: "/senior/score-ledger",
+    label: "Score ledger",
+    Icon: NotebookText,
+    roles: SENIOR_LEDGER_ROLES,
+  },
+  {
+    href: "/senior/academic-progress",
+    label: "Ledger progress",
+    Icon: Gauge,
+    roles: SENIOR_MANAGEMENT_ROLES,
+  },
 ];
 
 /** Finance-only (Accountant/Bursar) nav — billing first, then read-only students/classes. */
@@ -89,8 +104,15 @@ export function AppSidebar({
   // Senior (SHS) and Combined schools get the Score ledger item after Gradebook.
   const isSenior =
     school.schoolType === "SENIOR" || school.schoolType === "COMBINED";
+  // Senior items are further gated by role — a teacher sees the ledger but not the
+  // management progress view; a student/parent sees neither.
+  const seniorItems = SENIOR_ITEMS.filter((i) => hasAnyRole(user.roles, i.roles));
   const fullNav = isSenior
-    ? NAV.flatMap((n) => (n.href === "/gradebook" ? [n, ...SENIOR_ITEMS] : [n]))
+    ? NAV.flatMap((n) =>
+        n.href === "/gradebook"
+          ? [n, ...seniorItems.map(({ href, label, Icon }) => ({ href, label, Icon }))]
+          : [n],
+      )
     : NAV;
   // Finance-only staff see a billing-focused nav; everyone else sees the full set.
   const nav = isFinanceOnly(user.roles)

--- a/omnischools/lib/access.test.ts
+++ b/omnischools/lib/access.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import {
+  hasAnyRole,
+  isFinanceOnly,
+  SENIOR_LEDGER_ROLES,
+  SENIOR_MANAGEMENT_ROLES,
+} from "./access";
+
+describe("hasAnyRole", () => {
+  it("is true when any held role is allowed", () => {
+    expect(hasAnyRole(["TEACHER", "FORM_MASTER"], SENIOR_LEDGER_ROLES)).toBe(true);
+  });
+  it("is false when no held role is allowed", () => {
+    expect(hasAnyRole(["STUDENT"], SENIOR_LEDGER_ROLES)).toBe(false);
+  });
+  it("is false for an empty role set", () => {
+    expect(hasAnyRole([], SENIOR_MANAGEMENT_ROLES)).toBe(false);
+  });
+});
+
+describe("Senior role groups — the security boundary", () => {
+  it("STUDENT and PARENT reach NEITHER senior surface", () => {
+    for (const role of ["STUDENT", "PARENT"]) {
+      expect(hasAnyRole([role], SENIOR_LEDGER_ROLES)).toBe(false);
+      expect(hasAnyRole([role], SENIOR_MANAGEMENT_ROLES)).toBe(false);
+    }
+  });
+  it("a TEACHER uses the ledger but NOT the management progress view", () => {
+    expect(hasAnyRole(["TEACHER"], SENIOR_LEDGER_ROLES)).toBe(true);
+    expect(hasAnyRole(["TEACHER"], SENIOR_MANAGEMENT_ROLES)).toBe(false);
+  });
+  it("the Vice Headmaster / Headmaster / Admin reach the management view", () => {
+    for (const role of ["VICE_HEADMASTER_ACADEMIC", "HEADMASTER", "ADMIN"]) {
+      expect(hasAnyRole([role], SENIOR_MANAGEMENT_ROLES)).toBe(true);
+      expect(hasAnyRole([role], SENIOR_LEDGER_ROLES)).toBe(true);
+    }
+  });
+  it("a finance-only user is unaffected by the senior groups (separate concern)", () => {
+    expect(isFinanceOnly(["BURSAR"])).toBe(true);
+    expect(hasAnyRole(["BURSAR"], SENIOR_LEDGER_ROLES)).toBe(false);
+  });
+});

--- a/omnischools/lib/access.ts
+++ b/omnischools/lib/access.ts
@@ -13,6 +13,31 @@
 /** Roles that, on their own, restrict a user to the finance sections. */
 export const FINANCE_ROLES = ["ACCOUNTANT", "BURSAR"];
 
+/**
+ * Senior (SHS) tier role groups. The score ledger is a teaching surface; the Vice
+ * Headmaster progress view is management-only. STUDENT / PARENT never reach either.
+ */
+export const SENIOR_LEDGER_ROLES = [
+  "ADMIN",
+  "HEADMASTER",
+  "VICE_HEADMASTER_ACADEMIC",
+  "TEACHER",
+  "FORM_MASTER",
+];
+export const SENIOR_MANAGEMENT_ROLES = [
+  "ADMIN",
+  "HEADMASTER",
+  "VICE_HEADMASTER_ACADEMIC",
+];
+
+/** True when the user holds at least one of the allowed roles. */
+export function hasAnyRole(
+  roles: readonly string[],
+  allowed: readonly string[],
+): boolean {
+  return roles.some((r) => allowed.includes(r));
+}
+
 /** Section prefixes a finance-only user may reach. Order-independent. */
 export const FINANCE_SECTIONS = [
   "/billing",

--- a/omnischools/lib/access.ts
+++ b/omnischools/lib/access.ts
@@ -9,13 +9,16 @@
  *
  * Pure module — safe to import from both client (sidebar) and server (guards).
  */
+import type { KnownAppRole } from "@/lib/auth";
 
 /** Roles that, on their own, restrict a user to the finance sections. */
 export const FINANCE_ROLES = ["ACCOUNTANT", "BURSAR"];
 
 /**
- * Senior (SHS) tier role groups. The score ledger is a teaching surface; the Vice
- * Headmaster progress view is management-only. STUDENT / PARENT never reach either.
+ * Senior (SHS) tier role groups. The score ledger is a teaching surface (teachers + form
+ * masters + academic leadership); the Vice Headmaster progress view is management-only
+ * (Admin, Headmaster, Vice Headmaster Academic). STUDENT / PARENT never reach either.
+ * `satisfies readonly KnownAppRole[]` makes a typo'd role code a compile error.
  */
 export const SENIOR_LEDGER_ROLES = [
   "ADMIN",
@@ -23,12 +26,12 @@ export const SENIOR_LEDGER_ROLES = [
   "VICE_HEADMASTER_ACADEMIC",
   "TEACHER",
   "FORM_MASTER",
-];
+] as const satisfies readonly KnownAppRole[];
 export const SENIOR_MANAGEMENT_ROLES = [
   "ADMIN",
   "HEADMASTER",
   "VICE_HEADMASTER_ACADEMIC",
-];
+] as const satisfies readonly KnownAppRole[];
 
 /** True when the user holds at least one of the allowed roles. */
 export function hasAnyRole(

--- a/omnischools/lib/actions/score-ledger.ts
+++ b/omnischools/lib/actions/score-ledger.ts
@@ -3,7 +3,8 @@ import { and, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 import { withSchool } from "@/lib/db/rls";
 import { recordAudit } from "@/lib/db/audit";
-import { requireSchool, resolveActor } from "@/lib/auth/server";
+import { requireSchool, resolveActor, assertAnyRole } from "@/lib/auth/server";
+import { SENIOR_LEDGER_ROLES } from "@/lib/access";
 import { safeRevalidate } from "@/lib/revalidate";
 import { round2 } from "@/lib/gradebook-helpers";
 import type { Tx } from "@/lib/db";
@@ -257,6 +258,7 @@ export async function createSeniorAssessment(
   input: unknown,
 ): Promise<CreateAssessmentResult> {
   const { school } = await requireSchool();
+  await assertAnyRole(SENIOR_LEDGER_ROLES);
   const parsed = CreateAssessmentSchema.safeParse(input);
   if (!parsed.success) {
     return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid assessment." };
@@ -306,6 +308,7 @@ export async function deleteSeniorAssessment(
   input: unknown,
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   const { school } = await requireSchool();
+  await assertAnyRole(SENIOR_LEDGER_ROLES);
   const parsed = DeleteAssessmentSchema.safeParse(input);
   if (!parsed.success) return { ok: false, error: "Invalid input." };
   const actor = await resolveActor(school.id);
@@ -397,6 +400,7 @@ export type SaveMarksResult = { ok: true; saved: number } | { ok: false; error: 
 
 export async function saveAssessmentScores(input: unknown): Promise<SaveMarksResult> {
   const { school } = await requireSchool();
+  await assertAnyRole(SENIOR_LEDGER_ROLES);
   const parsed = SaveMarksSchema.safeParse(input);
   if (!parsed.success) {
     return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid scores." };
@@ -527,6 +531,7 @@ export type SavePortfolioResult =
  */
 export async function savePortfolioScores(input: unknown): Promise<SavePortfolioResult> {
   const { school } = await requireSchool();
+  await assertAnyRole(SENIOR_LEDGER_ROLES);
   const parsed = SavePortfolioSchema.safeParse(input);
   if (!parsed.success) {
     return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid scores." };
@@ -625,6 +630,7 @@ export type SetPathResult = { ok: true } | { ok: false; error: string };
 /** Choose the capture path for a (class × subject × period). Switchable per spec §4.4. */
 export async function setLedgerPath(input: unknown): Promise<SetPathResult> {
   const { school } = await requireSchool();
+  await assertAnyRole(SENIOR_LEDGER_ROLES);
   const parsed = SetPathSchema.safeParse(input);
   if (!parsed.success) return { ok: false, error: "Invalid path." };
   const d = parsed.data;
@@ -711,6 +717,7 @@ function parseCat(v: string): number | null | "invalid" {
  */
 export async function saveDirectLedgerScores(input: unknown): Promise<SaveDirectResult> {
   const { school } = await requireSchool();
+  await assertAnyRole(SENIOR_LEDGER_ROLES);
   const parsed = SaveDirectSchema.safeParse(input);
   if (!parsed.success) {
     return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid scores." };

--- a/omnischools/lib/auth/server.ts
+++ b/omnischools/lib/auth/server.ts
@@ -4,8 +4,13 @@ import { eq, and } from "drizzle-orm";
 import { env } from "@/lib/env";
 import { withoutTenantScope } from "@/lib/db/rls";
 import { schools, roleAssignments, roles, users, districts, regions } from "@/db/schema";
-import { getCurrentUser, type AppUser } from "@/lib/auth";
-import { isFinanceOnly, pathAllowedForFinance, FINANCE_HOME } from "@/lib/access";
+import { getCurrentUser, type AppUser, type AppRole } from "@/lib/auth";
+import {
+  isFinanceOnly,
+  pathAllowedForFinance,
+  FINANCE_HOME,
+  hasAnyRole,
+} from "@/lib/access";
 
 export interface ActiveSchool {
   id: string;
@@ -103,6 +108,31 @@ export async function assertWriteAccess(): Promise<void> {
   const user = await getCurrentUser();
   if (user && isFinanceOnly(user.roles)) {
     throw new Error("Forbidden: your role has read-only access to this record.");
+  }
+}
+
+/**
+ * Page guard: ensure a signed-in user + resolvable school AND that the user holds at least
+ * one of the allowed roles, else redirect to their dashboard. For role-restricted surfaces
+ * (the Senior score ledger — teaching; the Vice Headmaster progress view — management).
+ * Extends requireSchool, so the finance-only confinement still applies underneath.
+ */
+export async function requireSchoolRole(
+  allowed: readonly AppRole[],
+): Promise<{ user: AppUser; school: ActiveSchool }> {
+  const { user, school } = await requireSchool();
+  if (!hasAnyRole(user.roles, allowed)) redirect("/dashboard");
+  return { user, school };
+}
+
+/**
+ * Action guard: throw unless the current user holds one of the allowed roles. Call at the
+ * top of a mutating server action so STUDENT/PARENT (and other unlisted roles) cannot POST it.
+ */
+export async function assertAnyRole(allowed: readonly AppRole[]): Promise<void> {
+  const user = await getCurrentUser();
+  if (!user || !hasAnyRole(user.roles, allowed)) {
+    throw new Error("Forbidden: your role cannot perform this action.");
   }
 }
 


### PR DESCRIPTION
## Senior tier — role-gate the SHS surfaces (RBAC)

Closes the tier-wide security-posture gap Sarah (security) and Quinn (QA) flagged during the Item 3 gate (and Lucy's map §D14): the Senior pages gated only **BASIC schools**, not **roles** — so any authenticated user of a SENIOR/COMBINED school (including a **STUDENT or PARENT**) could open the management surfaces or POST the ledger actions.

### What it does
- **Role groups** (`lib/access.ts`, the pure client+server module): `SENIOR_LEDGER_ROLES` (Admin / Headmaster / Vice Headmaster / Teacher / Form Master — the teaching surface) and `SENIOR_MANAGEMENT_ROLES` (Admin / Headmaster / Vice Headmaster — management only), typed `as const satisfies readonly KnownAppRole[]` so a typo'd code fails compilation. Single source of truth.
- **Page guard** `requireSchoolRole(allowed)` (redirects to `/dashboard`) — wraps the existing `requireSchool` so finance-only confinement still applies underneath.
- **Action guard** `assertAnyRole(allowed)` (throws) — mirrors the existing `assertWriteAccess`.
- Applied: `/senior/score-ledger` → teaching roles; `/senior/academic-progress` (the VHM view) → management roles; **all six mutating ledger actions** assert teaching roles (the real boundary — a direct POST is blocked, not just the page); the sidebar filters the two senior items by role (UX/defense-in-depth).

### Review gates — both green
- **Sarah (security, her flagged issue):** APPROVE — "All 6 ledger actions role-guarded: YES · STUDENT/PARENT blocked from management view + actions: YES · Legitimate roles unaffected: YES." Both attack traces (STUDENT opening the page → redirect before any read; STUDENT POSTing the action → throw before parse/DB) blocked; finance confinement untouched.
- **Dex (architecture):** APPROVE — genuine reuse (extends `requireSchool`/`assertWriteAccess`, role groups in the pure module), complete + consistent action coverage, clean sidebar typing. Two MINORs (const typing + doc comment) applied.

### Verification
`pnpm typecheck` ✓ · `pnpm test` (**39 unit**) ✓ — incl. **7 role-boundary tests** proving STUDENT/PARENT reach neither surface, TEACHER gets the ledger but not the management view, and a finance-only user is unaffected · `pnpm build` ✓ · `db:verify-score-ledger` 18/18 ✓ (ADMIN dev-bypass still clears the guards) · both pages return **200** for the ADMIN dev user (no regression).

### Note
Applies uniformly across Items 1–3 (already merged). No schema change, no prod-paste needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
