### PR TITLE
feat(senior): Score Ledger Item 4 — Path B scan-and-extract (transient, Haiku 4.5)

### DIFF
--- a/omnischools/app/(app)/senior/score-ledger/page.tsx
+++ b/omnischools/app/(app)/senior/score-ledger/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { redirect } from "next/navigation";
 import { and, asc, eq, inArray } from "drizzle-orm";
 import { requireSchoolRole } from "@/lib/auth/server";
@@ -306,6 +307,30 @@ export default async function ScoreLedgerPage({
               </div>
             </div>
           </div>
+
+          {/* Path B — scan a paper ledger page; extract, verify and commit on the /scan screen. */}
+          {data.path === "SCAN_EXTRACT" && (
+            <section className="rounded-[14px] border border-gold-soft bg-gold-bg p-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <h2 className="font-display text-lg font-semibold text-navy">
+                    Scan your paper ledger · <em className="italic text-gold">Path B</em>
+                  </h2>
+                  <p className="mt-1 max-w-xl text-[12.5px] text-navy-2">
+                    Photograph a page of your paper book; Omnischools reads the five category scores and
+                    you verify each one before it commits. The photo is read once and discarded — never
+                    saved.
+                  </p>
+                </div>
+                <Link
+                  href={`/senior/score-ledger/scan?classId=${classId}&subjectId=${subjectId}&periodId=${periodId}`}
+                  className="rounded-md bg-navy px-5 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep"
+                >
+                  Scan a ledger page →
+                </Link>
+              </div>
+            </section>
+          )}
 
           {/* Path A only — record assessments; the ledger above recompiles on save.
               Path C enters the five categories directly in the grid above (no events). */}

--- a/omnischools/app/(app)/senior/score-ledger/scan/page.tsx
+++ b/omnischools/app/(app)/senior/score-ledger/scan/page.tsx
@@ -1,0 +1,249 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { and, asc, eq, inArray } from "drizzle-orm";
+import { requireSchoolRole } from "@/lib/auth/server";
+import { SENIOR_LEDGER_ROLES } from "@/lib/access";
+import { withSchool } from "@/lib/db/rls";
+import {
+  classes,
+  subjects,
+  students,
+  academicPeriod,
+  seniorLedgerPath,
+  seniorScoreLedger,
+  assessmentWeights,
+} from "@/db/schema";
+import {
+  resolveWeights,
+  type CategoryScores,
+  type CategoryWeights,
+} from "@/lib/score-ledger/compute";
+import { ScanWorkspace, type RosterEntry } from "@/components/senior/scan-workspace";
+
+export const dynamic = "force-dynamic";
+
+const numOrNull = (v: string | null) => (v == null ? null : Number(v));
+
+export default async function ScanPage({
+  searchParams,
+}: {
+  searchParams: { classId?: string; subjectId?: string; periodId?: string };
+}) {
+  const { school } = await requireSchoolRole(SENIOR_LEDGER_ROLES);
+  if (school.schoolType === "BASIC") redirect("/gradebook");
+
+  const { classId, subjectId, periodId } = searchParams;
+  const backHref = "/senior/score-ledger";
+  const ctxHref =
+    classId && subjectId && periodId
+      ? `${backHref}?classId=${classId}&subjectId=${subjectId}&periodId=${periodId}`
+      : backHref;
+
+  if (!classId || !subjectId || !periodId) {
+    return (
+      <div className="mx-auto max-w-page">
+        <BackLink href={backHref} />
+        <div className="rounded-xl border border-dashed border-border-2 bg-surface p-12 text-center text-sm text-navy-3">
+          Choose a class, subject and semester on the score ledger first.
+        </div>
+      </div>
+    );
+  }
+
+  const data = await withSchool(school.id, async (tx) => {
+    const [cls] = await tx
+      .select({ name: classes.name })
+      .from(classes)
+      .where(and(eq(classes.schoolId, school.id), eq(classes.id, classId)));
+    const [sub] = await tx
+      .select({ name: subjects.name })
+      .from(subjects)
+      .where(and(eq(subjects.schoolId, school.id), eq(subjects.id, subjectId)));
+    const [period] = await tx
+      .select({ label: academicPeriod.periodLabel, closedAt: academicPeriod.closedAt })
+      .from(academicPeriod)
+      .where(and(eq(academicPeriod.schoolId, school.id), eq(academicPeriod.periodId, periodId)));
+    const [pathRow] = await tx
+      .select({ path: seniorLedgerPath.path })
+      .from(seniorLedgerPath)
+      .where(
+        and(
+          eq(seniorLedgerPath.schoolId, school.id),
+          eq(seniorLedgerPath.classId, classId),
+          eq(seniorLedgerPath.subjectId, subjectId),
+          eq(seniorLedgerPath.periodId, periodId),
+        ),
+      );
+    const roster = await tx
+      .select({
+        id: students.id,
+        firstName: students.firstName,
+        lastName: students.lastName,
+        code: students.studentCode,
+      })
+      .from(students)
+      .where(
+        and(
+          eq(students.schoolId, school.id),
+          eq(students.classId, classId),
+          eq(students.status, "ACTIVE"),
+        ),
+      )
+      .orderBy(asc(students.lastName));
+    const weightRows = await tx
+      .select()
+      .from(assessmentWeights)
+      .where(eq(assessmentWeights.schoolId, school.id));
+    const ids = roster.map((r) => r.id);
+    const ledger = ids.length
+      ? await tx
+          .select()
+          .from(seniorScoreLedger)
+          .where(
+            and(
+              eq(seniorScoreLedger.schoolId, school.id),
+              eq(seniorScoreLedger.subjectId, subjectId),
+              eq(seniorScoreLedger.periodId, periodId),
+              inArray(seniorScoreLedger.studentId, ids),
+            ),
+          )
+      : [];
+    return {
+      cls,
+      sub,
+      period,
+      path: pathRow?.path ?? "AUTO_COMPILE",
+      roster,
+      weightRows,
+      ledger,
+    };
+  });
+
+  const subjectName = data.sub?.name ?? "this subject";
+  const className = data.cls?.name ?? "this class";
+  const termLabel = data.period?.label ?? "this semester";
+  const isClosed = !!data.period?.closedAt;
+
+  if (data.path !== "SCAN_EXTRACT") {
+    return (
+      <div className="mx-auto max-w-page">
+        <BackLink href={ctxHref} />
+        <Head className={className} subject={subjectName} />
+        <div className="rounded-xl border border-dashed border-border-2 bg-surface p-12 text-center text-sm text-navy-3">
+          This class isn&apos;t on the scan path. Choose{" "}
+          <span className="font-semibold text-navy">Scan my paper ledger (Path B)</span> on the score
+          ledger to photograph and verify a paper page.
+        </div>
+      </div>
+    );
+  }
+
+  const toW = (r: (typeof data.weightRows)[number]): CategoryWeights => ({
+    asgn: r.asgnWeight,
+    midSem: r.midSemWeight,
+    endSem: r.endSemWeight,
+    project: r.projectWeight,
+    portfolio: r.portfolioWeight,
+  });
+  const subjectWeightRow = data.weightRows.find((r) => r.subjectId === subjectId);
+  const defaultWeightRow = data.weightRows.find((r) => r.subjectId === null);
+  const weights = resolveWeights(
+    subjectWeightRow ? toW(subjectWeightRow) : null,
+    defaultWeightRow ? toW(defaultWeightRow) : null,
+  );
+
+  const roster: RosterEntry[] = data.roster.map((r) => ({
+    id: r.id,
+    name: `${r.firstName} ${r.lastName}`,
+    code: r.code,
+  }));
+  const committed: Record<string, CategoryScores> = {};
+  for (const l of data.ledger) {
+    committed[l.studentId] = {
+      asgn: numOrNull(l.asgnScore),
+      midSem: numOrNull(l.midSemScore),
+      endSem: numOrNull(l.endSemScore),
+      project: numOrNull(l.projectScore),
+      portfolio: numOrNull(l.portfolioScore),
+    };
+  }
+
+  return (
+    <div className="mx-auto max-w-page">
+      <BackLink href={ctxHref} />
+      <Head className={className} subject={subjectName} term={termLabel} />
+
+      {/* Verify-first contract (spec §4.2) + transient-image note — non-negotiable. */}
+      <div className="mb-5 grid grid-cols-[auto_1fr] gap-3 rounded-xl border border-gold-soft bg-gold-bg px-[22px] py-4">
+        <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-gold font-display text-lg italic text-navy">
+          i
+        </span>
+        <p className="text-[12.5px] leading-relaxed text-navy-2">
+          <strong className="text-navy">We save you the typing; you confirm the read.</strong>{" "}
+          Omnischools reads your ledger photo and fills in what it can. Cells it is unsure of are{" "}
+          <span className="rounded bg-warn-bg px-1 font-semibold text-warn">shaded and marked ?</span>{" "}
+          — check those first. The photo stays in your browser, is read once, and is discarded when you
+          commit — it is never saved.
+        </p>
+      </div>
+
+      {isClosed && (
+        <div className="mb-5 rounded-xl border border-terra bg-terra-bg px-4 py-3 text-sm text-terra">
+          {termLabel} is closed — its scores are final. Reopen the semester in Settings → Academic to
+          scan a new page.
+        </div>
+      )}
+
+      {roster.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border-2 bg-surface p-12 text-center text-sm text-navy-3">
+          No students in this class yet.
+        </div>
+      ) : (
+        <ScanWorkspace
+          classId={classId}
+          subjectId={subjectId}
+          periodId={periodId}
+          roster={roster}
+          committed={committed}
+          weights={weights}
+          isClosed={isClosed}
+          ledgerHref={ctxHref}
+        />
+      )}
+    </div>
+  );
+}
+
+function BackLink({ href }: { href: string }) {
+  return (
+    <Link
+      href={href}
+      className="mb-4 inline-flex items-center gap-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-gold"
+    >
+      ← Back to score ledger
+    </Link>
+  );
+}
+
+function Head({
+  className,
+  subject,
+  term,
+}: {
+  className: string;
+  subject: string;
+  term?: string;
+}) {
+  return (
+    <div className="mb-5">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gold">
+        Senior · {subject} · {className}
+        {term ? ` · ${term}` : ""} · Scan &amp; extract
+      </div>
+      <h1 className="mt-1 font-display text-3xl font-semibold text-navy">
+        End-of-semester upload · <em className="italic text-gold">verify the read.</em>
+      </h1>
+      <div className="mb-3 mt-2 h-0.5 w-16 bg-gold" />
+    </div>
+  );
+}

--- a/omnischools/app/api/senior/ledger-extract/route.ts
+++ b/omnischools/app/api/senior/ledger-extract/route.ts
@@ -1,0 +1,156 @@
+import { and, asc, eq } from "drizzle-orm";
+import { z } from "zod";
+import { requireSchool, assertAnyRole } from "@/lib/auth/server";
+import { SENIOR_LEDGER_ROLES } from "@/lib/access";
+import { withSchool } from "@/lib/db/rls";
+import {
+  students,
+  academicPeriod,
+  seniorLedgerPath,
+  assessmentWeights,
+} from "@/db/schema";
+import { resolveDenominators, type CategoryDenominators } from "@/lib/score-ledger/compute";
+import { scaleExtractedCell } from "@/lib/score-ledger/scan-diff";
+import { getLedgerExtractor, type ScanExtraction } from "@/lib/ocr";
+
+// The extractor may call Claude over the network (Node fetch); never run on the edge.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// ~9 MB of base64 — a generous ceiling for one ledger photo; a larger upload is rejected up
+// front. The image lives ONLY in this request: it is forwarded to the extractor and discarded
+// when the handler returns. Nothing writes it to storage, a column, a temp file, or a log.
+const MAX_IMAGE_CHARS = 12_000_000;
+
+const Body = z.object({
+  classId: z.string().uuid(),
+  subjectId: z.string().uuid(),
+  periodId: z.string().uuid(),
+  imageDataUrl: z
+    .string()
+    .max(MAX_IMAGE_CHARS, "That photo is too large — use a smaller or more compressed image.")
+    .regex(/^data:image\/[a-zA-Z0-9.+-]+;base64,/, "Attach a photo of the ledger page."),
+});
+
+type CatKey = "asgn" | "midSem" | "endSem" | "project" | "portfolio";
+const CAT_KEYS: CatKey[] = ["asgn", "midSem", "endSem", "project", "portfolio"];
+
+/**
+ * POST /api/senior/ledger-extract — Path B step 1 (owner ruling 1/3). Our own server route
+ * proxies the in-memory base64 photo to Claude Vision (Haiku 4.5, server-held key) and returns
+ * the extracted five-category grid with a per-cell confidence, each raw read already scaled to
+ * 0–100 by its category's school-defined denominator. The image is NEVER persisted — no table,
+ * no column, no bucket, no temp file, and it is not echoed into any log or the error path.
+ */
+export async function POST(req: Request) {
+  const { school } = await requireSchool();
+  await assertAnyRole(SENIOR_LEDGER_ROLES);
+
+  const json = await req.json().catch(() => null);
+  const parsed = Body.safeParse(json);
+  if (!parsed.success) {
+    return Response.json(
+      { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid upload." },
+      { status: 400 },
+    );
+  }
+  const { classId, subjectId, periodId, imageDataUrl } = parsed.data;
+
+  const ctx = await withSchool(school.id, async (tx) => {
+    const [pathRow] = await tx
+      .select({ path: seniorLedgerPath.path })
+      .from(seniorLedgerPath)
+      .where(
+        and(
+          eq(seniorLedgerPath.schoolId, school.id),
+          eq(seniorLedgerPath.classId, classId),
+          eq(seniorLedgerPath.subjectId, subjectId),
+          eq(seniorLedgerPath.periodId, periodId),
+        ),
+      );
+    const [period] = await tx
+      .select({ closedAt: academicPeriod.closedAt })
+      .from(academicPeriod)
+      .where(
+        and(eq(academicPeriod.schoolId, school.id), eq(academicPeriod.periodId, periodId)),
+      );
+    const roster = await tx
+      .select({
+        id: students.id,
+        firstName: students.firstName,
+        lastName: students.lastName,
+      })
+      .from(students)
+      .where(
+        and(
+          eq(students.schoolId, school.id),
+          eq(students.classId, classId),
+          eq(students.status, "ACTIVE"),
+        ),
+      )
+      .orderBy(asc(students.lastName));
+    const weightRows = await tx
+      .select()
+      .from(assessmentWeights)
+      .where(eq(assessmentWeights.schoolId, school.id));
+    return { path: pathRow?.path ?? "AUTO_COMPILE", closed: !!period?.closedAt, roster, weightRows };
+  });
+
+  if (ctx.path !== "SCAN_EXTRACT") {
+    return Response.json(
+      { ok: false, error: "Switch this class to Scan & extract (Path B) first." },
+      { status: 409 },
+    );
+  }
+  if (ctx.closed) {
+    return Response.json(
+      { ok: false, error: "This semester is closed — its scores are final." },
+      { status: 409 },
+    );
+  }
+  if (ctx.roster.length === 0) {
+    return Response.json({ ok: false, error: "No students in this class yet." }, { status: 409 });
+  }
+
+  // Resolve the five denominators (subject → school default → system 100), same two rows the
+  // weight resolver uses — the denominators are columns on those very ref_assessment_weights rows.
+  const toD = (r: (typeof ctx.weightRows)[number]): CategoryDenominators => ({
+    asgn: r.asgnDenominator,
+    midSem: r.midSemDenominator,
+    endSem: r.endSemDenominator,
+    project: r.projectDenominator,
+    portfolio: r.portfolioDenominator,
+  });
+  const subjectRow = ctx.weightRows.find((r) => r.subjectId === subjectId);
+  const defaultRow = ctx.weightRows.find((r) => r.subjectId === null);
+  const denom = resolveDenominators(
+    subjectRow ? toD(subjectRow) : null,
+    defaultRow ? toD(defaultRow) : null,
+  );
+
+  let extraction: ScanExtraction;
+  try {
+    const extractor = await getLedgerExtractor();
+    extraction = await extractor.extract({
+      imageDataUrl,
+      roster: ctx.roster.map((r) => ({ id: r.id, name: `${r.firstName} ${r.lastName}` })),
+    });
+  } catch {
+    // Q7 / H1: extraction failure degrades to a blank Path-C grid in place on the client. We
+    // return a soft failure (no image retained, nothing logged) — the caller shows the empty grid.
+    return Response.json({ ok: false, error: "extract_failed" }, { status: 200 });
+  }
+
+  // Scale each raw read to 0–100 by its category denominator (raw 8 under /10 → 80). The client
+  // bands by confidence and diffs against the committed row; both work in this 0–100 space.
+  const rows = extraction.rows.map((row) => {
+    const cells = {} as Record<CatKey, { raw: number | null; value: number | null; confidence: number }>;
+    for (const k of CAT_KEYS) {
+      const c = row.cells[k];
+      cells[k] = { raw: c.value, value: scaleExtractedCell(c.value, denom[k]), confidence: c.confidence };
+    }
+    return { readName: row.readName, studentId: row.studentId, cells };
+  });
+
+  return Response.json({ ok: true, rows });
+}

--- a/omnischools/components/senior/path-chooser.tsx
+++ b/omnischools/components/senior/path-chooser.tsx
@@ -29,7 +29,7 @@ const PATHS: {
     letter: "B",
     name: "Scan my paper ledger",
     desc: "I keep a paper book; photograph it and Omnischools extracts the scores. I verify cell-by-cell.",
-    available: false,
+    available: true,
   },
   {
     path: "DIRECT_ENTRY",

--- a/omnischools/components/senior/scan-workspace.tsx
+++ b/omnischools/components/senior/scan-workspace.tsx
@@ -1,0 +1,802 @@
+"use client";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { commitScanLedger } from "@/lib/actions/score-ledger";
+import { provisionalTotal, type CategoryScores, type CategoryWeights } from "@/lib/score-ledger/compute";
+import {
+  bandCell,
+  diffCell,
+  reasonRequiredForCommit,
+  mapRosterRows,
+  type CellBand,
+  type ExtractedNameRow,
+} from "@/lib/score-ledger/scan-diff";
+
+/**
+ * Path B verify-first workspace (INCR-2). The whole flow is client-held and TRANSIENT: the photo
+ * becomes an in-memory object URL, its base64 is POSTed to /api/senior/ledger-extract (server-held
+ * key), the extracted grid comes back, the teacher confirms the roster mapping + every low-confidence
+ * cell + every diff, and commit writes senior_score_ledger. The image is released on commit and on
+ * unmount — it is never persisted anywhere (owner ruling 3 / G1–G4). Nothing here writes the photo to
+ * storage, a field, or a log; the only network calls are the extract POST (image out) and the commit
+ * (numbers only — no image).
+ */
+
+type CatKey = "asgn" | "midSem" | "endSem" | "project" | "portfolio";
+const CATS: { key: CatKey; label: string; cls: string }[] = [
+  { key: "asgn", label: "Asg", cls: "text-green" },
+  { key: "midSem", label: "MS", cls: "text-navy-2" },
+  { key: "endSem", label: "ES", cls: "text-navy-2" },
+  { key: "project", label: "Pj", cls: "text-green" },
+  { key: "portfolio", label: "Pf", cls: "text-terra" },
+];
+const CAT_FULL: Record<CatKey, string> = {
+  asgn: "Assignment",
+  midSem: "Mid-sem",
+  endSem: "End-of-sem",
+  project: "Project",
+  portfolio: "Portfolio",
+};
+const REASONS: { code: string; label: string }[] = [
+  { code: "RE_GRADED", label: "Re-graded" },
+  { code: "TRANSCRIPTION_ERROR", label: "Transcription error" },
+  { code: "OTHER", label: "Other (add a note)" },
+];
+
+type ExtractCell = { raw: number | null; value: number | null; confidence: number };
+type ExtractRow = { readName: string; studentId: string | null; cells: Record<CatKey, ExtractCell> };
+export type RosterEntry = { id: string; name: string; code: string };
+
+const key = (id: string, k: CatKey) => `${id}:${k}`;
+const num = (v: string | undefined): number | null => {
+  if (v == null || v.trim() === "") return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+};
+
+const goldInput =
+  "w-14 rounded-md border border-gold-soft bg-gold-bg px-1.5 py-1 text-center font-mono text-[12px] font-bold text-navy outline-none focus:border-gold";
+const warnInput =
+  "w-14 rounded-md border border-warn bg-warn-bg px-1.5 py-1 text-center font-mono text-[12px] font-bold text-warn outline-none focus:border-gold";
+const emptyInput =
+  "w-14 rounded-md border border-border-2 bg-bg px-1.5 py-1 text-center font-mono text-[12px] text-border-2 outline-none focus:border-gold";
+
+export function ScanWorkspace({
+  classId,
+  subjectId,
+  periodId,
+  roster,
+  committed,
+  weights,
+  isClosed,
+  ledgerHref,
+}: {
+  classId: string;
+  subjectId: string;
+  periodId: string;
+  roster: RosterEntry[];
+  /** Current committed 0–100 ledger values per student — the diff baseline (Kofi Q1). */
+  committed: Record<string, CategoryScores>;
+  weights: CategoryWeights;
+  isClosed: boolean;
+  ledgerHref: string;
+}) {
+  const router = useRouter();
+  const fileRef = useRef<HTMLInputElement>(null);
+  const appendRef = useRef(false); // true when the next upload adds a page to the current set
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [phase, setPhase] = useState<"idle" | "busy" | "verify">("idle");
+  const [pageCount, setPageCount] = useState(0);
+  const [extractOk, setExtractOk] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Verify-phase state.
+  const [rows, setRows] = useState<ExtractRow[]>([]);
+  const [assign, setAssign] = useState<string[]>([]); // per extraction row: studentId | "" | "__discard__"
+  const [mappingConfirmed, setMappingConfirmed] = useState(false);
+  const [cellVals, setCellVals] = useState<Record<string, string>>({});
+  const [bands, setBands] = useState<Record<string, CellBand>>({});
+  const [reviewed, setReviewed] = useState<Set<string>>(new Set());
+  const [reasons, setReasons] = useState<Record<string, { code: string; note: string }>>({});
+  const [committing, setCommitting] = useState(false);
+
+  // Release the in-memory image on unmount (transient guarantee — G4).
+  useEffect(() => {
+    return () => {
+      if (imageUrl) URL.revokeObjectURL(imageUrl);
+    };
+  }, [imageUrl]);
+
+  const rosterById = useMemo(() => new Map(roster.map((r) => [r.id, r])), [roster]);
+  const committedFor = (id: string): CategoryScores =>
+    committed[id] ?? { asgn: null, midSem: null, endSem: null, project: null, portfolio: null };
+
+  function reset() {
+    if (imageUrl) URL.revokeObjectURL(imageUrl);
+    setImageUrl(null);
+    setPhase("idle");
+    setPageCount(0);
+    setExtractOk(true);
+    setRows([]);
+    setAssign([]);
+    setMappingConfirmed(false);
+    setCellVals({});
+    setBands({});
+    setReviewed(new Set());
+    setReasons({});
+    setError(null);
+  }
+
+  const rosterForMapping = useMemo(
+    () =>
+      roster.map((r) => {
+        const [firstName, ...rest] = r.name.split(" ");
+        return { id: r.id, firstName, lastName: rest.join(" ") };
+      }),
+    [roster],
+  );
+
+  async function onFile(file: File) {
+    const append = appendRef.current;
+    appendRef.current = false;
+    setError(null);
+    if (!file.type.startsWith("image/")) {
+      setError("Please choose a photo (JPEG or PNG) of your ledger page.");
+      return;
+    }
+    const objectUrl = URL.createObjectURL(file);
+    setImageUrl(objectUrl);
+    setPhase("busy");
+
+    let dataUrl: string;
+    try {
+      dataUrl = await readAsDataUrl(file);
+    } catch {
+      setPhase(append ? "verify" : "idle");
+      setError("Could not read that file. Try another photo.");
+      return;
+    }
+
+    try {
+      const res = await fetch("/api/senior/ledger-extract", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ classId, subjectId, periodId, imageDataUrl: dataUrl }),
+      });
+      const body = (await res.json().catch(() => null)) as
+        | { ok: true; rows: ExtractRow[] }
+        | { ok: false; error: string }
+        | null;
+      if (body && body.ok) {
+        if (append) mergePage(body.rows);
+        else startVerify(body.rows, true);
+        return;
+      }
+      // A page we can't read: on append, keep the pages so far; on the first page, degrade to a
+      // blank Path-C grid IN PLACE — never a dead end (Q7 / H1). Nothing was persisted server-side.
+      if (append) {
+        setPhase("verify");
+        if (body && body.error !== "extract_failed") setError(body.error);
+        else setError("We couldn't read that page — the pages added so far are kept.");
+        return;
+      }
+      if (body && body.error !== "extract_failed") {
+        setError(body.error);
+        setPhase("idle");
+        return;
+      }
+      startVerify([], false);
+    } catch {
+      if (append) {
+        setPhase("verify");
+        setError("We couldn't read that page — the pages added so far are kept.");
+      } else startVerify([], false);
+    }
+  }
+
+  /** Append another page's rows to the current set — one merged grid, committed atomically
+   * (Kofi Q6 / E1–E2). Re-opens the mapping step so the teacher confirms the combined roster. */
+  function mergePage(newRows: ExtractRow[]) {
+    const map = mapRosterRows(
+      newRows.map<ExtractedNameRow>((r) => ({ readName: r.readName, studentId: r.studentId })),
+      rosterForMapping,
+    );
+    setRows((prev) => [...prev, ...newRows]);
+    setAssign((prev) => [...prev, ...map.rows.map((m) => (m.status === "mapped" ? m.studentId : ""))]);
+    setMappingConfirmed(false);
+    setPageCount((n) => n + 1);
+    setPhase("verify");
+  }
+
+  /** Seed the verify state. ok=false → wholesale-failure fallback: blank Path-C grid, all roster
+   * covered, seeded from committed so untouched cells never blank a committed score. */
+  function startVerify(extractRows: ExtractRow[], ok: boolean) {
+    setExtractOk(ok);
+    setRows(extractRows);
+    setPageCount(ok ? 1 : 0);
+    if (ok) {
+      const map = mapRosterRows(
+        extractRows.map<ExtractedNameRow>((r) => ({ readName: r.readName, studentId: r.studentId })),
+        rosterForMapping,
+      );
+      setAssign(
+        map.rows.map((m) => (m.status === "mapped" ? m.studentId : "")),
+      );
+    } else {
+      // Fallback: seed the blank grid from committed values (all roster covered).
+      const vals: Record<string, string> = {};
+      for (const r of roster) {
+        const c = committedFor(r.id);
+        for (const cat of CATS) vals[key(r.id, cat.key)] = c[cat.key] == null ? "" : String(c[cat.key]);
+      }
+      setCellVals(vals);
+      setBands({});
+      setMappingConfirmed(true);
+    }
+    setPhase("verify");
+  }
+
+  // ---- roster mapping validation (Kofi Q5 / D1–D5) ----
+  const assignedIds = assign.filter((a) => a && a !== "__discard__");
+  const dupIds = assignedIds.filter((id, i) => assignedIds.indexOf(id) !== i);
+  const unresolvedRows = extractOk
+    ? assign.filter((a) => a === "").length
+    : 0;
+  const mappingValid = extractOk ? unresolvedRows === 0 && dupIds.length === 0 : true;
+
+  function confirmMapping() {
+    if (!mappingValid) return;
+    // Build covered cells from each assigned extraction row.
+    const vals: Record<string, string> = {};
+    const bnds: Record<string, CellBand> = {};
+    rows.forEach((row, i) => {
+      const sid = assign[i];
+      if (!sid || sid === "__discard__") return;
+      for (const cat of CATS) {
+        const cell = row.cells[cat.key];
+        const b = bandCell(cell.value, cell.confidence);
+        vals[key(sid, cat.key)] = b.value == null ? "" : String(b.value);
+        bnds[key(sid, cat.key)] = b.band;
+      }
+    });
+    setCellVals(vals);
+    setBands(bnds);
+    setMappingConfirmed(true);
+  }
+
+  const coveredIds = useMemo(() => {
+    if (!extractOk) return roster.map((r) => r.id);
+    return assign.filter((a) => a && a !== "__discard__");
+  }, [assign, extractOk, roster]);
+  const coveredSet = useMemo(() => new Set(coveredIds), [coveredIds]);
+
+  function setCell(id: string, k: CatKey, v: string) {
+    setCellVals((m) => ({ ...m, [key(id, k)]: v }));
+    setReviewed((s) => new Set(s).add(key(id, k)));
+    setError(null);
+  }
+  function confirmCell(k: string) {
+    setReviewed((s) => new Set(s).add(k));
+  }
+  function keepCommitted(id: string, k: CatKey) {
+    const c = committedFor(id)[k];
+    setCell(id, k, c == null ? "" : String(c));
+  }
+  function setReason(k: string, patch: Partial<{ code: string; note: string }>) {
+    setReasons((m) => ({ ...m, [k]: { code: m[k]?.code ?? "RE_GRADED", note: m[k]?.note ?? "", ...patch } }));
+  }
+
+  // Per covered cell: current value, committed, and what's still blocking commit.
+  const changes = useMemo(() => {
+    const out: {
+      id: string;
+      cat: CatKey;
+      committed: number | null;
+      final: number | null;
+      kind: string;
+      severity: string;
+      reasonRequired: boolean;
+    }[] = [];
+    for (const id of coveredIds) {
+      const cm = committedFor(id);
+      for (const cat of CATS) {
+        const final = num(cellVals[key(id, cat.key)]);
+        const committedVal = cm[cat.key];
+        const same = final === committedVal;
+        if (same) continue;
+        const band = bands[key(id, cat.key)] ?? "ACCEPTED";
+        const d = diffCell(committedVal, { band, value: final });
+        out.push({
+          id,
+          cat: cat.key,
+          committed: committedVal,
+          final,
+          kind: d.kind,
+          severity: d.severity,
+          reasonRequired: reasonRequiredForCommit(committedVal, final),
+        });
+      }
+    }
+    return out;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cellVals, coveredIds, bands]);
+
+  // Low-confidence cells still awaiting review (C2) — cannot commit until every one is reviewed.
+  const unreviewedLowConf = useMemo(() => {
+    let n = 0;
+    for (const id of coveredIds) {
+      for (const cat of CATS) {
+        const k = key(id, cat.key);
+        if (bands[k] === "LOW_CONF" && !reviewed.has(k)) n++;
+      }
+    }
+    return n;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bands, reviewed, coveredIds]);
+
+  // A required change defaults to RE_GRADED (the surface pre-bakes this — Lucy §4.1); only an
+  // explicit OTHER without a note blocks commit.
+  const missingReasons = changes.filter((c) => {
+    if (!c.reasonRequired) return false;
+    const r = reasons[key(c.id, c.cat)];
+    return r?.code === "OTHER" && !r.note.trim();
+  });
+
+  const canCommit =
+    !isClosed &&
+    coveredIds.length > 0 &&
+    unreviewedLowConf === 0 &&
+    missingReasons.length === 0;
+
+  function rowTotal(id: string): number | null {
+    const cats: CategoryScores = {
+      asgn: num(cellVals[key(id, "asgn")]),
+      midSem: num(cellVals[key(id, "midSem")]),
+      endSem: num(cellVals[key(id, "endSem")]),
+      project: num(cellVals[key(id, "project")]),
+      portfolio: num(cellVals[key(id, "portfolio")]),
+    };
+    if (!Object.values(cats).some((v) => v != null)) return null;
+    return provisionalTotal(cats, weights).total;
+  }
+
+  async function commit() {
+    if (!canCommit) {
+      if (unreviewedLowConf > 0)
+        setError(`${unreviewedLowConf} low-confidence cell(s) still marked ? — review them against the photo first.`);
+      else if (missingReasons.length > 0)
+        setError("Add a reason for every score that went down or was removed before committing.");
+      return;
+    }
+    setCommitting(true);
+    setError(null);
+    const scores = coveredIds.map((id) => ({
+      studentId: id,
+      asgn: cellVals[key(id, "asgn")] ?? "",
+      midSem: cellVals[key(id, "midSem")] ?? "",
+      endSem: cellVals[key(id, "endSem")] ?? "",
+      project: cellVals[key(id, "project")] ?? "",
+      portfolio: cellVals[key(id, "portfolio")] ?? "",
+    }));
+    const reasonPayload = changes
+      .filter((c) => c.reasonRequired)
+      .map((c) => {
+        const r = reasons[key(c.id, c.cat)];
+        return {
+          studentId: c.id,
+          category: c.cat,
+          code: r?.code ?? "RE_GRADED",
+          note: r?.note?.trim() || undefined,
+        };
+      });
+    const res = await commitScanLedger({
+      classId,
+      subjectId,
+      periodId,
+      origin: extractOk ? "SCAN_EXTRACT" : "DIRECT_ENTRY",
+      scores,
+      reasons: reasonPayload,
+    });
+    setCommitting(false);
+    if (res.ok) {
+      if (imageUrl) URL.revokeObjectURL(imageUrl); // discard the photo (G4)
+      router.push(ledgerHref);
+      router.refresh();
+    } else {
+      setError(res.error);
+    }
+  }
+
+  // ------------------------------------------------------------------ render
+
+  if (phase === "idle") {
+    return (
+      <div className="rounded-[10px] border-[1.5px] border-dashed border-border-2 bg-bg p-10 text-center">
+        <p className="font-display text-lg italic text-navy">Photograph your ledger page.</p>
+        <p className="mx-auto mt-2 max-w-md text-sm text-navy-3">
+          Take a clear, flat, well-lit photo. Omnischools reads the five category scores; you confirm
+          each one against the photo before it commits. The photo is never saved — it is read once and
+          discarded.
+        </p>
+        <input
+          ref={fileRef}
+          type="file"
+          accept="image/*"
+          capture="environment"
+          className="hidden"
+          onChange={(e) => {
+            const f = e.target.files?.[0];
+            if (f) void onFile(f);
+            e.target.value = "";
+          }}
+        />
+        <button
+          type="button"
+          disabled={isClosed}
+          onClick={() => fileRef.current?.click()}
+          className="mt-5 rounded-md bg-navy px-6 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-60"
+        >
+          Take or attach a photo
+        </button>
+        {error && <p className="mt-3 text-sm text-terra">{error}</p>}
+      </div>
+    );
+  }
+
+  if (phase === "busy") {
+    return (
+      <div className="rounded-xl border border-gold-soft bg-gold-bg p-10 text-center">
+        <p className="font-display text-lg italic text-navy">Reading your ledger…</p>
+        <p className="mt-1 text-sm text-navy-3">
+          This usually takes a few seconds. The photo is read once and not saved.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {/* Verify-phase file input — the idle-phase input is unmounted here (Add another page). */}
+      <input
+        ref={fileRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        className="hidden"
+        onChange={(e) => {
+          const f = e.target.files?.[0];
+          if (f) void onFile(f);
+          e.target.value = "";
+        }}
+      />
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.1em] text-navy-3">
+          {extractOk ? "Extracted ledger · verify the read" : "Extraction unavailable · enter directly (Path C)"}
+          {extractOk && pageCount > 1 ? ` · ${pageCount} pages merged` : ""}
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={reset}
+            className="rounded-md border border-border-2 bg-transparent px-3 py-2 text-sm font-semibold text-navy-3"
+          >
+            Re-upload page
+          </button>
+          {mappingConfirmed && (
+            <button
+              type="button"
+              onClick={commit}
+              disabled={committing || !canCommit}
+              className="rounded-md bg-navy px-5 py-2 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-60"
+            >
+              {committing ? "Committing…" : "Commit verified ledger →"}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {!extractOk && (
+        <div className="mb-4 rounded-xl border border-terra bg-terra-bg px-4 py-3 text-sm text-terra">
+          We couldn&apos;t read that photo. The grid below is blank for direct entry — type the five
+          category scores and commit. (Nothing from the photo was saved.)
+        </div>
+      )}
+      {error && <p className="mb-3 text-sm text-terra">{error}</p>}
+
+      <div className="grid gap-4 lg:grid-cols-[0.9fr_1.1fr]">
+        {/* Photo pane — in-session object URL only, never persisted. */}
+        <div className="rounded-[10px] border-[1.5px] border-dashed border-border-2 bg-bg p-3">
+          <div className="mb-2 text-[10px] font-bold uppercase tracking-[0.1em] text-navy-3">
+            Your ledger photo · in-session only
+          </div>
+          {imageUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={imageUrl} alt="Uploaded ledger page" className="w-full rounded-md border border-border" />
+          ) : (
+            <div className="grid h-40 place-items-center text-sm text-navy-3">No photo.</div>
+          )}
+        </div>
+
+        <div>
+          {/* Roster mapping confirm (Kofi Q5 / D1–D5) — mandatory before diff/commit. */}
+          {extractOk && !mappingConfirmed && (
+            <div className="mb-4 rounded-xl border border-gold-soft bg-gold-bg p-4">
+              <div className="mb-2 text-[11px] font-bold uppercase tracking-[0.1em] text-navy-3">
+                Confirm which student each row belongs to
+              </div>
+              <p className="mb-3 text-[12px] text-navy-2">
+                A right mark on the wrong student is the one error the eye misses. Confirm each row —
+                ambiguous names (e.g. two students share a surname) are left blank for you to pick.
+              </p>
+              <div className="space-y-1.5">
+                {rows.map((r, i) => (
+                  <div key={i} className="flex items-center gap-2 text-[12px]">
+                    <span className="w-40 truncate font-mono text-navy-2">{r.readName || "—"}</span>
+                    <span className="text-navy-3">→</span>
+                    <select
+                      value={assign[i] ?? ""}
+                      onChange={(e) =>
+                        setAssign((a) => a.map((v, j) => (j === i ? e.target.value : v)))
+                      }
+                      className={
+                        "rounded-md border bg-surface px-2 py-1 text-navy " +
+                        (assign[i] === "" ? "border-warn" : "border-border-2")
+                      }
+                    >
+                      <option value="">— choose student —</option>
+                      {roster.map((s) => (
+                        <option key={s.id} value={s.id}>
+                          {s.name}
+                        </option>
+                      ))}
+                      <option value="__discard__">— not on the roster (discard row) —</option>
+                    </select>
+                  </div>
+                ))}
+              </div>
+              {dupIds.length > 0 && (
+                <p className="mt-2 text-[12px] text-terra">
+                  Two rows point to the same student — each student can map to at most one row.
+                </p>
+              )}
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  onClick={confirmMapping}
+                  disabled={!mappingValid}
+                  className="rounded-md bg-navy px-4 py-1.5 text-[13px] font-semibold text-bg disabled:opacity-60"
+                >
+                  Confirm mapping →
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    appendRef.current = true;
+                    fileRef.current?.click();
+                  }}
+                  className="rounded-md border border-border-2 bg-surface px-3 py-1.5 text-[13px] font-semibold text-navy-2"
+                >
+                  + Add another page{pageCount > 1 ? ` (${pageCount} so far)` : ""}
+                </button>
+              </div>
+              <p className="mt-1.5 text-[11px] text-navy-3">
+                Add every page of this class before confirming — they merge into one grid and commit
+                together.
+              </p>
+            </div>
+          )}
+
+          {mappingConfirmed && (
+            <>
+              <div className="overflow-x-auto rounded-xl border border-border bg-surface">
+                <table className="w-full text-sm">
+                  <thead className="border-b-2 border-border-2 bg-bg text-center text-[9px] font-bold uppercase tracking-[0.1em] text-navy-3">
+                    <tr>
+                      <th className="sticky left-0 z-10 bg-bg px-3 py-2.5 text-left">Student</th>
+                      {CATS.map((c) => (
+                        <th key={c.key} className={`px-1.5 py-2.5 ${c.cls}`}>
+                          {c.label}
+                        </th>
+                      ))}
+                      <th className="px-1.5 py-2.5 text-navy-3">~Total</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    {roster.map((r) => {
+                      const isCovered = coveredSet.has(r.id);
+                      const t = rowTotal(r.id);
+                      const cm = committedFor(r.id);
+                      return (
+                        <tr key={r.id} className="hover:bg-gold-bg">
+                          <td className="sticky left-0 z-10 bg-surface px-3 py-2 text-left">
+                            <div className="text-[12px] font-semibold text-navy">{r.name}</div>
+                            <div className="font-mono text-[9px] text-navy-3">
+                              {r.code}
+                              {!isCovered && " · not on this page"}
+                            </div>
+                          </td>
+                          {CATS.map((c) => {
+                            if (!isCovered) {
+                              const v = cm[c.key];
+                              return (
+                                <td key={c.key} className="px-1.5 py-2 text-center font-mono text-[12px] text-border-2">
+                                  {v == null ? "—" : v}
+                                </td>
+                              );
+                            }
+                            const k = key(r.id, c.key);
+                            const v = cellVals[k] ?? "";
+                            const low = bands[k] === "LOW_CONF" && !reviewed.has(k);
+                            const cls = v.trim() === "" ? emptyInput : low ? warnInput : goldInput;
+                            return (
+                              <td key={c.key} className="px-1.5 py-2 text-center">
+                                <div className="relative inline-block">
+                                  <input
+                                    type="number"
+                                    min="0"
+                                    max="100"
+                                    step="0.01"
+                                    placeholder="—"
+                                    value={v}
+                                    disabled={isClosed}
+                                    onChange={(e) => setCell(r.id, c.key, e.target.value)}
+                                    className={cls}
+                                  />
+                                  {low && (
+                                    <button
+                                      type="button"
+                                      title="Confirm this reading"
+                                      onClick={() => confirmCell(k)}
+                                      className="absolute -right-1.5 -top-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-warn text-[9px] font-bold text-bg"
+                                    >
+                                      ?
+                                    </button>
+                                  )}
+                                </div>
+                              </td>
+                            );
+                          })}
+                          <td className="px-1.5 py-2 text-center font-mono text-[11px] text-navy-3">
+                            {t == null ? "—" : t.toFixed(1)}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+
+              {/* Legend — solid -bg tokens only (no slash-opacity on raw-hex tokens). */}
+              <div className="mt-3 flex flex-wrap gap-4 text-[11px] text-navy-3">
+                <span className="flex items-center gap-1.5">
+                  <span className="inline-block h-3 w-3 rounded bg-gold-bg" /> Read — confirm or correct
+                </span>
+                <span className="flex items-center gap-1.5">
+                  <span className="inline-block h-3 w-3 rounded bg-warn-bg" /> Low-confidence — check the photo
+                </span>
+                <span className="flex items-center gap-1.5">
+                  <span className="inline-block h-3 w-3 rounded border border-border-2 bg-bg" /> Blank — fill it in
+                </span>
+              </div>
+
+              {/* Changes since the committed ledger (Kofi Q3 / §4). */}
+              <ChangesPanel
+                changes={changes}
+                rosterById={rosterById}
+                reasons={reasons}
+                setReason={setReason}
+                keepCommitted={keepCommitted}
+              />
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ChangesPanel({
+  changes,
+  rosterById,
+  reasons,
+  setReason,
+  keepCommitted,
+}: {
+  changes: {
+    id: string;
+    cat: CatKey;
+    committed: number | null;
+    final: number | null;
+    kind: string;
+    severity: string;
+    reasonRequired: boolean;
+  }[];
+  rosterById: Map<string, RosterEntry>;
+  reasons: Record<string, { code: string; note: string }>;
+  setReason: (k: string, patch: Partial<{ code: string; note: string }>) => void;
+  keepCommitted: (id: string, k: CatKey) => void;
+}) {
+  if (changes.length === 0) {
+    return (
+      <p className="mt-4 text-[12px] text-navy-3">
+        No changes from the committed ledger yet — the read matches what is on record.
+      </p>
+    );
+  }
+  const tone: Record<string, string> = {
+    gold: "border-gold bg-gold-bg",
+    warn: "border-warn bg-warn-bg",
+    terra: "border-terra bg-terra-bg",
+    none: "border-border-2 bg-surface",
+  };
+  const fmt = (v: number | null) => (v == null ? "—" : String(v));
+  return (
+    <div className="mt-4">
+      <div className="mb-2 text-[10px] font-bold uppercase tracking-[0.1em] text-navy-3">
+        Changes since the committed ledger · {changes.length} to review
+      </div>
+      <div className="space-y-2">
+        {changes.map((c) => {
+          const k = `${c.id}:${c.cat}`;
+          const student = rosterById.get(c.id)?.name ?? c.id;
+          const r = reasons[k] ?? { code: "RE_GRADED", note: "" };
+          return (
+            <div key={k} className={`rounded-[10px] border px-4 py-3 ${tone[c.severity] ?? tone.none}`}>
+              <div className="text-[12px] text-navy-2">
+                <b className="text-navy">{student}</b> · {CAT_FULL[c.cat]} score · committed{" "}
+                <b className="text-navy">{fmt(c.committed)}</b> → this upload{" "}
+                <b className="text-navy">{fmt(c.final)}</b>
+                {c.kind === "GONE_MISSING" && " — score has gone missing; keep it or enter it by hand."}
+                {c.kind === "SCORE_DOWN" && " — score went down; confirm with a reason."}
+                {c.kind === "SILENT_ACCEPT" && " — new entry, accepted."}
+                {c.kind === "REVIEW" && " — changed; review against the photo."}
+              </div>
+              <div className="mt-2 flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => keepCommitted(c.id, c.cat)}
+                  className="rounded-md border border-border-2 bg-surface px-2.5 py-[5px] text-[10px] font-semibold text-navy-2"
+                >
+                  Keep committed ({fmt(c.committed)})
+                </button>
+                {c.reasonRequired && (
+                  <>
+                    <select
+                      value={r.code}
+                      onChange={(e) => setReason(k, { code: e.target.value })}
+                      className="rounded-md border border-border-2 bg-surface px-2 py-[5px] text-[10px] font-semibold text-navy-2"
+                    >
+                      {REASONS.map((o) => (
+                        <option key={o.code} value={o.code}>
+                          {o.label}
+                        </option>
+                      ))}
+                    </select>
+                    {r.code === "OTHER" && (
+                      <input
+                        type="text"
+                        value={r.note}
+                        placeholder="Reason (required)"
+                        onChange={(e) => setReason(k, { note: e.target.value })}
+                        className="rounded-md border border-border-2 bg-surface px-2 py-[5px] text-[11px] text-navy outline-none focus:border-gold"
+                      />
+                    )}
+                  </>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function readAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+}

--- a/omnischools/components/senior/scan-workspace.tsx
+++ b/omnischools/components/senior/scan-workspace.tsx
@@ -8,6 +8,9 @@ import {
   diffCell,
   reasonRequiredForCommit,
   mapRosterRows,
+  REASON_LABELS,
+  SCORE_DOWN_REASON_CODES,
+  REMOVAL_REASON_CODES,
   type CellBand,
   type ExtractedNameRow,
 } from "@/lib/score-ledger/scan-diff";
@@ -37,11 +40,8 @@ const CAT_FULL: Record<CatKey, string> = {
   project: "Project",
   portfolio: "Portfolio",
 };
-const REASONS: { code: string; label: string }[] = [
-  { code: "RE_GRADED", label: "Re-graded" },
-  { code: "TRANSCRIPTION_ERROR", label: "Transcription error" },
-  { code: "OTHER", label: "Other (add a note)" },
-];
+// Sentinel value for the roster-mapping "not on the roster" option (was a bare magic string).
+const DISCARD_ROW = "__discard__";
 
 type ExtractCell = { raw: number | null; value: number | null; confidence: number };
 type ExtractRow = { readName: string; studentId: string | null; cells: Record<CatKey, ExtractCell> };
@@ -92,7 +92,7 @@ export function ScanWorkspace({
 
   // Verify-phase state.
   const [rows, setRows] = useState<ExtractRow[]>([]);
-  const [assign, setAssign] = useState<string[]>([]); // per extraction row: studentId | "" | "__discard__"
+  const [assign, setAssign] = useState<string[]>([]); // per extraction row: studentId | "" | DISCARD_ROW
   const [mappingConfirmed, setMappingConfirmed] = useState(false);
   const [cellVals, setCellVals] = useState<Record<string, string>>({});
   const [bands, setBands] = useState<Record<string, CellBand>>({});
@@ -237,7 +237,7 @@ export function ScanWorkspace({
   }
 
   // ---- roster mapping validation (Kofi Q5 / D1–D5) ----
-  const assignedIds = assign.filter((a) => a && a !== "__discard__");
+  const assignedIds = assign.filter((a) => a && a !== DISCARD_ROW);
   const dupIds = assignedIds.filter((id, i) => assignedIds.indexOf(id) !== i);
   const unresolvedRows = extractOk
     ? assign.filter((a) => a === "").length
@@ -251,7 +251,7 @@ export function ScanWorkspace({
     const bnds: Record<string, CellBand> = {};
     rows.forEach((row, i) => {
       const sid = assign[i];
-      if (!sid || sid === "__discard__") return;
+      if (!sid || sid === DISCARD_ROW) return;
       for (const cat of CATS) {
         const cell = row.cells[cat.key];
         const b = bandCell(cell.value, cell.confidence);
@@ -266,7 +266,7 @@ export function ScanWorkspace({
 
   const coveredIds = useMemo(() => {
     if (!extractOk) return roster.map((r) => r.id);
-    return assign.filter((a) => a && a !== "__discard__");
+    return assign.filter((a) => a && a !== DISCARD_ROW);
   }, [assign, extractOk, roster]);
   const coveredSet = useMemo(() => new Set(coveredIds), [coveredIds]);
 
@@ -283,7 +283,9 @@ export function ScanWorkspace({
     setCell(id, k, c == null ? "" : String(c));
   }
   function setReason(k: string, patch: Partial<{ code: string; note: string }>) {
-    setReasons((m) => ({ ...m, [k]: { code: m[k]?.code ?? "RE_GRADED", note: m[k]?.note ?? "", ...patch } }));
+    // No forced default here — a score-down's RE_GRADED default lives in the render/commit
+    // fallbacks; a removal must have its code actively chosen (Kofi Q2), never pre-seeded.
+    setReasons((m) => ({ ...m, [k]: { code: m[k]?.code ?? "", note: m[k]?.note ?? "", ...patch } }));
   }
 
   // Per covered cell: current value, committed, and what's still blocking commit.
@@ -318,6 +320,8 @@ export function ScanWorkspace({
       }
     }
     return out;
+    // committedFor closes over `committed`, a stable per-session prop (the diff baseline never
+    // changes while this workspace is mounted), so it is intentionally not a dep.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cellVals, coveredIds, bands]);
 
@@ -331,14 +335,20 @@ export function ScanWorkspace({
       }
     }
     return n;
+    // CATS is a module constant and `key` is pure; the closure only reads the three listed deps.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [bands, reviewed, coveredIds]);
 
-  // A required change defaults to RE_GRADED (the surface pre-bakes this — Lucy §4.1); only an
-  // explicit OTHER without a note blocks commit.
+  // A score-down defaults to RE_GRADED (the surface pre-bakes this — Lucy §4.1); only an explicit
+  // OTHER without a note blocks. A removal (committed → blank) has NO default — the teacher must
+  // actively pick TRANSCRIPTION_ERROR or OTHER+note; RE_GRADED or a blank pick blocks (Kofi Q2).
   const missingReasons = changes.filter((c) => {
     if (!c.reasonRequired) return false;
     const r = reasons[key(c.id, c.cat)];
+    if (c.final == null) {
+      if (r?.code !== "TRANSCRIPTION_ERROR" && r?.code !== "OTHER") return true;
+      return r.code === "OTHER" && !r.note.trim();
+    }
     return r?.code === "OTHER" && !r.note.trim();
   });
 
@@ -382,10 +392,12 @@ export function ScanWorkspace({
       .filter((c) => c.reasonRequired)
       .map((c) => {
         const r = reasons[key(c.id, c.cat)];
+        // Removals carry the actively-chosen code (canCommit already blocks a removal without a
+        // valid one); score-downs fall back to the pre-baked RE_GRADED default (§7.3).
         return {
           studentId: c.id,
           category: c.cat,
-          code: r?.code ?? "RE_GRADED",
+          code: r?.code || (c.final == null ? "TRANSCRIPTION_ERROR" : "RE_GRADED"),
           note: r?.note?.trim() || undefined,
         };
       });
@@ -549,7 +561,7 @@ export function ScanWorkspace({
                           {s.name}
                         </option>
                       ))}
-                      <option value="__discard__">— not on the roster (discard row) —</option>
+                      <option value={DISCARD_ROW}>— not on the roster (discard row) —</option>
                     </select>
                   </div>
                 ))}
@@ -627,18 +639,23 @@ export function ScanWorkspace({
                             const k = key(r.id, c.key);
                             const v = cellVals[k] ?? "";
                             const low = bands[k] === "LOW_CONF" && !reviewed.has(k);
-                            const cls = v.trim() === "" ? emptyInput : low ? warnInput : goldInput;
+                            // A bonus mark (category >100, e.g. 11/10 portfolio → 110) is allowed
+                            // (Kofi Owner-Option-A) — soft-warn like Path A's overMax, never a block.
+                            const nv = num(v);
+                            const over = nv != null && nv > 100;
+                            const cls =
+                              v.trim() === "" ? emptyInput : low || over ? warnInput : goldInput;
                             return (
                               <td key={c.key} className="px-1.5 py-2 text-center">
                                 <div className="relative inline-block">
                                   <input
                                     type="number"
                                     min="0"
-                                    max="100"
                                     step="0.01"
                                     placeholder="—"
                                     value={v}
                                     disabled={isClosed}
+                                    title={over ? "Above 100 — a bonus mark; it still commits." : undefined}
                                     onChange={(e) => setCell(r.id, c.key, e.target.value)}
                                     className={cls}
                                   />
@@ -739,7 +756,12 @@ function ChangesPanel({
         {changes.map((c) => {
           const k = `${c.id}:${c.cat}`;
           const student = rosterById.get(c.id)?.name ?? c.id;
-          const r = reasons[k] ?? { code: "RE_GRADED", note: "" };
+          // A removal (committed → blank) has no pre-selected reason and excludes RE_GRADED — the
+          // teacher must actively pick why the score is gone (Kofi Q2). A score-down pre-bakes
+          // RE_GRADED (§7.3). "Enter manually" (typing into the grid cell) stays the primary path.
+          const isRemoval = c.final == null;
+          const reasonCodes = isRemoval ? REMOVAL_REASON_CODES : SCORE_DOWN_REASON_CODES;
+          const r = reasons[k] ?? { code: isRemoval ? "" : "RE_GRADED", note: "" };
           return (
             <div key={k} className={`rounded-[10px] border px-4 py-3 ${tone[c.severity] ?? tone.none}`}>
               <div className="text-[12px] text-navy-2">
@@ -764,11 +786,15 @@ function ChangesPanel({
                     <select
                       value={r.code}
                       onChange={(e) => setReason(k, { code: e.target.value })}
-                      className="rounded-md border border-border-2 bg-surface px-2 py-[5px] text-[10px] font-semibold text-navy-2"
+                      className={
+                        "rounded-md border bg-surface px-2 py-[5px] text-[10px] font-semibold text-navy-2 " +
+                        (isRemoval && r.code === "" ? "border-warn" : "border-border-2")
+                      }
                     >
-                      {REASONS.map((o) => (
-                        <option key={o.code} value={o.code}>
-                          {o.label}
+                      {isRemoval && <option value="">— why is it gone? —</option>}
+                      {reasonCodes.map((code) => (
+                        <option key={code} value={code}>
+                          {REASON_LABELS[code]}
                         </option>
                       ))}
                     </select>

--- a/omnischools/db/migrations/0041_little_human_torch.sql
+++ b/omnischools/db/migrations/0041_little_human_torch.sql
@@ -1,0 +1,7 @@
+CREATE TYPE "public"."ledger_correction_reason" AS ENUM('RE_GRADED', 'TRANSCRIPTION_ERROR', 'OTHER');--> statement-breakpoint
+ALTER TABLE "ref_assessment_weights" ADD COLUMN "asgn_denominator" smallint DEFAULT 100 NOT NULL;--> statement-breakpoint
+ALTER TABLE "ref_assessment_weights" ADD COLUMN "mid_sem_denominator" smallint DEFAULT 100 NOT NULL;--> statement-breakpoint
+ALTER TABLE "ref_assessment_weights" ADD COLUMN "end_sem_denominator" smallint DEFAULT 100 NOT NULL;--> statement-breakpoint
+ALTER TABLE "ref_assessment_weights" ADD COLUMN "project_denominator" smallint DEFAULT 100 NOT NULL;--> statement-breakpoint
+ALTER TABLE "ref_assessment_weights" ADD COLUMN "portfolio_denominator" smallint DEFAULT 100 NOT NULL;--> statement-breakpoint
+ALTER TABLE "ref_assessment_weights" ADD CONSTRAINT "assessment_denominators_positive" CHECK ("ref_assessment_weights"."asgn_denominator" > 0 AND "ref_assessment_weights"."mid_sem_denominator" > 0 AND "ref_assessment_weights"."end_sem_denominator" > 0 AND "ref_assessment_weights"."project_denominator" > 0 AND "ref_assessment_weights"."portfolio_denominator" > 0);

--- a/omnischools/db/migrations/meta/0041_snapshot.json
+++ b/omnischools/db/migrations/meta/0041_snapshot.json
@@ -1,0 +1,8744 @@
+{
+  "id": "8e8360ce-d029-495a-9b46-6fd988002b63",
+  "prevId": "fea2b143-77f8-41db-ada5-a5f1be060c3a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ref_district": {
+      "name": "ref_district",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_district_region_id_ref_region_id_fk": {
+          "name": "ref_district_region_id_ref_region_id_fk",
+          "tableFrom": "ref_district",
+          "tableTo": "ref_region",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_district_code_unique": {
+          "name": "ref_district_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_region": {
+      "name": "ref_region",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_region_code_unique": {
+          "name": "ref_region_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_school_product": {
+      "name": "ref_school_product",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product": {
+          "name": "product",
+          "type": "product",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_school_product_school_id_ref_school_id_fk": {
+          "name": "ref_school_product_school_id_ref_school_id_fk",
+          "tableFrom": "ref_school_product",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_school_product": {
+          "name": "uniq_school_product",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "product"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_school": {
+      "name": "ref_school",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ges_code": {
+          "name": "ges_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cssps_code": {
+          "name": "cssps_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_type": {
+          "name": "school_type",
+          "type": "school_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'BASIC'"
+        },
+        "subtype": {
+          "name": "subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shs_category": {
+          "name": "shs_category",
+          "type": "shs_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownership_type": {
+          "name": "ownership_type",
+          "type": "ownership_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRIVATE'"
+        },
+        "year_founded": {
+          "name": "year_founded",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stamp_url": {
+          "name": "stamp_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_color": {
+          "name": "brand_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cadence": {
+          "name": "billing_cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_methods": {
+          "name": "payment_methods",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residency_model": {
+          "name": "residency_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "house_count": {
+          "name": "house_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visiting_day": {
+          "name": "visiting_day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waec_centre_code": {
+          "name": "waec_centre_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waec_office": {
+          "name": "waec_office",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_wassce_year": {
+          "name": "first_wassce_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_retention_months": {
+          "name": "record_retention_months",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audit_retention_months": {
+          "name": "audit_retention_months",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_2fa": {
+          "name": "require_2fa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_hours": {
+          "name": "session_hours",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "district_id": {
+          "name": "district_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_school_district_id_ref_district_id_fk": {
+          "name": "ref_school_district_id_ref_district_id_fk",
+          "tableFrom": "ref_school",
+          "tableTo": "ref_district",
+          "columnsFrom": [
+            "district_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ref_school_region_id_ref_region_id_fk": {
+          "name": "ref_school_region_id_ref_region_id_fk",
+          "tableFrom": "ref_school",
+          "tableTo": "ref_region",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_school_ges_code_unique": {
+          "name": "ref_school_ges_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "ges_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_assignment": {
+      "name": "role_assignment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_ref": {
+          "name": "scope_ref",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_assignment_user_id_ref_user_id_fk": {
+          "name": "role_assignment_user_id_ref_user_id_fk",
+          "tableFrom": "role_assignment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_assignment_school_id_ref_school_id_fk": {
+          "name": "role_assignment_school_id_ref_school_id_fk",
+          "tableFrom": "role_assignment",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_assignment_role_id_ref_role_id_fk": {
+          "name": "role_assignment_role_id_ref_role_id_fk",
+          "tableFrom": "role_assignment",
+          "tableTo": "ref_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_role": {
+      "name": "ref_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_role_code_unique": {
+          "name": "ref_role_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_user": {
+      "name": "ref_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_user_phone_unique": {
+          "name": "ref_user_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_compensation": {
+      "name": "staff_compensation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "salary_status": {
+          "name": "salary_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SCHOOL_PAID'"
+        },
+        "monthly_amount": {
+          "name": "monthly_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "pay_method": {
+          "name": "pay_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'BANK'"
+        },
+        "pay_cadence": {
+          "name": "pay_cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MONTHLY'"
+        },
+        "ssnit_deduction": {
+          "name": "ssnit_deduction",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "paye_deduction": {
+          "name": "paye_deduction",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "staff_compensation_school_idx": {
+          "name": "staff_compensation_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_compensation_school_id_ref_school_id_fk": {
+          "name": "staff_compensation_school_id_ref_school_id_fk",
+          "tableFrom": "staff_compensation",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "staff_compensation_user_id_ref_user_id_fk": {
+          "name": "staff_compensation_user_id_ref_user_id_fk",
+          "tableFrom": "staff_compensation",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_staff_compensation_per_school": {
+          "name": "uniq_staff_compensation_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_profile": {
+      "name": "staff_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qualification_level": {
+          "name": "qualification_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highest_qualification": {
+          "name": "highest_qualification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "undergraduate": {
+          "name": "undergraduate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ntc_licence_number": {
+          "name": "ntc_licence_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ntc_licence_expiry": {
+          "name": "ntc_licence_expiry",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialisations": {
+          "name": "specialisations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "staff_profile_school_idx": {
+          "name": "staff_profile_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_profile_school_id_ref_school_id_fk": {
+          "name": "staff_profile_school_id_ref_school_id_fk",
+          "tableFrom": "staff_profile",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "staff_profile_user_id_ref_user_id_fk": {
+          "name": "staff_profile_user_id_ref_user_id_fk",
+          "tableFrom": "staff_profile",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_staff_profile_per_school": {
+          "name": "uniq_staff_profile_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.academic_period": {
+      "name": "academic_period",
+      "schema": "",
+      "columns": {
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_number": {
+          "name": "period_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_label": {
+          "name": "period_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_on": {
+          "name": "ends_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by_user_id": {
+          "name": "closed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "academic_period_closed_by_user_id_ref_user_id_fk": {
+          "name": "academic_period_closed_by_user_id_ref_user_id_fk",
+          "tableFrom": "academic_period",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "closed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "academic_period_school_id_academic_year_ref_academic_period_config_school_id_academic_year_fk": {
+          "name": "academic_period_school_id_academic_year_ref_academic_period_config_school_id_academic_year_fk",
+          "tableFrom": "academic_period",
+          "tableTo": "ref_academic_period_config",
+          "columnsFrom": [
+            "school_id",
+            "academic_year"
+          ],
+          "columnsTo": [
+            "school_id",
+            "academic_year"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "academic_period_tenant_uk": {
+          "name": "academic_period_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_academic_period_config": {
+      "name": "ref_academic_period_config",
+      "schema": "",
+      "columns": {
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_type": {
+          "name": "period_type",
+          "type": "period_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_count": {
+          "name": "period_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "period_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured_at": {
+          "name": "configured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "configured_by": {
+          "name": "configured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_academic_period_config_school_id_ref_school_id_fk": {
+          "name": "ref_academic_period_config_school_id_ref_school_id_fk",
+          "tableFrom": "ref_academic_period_config",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ref_academic_period_config_configured_by_ref_user_id_fk": {
+          "name": "ref_academic_period_config_configured_by_ref_user_id_fk",
+          "tableFrom": "ref_academic_period_config",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "configured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ref_academic_period_config_school_id_academic_year_pk": {
+          "name": "ref_academic_period_config_school_id_academic_year_pk",
+          "columns": [
+            "school_id",
+            "academic_year"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gen_period_defaults": {
+      "name": "gen_period_defaults",
+      "schema": "",
+      "columns": {
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_line": {
+          "name": "product_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_number": {
+          "name": "period_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_label": {
+          "name": "period_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_on": {
+          "name": "ends_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_at": {
+          "name": "extracted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gen_period_defaults_reviewed_by_ref_user_id_fk": {
+          "name": "gen_period_defaults_reviewed_by_ref_user_id_fk",
+          "tableFrom": "gen_period_defaults",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gen_period_defaults_academic_year_product_line_period_number_pk": {
+          "name": "gen_period_defaults_academic_year_product_line_period_number_pk",
+          "columns": [
+            "academic_year",
+            "product_line",
+            "period_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.school_holiday": {
+      "name": "school_holiday",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_on": {
+          "name": "ends_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PUBLIC'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "school_holiday_school_idx": {
+          "name": "school_holiday_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "school_holiday_school_id_ref_school_id_fk": {
+          "name": "school_holiday_school_id_ref_school_id_fk",
+          "tableFrom": "school_holiday",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "audit_id": {
+          "name": "audit_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_role": {
+          "name": "actor_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before_jsonb": {
+          "name": "before_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_jsonb": {
+          "name": "after_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_school_time_idx": {
+          "name": "audit_school_time_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_entity_idx": {
+          "name": "audit_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_school_id_ref_school_id_fk": {
+          "name": "audit_log_school_id_ref_school_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_log_actor_user_id_ref_user_id_fk": {
+          "name": "audit_log_actor_user_id_ref_user_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_anomaly_rule": {
+      "name": "ref_anomaly_rule",
+      "schema": "",
+      "columns": {
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_code": {
+          "name": "rule_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "anomaly_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applies_to": {
+          "name": "applies_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold_jsonb": {
+          "name": "threshold_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_anomaly_rule_rule_code_unique": {
+          "name": "ref_anomaly_rule_rule_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rule_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.marketing_lead": {
+      "name": "marketing_lead",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organisation": {
+          "name": "organisation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'demo_form'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.class": {
+      "name": "class",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "programme": {
+          "name": "programme",
+          "type": "programme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_teacher_user_id": {
+          "name": "class_teacher_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_capacity": {
+          "name": "target_capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "class_school_id_ref_school_id_fk": {
+          "name": "class_school_id_ref_school_id_fk",
+          "tableFrom": "class",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "class_class_teacher_user_id_ref_user_id_fk": {
+          "name": "class_class_teacher_user_id_ref_user_id_fk",
+          "tableFrom": "class",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "class_teacher_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_class_per_school": {
+          "name": "uniq_class_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        },
+        "class_tenant_uk": {
+          "name": "class_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.household": {
+      "name": "household",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "household_school_idx": {
+          "name": "household_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "household_school_id_ref_school_id_fk": {
+          "name": "household_school_id_ref_school_id_fk",
+          "tableFrom": "household",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.house": {
+      "name": "house",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "colour": {
+          "name": "colour",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "house_school_id_ref_school_id_fk": {
+          "name": "house_school_id_ref_school_id_fk",
+          "tableFrom": "house",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_house_per_school": {
+          "name": "uniq_house_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        },
+        "house_tenant_uk": {
+          "name": "house_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_guardian": {
+      "name": "student_guardian",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "guardian_relation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GUARDIAN'"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "guardian_student_idx": {
+          "name": "guardian_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_guardian_school_id_ref_school_id_fk": {
+          "name": "student_guardian_school_id_ref_school_id_fk",
+          "tableFrom": "student_guardian",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_guardian_school_id_student_id_students_school_id_id_fk": {
+          "name": "student_guardian_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "student_guardian",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_health_record": {
+      "name": "student_health_record",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blood_group": {
+          "name": "blood_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medications": {
+          "name": "medications",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_relation": {
+          "name": "emergency_contact_relation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "health_student_idx": {
+          "name": "health_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_health_record_school_id_ref_school_id_fk": {
+          "name": "student_health_record_school_id_ref_school_id_fk",
+          "tableFrom": "student_health_record",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_health_record_updated_by_user_id_ref_user_id_fk": {
+          "name": "student_health_record_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "student_health_record",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "student_health_record_school_id_student_id_students_school_id_id_fk": {
+          "name": "student_health_record_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "student_health_record",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "student_health_record_student_id_unique": {
+          "name": "student_health_record_student_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.students": {
+      "name": "students",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_code": {
+          "name": "student_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "other_names": {
+          "name": "other_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "student_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "current_class_label": {
+          "name": "current_class_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "programme": {
+          "name": "programme",
+          "type": "programme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residency": {
+          "name": "residency",
+          "type": "residency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "house_id": {
+          "name": "house_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrolled_on": {
+          "name": "enrolled_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admission_application_id": {
+          "name": "admission_application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "students_school_idx": {
+          "name": "students_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "students_school_id_ref_school_id_fk": {
+          "name": "students_school_id_ref_school_id_fk",
+          "tableFrom": "students",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "students_household_id_household_id_fk": {
+          "name": "students_household_id_household_id_fk",
+          "tableFrom": "students",
+          "tableTo": "household",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "students_school_id_class_id_class_school_id_id_fk": {
+          "name": "students_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "students",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "students_school_id_house_id_house_school_id_id_fk": {
+          "name": "students_school_id_house_id_house_school_id_id_fk",
+          "tableFrom": "students",
+          "tableTo": "house",
+          "columnsFrom": [
+            "school_id",
+            "house_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_student_code_per_school": {
+          "name": "uniq_student_code_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_code"
+          ]
+        },
+        "students_tenant_uk": {
+          "name": "students_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admission_application": {
+      "name": "admission_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_first_name": {
+          "name": "applicant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_last_name": {
+          "name": "applicant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_other_names": {
+          "name": "applicant_other_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desired_class_label": {
+          "name": "desired_class_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guardian_name": {
+          "name": "guardian_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guardian_phone": {
+          "name": "guardian_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guardian_email": {
+          "name": "guardian_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "admission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SUBMITTED'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admission_school_status_idx": {
+          "name": "admission_school_status_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admission_application_school_id_ref_school_id_fk": {
+          "name": "admission_application_school_id_ref_school_id_fk",
+          "tableFrom": "admission_application",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admission_application_decided_by_user_id_ref_user_id_fk": {
+          "name": "admission_application_decided_by_user_id_ref_user_id_fk",
+          "tableFrom": "admission_application",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "admission_application_school_id_student_id_students_school_id_id_fk": {
+          "name": "admission_application_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "admission_application",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admission_application_tenant_uk": {
+          "name": "admission_application_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admission_document": {
+      "name": "admission_document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admission_document_school_id_ref_school_id_fk": {
+          "name": "admission_document_school_id_ref_school_id_fk",
+          "tableFrom": "admission_document",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admission_document_school_id_application_id_admission_application_school_id_id_fk": {
+          "name": "admission_document_school_id_application_id_admission_application_school_id_id_fk",
+          "tableFrom": "admission_document",
+          "tableTo": "admission_application",
+          "columnsFrom": [
+            "school_id",
+            "application_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_category": {
+      "name": "fee_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_category_school_id_ref_school_id_fk": {
+          "name": "fee_category_school_id_ref_school_id_fk",
+          "tableFrom": "fee_category",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_fee_category_per_school": {
+          "name": "uniq_fee_category_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        },
+        "fee_category_tenant_uk": {
+          "name": "fee_category_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_line_item": {
+      "name": "invoice_line_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_category_id": {
+          "name": "fee_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_optional": {
+          "name": "is_optional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_line_item_school_id_ref_school_id_fk": {
+          "name": "invoice_line_item_school_id_ref_school_id_fk",
+          "tableFrom": "invoice_line_item",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_line_item_school_id_invoice_id_invoice_school_id_id_fk": {
+          "name": "invoice_line_item_school_id_invoice_id_invoice_school_id_id_fk",
+          "tableFrom": "invoice_line_item",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "school_id",
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_line_item_school_id_fee_category_id_fee_category_school_id_id_fk": {
+          "name": "invoice_line_item_school_id_fee_category_id_fee_category_school_id_id_fk",
+          "tableFrom": "invoice_line_item",
+          "tableTo": "fee_category",
+          "columnsFrom": [
+            "school_id",
+            "fee_category_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice": {
+      "name": "invoice",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal_amount": {
+          "name": "subtotal_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "billed_amount": {
+          "name": "billed_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "balance_amount": {
+          "name": "balance_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ISSUED'"
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_student_idx": {
+          "name": "invoice_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_school_id_ref_school_id_fk": {
+          "name": "invoice_school_id_ref_school_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_school_id_student_id_students_school_id_id_fk": {
+          "name": "invoice_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "invoice_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_invoice_number_per_school": {
+          "name": "uniq_invoice_number_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "invoice_number"
+          ]
+        },
+        "invoice_tenant_uk": {
+          "name": "invoice_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_allocation": {
+      "name": "payment_allocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allocation_type": {
+          "name": "allocation_type",
+          "type": "allocation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INVOICE'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allocation_method": {
+          "name": "allocation_method",
+          "type": "allocation_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MANUAL'"
+        },
+        "allocated_by_user_id": {
+          "name": "allocated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allocated_at": {
+          "name": "allocated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payment_allocation_school_id_ref_school_id_fk": {
+          "name": "payment_allocation_school_id_ref_school_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_allocation_allocated_by_user_id_ref_user_id_fk": {
+          "name": "payment_allocation_allocated_by_user_id_ref_user_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "allocated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_allocation_school_id_payment_id_payment_school_id_id_fk": {
+          "name": "payment_allocation_school_id_payment_id_payment_school_id_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "payment",
+          "columnsFrom": [
+            "school_id",
+            "payment_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_allocation_school_id_invoice_id_invoice_school_id_id_fk": {
+          "name": "payment_allocation_school_id_invoice_id_invoice_school_id_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "school_id",
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_audit_log": {
+      "name": "payment_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "payment_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "payment_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ADMIN'"
+        },
+        "before_state": {
+          "name": "before_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_state": {
+          "name": "after_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_audit_school_time_idx": {
+          "name": "payment_audit_school_time_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_audit_log_school_id_ref_school_id_fk": {
+          "name": "payment_audit_log_school_id_ref_school_id_fk",
+          "tableFrom": "payment_audit_log",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_audit_log_actor_user_id_ref_user_id_fk": {
+          "name": "payment_audit_log_actor_user_id_ref_user_id_fk",
+          "tableFrom": "payment_audit_log",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment": {
+      "name": "payment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gross_amount": {
+          "name": "gross_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_amount": {
+          "name": "fee_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "net_amount": {
+          "name": "net_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GHS'"
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method_reference": {
+          "name": "method_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregator": {
+          "name": "aggregator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settlement_status": {
+          "name": "settlement_status",
+          "type": "settlement_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_by_user_id": {
+          "name": "voided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_is_refund": {
+          "name": "void_is_refund",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "payment_student_idx": {
+          "name": "payment_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_school_id_ref_school_id_fk": {
+          "name": "payment_school_id_ref_school_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_recorded_by_user_id_ref_user_id_fk": {
+          "name": "payment_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_voided_by_user_id_ref_user_id_fk": {
+          "name": "payment_voided_by_user_id_ref_user_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "voided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_school_id_student_id_students_school_id_id_fk": {
+          "name": "payment_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "payment_tenant_uk": {
+          "name": "payment_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.receipt": {
+      "name": "receipt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receipt_number": {
+          "name": "receipt_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_token": {
+          "name": "public_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_replacement_id": {
+          "name": "void_replacement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "receipt_school_id_ref_school_id_fk": {
+          "name": "receipt_school_id_ref_school_id_fk",
+          "tableFrom": "receipt",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "receipt_school_id_payment_id_payment_school_id_id_fk": {
+          "name": "receipt_school_id_payment_id_payment_school_id_id_fk",
+          "tableFrom": "receipt",
+          "tableTo": "payment",
+          "columnsFrom": [
+            "school_id",
+            "payment_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "receipt_school_id_student_id_students_school_id_id_fk": {
+          "name": "receipt_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "receipt",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "receipt_payment_id_unique": {
+          "name": "receipt_payment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "payment_id"
+          ]
+        },
+        "receipt_public_token_unique": {
+          "name": "receipt_public_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_token"
+          ]
+        },
+        "uniq_receipt_number_per_school": {
+          "name": "uniq_receipt_number_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "receipt_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discount_tier": {
+      "name": "discount_tier",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_id": {
+          "name": "discount_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "discount_tier_school_id_ref_school_id_fk": {
+          "name": "discount_tier_school_id_ref_school_id_fk",
+          "tableFrom": "discount_tier",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discount_tier_school_id_discount_id_discount_school_id_id_fk": {
+          "name": "discount_tier_school_id_discount_id_discount_school_id_id_fk",
+          "tableFrom": "discount_tier",
+          "tableTo": "discount",
+          "columnsFrom": [
+            "school_id",
+            "discount_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_discount_tier_rank": {
+          "name": "uniq_discount_tier_rank",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discount_id",
+            "rank"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discount": {
+      "name": "discount",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "discount_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'FIXED'"
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applies_to_category_id": {
+          "name": "applies_to_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_label": {
+          "name": "duration_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_approval": {
+          "name": "requires_approval",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stackable": {
+          "name": "stackable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_tiered": {
+          "name": "is_tiered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "applied_count": {
+          "name": "applied_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "discount_school_id_ref_school_id_fk": {
+          "name": "discount_school_id_ref_school_id_fk",
+          "tableFrom": "discount",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discount_applies_to_category_id_fee_category_id_fk": {
+          "name": "discount_applies_to_category_id_fee_category_id_fk",
+          "tableFrom": "discount",
+          "tableTo": "fee_category",
+          "columnsFrom": [
+            "applies_to_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "discount_approved_by_user_id_ref_user_id_fk": {
+          "name": "discount_approved_by_user_id_ref_user_id_fk",
+          "tableFrom": "discount",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_discount_per_school": {
+          "name": "uniq_discount_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        },
+        "discount_tenant_uk": {
+          "name": "discount_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_structure_item": {
+      "name": "fee_structure_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_structure_id": {
+          "name": "fee_structure_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_category_id": {
+          "name": "fee_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_structure_item_school_id_ref_school_id_fk": {
+          "name": "fee_structure_item_school_id_ref_school_id_fk",
+          "tableFrom": "fee_structure_item",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fee_structure_item_fee_category_id_fee_category_id_fk": {
+          "name": "fee_structure_item_fee_category_id_fee_category_id_fk",
+          "tableFrom": "fee_structure_item",
+          "tableTo": "fee_category",
+          "columnsFrom": [
+            "fee_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "fee_structure_item_school_id_fee_structure_id_fee_structure_school_id_id_fk": {
+          "name": "fee_structure_item_school_id_fee_structure_id_fee_structure_school_id_id_fk",
+          "tableFrom": "fee_structure_item",
+          "tableTo": "fee_structure",
+          "columnsFrom": [
+            "school_id",
+            "fee_structure_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_structure": {
+      "name": "fee_structure",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_structure_school_id_ref_school_id_fk": {
+          "name": "fee_structure_school_id_ref_school_id_fk",
+          "tableFrom": "fee_structure",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_fee_structure_per_school": {
+          "name": "uniq_fee_structure_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        },
+        "fee_structure_tenant_uk": {
+          "name": "fee_structure_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_discount_application": {
+      "name": "invoice_discount_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_id": {
+          "name": "discount_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind_snapshot": {
+          "name": "kind_snapshot",
+          "type": "discount_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "applied_by_user_id": {
+          "name": "applied_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_discount_app_school_idx": {
+          "name": "invoice_discount_app_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_discount_app_invoice_idx": {
+          "name": "invoice_discount_app_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_discount_app_discount_idx": {
+          "name": "invoice_discount_app_discount_idx",
+          "columns": [
+            {
+              "expression": "discount_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_discount_application_school_id_ref_school_id_fk": {
+          "name": "invoice_discount_application_school_id_ref_school_id_fk",
+          "tableFrom": "invoice_discount_application",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_discount_application_applied_by_user_id_ref_user_id_fk": {
+          "name": "invoice_discount_application_applied_by_user_id_ref_user_id_fk",
+          "tableFrom": "invoice_discount_application",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "applied_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_discount_application_school_id_invoice_id_invoice_school_id_id_fk": {
+          "name": "invoice_discount_application_school_id_invoice_id_invoice_school_id_id_fk",
+          "tableFrom": "invoice_discount_application",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "school_id",
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_discount_application_school_id_student_id_students_school_id_id_fk": {
+          "name": "invoice_discount_application_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "invoice_discount_application",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_discount_application_school_id_discount_id_discount_school_id_id_fk": {
+          "name": "invoice_discount_application_school_id_discount_id_discount_school_id_id_fk",
+          "tableFrom": "invoice_discount_application",
+          "tableTo": "discount",
+          "columnsFrom": [
+            "school_id",
+            "discount_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attendance_correction": {
+      "name": "attendance_correction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_record_id": {
+          "name": "attendance_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_status": {
+          "name": "requested_status",
+          "type": "attendance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "correction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "decision_note": {
+          "name": "decision_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attendance_correction_school_id_ref_school_id_fk": {
+          "name": "attendance_correction_school_id_ref_school_id_fk",
+          "tableFrom": "attendance_correction",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_correction_requested_by_user_id_ref_user_id_fk": {
+          "name": "attendance_correction_requested_by_user_id_ref_user_id_fk",
+          "tableFrom": "attendance_correction",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attendance_correction_decided_by_user_id_ref_user_id_fk": {
+          "name": "attendance_correction_decided_by_user_id_ref_user_id_fk",
+          "tableFrom": "attendance_correction",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attendance_correction_school_id_attendance_record_id_attendance_record_school_id_id_fk": {
+          "name": "attendance_correction_school_id_attendance_record_id_attendance_record_school_id_id_fk",
+          "tableFrom": "attendance_correction",
+          "tableTo": "attendance_record",
+          "columnsFrom": [
+            "school_id",
+            "attendance_record_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attendance_record": {
+      "name": "attendance_record",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "attendance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marked_by_user_id": {
+          "name": "marked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marked_at": {
+          "name": "marked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attendance_class_date_idx": {
+          "name": "attendance_class_date_idx",
+          "columns": [
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attendance_record_school_id_ref_school_id_fk": {
+          "name": "attendance_record_school_id_ref_school_id_fk",
+          "tableFrom": "attendance_record",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_record_marked_by_user_id_ref_user_id_fk": {
+          "name": "attendance_record_marked_by_user_id_ref_user_id_fk",
+          "tableFrom": "attendance_record",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "marked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attendance_record_school_id_student_id_students_school_id_id_fk": {
+          "name": "attendance_record_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "attendance_record",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_record_school_id_class_id_class_school_id_id_fk": {
+          "name": "attendance_record_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "attendance_record",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_attendance_student_day": {
+          "name": "uniq_attendance_student_day",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "date"
+          ]
+        },
+        "attendance_record_tenant_uk": {
+          "name": "attendance_record_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attendance_settings": {
+      "name": "attendance_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_start": {
+          "name": "day_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'08:00'"
+        },
+        "late_threshold": {
+          "name": "late_threshold",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'08:15'"
+        },
+        "day_end": {
+          "name": "day_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'15:00'"
+        },
+        "edit_window_hours": {
+          "name": "edit_window_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 24
+        },
+        "absence_sms": {
+          "name": "absence_sms",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "abs_watch_days": {
+          "name": "abs_watch_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "abs_critical_days": {
+          "name": "abs_critical_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "pct_watch": {
+          "name": "pct_watch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 70
+        },
+        "pct_critical": {
+          "name": "pct_critical",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attendance_settings_school_id_ref_school_id_fk": {
+          "name": "attendance_settings_school_id_ref_school_id_fk",
+          "tableFrom": "attendance_settings",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "attendance_settings_school_id_unique": {
+          "name": "attendance_settings_school_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.grade_scale": {
+      "name": "grade_scale",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_score": {
+          "name": "min_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grade_scale_school_idx": {
+          "name": "grade_scale_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grade_scale_school_id_ref_school_id_fk": {
+          "name": "grade_scale_school_id_ref_school_id_fk",
+          "tableFrom": "grade_scale",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_grade_per_school": {
+          "name": "uniq_grade_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "grade"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gradebook_column_score": {
+      "name": "gradebook_column_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_score": {
+          "name": "raw_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gradebook_column_score_column_idx": {
+          "name": "gradebook_column_score_column_idx",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gradebook_column_score_school_id_ref_school_id_fk": {
+          "name": "gradebook_column_score_school_id_ref_school_id_fk",
+          "tableFrom": "gradebook_column_score",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_score_updated_by_user_id_ref_user_id_fk": {
+          "name": "gradebook_column_score_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "gradebook_column_score",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_score_school_id_column_id_gradebook_column_school_id_id_fk": {
+          "name": "gradebook_column_score_school_id_column_id_gradebook_column_school_id_id_fk",
+          "tableFrom": "gradebook_column_score",
+          "tableTo": "gradebook_column",
+          "columnsFrom": [
+            "school_id",
+            "column_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_score_school_id_student_id_students_school_id_id_fk": {
+          "name": "gradebook_column_score_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "gradebook_column_score",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_column_score_per_student": {
+          "name": "uniq_column_score_per_student",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "column_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gradebook_column": {
+      "name": "gradebook_column",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CA'"
+        },
+        "max_score": {
+          "name": "max_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gradebook_column_context_idx": {
+          "name": "gradebook_column_context_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gradebook_column_school_id_ref_school_id_fk": {
+          "name": "gradebook_column_school_id_ref_school_id_fk",
+          "tableFrom": "gradebook_column",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_created_by_user_id_ref_user_id_fk": {
+          "name": "gradebook_column_created_by_user_id_ref_user_id_fk",
+          "tableFrom": "gradebook_column",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_school_id_class_id_class_school_id_id_fk": {
+          "name": "gradebook_column_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "gradebook_column",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "gradebook_column_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "gradebook_column",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "gradebook_column_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "gradebook_column",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_column_per_class_subject_period": {
+          "name": "uniq_column_per_class_subject_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "class_id",
+            "subject_id",
+            "period_id",
+            "name"
+          ]
+        },
+        "gradebook_column_tenant_uk": {
+          "name": "gradebook_column_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gradebook_config": {
+      "name": "gradebook_config",
+      "schema": "",
+      "columns": {
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "class_weight": {
+          "name": "class_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "exam_weight": {
+          "name": "exam_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gradebook_config_school_id_ref_school_id_fk": {
+          "name": "gradebook_config_school_id_ref_school_id_fk",
+          "tableFrom": "gradebook_config",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gradebook_score": {
+      "name": "gradebook_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_score": {
+          "name": "class_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exam_score": {
+          "name": "exam_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "score_period_subject_idx": {
+          "name": "score_period_subject_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gradebook_score_school_id_ref_school_id_fk": {
+          "name": "gradebook_score_school_id_ref_school_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_score_updated_by_user_id_ref_user_id_fk": {
+          "name": "gradebook_score_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gradebook_score_school_id_student_id_students_school_id_id_fk": {
+          "name": "gradebook_score_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_score_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "gradebook_score_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_score_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "gradebook_score_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_score_student_subject_period": {
+          "name": "uniq_score_student_subject_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "subject_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_card": {
+      "name": "report_card",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overall_total": {
+          "name": "overall_total",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overall_grade": {
+          "name": "overall_grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_count": {
+          "name": "subject_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "report_card_school_id_ref_school_id_fk": {
+          "name": "report_card_school_id_ref_school_id_fk",
+          "tableFrom": "report_card",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "report_card_generated_by_user_id_ref_user_id_fk": {
+          "name": "report_card_generated_by_user_id_ref_user_id_fk",
+          "tableFrom": "report_card",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "report_card_school_id_student_id_students_school_id_id_fk": {
+          "name": "report_card_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "report_card",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "report_card_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "report_card_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "report_card",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_report_student_period": {
+          "name": "uniq_report_student_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subject": {
+      "name": "subject",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subject_school_id_ref_school_id_fk": {
+          "name": "subject_school_id_ref_school_id_fk",
+          "tableFrom": "subject",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_subject_per_school": {
+          "name": "uniq_subject_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        },
+        "subject_tenant_uk": {
+          "name": "subject_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_assessment_weights": {
+      "name": "ref_assessment_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asgn_weight": {
+          "name": "asgn_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "mid_sem_weight": {
+          "name": "mid_sem_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "end_sem_weight": {
+          "name": "end_sem_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 40
+        },
+        "project_weight": {
+          "name": "project_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "portfolio_weight": {
+          "name": "portfolio_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "asgn_denominator": {
+          "name": "asgn_denominator",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "mid_sem_denominator": {
+          "name": "mid_sem_denominator",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "end_sem_denominator": {
+          "name": "end_sem_denominator",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "project_denominator": {
+          "name": "project_denominator",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "portfolio_denominator": {
+          "name": "portfolio_denominator",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_school_default_weights": {
+          "name": "uniq_school_default_weights",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"ref_assessment_weights\".\"subject_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ref_assessment_weights_school_id_ref_school_id_fk": {
+          "name": "ref_assessment_weights_school_id_ref_school_id_fk",
+          "tableFrom": "ref_assessment_weights",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ref_assessment_weights_updated_by_user_id_ref_user_id_fk": {
+          "name": "ref_assessment_weights_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "ref_assessment_weights",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ref_assessment_weights_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "ref_assessment_weights_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "ref_assessment_weights",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_weights_per_school_subject": {
+          "name": "uniq_weights_per_school_subject",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "subject_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "assessment_weights_sum_100": {
+          "name": "assessment_weights_sum_100",
+          "value": "\"ref_assessment_weights\".\"asgn_weight\" + \"ref_assessment_weights\".\"mid_sem_weight\" + \"ref_assessment_weights\".\"end_sem_weight\" + \"ref_assessment_weights\".\"project_weight\" + \"ref_assessment_weights\".\"portfolio_weight\" = 100"
+        },
+        "assessment_denominators_positive": {
+          "name": "assessment_denominators_positive",
+          "value": "\"ref_assessment_weights\".\"asgn_denominator\" > 0 AND \"ref_assessment_weights\".\"mid_sem_denominator\" > 0 AND \"ref_assessment_weights\".\"end_sem_denominator\" > 0 AND \"ref_assessment_weights\".\"project_denominator\" > 0 AND \"ref_assessment_weights\".\"portfolio_denominator\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.senior_assessment_score": {
+      "name": "senior_assessment_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assessment_id": {
+          "name": "assessment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_mark": {
+          "name": "raw_mark",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "senior_assessment_score_assessment_idx": {
+          "name": "senior_assessment_score_assessment_idx",
+          "columns": [
+            {
+              "expression": "assessment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "senior_assessment_score_school_id_ref_school_id_fk": {
+          "name": "senior_assessment_score_school_id_ref_school_id_fk",
+          "tableFrom": "senior_assessment_score",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_score_updated_by_user_id_ref_user_id_fk": {
+          "name": "senior_assessment_score_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "senior_assessment_score",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_score_school_id_assessment_id_senior_assessment_school_id_id_fk": {
+          "name": "senior_assessment_score_school_id_assessment_id_senior_assessment_school_id_id_fk",
+          "tableFrom": "senior_assessment_score",
+          "tableTo": "senior_assessment",
+          "columnsFrom": [
+            "school_id",
+            "assessment_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_score_school_id_student_id_students_school_id_id_fk": {
+          "name": "senior_assessment_score_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "senior_assessment_score",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_assessment_score_per_student": {
+          "name": "uniq_assessment_score_per_student",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "assessment_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.senior_assessment": {
+      "name": "senior_assessment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "assessment_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_mark": {
+          "name": "max_mark",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assessed_on": {
+          "name": "assessed_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_one_mid_sem_per_context": {
+          "name": "uniq_one_mid_sem_per_context",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"senior_assessment\".\"category\" = 'MID_SEM_EXAM'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_one_end_sem_per_context": {
+          "name": "uniq_one_end_sem_per_context",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"senior_assessment\".\"category\" = 'END_SEM_EXAM'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "senior_assessment_context_idx": {
+          "name": "senior_assessment_context_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "senior_assessment_school_id_ref_school_id_fk": {
+          "name": "senior_assessment_school_id_ref_school_id_fk",
+          "tableFrom": "senior_assessment",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_created_by_user_id_ref_user_id_fk": {
+          "name": "senior_assessment_created_by_user_id_ref_user_id_fk",
+          "tableFrom": "senior_assessment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_school_id_class_id_class_school_id_id_fk": {
+          "name": "senior_assessment_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "senior_assessment",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "senior_assessment_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "senior_assessment",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "senior_assessment_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "senior_assessment",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_assessment_per_context": {
+          "name": "uniq_assessment_per_context",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "class_id",
+            "subject_id",
+            "period_id",
+            "category",
+            "title"
+          ]
+        },
+        "senior_assessment_tenant_uk": {
+          "name": "senior_assessment_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.senior_ledger_path": {
+      "name": "senior_ledger_path",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "capture_path",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AUTO_COMPILE'"
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "senior_ledger_path_school_id_ref_school_id_fk": {
+          "name": "senior_ledger_path_school_id_ref_school_id_fk",
+          "tableFrom": "senior_ledger_path",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_ledger_path_updated_by_user_id_ref_user_id_fk": {
+          "name": "senior_ledger_path_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "senior_ledger_path",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "senior_ledger_path_school_id_class_id_class_school_id_id_fk": {
+          "name": "senior_ledger_path_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "senior_ledger_path",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_ledger_path_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "senior_ledger_path_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "senior_ledger_path",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_ledger_path_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "senior_ledger_path_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "senior_ledger_path",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_ledger_path_context": {
+          "name": "uniq_ledger_path_context",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "class_id",
+            "subject_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.senior_score_ledger": {
+      "name": "senior_score_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asgn_score": {
+          "name": "asgn_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mid_sem_score": {
+          "name": "mid_sem_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_sem_score": {
+          "name": "end_sem_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_score": {
+          "name": "project_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "portfolio_score": {
+          "name": "portfolio_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weighted_total": {
+          "name": "weighted_total",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asgn_weight_used": {
+          "name": "asgn_weight_used",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mid_sem_weight_used": {
+          "name": "mid_sem_weight_used",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_sem_weight_used": {
+          "name": "end_sem_weight_used",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_weight_used": {
+          "name": "project_weight_used",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "portfolio_weight_used": {
+          "name": "portfolio_weight_used",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "portfolio_manual": {
+          "name": "portfolio_manual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ledger_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "compiled_by_user_id": {
+          "name": "compiled_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compiled_at": {
+          "name": "compiled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "senior_ledger_period_subject_idx": {
+          "name": "senior_ledger_period_subject_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "senior_score_ledger_school_id_ref_school_id_fk": {
+          "name": "senior_score_ledger_school_id_ref_school_id_fk",
+          "tableFrom": "senior_score_ledger",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_compiled_by_user_id_ref_user_id_fk": {
+          "name": "senior_score_ledger_compiled_by_user_id_ref_user_id_fk",
+          "tableFrom": "senior_score_ledger",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "compiled_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_school_id_student_id_students_school_id_id_fk": {
+          "name": "senior_score_ledger_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "senior_score_ledger",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "senior_score_ledger_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "senior_score_ledger",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "senior_score_ledger_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "senior_score_ledger",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_ledger_student_subject_period": {
+          "name": "uniq_ledger_student_subject_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "subject_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.senior_subject_teacher": {
+      "name": "senior_subject_teacher",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teacher_user_id": {
+          "name": "teacher_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "senior_subject_teacher_school_id_ref_school_id_fk": {
+          "name": "senior_subject_teacher_school_id_ref_school_id_fk",
+          "tableFrom": "senior_subject_teacher",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_subject_teacher_teacher_user_id_ref_user_id_fk": {
+          "name": "senior_subject_teacher_teacher_user_id_ref_user_id_fk",
+          "tableFrom": "senior_subject_teacher",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "teacher_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "senior_subject_teacher_school_id_class_id_class_school_id_id_fk": {
+          "name": "senior_subject_teacher_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "senior_subject_teacher",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_subject_teacher_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "senior_subject_teacher_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "senior_subject_teacher",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_subject_teacher_context": {
+          "name": "uniq_subject_teacher_context",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "class_id",
+            "subject_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.timetable_slot": {
+      "name": "timetable_slot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_index": {
+          "name": "period_index",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teacher_user_id": {
+          "name": "teacher_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "timetable_teacher_slot_idx": {
+          "name": "timetable_teacher_slot_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "teacher_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "timetable_slot_school_id_ref_school_id_fk": {
+          "name": "timetable_slot_school_id_ref_school_id_fk",
+          "tableFrom": "timetable_slot",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "timetable_slot_subject_id_subject_id_fk": {
+          "name": "timetable_slot_subject_id_subject_id_fk",
+          "tableFrom": "timetable_slot",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "timetable_slot_teacher_user_id_ref_user_id_fk": {
+          "name": "timetable_slot_teacher_user_id_ref_user_id_fk",
+          "tableFrom": "timetable_slot",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "teacher_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "timetable_slot_school_id_class_id_class_school_id_id_fk": {
+          "name": "timetable_slot_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "timetable_slot",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_timetable_class_slot": {
+          "name": "uniq_timetable_class_slot",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "class_id",
+            "day_of_week",
+            "period_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.announcement": {
+      "name": "announcement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "audience",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'WHOLE_SCHOOL'"
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_by_user_id": {
+          "name": "posted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "announcement_school_id_ref_school_id_fk": {
+          "name": "announcement_school_id_ref_school_id_fk",
+          "tableFrom": "announcement",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "announcement_class_id_class_id_fk": {
+          "name": "announcement_class_id_class_id_fk",
+          "tableFrom": "announcement",
+          "tableTo": "class",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "announcement_posted_by_user_id_ref_user_id_fk": {
+          "name": "announcement_posted_by_user_id_ref_user_id_fk",
+          "tableFrom": "announcement",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "posted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "notif_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'QUEUED'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_ref": {
+          "name": "provider_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_by_user_id": {
+          "name": "sent_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notif_school_time_idx": {
+          "name": "notif_school_time_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_log_school_id_ref_school_id_fk": {
+          "name": "notification_log_school_id_ref_school_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_log_student_id_students_id_fk": {
+          "name": "notification_log_student_id_students_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_log_template_id_sms_template_id_fk": {
+          "name": "notification_log_template_id_sms_template_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "sms_template",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_log_sent_by_user_id_ref_user_id_fk": {
+          "name": "notification_log_sent_by_user_id_ref_user_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "sent_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_template": {
+      "name": "sms_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sms_template_school_id_ref_school_id_fk": {
+          "name": "sms_template_school_id_ref_school_id_fk",
+          "tableFrom": "sms_template",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_template_per_school": {
+          "name": "uniq_template_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "conversation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "assigned_to_user_id": {
+          "name": "assigned_to_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SMS'"
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "routed_by_rule_id": {
+          "name": "routed_by_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "routed_by_rule_name": {
+          "name": "routed_by_rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_school_activity_idx": {
+          "name": "conversation_school_activity_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_phone_idx": {
+          "name": "conversation_phone_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_school_id_ref_school_id_fk": {
+          "name": "conversation_school_id_ref_school_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_student_id_students_id_fk": {
+          "name": "conversation_student_id_students_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "conversation_assigned_to_user_id_ref_user_id_fk": {
+          "name": "conversation_assigned_to_user_id_ref_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "assigned_to_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_tenant_uk": {
+          "name": "conversation_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbox_message": {
+      "name": "inbox_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "message_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_by_user_id": {
+          "name": "sent_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inbox_message_conversation_idx": {
+          "name": "inbox_message_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbox_message_school_id_ref_school_id_fk": {
+          "name": "inbox_message_school_id_ref_school_id_fk",
+          "tableFrom": "inbox_message",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbox_message_sent_by_user_id_ref_user_id_fk": {
+          "name": "inbox_message_sent_by_user_id_ref_user_id_fk",
+          "tableFrom": "inbox_message",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "sent_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbox_message_school_id_conversation_id_conversation_school_id_id_fk": {
+          "name": "inbox_message_school_id_conversation_id_conversation_school_id_id_fk",
+          "tableFrom": "inbox_message",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "school_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbox_routing_rule": {
+      "name": "inbox_routing_rule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_fallback": {
+          "name": "is_fallback",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "match_topic": {
+          "name": "match_topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_class": {
+          "name": "match_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_keywords": {
+          "name": "match_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assign_to_user_id": {
+          "name": "assign_to_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_all_admins": {
+          "name": "notify_all_admins",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inbox_routing_rule_school_pos_idx": {
+          "name": "inbox_routing_rule_school_pos_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbox_routing_rule_school_id_ref_school_id_fk": {
+          "name": "inbox_routing_rule_school_id_ref_school_id_fk",
+          "tableFrom": "inbox_routing_rule",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbox_routing_rule_assign_to_user_id_ref_user_id_fk": {
+          "name": "inbox_routing_rule_assign_to_user_id_ref_user_id_fk",
+          "tableFrom": "inbox_routing_rule",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "assign_to_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite": {
+      "name": "invite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignments": {
+          "name": "assignments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_user_id": {
+          "name": "accepted_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invite_school_status_idx": {
+          "name": "invite_school_status_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_school_id_ref_school_id_fk": {
+          "name": "invite_school_id_ref_school_id_fk",
+          "tableFrom": "invite",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_invited_by_user_id_ref_user_id_fk": {
+          "name": "invite_invited_by_user_id_ref_user_id_fk",
+          "tableFrom": "invite",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invite_accepted_user_id_ref_user_id_fk": {
+          "name": "invite_accepted_user_id_ref_user_id_fk",
+          "tableFrom": "invite",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "accepted_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_token_unique": {
+          "name": "invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_category": {
+      "name": "book_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "book_entry_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_category_school_idx": {
+          "name": "book_category_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_category_school_id_ref_school_id_fk": {
+          "name": "book_category_school_id_ref_school_id_fk",
+          "tableFrom": "book_category",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_book_category_per_school": {
+          "name": "uniq_book_category_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "kind",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_entry": {
+      "name": "book_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "book_entry_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_date": {
+          "name": "entry_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "party": {
+          "name": "party",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_entry_school_date_idx": {
+          "name": "book_entry_school_date_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entry_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_entry_school_id_ref_school_id_fk": {
+          "name": "book_entry_school_id_ref_school_id_fk",
+          "tableFrom": "book_entry",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_entry_category_id_book_category_id_fk": {
+          "name": "book_entry_category_id_book_category_id_fk",
+          "tableFrom": "book_entry",
+          "tableTo": "book_category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "book_entry_created_by_user_id_ref_user_id_fk": {
+          "name": "book_entry_created_by_user_id_ref_user_id_fk",
+          "tableFrom": "book_entry",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fixed_asset": {
+      "name": "fixed_asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acquired_on": {
+          "name": "acquired_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_cost": {
+          "name": "original_cost",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accumulated_depreciation": {
+          "name": "accumulated_depreciation",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "useful_life_years": {
+          "name": "useful_life_years",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fixed_asset_school_idx": {
+          "name": "fixed_asset_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fixed_asset_school_id_ref_school_id_fk": {
+          "name": "fixed_asset_school_id_ref_school_id_fk",
+          "tableFrom": "fixed_asset",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.whatsapp_template": {
+      "name": "whatsapp_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTILITY'"
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en_GH'"
+        },
+        "header_type": {
+          "name": "header_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NONE'"
+        },
+        "header_text": {
+          "name": "header_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_filename": {
+          "name": "header_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footer": {
+          "name": "footer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buttons": {
+          "name": "buttons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sample_values": {
+          "name": "sample_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "whatsapp_template_school_idx": {
+          "name": "whatsapp_template_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "whatsapp_template_school_id_ref_school_id_fk": {
+          "name": "whatsapp_template_school_id_ref_school_id_fk",
+          "tableFrom": "whatsapp_template",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "whatsapp_template_created_by_user_id_ref_user_id_fk": {
+          "name": "whatsapp_template_created_by_user_id_ref_user_id_fk",
+          "tableFrom": "whatsapp_template",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_whatsapp_template_name_per_school": {
+          "name": "uniq_whatsapp_template_name_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.admission_status": {
+      "name": "admission_status",
+      "schema": "public",
+      "values": [
+        "SUBMITTED",
+        "UNDER_REVIEW",
+        "ACCEPTED",
+        "REJECTED",
+        "WAITLISTED"
+      ]
+    },
+    "public.allocation_method": {
+      "name": "allocation_method",
+      "schema": "public",
+      "values": [
+        "MANUAL",
+        "AUTO_OLDEST_FIRST",
+        "AUTO_NEWEST_FIRST"
+      ]
+    },
+    "public.allocation_type": {
+      "name": "allocation_type",
+      "schema": "public",
+      "values": [
+        "INVOICE",
+        "CREDIT",
+        "REFUND"
+      ]
+    },
+    "public.anomaly_severity": {
+      "name": "anomaly_severity",
+      "schema": "public",
+      "values": [
+        "LOW",
+        "MEDIUM",
+        "HIGH"
+      ]
+    },
+    "public.app_role": {
+      "name": "app_role",
+      "schema": "public",
+      "values": [
+        "ADMIN",
+        "HEADMASTER",
+        "VICE_HEADMASTER_ACADEMIC",
+        "TEACHER",
+        "FORM_MASTER",
+        "HOUSEMASTER",
+        "STUDENT",
+        "PARENT",
+        "BURSAR",
+        "DEAN_OF_BOARDING",
+        "MATRON"
+      ]
+    },
+    "public.assessment_category": {
+      "name": "assessment_category",
+      "schema": "public",
+      "values": [
+        "ASSIGNMENT",
+        "MID_SEM_EXAM",
+        "END_SEM_EXAM",
+        "PROJECT"
+      ]
+    },
+    "public.attendance_status": {
+      "name": "attendance_status",
+      "schema": "public",
+      "values": [
+        "PRESENT",
+        "ABSENT",
+        "LATE",
+        "EXCUSED",
+        "MEDICAL"
+      ]
+    },
+    "public.audience": {
+      "name": "audience",
+      "schema": "public",
+      "values": [
+        "WHOLE_SCHOOL",
+        "CLASS"
+      ]
+    },
+    "public.book_entry_kind": {
+      "name": "book_entry_kind",
+      "schema": "public",
+      "values": [
+        "INCOME",
+        "EXPENSE"
+      ]
+    },
+    "public.capture_path": {
+      "name": "capture_path",
+      "schema": "public",
+      "values": [
+        "AUTO_COMPILE",
+        "SCAN_EXTRACT",
+        "DIRECT_ENTRY"
+      ]
+    },
+    "public.conversation_status": {
+      "name": "conversation_status",
+      "schema": "public",
+      "values": [
+        "OPEN",
+        "CLOSED"
+      ]
+    },
+    "public.correction_status": {
+      "name": "correction_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPROVED",
+        "REJECTED"
+      ]
+    },
+    "public.discount_kind": {
+      "name": "discount_kind",
+      "schema": "public",
+      "values": [
+        "PERCENT",
+        "FIXED"
+      ]
+    },
+    "public.guardian_relation": {
+      "name": "guardian_relation",
+      "schema": "public",
+      "values": [
+        "MOTHER",
+        "FATHER",
+        "GUARDIAN",
+        "OTHER"
+      ]
+    },
+    "public.invite_status": {
+      "name": "invite_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "REVOKED",
+        "EXPIRED"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "ISSUED",
+        "PARTIAL",
+        "PAID",
+        "OVERDUE",
+        "EXEMPT",
+        "VOIDED"
+      ]
+    },
+    "public.ledger_correction_reason": {
+      "name": "ledger_correction_reason",
+      "schema": "public",
+      "values": [
+        "RE_GRADED",
+        "TRANSCRIPTION_ERROR",
+        "OTHER"
+      ]
+    },
+    "public.ledger_status": {
+      "name": "ledger_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "COMPLETE",
+        "STPSHS_READY"
+      ]
+    },
+    "public.message_direction": {
+      "name": "message_direction",
+      "schema": "public",
+      "values": [
+        "INBOUND",
+        "OUTBOUND"
+      ]
+    },
+    "public.notif_status": {
+      "name": "notif_status",
+      "schema": "public",
+      "values": [
+        "QUEUED",
+        "SENT",
+        "FAILED"
+      ]
+    },
+    "public.ownership_type": {
+      "name": "ownership_type",
+      "schema": "public",
+      "values": [
+        "PUBLIC",
+        "PRIVATE",
+        "MISSION",
+        "INTERNATIONAL"
+      ]
+    },
+    "public.payment_actor_type": {
+      "name": "payment_actor_type",
+      "schema": "public",
+      "values": [
+        "ADMIN",
+        "SYSTEM",
+        "WEBHOOK",
+        "RECONCILIATION_JOB"
+      ]
+    },
+    "public.payment_event_type": {
+      "name": "payment_event_type",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "ALLOCATION_ADDED",
+        "ALLOCATION_VOIDED",
+        "SETTLED",
+        "VOIDED",
+        "SMS_SENT",
+        "SMS_FAILED",
+        "REFUNDED",
+        "DISCOUNT_OVERRIDDEN"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "MTN_MOMO",
+        "TELECEL_CASH",
+        "AIRTELTIGO_MONEY",
+        "BANK_TRANSFER",
+        "CASH",
+        "CHEQUE",
+        "OTHER"
+      ]
+    },
+    "public.period_source": {
+      "name": "period_source",
+      "schema": "public",
+      "values": [
+        "GES_DEFAULT",
+        "SCHOOL_OVERRIDE"
+      ]
+    },
+    "public.period_type": {
+      "name": "period_type",
+      "schema": "public",
+      "values": [
+        "TERM",
+        "SEMESTER"
+      ]
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "public",
+      "values": [
+        "BASIC",
+        "SENIOR",
+        "OVERSIGHT"
+      ]
+    },
+    "public.programme": {
+      "name": "programme",
+      "schema": "public",
+      "values": [
+        "GENERAL_ARTS",
+        "GENERAL_SCIENCE",
+        "BUSINESS",
+        "AGRICULTURE",
+        "VISUAL_ARTS",
+        "HOME_ECONOMICS",
+        "TECHNICAL"
+      ]
+    },
+    "public.residency": {
+      "name": "residency",
+      "schema": "public",
+      "values": [
+        "BOARDER",
+        "DAY",
+        "DEBOARDINIZED"
+      ]
+    },
+    "public.school_type": {
+      "name": "school_type",
+      "schema": "public",
+      "values": [
+        "BASIC",
+        "SENIOR",
+        "COMBINED"
+      ]
+    },
+    "public.settlement_status": {
+      "name": "settlement_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "CONFIRMED",
+        "SETTLED",
+        "RECONCILED",
+        "DISPUTED"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "MALE",
+        "FEMALE"
+      ]
+    },
+    "public.shs_category": {
+      "name": "shs_category",
+      "schema": "public",
+      "values": [
+        "A",
+        "B",
+        "C",
+        "D",
+        "E",
+        "F"
+      ]
+    },
+    "public.student_status": {
+      "name": "student_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "INACTIVE",
+        "GRADUATED",
+        "WITHDRAWN",
+        "TRANSFERRED"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/omnischools/db/migrations/meta/_journal.json
+++ b/omnischools/db/migrations/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1783286276085,
       "tag": "0040_green_captain_stacy",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1784070584660,
+      "tag": "0041_little_human_torch",
+      "breakpoints": true
     }
   ]
 }

--- a/omnischools/db/schema/_enums.ts
+++ b/omnischools/db/schema/_enums.ts
@@ -187,3 +187,15 @@ export const capturePathEnum = pgEnum("capture_path", [
   "SCAN_EXTRACT",
   "DIRECT_ENTRY",
 ]);
+
+// Score-ledger correction reason (Path B scan diff — Item 4/INCR-2). This is the
+// authoritative DOMAIN of allowed reason codes; it is deliberately NOT a table column.
+// The chosen code persists as the free-text `reason` on auditLog (lib/db/audit.ts) when a
+// teacher accepts a score-down or a Case-D "keep blank" — no new ledger column (Kofi Q1/Q4).
+// Exposed as a pgEnum (matching the codebase's enum-heavy style) so the app + any future
+// Item 7 version-chain column share one typed source of truth. Free text is mandatory on OTHER.
+export const ledgerCorrectionReasonEnum = pgEnum("ledger_correction_reason", [
+  "RE_GRADED",
+  "TRANSCRIPTION_ERROR",
+  "OTHER",
+]);

--- a/omnischools/db/schema/score-ledger.ts
+++ b/omnischools/db/schema/score-ledger.ts
@@ -52,6 +52,16 @@ export const assessmentWeights = pgTable(
     endSemWeight: smallint("end_sem_weight").notNull().default(40),
     projectWeight: smallint("project_weight").notNull().default(15),
     portfolioWeight: smallint("portfolio_weight").notNull().default(15),
+    // Per-category scan denominator (Path B / Item 4). A raw number the extractor read is
+    // interpreted against its category's denominator: raw 8 under /10 → 80/100. Same grain
+    // and resolution as the weights above (subject row → school-default row → system 100).
+    // System default 100 = identity (never inflates a mark). Scaling is a pure lib function
+    // (compute.ts:percent) — never a DB trigger. Asankrangwa seeds portfolio /10 (rest /100).
+    asgnDenominator: smallint("asgn_denominator").notNull().default(100),
+    midSemDenominator: smallint("mid_sem_denominator").notNull().default(100),
+    endSemDenominator: smallint("end_sem_denominator").notNull().default(100),
+    projectDenominator: smallint("project_denominator").notNull().default(100),
+    portfolioDenominator: smallint("portfolio_denominator").notNull().default(100),
     updatedByUserId: uuid("updated_by_user_id").references(() => users.id),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -68,6 +78,13 @@ export const assessmentWeights = pgTable(
     sumTo100: check(
       "assessment_weights_sum_100",
       sql`${t.asgnWeight} + ${t.midSemWeight} + ${t.endSemWeight} + ${t.projectWeight} + ${t.portfolioWeight} = 100`,
+    ),
+    // Every per-category denominator must be strictly positive — guards the scan-scale
+    // divide (a /0 denominator would corrupt every mark). One combined CHECK mirrors the
+    // single-constraint style of sumTo100 above.
+    denomPositive: check(
+      "assessment_denominators_positive",
+      sql`${t.asgnDenominator} > 0 AND ${t.midSemDenominator} > 0 AND ${t.endSemDenominator} > 0 AND ${t.projectDenominator} > 0 AND ${t.portfolioDenominator} > 0`,
     ),
     // Composite school-scoped FK — only enforced when subject_id is set (MATCH SIMPLE
     // skips rows with any NULL key column, which is exactly the school-default row).

--- a/omnischools/db/seed/asankrangwa.ts
+++ b/omnischools/db/seed/asankrangwa.ts
@@ -337,6 +337,9 @@ async function main() {
   const form3GA = classRows.find((c) => c.name === "Form 3 General Arts")!;
 
   // School-default assessment weights (15/15/40/15/15 — end-of-sem dominant, Asankrangwa).
+  // Denominators: portfolio is marked out of 10 at Asankrangwa (Path B scan scale, Item 4);
+  // the other four categories are out of 100, so they inherit the column default (100) and
+  // are left unset here. Seeded real config — the system fallback (all /100) never inflates.
   await db.insert(assessmentWeights).values({
     schoolId: school.id,
     subjectId: null,
@@ -345,6 +348,7 @@ async function main() {
     endSemWeight: SYSTEM_DEFAULT_WEIGHTS.endSem,
     projectWeight: SYSTEM_DEFAULT_WEIGHTS.project,
     portfolioWeight: SYSTEM_DEFAULT_WEIGHTS.portfolio,
+    portfolioDenominator: 10,
     updatedByUserId: userByPhone.get("+233244000002"),
   });
 

--- a/omnischools/db/sql/prod-paste-0041-ledger-denominators.sql
+++ b/omnischools/db/sql/prod-paste-0041-ledger-denominators.sql
@@ -1,0 +1,36 @@
+-- Omnischools — migration 0041: Score Ledger Item 4 · Path B (INCR-2) denominators.
+-- Adds the five per-category scan denominators to ref_assessment_weights and the
+-- ledger_correction_reason enum (Path B score-down / Case-D reason codes).
+-- Idempotent — safe to run more than once.
+--
+-- *** RLS: NOTHING TO DO. ***
+-- This migration adds NO new table. ref_assessment_weights already carries
+-- ENABLE + FORCE ROW LEVEL SECURITY + the tenant_isolation policy (pasted at 0038 —
+-- see prod-paste-0038-senior-ledger.sql). Adding columns does not change RLS, so there
+-- is NO policy delta and NO cross-tenant leak risk here. The reason enum is a Postgres
+-- type, not a table, so it has no RLS at all.
+--
+-- 0041 is plain, portable DDL (a type + five columns + one CHECK). It is applied to prod
+-- by the normal drizzle migrate flow at deploy; these idempotent statements are provided
+-- only so the change can be hand-verified/hand-applied in the Supabase SQL editor if needed.
+-- Prod needs the column ALTER + the enum — NOT new RLS.
+
+-- ---- enum: allowed score-down / Case-D reason codes (persist in audit_log.reason) ----
+DO $$ BEGIN
+  CREATE TYPE "ledger_correction_reason" AS ENUM('RE_GRADED','TRANSCRIPTION_ERROR','OTHER');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- ---- new columns on the existing tenant table ref_assessment_weights ----
+-- smallint NOT NULL DEFAULT 100 (system-default denominator = identity; never inflates).
+ALTER TABLE "ref_assessment_weights" ADD COLUMN IF NOT EXISTS "asgn_denominator" smallint DEFAULT 100 NOT NULL;
+ALTER TABLE "ref_assessment_weights" ADD COLUMN IF NOT EXISTS "mid_sem_denominator" smallint DEFAULT 100 NOT NULL;
+ALTER TABLE "ref_assessment_weights" ADD COLUMN IF NOT EXISTS "end_sem_denominator" smallint DEFAULT 100 NOT NULL;
+ALTER TABLE "ref_assessment_weights" ADD COLUMN IF NOT EXISTS "project_denominator" smallint DEFAULT 100 NOT NULL;
+ALTER TABLE "ref_assessment_weights" ADD COLUMN IF NOT EXISTS "portfolio_denominator" smallint DEFAULT 100 NOT NULL;
+
+-- ---- CHECK: every denominator strictly positive (guards the scan-scale divide-by-zero) ----
+DO $$ BEGIN
+  ALTER TABLE "ref_assessment_weights" ADD CONSTRAINT "assessment_denominators_positive"
+    CHECK ("asgn_denominator" > 0 AND "mid_sem_denominator" > 0 AND "end_sem_denominator" > 0
+       AND "project_denominator" > 0 AND "portfolio_denominator" > 0);
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;

--- a/omnischools/docs/senior-build-plan.md
+++ b/omnischools/docs/senior-build-plan.md
@@ -94,11 +94,39 @@ persists the image** — all tenant-scoped, gates green.
 | Commit path — writes `senior_score_ledger` `path_used = SCAN_EXTRACT` + `recordAudit` + reason codes; drops the image | Claude Code | ⬜ |
 | Seed already set (Asankrangwa portfolio denom /10 in `db/seed/asankrangwa.ts`) | Wells | ✅ (not run — seed not idempotent) |
 | Build · typecheck · tests · RLS test · preview round-trip (real photo → extract → commit) | Claude Code | ⬜ |
-| QA — 4 diff cases, denominator scaling, confidence bands, roster mis-map, multi-page, tenant isolation | Quinn | ⬜ |
-| Architecture/portability — provider swappable behind `LedgerExtractor`? model id a single constant? API key server-only? | Dex | ⬜ |
-| Security — image truly never persisted, key server-side only, cross-tenant read, prod parity | Sarah | ⬜ holds merge |
-| Gate fixes (single aggregated rework brief) | Claude Code | ⬜ |
-| Merge · verify it landed with `git log origin/main` | Sarah | ⬜ |
+| QA — 4 diff cases, denominator scaling, confidence bands, roster mis-map, multi-page, tenant isolation | Quinn | ✅ PASS (build+typecheck+69 tests green; 3 MINOR, below) |
+| Architecture/portability — provider swappable behind `LedgerExtractor`? model id a single constant? API key server-only? | Dex | ✅ APPROVE (3 MINOR, below) |
+| Security — image truly never persisted, key server-side only, cross-tenant read, prod parity | Sarah | ✅ APPROVE (merge held for owner go) |
+| Gate fixes (single aggregated rework brief) | Claude Code | ⬜ (MINOR only — see below) |
+| Live-preview round-trip (real photo → extract → commit) | Claude Code | ⬜ still owed (DB/UI-layer criteria verified by code-read only) |
+| Merge · verify it landed with `git log origin/main` | Sarah | ⬜ pending owner go |
+
+**Gate findings (all MINOR / non-blocking — Sarah cleared the merge):**
+- **Dex-1 — dead enum.** `ledgerCorrectionReasonEnum` documented as the reason-code source of truth but nothing imports it; the Zod domain + UI list are declared separately → 3-way drift risk. Fix: derive `REASON_CODES` from `ledgerCorrectionReasonEnum.enumValues` (1 line), or drop the enum (YAGNI).
+- **Quinn-1 — scaler cap vs commit bound.** A scaled value >100 (bonus mark, e.g. 11/10 portfolio) seeds into the grid then is rejected by `commitScanLedger` (0–100), blocking commit. Safe (no corruption) but inconsistent with Path A (allows bonus to 999.99). **Kofi ruling needed:** should Path B allow bonus marks?
+- **Quinn-2 — reason pre-baked.** Score-down / Case-D keep-blank pre-bakes `RE_GRADED` and commits (only `OTHER`-without-note blocks). A reason is always audited. **Kofi/Lucy confirm** this counts as "teacher-confirmed" for the highest-severity GONE_MISSING keep-blank.
+- **Nits:** bare-surname → `unmapped` not `ambiguous` (still blocks); two `exhaustive-deps` suppressions want a "why safe" comment; `"__discard__"` magic string → named const.
+- **Note (pre-existing, not this diff):** `SENIOR_LEDGER_ROLES` includes `VICE_HEADMASTER_ACADEMIC`, so a VHM can commit/see scores on the *edit* surface (shipped in #138; the completion-only rule targets the progress view).
+- **Deploy:** prod needs `0041` (enum + 5 denominator columns + CHECK) via migrate or `prod-paste-0041-ledger-denominators.sql`. **No new RLS to paste** (no tenant table added).
+
+### Kofi rulings on the gate findings (2026-07-15)
+
+**Correction to the premise:** Path **C** also caps at 0–100 (shares `parseCat`). **Path A is the sole path admitting >100.** This is a 3-path consistency question, not a Path-B patch.
+
+**Quinn-1 — bonus marks (>100).**
+- **Kofi's call (settled, no owner needed): Path B's committer must accept the full range its own scaler emits (0–`MAX_PERCENT` 999.99) with a soft-warn (mirroring Path A `exceedsMax`), never a hard grid-wide block.** The scaler faithfully emits 110 for a `/10` portfolio read of 11; the committer currently rejects it — an internal self-contradiction that must be fixed regardless of policy. All three paths must share one bound.
+- **OWNER CALL — bonus legitimacy direction:**
+  - **Option A (Kofi-recommended):** bonus allowed; unify UP at 999.99 + soft-warn (Path A already ships this). Requires the STPSHS export + report-card boundary (§8) to tolerate/clamp totals >100.
+  - **Option B:** no bonus; cap every category at 100 — **and also clamp Path A at 100** so all three agree (reverses shipped Path A behaviour, discards a faithful 11/10 read).
+- **AC delta (Option A): A8** denom 10 + raw 11 → commits `portfolioScore = 110.00` with a pre-commit soft-warn, no hard block. **A9** one >100 cell never blocks the other rows. **A10** negative/non-numeric still rejected; scaled >999.99 caps at 999.99. **A11** same value commits identically via A/B/C. _(Option B inverts A8–A11 to per-cell reject naming student+category, plus a Path-A-clamp regression.)_
+
+**Quinn-2 — pre-baked `RE_GRADED` reason.**
+- **Score-down (76→73): CONFIRMED — pre-baked, changeable, always-audited `RE_GRADED` default is fine.** §7.3 asks only that the change be visible + timestamped; the surface itself pre-bakes it (`Keep 73 · re-graded` primary). No change.
+- **GONE_MISSING keep-blank (82→blank): REJECTED as implemented — MUST fix before DoD closes.** §7.2 ("either way needs confirmation"), §7.3 (errors + deliberate alterations both live here), and the surface (primary action `Enter manually`, not remove) all require an **active** teacher choice. Required behaviour: removal reason **not pre-selected** and removal **not the default**; **server rejects `RE_GRADED` for a keep-blank** and requires `TRANSCRIPTION_ERROR` or `OTHER`+note (a re-grade yields a score, never a blank — incoherent for a removal). This structurally forces the teacher off the autopilot default.
+- **AC delta: Q2-a** score-down commits with default `RE_GRADED` + audit row. **Q2-b** reason changeable → audit reflects it. **Q2-c** removal with default `RE_GRADED` → **blocked**, atomic, message "a removed score can't be re-graded." **Q2-d** client submitting `RE_GRADED` directly on a removal → **server** rejects. **Q2-e** removal + active `TRANSCRIPTION_ERROR` → commits, audit before=82/after=null. **Q2-f** score-up + blank→filled still commit with NO reason (B4/B8 unchanged).
+- **OWNER CALL (minor, deferrable):** a dedicated removal code (`ENTERED_IN_ERROR`/`SCORE_VOIDED`) — not mandated, `TRANSCRIPTION_ERROR`/`OTHER`+note suffice today.
+
+**Net:** Quinn-2 removal-reason fix + Quinn-1 committer-range fix ship together (both Kofi's call). The one open item is the owner's **bonus direction (Option A vs B)**, which gates the path-unification.
 
 ### Critical path
 

--- a/omnischools/docs/senior-build-plan.md
+++ b/omnischools/docs/senior-build-plan.md
@@ -19,8 +19,9 @@
 - Item 0 — period config ✅ shipped in Basic.
 - Item 1 — 5-category model + Path A auto-compile ✅ merged (PR #131, migration 0038)
 - Item 2 — Path C direct entry ✅ gates green (PR #134, migration 0039)
-- Item 3 — VHM progress view ✅ gates green (PR pending, migration 0040) · **Item 4 — Path B OCR** ← _next_
+- Item 3 — VHM progress view ✅ merged (PR #137, migration 0040) · RBAC role-gating ✅ merged (PR #138)
   - Read-only dashboard `/senior/academic-progress`: per (class×subject) — completion counts per category, STPSHS `n/5` tier, path pill, teacher, last activity, ready/behind/at-risk. **Counts only, NEVER score values (§6.2).** Rows enumerate from the new `senior_subject_teacher` assignment table (LEFT JOIN progress) so never-started teachers appear. At-risk flags computed on-the-fly (inactive 14+ days, N-not-ready). Headmaster roll-up (§6.4) + full filter bar + role gating deferred.
+- **Item 4 — Path B scan-and-extract** ← _next (INCR-2, below)_ · migration **0041**
 - Item 5 — PWA phase 1 · Item 6 — paper ledger book · Item 7 — versioned diff · Item 8 — STPSHS sheet
 
 ## Current increment — INCR-1: F0 + Score Ledger Item 1
@@ -46,3 +47,105 @@
 Deploy note: paste `db/sql/prod-paste-0038-senior-ledger.sql` on prod (RLS is not auto-applied).
 
 **INCR-1 done when:** an SHS teacher can enter assignment/mid-sem/end-sem/project events for a class-subject-semester, compile the four computable categories, enter portfolio manually, and see the weighted total using per-(subject×school) weights (default 15/15/40/15/15) — all tenant-scoped, audit-logged, gates green.
+
+---
+
+## Next increment — INCR-2: Score Ledger Item 4 · Path B (scan-and-extract) · migration 0041
+
+### Owner rulings — LOCKED (2026-07-14/15)
+
+1. **OCR provider = Claude Vision, Haiku 4.5** (`claude-haiku-4-5-20251001`). Anthropic messages API,
+   image as base64, behind a `LedgerExtractor` interface. Upgrade path to **Sonnet 5**
+   (`claude-sonnet-5`) revisited after go-live once real teacher-ledger feedback lands — a one-constant
+   swap, no rewrite. Implementation must consult the `claude-api` skill for the request shape.
+2. **Cross-border PII consent: yes — the image is never persisted.** Sent to Claude Vision, not stored.
+3. **Image lifecycle = transient.** Photo lives only in the browser + in-flight to Claude; **deleted
+   after extraction** when the teacher clicks complete/done/keep. → **no `score-ledger-uploads` bucket,
+   no storage RLS, no retention job, no image column.**
+4. **Cross-path upload: yes.** A Path A/C teacher may upload a scan; diff runs against what's committed.
+5. **Scale = school-defined per-category denominator** (e.g. portfolio /10, others /100). Raw number is
+   scaled against its category denominator before it becomes the 0–100 stored value.
+6. **Confidence numbers:** `LOW_CONF_FLAG = 0.85`, `LOW_CONF_FLOOR = 0.60` (named constants, retunable).
+7. **Reason codes:** `RE_GRADED` · `TRANSCRIPTION_ERROR` · `OTHER` (free text mandatory on `OTHER`).
+8. **Fallback path label:** `DIRECT_ENTRY` when nothing came from a scan, else `SCAN_EXTRACT`.
+
+**INCR-2 done when:** an SHS teacher can photograph their handwritten paper ledger page, have Claude
+Vision extract the five-category grid, see it side by side with the photo (in-session only), have every
+low-confidence cell flagged and every row's student-mapping confirmed, work the four diff cases against
+the committed values (blank→filled silent-accept · unchanged · score-down needing a reason ·
+score-gone-missing) with each raw number scaled by its category's school-defined denominator, and commit
+the verified grid — writing the same `senior_score_ledger` rows Paths A/C write, with
+`path_used = SCAN_EXTRACT` and full audit trail. **The photograph is discarded on commit; nothing
+persists the image** — all tenant-scoped, gates green.
+
+### Step table
+
+| Step | Owner | State |
+|---|---|---|
+| Rulings on the 7 open questions + acceptance criteria | Kofi | ✅ (rulings + AC below) |
+| Surface map — scan §2 | Lucy | ✅ `docs/senior/path-b-scan-surface-map.md` |
+| Schema — 5 denominator cols on `ref_assessment_weights` + `ledger_correction_reason` enum; migration **0041** applied to dev + verified; prod = column ALTER only (no new RLS) | Wells | ✅ `0041_little_human_torch.sql` · `db/sql/prod-paste-0041-ledger-denominators.sql` · `docs/senior/incr2-denominator-schema.md` |
+| Extend `resolveWeights`→ also resolve denominators (`SYSTEM_DEFAULT_DENOMINATORS` = all 100; reuse `percent()`) | Claude Code | ⬜ |
+| Extract API route — our endpoint proxies base64 → Claude Vision (Haiku 4.5) → grid + per-cell confidence; **image never persisted**; server-held `ANTHROPIC_API_KEY` | Claude Code | ⬜ |
+| Extractor adapter — `LedgerExtractor` interface + Claude Vision impl (+ stub for tests) | Claude Code | ⬜ |
+| Roster row-mapping — extracted name-row → `student_id`, teacher-confirmed (Q5) | Claude Code | ⬜ |
+| Diff + scale engine — pure funcs in `lib/score-ledger/` (denominator scaling + 4 diff cases), vitest, no DB | Claude Code | ⬜ |
+| Verification UI — side-by-side photo/grid (in-session), low-conf flags, 4 diff flags, keep-old/keep-new/manual, commit-and-discard | Claude Code | ⬜ |
+| Commit path — writes `senior_score_ledger` `path_used = SCAN_EXTRACT` + `recordAudit` + reason codes; drops the image | Claude Code | ⬜ |
+| Seed already set (Asankrangwa portfolio denom /10 in `db/seed/asankrangwa.ts`) | Wells | ✅ (not run — seed not idempotent) |
+| Build · typecheck · tests · RLS test · preview round-trip (real photo → extract → commit) | Claude Code | ⬜ |
+| QA — 4 diff cases, denominator scaling, confidence bands, roster mis-map, multi-page, tenant isolation | Quinn | ⬜ |
+| Architecture/portability — provider swappable behind `LedgerExtractor`? model id a single constant? API key server-only? | Dex | ⬜ |
+| Security — image truly never persisted, key server-side only, cross-tenant read, prod parity | Sarah | ⬜ holds merge |
+| Gate fixes (single aggregated rework brief) | Claude Code | ⬜ |
+| Merge · verify it landed with `git log origin/main` | Sarah | ⬜ |
+
+### Critical path
+
+Kofi ✅ + Lucy ✅ + Wells ✅ are done → **implementation is unblocked.** Claude Code: `resolveWeights`
+extension → extract API route + adapter → diff/scale engine → roster mapping → verification UI → commit
+path → self-verify → three gates → Sarah merge. No owner gate remains on the path.
+
+### Kofi rulings (2026-07-14)
+
+- **Q1 — diff-against-committed; no version/upload/history table in Item 4** (that's Item 7). The only
+  new DDL is Q1b's denominator columns. Reason codes ride the existing `recordAudit`→`auditLog`.
+- **Q1b — extend `ref_assessment_weights`** with 5 denominator cols (`smallint NOT NULL DEFAULT 100,
+  CHECK > 0`); same resolution as weights (subject → school-default → system 100). No new table.
+- **Q2 — confidence bands:** ≥0.85 accepted · 0.60–0.85 low-conf (shown, must review) · <0.60 dropped
+  to blank (never show a possibly-wrong number).
+- **Q3 — four diff cases binding; low-confidence overrides silent-accept; compound (changed AND
+  low-conf) always forces review.**
+- **Q4 — reason enum + optional free text; mandatory only on score-down and Case-D keep-blank.**
+- **Q5 — roster mapping is a mandatory teacher-confirmed step** (§5.2 — highest-severity silent
+  failure); never auto-pick an ambiguous name; an absent roster row is NOT a Case-D blank.
+- **Q6 — 1..n images → one merged grid, atomic commit; partial coverage allowed but never silent.**
+- **Q7 — extraction error degrades to Path C blank grid in place; never a hard failure.**
+
+### INCR-2 · Acceptance criteria (for Quinn)
+
+`raw` = number extracted · `denominator` = resolved per-category value (subject → school-default → 100) · `committed` = current `senior_score_ledger` cell.
+
+**A · Denominator scaling** (🟡 own test class)
+- A1 portfolio denom 10, raw 8 → store 80.00. · A2 assignment denom 100, raw 72 → 72.00. · A3 no denom → fall back 100; raw 8 → 8.00 (never inflated). · A4 subject override > school-default > 100. · A5 denom 10, raw 850 → cap MAX_PERCENT (999.99), no overflow. · A6 raw blank → null, not 0. · A7 denom 0 (blocked by CHECK) → insert fails; scaler returns null.
+
+**B · Four diff cases** (§7.2)
+- B1 committed blank + extracted ≥0.85 → silent-accept. · B2 committed==extracted → no flag. · B3 76→73 → flagged + reason required. · B4 71→74 @≥0.85 → review, NO reason. · B5 82→blank → highest severity, never auto-nulls, forces keep/re-upload/manual. · B6 71→74 @0.60–0.85 → forces review, not silent. · B7 blank→val @0.60–0.85 → review, not silent-accept. · B8 up/blank→filled/unchanged commit with NO reason; score-down + Case-D keep-blank blocked until reason. · B9 score-down w/ reason → auditLog row before/after + reason; no image in payload.
+
+**C · Confidence bands** (Q2)
+- C1 ≥0.85 normal. · C2 [0.60,0.85) low-conf, can't commit until reviewed. · C3 <0.60 blank must-enter. · C4 Path A/C context → no cell ever low-conf styled.
+
+**D · Roster mapping** (🟡 own test class; §5.2)
+- D1 "A. Boateng" w/ Akwasi+Abena → row unmapped, commit blocked, no auto-select. · D2 name matching no active student → no commit until mapped/discarded. · D3 active student absent from page → committed row untouched, flagged gap. · D4 two rows → same student → commit blocked. · D5 all rows mapped to exactly one active student → commit proceeds.
+
+**E · Multi-page** (Q6)
+- E1 2-page/37-student → one 37-row grid. · E2 commit atomic. · E3 page 2 missing → commit covered only; uncovered untouched + flagged, never blanked.
+
+**F · Cross-path** (§7.4)
+- F1 Path A committed values → scan diffs against them. · F2 Path C typed values → same. · F3 scan commit → rows `path_used = SCAN_EXTRACT`, appear in VHM view (regression-check). · F4 wholesale failure, teacher types blank grid → `path_used = DIRECT_ENTRY`.
+
+**G · Transient-image guarantee** (🔴 Sarah gates)
+- G1 after commit: no Storage object / column / auditLog payload references or contains the image; zero image columns. · G2 base64 server-side only, key never in client bundle. · G3 extraction error → image still discarded (no temp file, no retained base64, no log/Sentry). · G4 complete/done/keep → in-memory image released.
+
+**H · Fallback** (Q7)
+- H1 wholesale failure → blank five-category grid in place, no dead-end. · H2 single sub-0.60 cell → manual-entry blank inside a `SCAN_EXTRACT` grid; `path_used` stays `SCAN_EXTRACT`.

--- a/omnischools/docs/senior/incr2-denominator-schema.md
+++ b/omnischools/docs/senior/incr2-denominator-schema.md
@@ -1,0 +1,96 @@
+# INCR-2 · Score Ledger Item 4 (Path B) — Denominator + Reason-code Schema
+
+**Author:** Wells (DB engineer) · **Status:** Designed, generated, applied to dev, RLS-verified.
+**Migration:** `0041_little_human_torch.sql` (applied to dev DB `omnischools_dev`).
+**Scope:** INCR-2 only — the *data-layer* change Path B needs (per-category scan denominators
++ the correction-reason domain). No image storage, no upload/provenance/version table (Kofi Q1
+LOCKED: diff-against-committed; the version chain is Item 7).
+
+> **Migration number note.** The build plan step table says "migration 0040", but `0040`
+> (`senior_subject_teacher`, Item 3 VHM view) has already merged to `main`. INCR-2 is therefore
+> **`0041`**, not 0040. The number in the plan predates Item 3 consuming 0040.
+
+---
+
+## 0. What this migration is (and is not)
+
+Net DDL: **1 enum + 5 columns + 1 CHECK** on the *existing* tenant table `ref_assessment_weights`.
+- **No new table** → no new `tenant_uk`, no new FK, **no new RLS**, no prod-paste RLS policy.
+- **No image column / bucket / upload table** — owner ruling: the photo is transient, never persisted.
+- **No new ledger column for the reason** — the reason value rides `audit_log.reason` (existing).
+
+---
+
+## 1. Per-category denominators on `ref_assessment_weights` (Kofi Q1b)
+
+Five columns, `smallint NOT NULL DEFAULT 100`, guarded by one combined `CHECK (… > 0)`:
+
+| Column | Meaning |
+|---|---|
+| `asgn_denominator` | scale for a scanned assignment raw number |
+| `mid_sem_denominator` | scale for a scanned mid-sem raw number |
+| `end_sem_denominator` | scale for a scanned end-sem raw number |
+| `project_denominator` | scale for a scanned project raw number |
+| `portfolio_denominator` | scale for a scanned portfolio raw number (Asankrangwa = 10) |
+
+**Why extend `ref_assessment_weights` (not a new table):** the denominator has the *exact same
+grain and resolution as the weights* — subject-override row → school-default row (`subject_id NULL`)
+→ system constant `100`. Co-locating means the resolver fetches one row, not two, and reuses the
+existing FK, the `uniq_school_default_weights` partial index, and the table's RLS unchanged. A
+dedicated table would duplicate all of that for zero benefit.
+
+**System default = 100 = identity.** An unconfigured category never inflates a mark (`raw 8` under
+`/100` → `8.00`). Only a *smaller* configured denominator scales up (`raw 8` under `/10` → `80.00`).
+Never inflated by accident — the fallback is the largest sane denominator.
+
+**CHECK `assessment_denominators_positive`.** One combined constraint (mirrors the single
+`assessment_weights_sum_100` style). A `0` denominator is a divide-by-zero silent-corruption path,
+so it is blocked at the DB; the lib scaler *also* returns `null` on a non-positive denominator
+(defence in depth). Acceptance A5/A7 land on `compute.ts:percent`, which already caps at `MAX_PERCENT`
+and guards `maxMark > 0`.
+
+## 2. Reason codes → `pgEnum`, not a `ref_` table (owner: Wells's call)
+
+`ledger_correction_reason` = `RE_GRADED | TRANSCRIPTION_ERROR | OTHER` (LOCKED membership).
+
+**Chosen: a `pgEnum` in `_enums.ts`.** Rationale:
+- Matches the codebase's enum-heavy convention (every other closed vocabulary is a `pgEnum`).
+- It is the *domain of allowed codes* only — **not a column**. The chosen code persists as the
+  free-text `audit_log.reason` (`recordAudit`/`AuditEntry.reason`), per Kofi Q1/Q4. So there is no
+  FK integrity to gain from a lookup table — a `ref_` table would add a global table + RLS
+  classification + seed and buy nothing (`audit_log.reason` would still be free text).
+- One typed source of truth the app validates against, and ready if Item 7's version chain later
+  adopts it as a real column.
+- drizzle-kit still materializes the Postgres type (a bare `CREATE TYPE`) even though no column
+  references it yet — cheap, portable, and keeps dev == prod.
+
+Free text is mandatory on `OTHER`; that is app-layer validation (Sarah/Claude Code), not a DB check.
+
+## 3. RLS & prod
+
+`ref_assessment_weights` already has `ENABLE + FORCE ROW LEVEL SECURITY + tenant_isolation` (0038).
+Adding columns changes none of it. **No RLS delta, no leak risk, nothing to hand-paste.**
+`db/sql/prod-paste-0041-ledger-denominators.sql` documents this explicitly and carries the idempotent
+column/enum/CHECK DDL for hand-verification; prod gets that DDL via the normal drizzle migrate flow.
+Deploy note: prod needs **the column ALTER + the enum, NOT new RLS.**
+
+## 4. Seed (Asankrangwa, WR-WAW-014)
+
+`db/seed/asankrangwa.ts` — the school-default `assessmentWeights` insert (scoped to `school.id`)
+now sets `portfolioDenominator: 10`; the other four inherit the `100` column default. This is the
+seeded *real* config, distinct from the system fallback. Seed is **not idempotent and was not run**
+(school data has no `onConflict`); the change is a single field on the existing Asankrangwa row.
+
+## 5. Hand-off to the implementer (`compute.ts:resolveWeights`)
+
+The denominator resolution must **mirror the weights resolution exactly** — same two candidate rows,
+same precedence. Recommended extension (pure lib, no DB, no trigger):
+
+- Add a `CategoryDenominators` interface (five numbers) and `SYSTEM_DEFAULT_DENOMINATORS` = all `100`.
+- Add `resolveDenominators(subjectRow, schoolDefaultRow)` = `subjectRow ?? schoolDefaultRow ?? SYSTEM_DEFAULT_DENOMINATORS`
+  — identical shape to `resolveWeights`. Feed it the *same* two fetched `ref_assessment_weights`
+  rows the weight resolver already gets (the denominators are columns on those very rows), so no
+  extra query.
+- Scale each scanned raw number with the existing `percent(raw, denominator)` — it already returns
+  `null` on blank/`≤0` and caps at `MAX_PERCENT`, satisfying A3/A5/A6/A7. `raw 8` under `/10` →
+  `percent(8, 10)` → `80.00`.

--- a/omnischools/docs/senior/path-b-scan-surface-map.md
+++ b/omnischools/docs/senior/path-b-scan-surface-map.md
@@ -1,0 +1,279 @@
+# Path B Scan-and-Extract — Surface Map (INCR-2: Score Ledger Item 4)
+
+**Author:** Lucy (design cartographer) · **Status:** design spec, ready for the implementation engineer (Claude Code).
+**Scope of this map:** `Surfaces/schoolup-shs-score-ledger.html` **§2** only — the scan → extract → verify → diff workflow (Path B / `SCAN_EXTRACT`). §1 (Path A grid) and §3 (STPSHS export) are already mapped in `ledger-surface-map.md`; this map picks up where that one flagged §2 as "out of scope, colour vocabulary reused."
+
+This is an exhaustive 1:1 map of the §2 surface. **Rule where surface and spec disagree: spec/Kofi ruling wins on logic, surface wins on visual presentation** — every drift is called out inline and collected in the drift log. States are keyed to the **INCR-2 acceptance criteria** in `senior-build-plan.md` (B1–B9, C1–C4, D1–D5, E1–E3, F1–F4, G1–G4, H1–H2) and the **Kofi rulings Q1–Q7** so the ported behaviour matches the ruled behaviour exactly.
+
+## Source + reuse
+
+| File | Role |
+|---|---|
+| `Surfaces/schoolup-shs-score-ledger.html` **§2** | **PRIMARY visual source** — scan panel, extracted grid, low-conf cell, 4 diff flags (lines 593–738; CSS 268–326). |
+| `Surfaces/schoolup-shs-score-ledger-pwa.html` | **Checked — no phone variant of §2 exists.** The PWA covers card/grid view + class switcher only; the scan flow has **no** PWA surface. See §7 (Responsive/PWA). |
+| `omnischools/docs/senior/ledger-surface-map.md` | Format precedent + the §1 grid/cell vocabulary this reuses (esp. §3.4 cell states, §0 token table). |
+| `omnischools/components/senior/senior-ledger-grid.tsx` | **The grid component to extend** — `SeniorLedgerGrid` (`LedgerRow`, `CATS`, cell classes). The extracted grid is this grid in a read-and-verify mode; do **not** invent a new grid. |
+| `omnischools/components/senior/path-chooser.tsx` | `CapturePath` type already carries `"SCAN_EXTRACT"`; Path B card currently `available:false` — flip to `true` and wire it to this screen. |
+| `omnischools/app/(app)/senior/score-ledger/page.tsx` | The route that hosts the ledger; the scan screen is its `/scan` sibling (URL below). Reuses `requireSchool()`, `withSchool()`, `resolveWeights`, the hero-header idiom. |
+| `omnischools/docs/senior-build-plan.md` **INCR-2** | Kofi rulings Q1–Q7 + acceptance criteria — the behavioural source of truth this map's states cite. |
+
+---
+
+## 0. Tokens used in §2 (subset of the §0 table in `ledger-surface-map.md`)
+
+Use the **Tailwind token class**, never inline `var(--x)` in JSX (the surface is hand-written HTML with `var(--x)`; translate each to the class of the same token).
+
+| Surface `var(--x)` | Hex | Tailwind class | Where it is used in §2 |
+|---|---|---|---|
+| `--navy` | `#1A2B47` | `text-navy` / `bg-navy` / `border-navy` | primary text, `Commit` button, diff `.df-choice.primary`, gold-icon text |
+| `--navy-2` | `#2D3F5C` | `text-navy-2` | diff-flag body text, `.df-choice` label, scan-mock handwriting |
+| `--navy-3` | `#5C6675` | `text-navy-3` | crumb, captions, section labels, handwritten header rule |
+| `--gold` | `#C8975B` | `text-gold` / `bg-gold` / `border-gold` | h1 italic accent, corner stamp bg, **silent-accept flag border + icon** |
+| `--gold-soft` | `#E8D4B8` | `border-gold-soft` | — (scan-mock inner) |
+| `--gold-bg` | `#F5EBDC` | `bg-gold-bg` | **accepted extracted cell (`.manual`)** + **silent-accept flag background** |
+| `--bg` | `#FAF7F2` | `bg-bg` | page bg, `.scan-image` dashed frame bg, warn/terra icon glyph colour |
+| `--surface` | `#FFFFFF` | `bg-surface` | scan-mock paper, `.df-choice` bg, extracted-grid panel |
+| `--green` / `--green-bg` | `#2F6B47` / `#E5EFE8` | `text-green` / `bg-green-bg` | **NOT used in the scan grid** — see §3 note (scan values are manual-origin, never `computed`) |
+| `--terra` | `#B84A39` | `text-terra` / `bg-terra` / `border-terra` | **score-gone-missing flag** border + icon |
+| `--terra-bg` | `#F5E1DC` | `bg-terra-bg` | **score-gone-missing flag** background |
+| `--warn` | `#C58A2E` | `text-warn` / `bg-warn` / `border-warn` | **low-confidence cell** text + `?`; **review flag** (score-down / compound) border + icon |
+| `--warn-bg` | `#F5E9D0` | `bg-warn-bg` | **low-confidence cell** bg; **review flag** background |
+| `--border` | `#E5DFD3` | `border-border` | grid dividers, scan-mock inset border |
+| `--border-2` | `#D4CCBA` | `border-border-2` | `.scan-image` dashed frame, handwritten row dots, `.df-choice` border, **blank/`—` cell colour** |
+
+**Type:** `font-display` = Fraunces (h1, section title, flag icon glyph `!`, scan-mock title); `font-body` = Manrope (all body, student names); `font-mono` = JetBrains Mono (all scores, corner stamp). **Empty/missing score = em-dash `—`** in `text-border-2` — never `0`/`N/A`/`null` (`design-tokens.json._conventions.empty-cells`).
+
+**Handwriting mock font:** the surface sets `.scan-mock { font-family:'Caveat','Comic Sans MS',cursive }`. **This is mock-only.** `Caveat` is **not** in the font `<link>` (only Fraunces/Manrope/JetBrains Mono load). In production the left pane is the **uploaded photo `<img>`**, not a CSS handwriting mock — do not port the cursive font. See §2.1.
+
+---
+
+## 1. §2 top-to-bottom region order
+
+The screen (route `…/scan`) is the app shell (identical sidebar to §1) + a main column with, in order:
+
+1. **`.page-head`** — crumb, h1, lede, two actions.
+2. **`.scan-panel`** (`grid-cols-[0.9fr_1.1fr] gap-4`) — **left:** uploaded photo (`.scan-image`); **right:** extracted grid + caption.
+3. **Diff section label** — "Changes since mid-semester upload · 4 to review".
+4. **Four `.diff-flag` rows** — in this order: compound review (warn) · silent-accept (gold) · score-down review (warn) · gone-missing (terra).
+
+Then the right-rail `.notes` panel (design intent, not built).
+
+### 1.1 App shell / sidebar (identical to §1 — do not re-derive)
+`bg-navy` Senior sidebar. Crest gold `A` + `Omnischools Senior` / `Asankrangwa SHS`. Scope chip: `Teaching` / `Mr. K. Owusu` / `Mathematics · Form 2 Science`. Nav groups **My teaching** (Today's lessons · Classes · **Score ledger [active]** · Lesson plans · Assignments) · **Students** (Class registers · Parent messages) · **Semester end** (Report cards · STPSHS export). Footer `KO` / `K. Owusu` / `Subject teacher · Maths`. `Powered by Omnischools`. **Score ledger stays the active nav item on the scan screen** (scan is a sub-route of the ledger, not its own nav entry).
+
+### 1.2 `.page-head` (verbatim copy)
+- **URL (browser bar):** `app.omnischools.gh / senior / ledger / form-2-science / mathematics / 2025-26-t2 / scan` → route `/senior/score-ledger/scan?classId&subjectId&periodId` (reuse the query-param mechanism of the ledger page).
+- **Crumb:** `Senior · Mathematics · Form 2 Science · Semester 2 · Scan upload · Verify v2` (`text-navy-3 text-[11px] uppercase tracking-[0.12em]`).
+- **h1:** `End-of-semester upload · <em class="italic text-gold">verify the read.</em>` (`font-display 28px 500`).
+- **Lede:** `Uploaded 26 June 2026 · supersedes the 8 May mid-semester upload · 4 changes to review` (`text-navy-3 text-[13px]`).
+  - **Drift (copy vs Kofi Q1):** "supersedes the 8 May mid-semester upload" reads as a version chain. **Kofi Q1 ruled diff-against-committed — no version/upload table in Item 4.** The diff baseline is the **currently-committed `senior_score_ledger` row**, not a stored "mid-semester upload." Keep the copy (it reads naturally to the teacher); the *implementation* compares against the committed row. The "8 May" date and "supersedes" wording are presentation only.
+- **Actions (right):** `Re-upload page` (`.btn.ghost` = `bg-transparent border-border-2 text-navy-3`) · **`Commit verified ledger →`** (`.btn.primary` = `bg-navy text-bg font-bold`). Commit is the **atomic** write (Kofi Q6 / E2) that persists confirmed rows with `path_used = SCAN_EXTRACT` + `recordAudit`, then **discards the image** (Kofi ruling 3 / G4).
+
+---
+
+## 2. `.scan-panel` — photo ↔ extraction, side by side
+
+`.scan-panel { display:grid; grid-template-columns:0.9fr 1.1fr; gap:16px; }` → `grid grid-cols-[0.9fr_1.1fr] gap-4`. The extraction column is deliberately the wider one (1.1fr).
+
+### 2.1 Left: `.scan-image` — the uploaded photo (in-session only)
+Surface markup is a **CSS mock of a handwritten page**; production renders the **actual uploaded photo**.
+
+- Frame: `.scan-image` = `bg-bg border-[1.5px] border-dashed border-border-2 rounded-[10px] p-4 aspect-[4/3]` centred.
+- **Production:** an `<img>` from an **in-memory object URL** (browser only, never persisted — Kofi ruling 3 / G1/G4). On the mock this is `.scan-mock` (`bg-surface rounded-md p-3.5`, cursive text, `::before` hairline inset `border border-border rounded-xs`).
+- **Corner stamp (`.scan-corner-stamp`, absolute top-right):** `PAGE 1/2 · F2 SCI · MATHS · T2` — `font-mono text-[9px] bg-gold text-navy rounded-xs px-2 py-[3px] font-bold tracking-[0.04em]`. **This is the multi-page indicator** (page 1 of 2). Per the surface notes + build-plan dependency note, the stamp is the **Item 6 branded-ledger-book QR metadata**; **Item 4 does not read it** — class/subject/period come from the navigation context (query params). Render a page indicator, but drive it from the upload set index (Kofi Q6 / E1), not from OCR of the stamp.
+- Mock content (for reference only — not built): title `Mathematics — Form 2 Science — Semester 2` (`font-display italic 13px text-navy` centred); a bold header row `Name · Asg · MS · ES · Pj · Pf` (border-bottom `1.5px navy-3`); then handwritten rows (`grid-cols-[1.5fr_repeat(5,1fr)]`, dotted `border-b border-dashed border-border-2`):
+
+  | Handwritten name | Asg | MS | ES | Pj | Pf |
+  |---|---|---|---|---|---|
+  | A. Mensah | 72 | 68 | 81 | 75 | 8 |
+  | A. Boateng | 65 | **74** | 69 | 80 | 7 |
+  | A. Asante | 88 | 85 | 89 | 92 | 10 |
+  | D. Owusu | 58 | 62 | 55 | 66 | 5 |
+  | E. Adjei | 79 | 74 | 82 | 78 | 9 |
+  | E. Tetteh | 71 | 69 | 73 | 70 | 7 |
+  | E. Coleman | 84 | 88 | 86 | 90 | 9 |
+
+  Note the **abbreviated names** (`A. Mensah`, `A. Boateng`) — this is exactly the roster-mapping ambiguity Kofi Q5 / D1 guards (see §5). The `Pf` column reads single digits (8, 7, 10, 5…) — this is the **denominator-scaling** case (portfolio on a /10 scale; Kofi Q1b / A1): raw `8` under portfolio denom `10` stores `80.00`, not `8`.
+
+### 2.2 Right: extracted ledger grid + caption
+- Label above grid: `Extracted ledger · sample` (`text-[10px] uppercase tracking-[0.1em] text-navy-3 font-bold`).
+- Grid = `.ledger-grid` at `font-size:11px`. **Header omits the Weighted/total column** (present in §1, absent here) — the scan grid verifies the five raw category reads only; the weighted total is computed after commit. Header cells + colours (identical classes to §1): `Student` (`.student-col`, left, sticky-left) · `Asg` (`.cat-asgn` → `text-green`) · `MS` (`.cat-mid` → `text-navy-2`) · `ES` (`.cat-end` → `text-navy-2`) · `Pj` (`.cat-proj` → `text-green`) · `Pf` (`.cat-port` → `text-terra`). **Header colours are category-semantic, not confidence** — keep them.
+- **Body rows** (7 of 37 shown, full names resolved from the abbreviations):
+
+  | Student | Asg | MS | ES | Pj | Pf | cell states |
+  |---|---|---|---|---|---|---|
+  | Abena Mensah | 72 | 68 | 81 | 75 | 8 | all `.manual` |
+  | **Akwasi Boateng** | 65 | **74** | 69 | 80 | 7 | MS = `.low-conf`; rest `.manual` |
+  | Ama Asante | 88 | 85 | 89 | 92 | 10 | all `.manual` |
+  | Daniel Owusu | 58 | 62 | 55 | 66 | 5 | all `.manual` |
+  | Efua Adjei | 79 | 74 | 82 | 78 | 9 | all `.manual` |
+  | Emmanuel Tetteh | 71 | 69 | 73 | 70 | 7 | all `.manual` |
+  | Esi Coleman | 84 | 88 | 86 | 90 | 9 | all `.manual` |
+
+- Caption (below grid, `text-[10.5px] text-navy-3 italic`): `Showing 7 of 37 students · 4 cells flagged across the full class (low-confidence OCR) · 4 differences from the mid-semester upload, below.`
+
+---
+
+## 3. Extracted-grid cell states — the exact vocabulary (nail these)
+
+The scan grid reuses `SeniorLedgerGrid`'s cell classes, **but the semantic mapping differs from Path A**: scan-extracted values are **manual-origin (gold), never computed (green)**. There are three cell states, mapped to Kofi Q2 confidence bands (final constants `LOW_CONF_FLAG = 0.85`, `LOW_CONF_FLOOR = 0.60`):
+
+| State | Surface class | Tailwind (solid tokens) | Confidence band (C1–C3) | Renders |
+|---|---|---|---|---|
+| **Accepted / normal** | `.score-cell.manual` | `bg-gold-bg text-navy font-bold` | **≥ 0.85** (C1) | the read value, no marker |
+| **Low-confidence** | `.score-cell.low-conf` | `bg-warn-bg text-warn font-bold` + absolute `?` top-right (`content:"?"; top:2px; right:5px; text-[9px] text-warn font-bold`) | **0.60–0.85** (C2) | the read value **dim/`?`**; **must be reviewed before commit** — cannot silently commit |
+| **Blank / must-enter** | `.score-cell.empty` | `text-border-2`, renders `—` | **< 0.60** dropped to blank (C3), **or** a score that went missing | `—`; teacher enters manually |
+
+**Load-bearing rules (do not soften):**
+- **`.computed` (green) is never used in a Path B / `SCAN_EXTRACT` grid.** Green means auto-compiled-from-events (Path A). A scanned number is manual-origin → **gold `.manual`**. The §1 legend's three swatches (computed-green / manual-gold / low-conf-warn) still describe the vocabulary; on this screen only manual + low-conf + empty appear.
+- **`< 0.60 → blank, never a possibly-wrong number** (C3). Do not show a sub-floor guess as an accepted value.
+- **`.low-conf` cell blocks commit until reviewed** (C2). The `?` is the review prompt.
+- **In Path A/C context, no cell is ever `.low-conf`** (C4) — the class exists only for the scan grid.
+- The demo shows only Akwasi Boateng's MS cell as `.low-conf`; the caption says **4 cells flagged across the full 37** — the state is per-cell, not per-row.
+
+> **Token-opacity trap (verify in live preview, not build):** the three tint backgrounds are the dedicated **solid `-bg` tokens** — `bg-gold-bg` / `bg-warn-bg` / `bg-terra-bg`. **Do NOT** express any of these as slash-opacity on a raw-hex token (`bg-warn/10`, `bg-gold/20`, `text-warn/70`) — that silently breaks on the raw-hex token set (memory `no-alpha-token-opacity`). The `?` marker colour is solid `text-warn`. This is the one place §2 is most at risk of the trap because every state is a coloured tint. The existing `SeniorLedgerGrid` already uses `bg-warn-bg` solid in its legend — match it.
+
+---
+
+## 4. The four diff flags — verbatim copy, exact tokens, per-flag actions
+
+Section label above the flags: `Changes since mid-semester upload · 4 to review` (`text-[10px] uppercase tracking-[0.1em] text-navy-3 font-bold`, `mb-2`).
+
+Base component `.diff-flag` = `flex gap-3 px-4 py-[13px] rounded-[10px] mb-2.5`, with `.df-icon` (28px, `rounded-[7px]`, Fraunces italic `!` glyph), `.df-text` (`text-[11px] text-navy-2 leading-[1.55] flex-1`, bold = `text-navy`), `.df-choices` (`flex gap-1.5`). `.df-choice` = `text-[10px] px-2.5 py-[5px] rounded-md border border-border-2 bg-surface font-semibold text-navy-2`; `.df-choice.primary` = `bg-navy text-bg border-navy`.
+
+The four rendered flags (the surface renders the four **non-unchanged** cases; "unchanged" is the fifth conceptual case that renders **no flag**):
+
+| # | Case (Kofi Q3 / §7.2) | Severity + tokens | Icon | `.df-text` (verbatim, `**` = `<b>` `text-navy`) | Choices (left→right) · primary = `.df-choice.primary` |
+|---|---|---|---|---|---|
+| 1 | **Compound: changed AND low-confidence** — Akwasi Boateng | **WARN** (default `.diff-flag`): `bg-warn-bg border-warn` | `bg-warn text-bg` | **Akwasi Boateng** · Mid-sem score · mid-semester upload showed **71** · this upload shows **74**. Cell is also flagged low-confidence OCR. **Review the photo** before accepting. | `Keep 71` · **`Keep 74`** (primary) · `Enter manually` |
+| 2 | **Blank → filled: silent-accept** — Kojo Mensah | **GOLD**: `bg-gold-bg border-gold` (inline override) | `bg-gold text-navy` | **Kojo Mensah** · End-of-sem score · mid-semester upload showed **—** (blank, exam hadn't happened yet) · this upload shows **64**. Expected change — new entry, accepted silently if you don't intervene. | `Accept` (single, **not** primary) |
+| 3 | **Score-down: review with reason** — Mariama Iddrisu | **WARN** (default): `bg-warn-bg border-warn` | `bg-warn text-bg` | **Mariama Iddrisu** · Assignment score · mid-semester upload showed **76** · this upload shows **73**. Score went down — unusual unless re-graded. **Confirm the change with reason.** | `Keep 76` · **`Keep 73 · re-graded`** (primary) · `Enter manually` |
+| 4 | **Score gone missing: highest severity** — Yaa Asantewaa | **TERRA**: `bg-terra-bg border-terra` (inline override) | `bg-terra text-bg` | **Yaa Asantewaa** · Mid-sem score · mid-semester upload showed **82** · this upload shows **blank**. **Score has gone missing** from the ledger between uploads. Re-photograph the page or enter the score manually. | `Keep 82` · `Re-upload page` · **`Enter manually`** (primary) |
+
+**Exact flag → token mapping (the four colours the task asks for):**
+- **Silent-accept (blank→filled):** `--gold-bg` bg + `--gold` border; icon `--gold` bg / `--navy` glyph. **Gold = expected, low-stakes.**
+- **Unchanged:** *no flag rendered* (Kofi Q3 case B / B2 — no interaction).
+- **Review (score-down, and the compound changed+low-conf):** `--warn-bg` bg + `--warn` border; icon `--warn` bg / `--bg` glyph. `.diff-flag`'s **default** colour is warn — flags 1 and 3 use no override.
+- **Gone-missing (filled→blank):** `--terra-bg` bg + `--terra` border; icon `--terra` bg / `--bg` glyph. **Terra = highest severity.**
+
+**Behaviour bindings (Kofi Q3 / B1–B9):**
+- **Flag 1 (compound):** low-confidence overrides silent-accept precedence — a changed **and** low-conf cell **always forces review**, never silent (B6). A pure score-up at ≥0.85 would be review-only with **no reason** (B4/B8); here it is low-conf so it is forced-review regardless.
+- **Flag 2 (silent-accept):** blank→filled at ≥0.85 commits with **no required action / no reason** (B1/B8). The single `Accept` button is a confirm affordance; if the teacher does nothing it accepts on commit.
+- **Flag 3 (score-down):** requires a **reason code before the new (lower) value commits** (B3/B8). See §4.1.
+- **Flag 4 (gone-missing):** **never auto-nulls a committed score** (B5). Default action is `Enter manually`; `Keep 82` retains the committed value; `Re-upload page` re-photographs. Choosing to actually remove/keep-blank requires a **reason** (Kofi Q4 — mandatory on Case D keep-blank).
+
+### 4.1 Per-flag actions + where the reason-code picker appears
+
+Four action verbs across the flags:
+
+| Action | Appears on | Effect |
+|---|---|---|
+| **keep-old** | `Keep 71` · `Keep 76` · `Keep 82` | retain the committed value; extracted value discarded. No reason. |
+| **keep-new** | `Keep 74` | accept the extracted value. Review-only, **no reason** (score-up / B4/B8). |
+| **keep-new-with-reason** | `Keep 73 · re-graded` | accept the lower extracted value **with a reason code**. **This is where the reason-code picker lives.** |
+| **enter-manually** | `Enter manually` (flags 1, 3, 4) | open the cell for direct typing; result is a `SCAN_EXTRACT` grid cell hand-corrected (H2, `path_used` stays `SCAN_EXTRACT`). |
+| **accept** (silent) | `Accept` (flag 2) | commit the new value, no reason. |
+| **re-upload** | `Re-upload page` (flag 4 + page-head) | re-photograph this page and re-extract. |
+
+**Reason-code picker (`RE_GRADED` / `TRANSCRIPTION_ERROR` / `OTHER`) — placement (Kofi Q4 / final decision 2):**
+- The surface **pre-bakes the reason into the button label**: `Keep 73 · re-graded` — the button both accepts the lower value and names `RE_GRADED` as the default reason.
+- **Implementer:** render the `· re-graded` suffix as a **selectable reason** that defaults to `RE_GRADED`, with `TRANSCRIPTION_ERROR` and `OTHER` as alternatives; **`OTHER` requires mandatory free text**. Surface it inline on the score-down flag (a small dropdown/segmented control adjacent to / inside the primary choice), and again when the teacher chooses to remove a score on **Flag 4** (Case D keep-blank).
+- **Reason is mandatory only on score-down and Case D keep-blank** (Q4 / B8). **Never** required on score-up, blank→filled, or unchanged.
+- Reason persists to **`auditLog.reason`** (Q1/Q4 — no new column, no image reference in the payload / B9/G1).
+
+---
+
+## 5. Roster-mapping confirmation (name → student) — spec-added, not drawn on §2
+
+The surface shows the **result** of mapping (handwritten `A. Mensah` → resolved `Abena Mensah` in the extracted grid) but renders **no explicit confirmation UI**. **Kofi Q5 / D1–D5 make row→student mapping a mandatory teacher-confirmed step** (roster misattribution is the highest-severity silent failure — a right mark on the wrong student is not caught by eye). This is a **spec-wins-on-logic** addition the implementer must build even though §2 doesn't picture it:
+
+- **System proposes** a fuzzy mapping (abbreviated name → active student); **teacher confirms the full alignment before any diff/commit.**
+- **Ambiguous name → block the row, never auto-pick** (D1). The demo's abbreviations (`A. Mensah`, `A. Boateng`, `A. Asante`, `E. Adjei`, `E. Tetteh`, `E. Coleman`) are exactly this hazard — e.g. `A. Boateng` where a roster could hold Akwasi **and** Abena Boateng.
+- **Name not in roster → map or explicitly discard** (D2); scores don't commit until resolved.
+- **Active student with no extracted row → committed row left untouched, flagged coverage-gap** (D3) — an absent row is **not** a Case D blank.
+- **Two rows → one student → commit blocked** (D4). Each row maps to exactly one active student; each student to at most one row (D5).
+- Suggested placement: a confirm-mapping step **before** the diff flags render (mapping must be settled first), or an inline unmapped-row banner on the extracted grid. Copy is spec-added (not on the surface) — keep the Ghanaian operational voice, defer exact wording to the implementer, flag as drift.
+
+---
+
+## 6. Multi-page + commit (Kofi Q6 / E1–E3)
+
+- The corner stamp `PAGE 1/2` signals a **1..n image set**. A 37-student / 2-page class → **one merged 37-row grid, each student once** (E1). Drive the page indicator from the upload-set index, not from OCR of the stamp (§2.1).
+- **Commit is atomic** — `Commit verified ledger →` writes all confirmed rows in **one transaction** (E2), sets `path_used = SCAN_EXTRACT`, `recordAudit`s, then **discards the image** (G4).
+- **Partial coverage allowed but never silent** (E3): if page 2 is missing, warn, then commit only confirmed rows; **uncovered students' committed rows are never touched or blanked** and stay flagged incomplete.
+
+---
+
+## 7. Fallback to manual (Path C) — the error/empty grid (Kofi Q7 / H1–H2)
+
+Not drawn on §2, but a required state: **extraction failure degrades to Path C in place — never a hard failure / dead-end.**
+
+- **Wholesale failure** (Claude Vision down, unreadable photo) → the **same five-category grid renders blank on the same screen** for direct entry (H1). No navigation away. Reuse `SeniorLedgerGrid` with `mode="direct"` (all five cells editable) and empty `rows`.
+- `path_used` records real provenance: **`DIRECT_ENTRY`** if nothing came from a scan; **`SCAN_EXTRACT`** if the grid was scan-populated even where hand-corrected (final decision 3 / F4).
+- A **single** sub-0.60 cell is Q2's blank (`.empty`) inside a `SCAN_EXTRACT` grid — **not** a whole-session flip to Path C (H2).
+- **Transient-image guarantee holds in the error path** (G3): no temp file, no retained base64, no base64 in logs/Sentry.
+- Error copy is spec-added (not on the surface). Keep the calm operational voice; flag as drift for wording sign-off.
+
+---
+
+## 8. Responsive / PWA
+
+- **No PWA phone variant of §2 exists.** `schoolup-shs-score-ledger-pwa.html` was checked end-to-end: it covers **card/grid view + the class chevron/bottom-sheet switcher only** — there is no scan/OCR/diff surface in it. The scan flow is **desktop-web only** in the surfaces. Do not invent a phone scan surface; if one is needed later it is a new design task, not a port.
+- **Desktop responsive:** §2 defines no dedicated media query for `.scan-panel`. The page's global `@media (max-width:1280px)` collapses `.layout` (main + notes) to one column but leaves `.scan-panel` at `0.9fr 1.1fr`. At narrow widths the photo/grid two-up will crush — **stack the photo above the grid** (`grid-cols-1`) below the app's content breakpoint. The diff flags are already single-column `flex` and reflow; at narrow width let `.df-choices` wrap under `.df-text`.
+
+---
+
+## 9. Interaction-state inventory (every state in §2)
+
+| Region | State | Visual |
+|---|---|---|
+| Extracted cell | accepted / low-conf / blank | `bg-gold-bg text-navy` / `bg-warn-bg text-warn` + `?` / `—` `text-border-2` |
+| Confidence band → cell | ≥0.85 / 0.60–0.85 / <0.60 | accepted / low-conf (must review) / blank must-enter |
+| Diff flag | silent-accept / review / gone-missing | `gold-bg + gold` / `warn-bg + warn` / `terra-bg + terra` |
+| Diff flag | unchanged | **not rendered** (no flag) |
+| Diff flag | compound (changed+low-conf) | warn (forced review, never silent) |
+| `.df-choice` | default / primary | `bg-surface border-border-2 text-navy-2` / `bg-navy text-bg` |
+| Reason picker | default `RE_GRADED` / `TRANSCRIPTION_ERROR` / `OTHER`+free-text | inline on score-down + Case D keep-blank; `OTHER` free text required |
+| Roster row | mapped / ambiguous-blocked / not-in-roster / coverage-gap | proceed / block commit no auto-pick / map-or-discard / committed row untouched + flagged |
+| Multi-page | full coverage / partial | atomic commit all / warn + commit confirmed only, uncovered untouched |
+| Extraction | success / low-conf cell / wholesale failure | scan grid populated / `.empty` cell in `SCAN_EXTRACT` grid / blank Path C grid in place |
+| Page-head action | idle Commit / Re-upload | `bg-navy text-bg` primary / `.btn.ghost` |
+| Photo pane | uploaded (in-session) | `<img>` object URL, discarded on commit — never persisted |
+| Path chooser (host page) | Path B card | flip `available:true` in `path-chooser.tsx`; active = `border-gold bg-gold-bg` + "Active" |
+
+---
+
+## 10. Component mapping (surface region → build target)
+
+| §2 region | Reuse | New work for Item 4 |
+|---|---|---|
+| App shell / sidebar / `.page-head` | ledger `page.tsx` shell + hero idiom | swap copy + `/scan` crumb + Commit/Re-upload actions |
+| `.scan-image` photo pane | — | `<img>` from in-session object URL; multi-page indicator from upload-set index; **never persist** |
+| Extracted grid | `SeniorLedgerGrid` (`LedgerRow`, `CATS`, sticky-left, cell classes) | read-and-verify mode: no weighted column; cells `manual`/`low-conf`/`empty`; per-cell confidence prop; **never `computed`/green** |
+| Low-conf cell + `?` | `.score-cell.low-conf` class (already in tokens/CSS + grid legend) | wire to confidence band `0.60–0.85`; block commit until reviewed |
+| Diff flags | — (new) | 4 `.diff-flag` variants (gold/warn/terra), verbatim copy, per-flag actions |
+| Reason-code picker | `components/ui/fields` (Select) | `RE_GRADED`/`TRANSCRIPTION_ERROR`/`OTHER`+free text; mandatory on score-down + Case D; persist to `auditLog.reason` |
+| Roster-mapping confirm | roster/name resolution | teacher-confirmed step (Q5); ambiguity blocks; **spec-added, not on surface** |
+| Denominator scaling | `lib/score-ledger/compute.ts` (`percent()`, `MAX_PERCENT` guard) | scale raw→0–100 by per-category school denominator before diff (Q1b / A1–A7); pure fn, never a DB trigger |
+| Diff engine | — (new, `lib/score-ledger/`) | 4 pure diff-case functions + vitest, no DB (Q3 / B1–B9) |
+| Extract API + adapter | — (new) | server route proxies base64 → Claude Vision (Haiku 4.5) behind `LedgerExtractor`; server-held key; **image never persisted** (G1–G3) |
+| Fallback grid | `SeniorLedgerGrid` `mode="direct"` | render blank in place on wholesale failure (Q7 / H1) |
+| Commit | `saveDirectLedgerScores`-style server action + `recordAudit` | atomic write `path_used=SCAN_EXTRACT`; drop image (Q6 / G4) |
+
+---
+
+## 11. Open questions / drift log
+
+1. **"supersedes the mid-semester upload" copy vs diff-against-committed (Kofi Q1).** The lede and every flag say "mid-semester upload showed X." **No upload/version table exists in Item 4** — the diff baseline is the **committed `senior_score_ledger` row**. Copy stays (surface wins on presentation); logic reads the committed row. Item 7 adds the supersedes-chain later.
+2. **Roster-mapping confirmation is not drawn on §2 but is spec-mandatory (Q5/D).** The surface shows only the resolved full names. The implementer must add the teacher-confirmed mapping step (ambiguity blocks, no auto-pick). Copy is spec-added — confirm wording with PO, keep the operational voice.
+3. **Extraction-error / fallback grid + error copy not on §2 (Q7/H).** Degrade to blank Path C grid in place; error banner copy is spec-added — confirm wording.
+4. **Scan grid uses `manual` (gold), never `computed` (green).** Cross-map note: the §1 legend's "computed = green" swatch does not apply to scan values. Scanned = manual-origin. Don't let a green cell appear in a `SCAN_EXTRACT` grid.
+5. **Weighted/total column intentionally absent from the scan grid.** §2's extracted grid has no `Weighted` column (§1 does). The total computes after commit, not during verify — do not add it to the verify grid.
+6. **Corner-stamp `PAGE 1/2` is Item 6 (branded ledger book) metadata; Item 4 does not OCR it.** Drive the page indicator from the upload-set index; take class/subject/period from the nav context (build-plan dependency note).
+7. **Denominator scaling is invisible on the surface but load-bearing (Q1b / risk 🟡).** The `Pf` single-digit reads (8, 7, 10…) are /10 portfolio marks; raw `8` → stored `80.00`. The surface shows the raw read; the stored/diffed value is scaled. Ensure the diff compares **scaled** extracted vs committed, and the grid can show the raw read while storing the scaled value.
+8. **Token-opacity trap (verify in live preview).** All §2 tints are solid `-bg` tokens (`bg-gold-bg`/`bg-warn-bg`/`bg-terra-bg`) + solid `text-warn`. Never slash-opacity on raw-hex tokens. §2 is high-risk here (every state is a coloured tint) — verify in the live preview, not the build (memory `no-alpha-token-opacity`).
+9. **Transient image (risk 🔴 — Sarah gates).** The `.scan-image` pane holds an in-session object URL only; the base64 goes server-side (our API route, server-held `ANTHROPIC_API_KEY`), and the image is discarded on commit/complete — no Storage object, no column, no `auditLog` payload reference, no log/Sentry capture (G1–G4). Design reflects this: nothing on the surface implies a saved photo.
+
+---
+
+*Map produced against: `Surfaces/schoolup-shs-score-ledger.html` §2 (lines 593–738; CSS 268–326); `Surfaces/schoolup-shs-score-ledger-pwa.html` (confirmed no §2 variant); `omnischools/docs/senior-build-plan.md` INCR-2 (Kofi Q1–Q7, acceptance B/C/D/E/F/G/H, final decisions 1–4); `omnischools/docs/senior/ledger-surface-map.md` (format + §1 vocabulary); `md files/design-tokens.json` v1.0.0; existing `components/senior/senior-ledger-grid.tsx`, `path-chooser.tsx`, and `app/(app)/senior/score-ledger/page.tsx`.*

--- a/omnischools/lib/actions/score-ledger.ts
+++ b/omnischools/lib/actions/score-ledger.ts
@@ -6,7 +6,6 @@ import { recordAudit } from "@/lib/db/audit";
 import { requireSchool, resolveActor, assertAnyRole } from "@/lib/auth/server";
 import { SENIOR_LEDGER_ROLES } from "@/lib/access";
 import { safeRevalidate } from "@/lib/revalidate";
-import { round2 } from "@/lib/gradebook-helpers";
 import type { Tx } from "@/lib/db";
 import {
   students,
@@ -23,12 +22,14 @@ import {
   weightedTotalComplete,
   computedStatus,
   allCategoriesPresent,
+  parseCategoryCell,
   type CategoryScores,
   type CategoryWeights,
   type EventMark,
   type ComputableCategory,
 } from "@/lib/score-ledger/compute";
-import { reasonRequiredForCommit } from "@/lib/score-ledger/scan-diff";
+import { reasonRequiredForCommit, removalRejectsReGraded } from "@/lib/score-ledger/scan-diff";
+import { ledgerCorrectionReasonEnum } from "@/db/schema/_enums";
 
 const LEDGER_PATH = "/senior/score-ledger";
 const CATEGORIES = [
@@ -697,15 +698,6 @@ const SaveDirectSchema = z.object({
 
 export type SaveDirectResult = { ok: true; saved: number } | { ok: false; error: string };
 
-/** Parse one direct-entry cell: "" → null; otherwise a 0–100 number, or `invalid`. */
-function parseCat(v: string): number | null | "invalid" {
-  const t = v.trim();
-  if (t === "") return null;
-  const n = Number(t);
-  if (!Number.isFinite(n) || n < 0 || n > 100) return "invalid";
-  return round2(n);
-}
-
 /**
  * Path C (spec §4.3) — the teacher types the five category scores straight onto the
  * ledger; the entered values ARE the record (no assessment events, no compile). Each
@@ -728,14 +720,14 @@ export async function saveDirectLedgerScores(input: unknown): Promise<SaveDirect
   const parsedRows: { studentId: string; cats: CategoryScores }[] = [];
   for (const s of d.scores) {
     const vals = {
-      asgn: parseCat(s.asgn),
-      midSem: parseCat(s.midSem),
-      endSem: parseCat(s.endSem),
-      project: parseCat(s.project),
-      portfolio: parseCat(s.portfolio),
+      asgn: parseCategoryCell(s.asgn),
+      midSem: parseCategoryCell(s.midSem),
+      endSem: parseCategoryCell(s.endSem),
+      project: parseCategoryCell(s.project),
+      portfolio: parseCategoryCell(s.portfolio),
     };
     if (Object.values(vals).some((v) => v === "invalid")) {
-      return { ok: false, error: "Each category score must be between 0 and 100." };
+      return { ok: false, error: "Each category score must be between 0 and 999.99." };
     }
     parsedRows.push({ studentId: s.studentId, cats: vals as CategoryScores });
   }
@@ -888,9 +880,10 @@ const CAT_LABEL: Record<ScanCat, string> = {
   project: "project",
   portfolio: "portfolio",
 };
-// The authoritative reason domain — ledger_correction_reason (db/schema/_enums.ts). The chosen
+// The authoritative reason domain IS the DB enum ledger_correction_reason (db/schema/_enums.ts) —
+// derived, not re-declared, so the Zod domain can never drift from the column (Dex-1). The chosen
 // code rides audit_log.reason (Kofi Q1/Q4); there is no ledger column and no image reference.
-const REASON_CODES = ["RE_GRADED", "TRANSCRIPTION_ERROR", "OTHER"] as const;
+const REASON_CODES = ledgerCorrectionReasonEnum.enumValues;
 
 const CommitScanSchema = z.object({
   classId: z.string().uuid(),
@@ -949,14 +942,14 @@ export async function commitScanLedger(input: unknown): Promise<CommitScanResult
   const parsedRows: { studentId: string; cats: CategoryScores }[] = [];
   for (const s of d.scores) {
     const vals = {
-      asgn: parseCat(s.asgn),
-      midSem: parseCat(s.midSem),
-      endSem: parseCat(s.endSem),
-      project: parseCat(s.project),
-      portfolio: parseCat(s.portfolio),
+      asgn: parseCategoryCell(s.asgn),
+      midSem: parseCategoryCell(s.midSem),
+      endSem: parseCategoryCell(s.endSem),
+      project: parseCategoryCell(s.project),
+      portfolio: parseCategoryCell(s.portfolio),
     };
     if (Object.values(vals).some((v) => v === "invalid")) {
-      return { ok: false, error: "Each category score must be between 0 and 100." };
+      return { ok: false, error: "Each category score must be between 0 and 999.99." };
     }
     parsedRows.push({ studentId: s.studentId, cats: vals as CategoryScores });
   }
@@ -1061,6 +1054,14 @@ export async function commitScanLedger(input: unknown): Promise<CommitScanResult
                 error: `A reason is required to ${
                   after == null ? "remove" : "lower"
                 } a ${CAT_LABEL[cat]} score. Review the flagged change before committing.`,
+              };
+            }
+            // Server teeth (Kofi Q2 / Q2-c…e): a removed score can't be re-graded — a re-grade
+            // yields a score, never a blank. Recomputed here, never trusting the client default.
+            if (removalRejectsReGraded(before, after, reason.code)) {
+              return {
+                ok: false,
+                error: `A removed ${CAT_LABEL[cat]} score can't be re-graded — pick why the score is gone (transcription error, or 'Other' with a note).`,
               };
             }
             corrections.push({ studentId, cat, before, after, code: reason.code, note: reason.note });

--- a/omnischools/lib/actions/score-ledger.ts
+++ b/omnischools/lib/actions/score-ledger.ts
@@ -28,6 +28,7 @@ import {
   type EventMark,
   type ComputableCategory,
 } from "@/lib/score-ledger/compute";
+import { reasonRequiredForCommit } from "@/lib/score-ledger/scan-diff";
 
 const LEDGER_PATH = "/senior/score-ledger";
 const CATEGORIES = [
@@ -634,10 +635,6 @@ export async function setLedgerPath(input: unknown): Promise<SetPathResult> {
   const parsed = SetPathSchema.safeParse(input);
   if (!parsed.success) return { ok: false, error: "Invalid path." };
   const d = parsed.data;
-  // Path B (scan/OCR) is not built until Item 4 — don't let it be selected yet.
-  if (d.path === "SCAN_EXTRACT") {
-    return { ok: false, error: "Scan & extract (Path B) is coming soon." };
-  }
   // Don't switch the capture medium of a closed (finalised) semester.
   const closed = await closedPeriodError(school.id, d.periodId);
   if (closed) return { ok: false, error: closed };
@@ -877,5 +874,288 @@ export async function saveDirectLedgerScores(input: unknown): Promise<SaveDirect
     return outcome;
   } catch {
     return { ok: false, error: "Could not save scores. Please try again." };
+  }
+}
+
+// ------------------------------------------- Path B — scan verify & commit (Item 4 / INCR-2)
+const SCAN_PATH = "/senior/score-ledger/scan";
+const SCAN_CATS = ["asgn", "midSem", "endSem", "project", "portfolio"] as const;
+type ScanCat = (typeof SCAN_CATS)[number];
+const CAT_LABEL: Record<ScanCat, string> = {
+  asgn: "assignment",
+  midSem: "mid-sem",
+  endSem: "end-sem",
+  project: "project",
+  portfolio: "portfolio",
+};
+// The authoritative reason domain — ledger_correction_reason (db/schema/_enums.ts). The chosen
+// code rides audit_log.reason (Kofi Q1/Q4); there is no ledger column and no image reference.
+const REASON_CODES = ["RE_GRADED", "TRANSCRIPTION_ERROR", "OTHER"] as const;
+
+const CommitScanSchema = z.object({
+  classId: z.string().uuid(),
+  subjectId: z.string().uuid(),
+  periodId: z.string().uuid(),
+  // Real provenance (Kofi final decision 3 / F4): SCAN_EXTRACT if any cell came from the scan,
+  // DIRECT_ENTRY if extraction failed wholesale and the teacher typed a blank grid in place.
+  origin: z.enum(["SCAN_EXTRACT", "DIRECT_ENTRY"]),
+  scores: z.array(DirectRowSchema),
+  reasons: z
+    .array(
+      z.object({
+        studentId: z.string().uuid(),
+        category: z.enum(SCAN_CATS),
+        code: z.enum(REASON_CODES),
+        note: z.string().trim().max(280).optional(),
+      }),
+    )
+    .default([]),
+});
+
+export type CommitScanResult = { ok: true; saved: number } | { ok: false; error: string };
+
+const numOrNull = (v: string | null) => (v == null ? null : Number(v));
+
+/**
+ * Path B commit (spec §4.2 / Kofi Q6 / E2) — the teacher has verified the extracted grid and
+ * settled every cell; commit writes the confirmed five category values to senior_score_ledger
+ * (the SAME rows Paths A/C write) in ONE transaction, records the real path used + every
+ * correction reason on audit_log, and returns. There is no scan record and no image — the photo
+ * lived only in the browser + in-flight to Claude and is discarded on the client at this point
+ * (owner ruling 3 / G4). A reason is enforced server-side for every score-down and every
+ * committed→blank keep-blank (Q4 / B8), recomputed here from what was actually submitted — never
+ * trusting a client flag. Uncovered students (multi-page partial / D3 / E3) are simply not in the
+ * payload, so their committed rows are untouched, never blanked.
+ */
+export async function commitScanLedger(input: unknown): Promise<CommitScanResult> {
+  const { school } = await requireSchool();
+  await assertAnyRole(SENIOR_LEDGER_ROLES);
+  const parsed = CommitScanSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid scores." };
+  }
+  const d = parsed.data;
+  const closed = await closedPeriodError(school.id, d.periodId);
+  if (closed) return { ok: false, error: closed };
+
+  // A free-text note is mandatory on OTHER (Kofi Q4) — validated before the DB.
+  for (const r of d.reasons) {
+    if (r.code === "OTHER" && !(r.note && r.note.length > 0)) {
+      return { ok: false, error: "Add a short note explaining the 'Other' reason." };
+    }
+  }
+
+  // Validate + parse every cell up-front, before the transaction (atomicity — same as Path C).
+  const parsedRows: { studentId: string; cats: CategoryScores }[] = [];
+  for (const s of d.scores) {
+    const vals = {
+      asgn: parseCat(s.asgn),
+      midSem: parseCat(s.midSem),
+      endSem: parseCat(s.endSem),
+      project: parseCat(s.project),
+      portfolio: parseCat(s.portfolio),
+    };
+    if (Object.values(vals).some((v) => v === "invalid")) {
+      return { ok: false, error: "Each category score must be between 0 and 100." };
+    }
+    parsedRows.push({ studentId: s.studentId, cats: vals as CategoryScores });
+  }
+
+  const reasonByKey = new Map(
+    d.reasons.map((r) => [`${r.studentId}:${r.category}`, r] as const),
+  );
+  const actor = await resolveActor(school.id);
+
+  try {
+    const outcome = await withSchool(
+      school.id,
+      async (tx): Promise<{ ok: true; saved: number } | { ok: false; error: string }> => {
+        // The context must be on Path B (the /scan screen is only reachable then).
+        const [pathRow] = await tx
+          .select({ path: seniorLedgerPath.path })
+          .from(seniorLedgerPath)
+          .where(
+            and(
+              eq(seniorLedgerPath.schoolId, school.id),
+              eq(seniorLedgerPath.classId, d.classId),
+              eq(seniorLedgerPath.subjectId, d.subjectId),
+              eq(seniorLedgerPath.periodId, d.periodId),
+            ),
+          );
+        if (pathRow?.path !== "SCAN_EXTRACT") {
+          return { ok: false, error: "Switch this class to Scan & extract (Path B) first." };
+        }
+
+        // Only ACTIVE students in this class (tenant + roster scope).
+        const roster = await tx
+          .select({ id: students.id })
+          .from(students)
+          .where(
+            and(
+              eq(students.schoolId, school.id),
+              eq(students.classId, d.classId),
+              eq(students.status, "ACTIVE"),
+            ),
+          );
+        const validStudents = new Set(roster.map((r) => r.id));
+        const ids = roster.map((r) => r.id);
+
+        // The currently-committed cells — the diff baseline (Kofi Q1) and the STPSHS_READY carry.
+        const existing = ids.length
+          ? await tx
+              .select({
+                studentId: seniorScoreLedger.studentId,
+                asgnScore: seniorScoreLedger.asgnScore,
+                midSemScore: seniorScoreLedger.midSemScore,
+                endSemScore: seniorScoreLedger.endSemScore,
+                projectScore: seniorScoreLedger.projectScore,
+                portfolioScore: seniorScoreLedger.portfolioScore,
+                status: seniorScoreLedger.status,
+              })
+              .from(seniorScoreLedger)
+              .where(
+                and(
+                  eq(seniorScoreLedger.schoolId, school.id),
+                  eq(seniorScoreLedger.subjectId, d.subjectId),
+                  eq(seniorScoreLedger.periodId, d.periodId),
+                  inArray(seniorScoreLedger.studentId, ids),
+                ),
+              )
+          : [];
+        const committedByStudent = new Map(
+          existing.map((e) => [
+            e.studentId,
+            {
+              asgn: numOrNull(e.asgnScore),
+              midSem: numOrNull(e.midSemScore),
+              endSem: numOrNull(e.endSemScore),
+              project: numOrNull(e.projectScore),
+              portfolio: numOrNull(e.portfolioScore),
+            } as CategoryScores,
+          ]),
+        );
+        const prevStatus = new Map(existing.map((e) => [e.studentId, e.status]));
+
+        // Enforce a reason for every score-down and every committed→blank (Q4 / B8), recomputed
+        // from committed-vs-final. Collect the corrections for the before/after audit trail (B9).
+        type Correction = {
+          studentId: string;
+          cat: ScanCat;
+          before: number | null;
+          after: number | null;
+          code: string;
+          note?: string;
+        };
+        const corrections: Correction[] = [];
+        for (const { studentId, cats } of parsedRows) {
+          if (!validStudents.has(studentId)) continue;
+          const committed = committedByStudent.get(studentId) ?? null;
+          for (const cat of SCAN_CATS) {
+            const before = committed ? committed[cat] : null;
+            const after = cats[cat];
+            if (!reasonRequiredForCommit(before, after)) continue;
+            const reason = reasonByKey.get(`${studentId}:${cat}`);
+            if (!reason) {
+              return {
+                ok: false,
+                error: `A reason is required to ${
+                  after == null ? "remove" : "lower"
+                } a ${CAT_LABEL[cat]} score. Review the flagged change before committing.`,
+              };
+            }
+            corrections.push({ studentId, cat, before, after, code: reason.code, note: reason.note });
+          }
+        }
+
+        const weights = await loadWeights(tx, school.id, d.subjectId);
+        let n = 0;
+        for (const { studentId, cats } of parsedRows) {
+          if (!validStudents.has(studentId)) continue;
+          const total = weightedTotalComplete(cats, weights);
+          const status =
+            prevStatus.get(studentId) === "STPSHS_READY" && allCategoriesPresent(cats)
+              ? ("STPSHS_READY" as const)
+              : computedStatus(cats);
+          const row = {
+            asgnScore: cats.asgn == null ? null : cats.asgn.toFixed(2),
+            midSemScore: cats.midSem == null ? null : cats.midSem.toFixed(2),
+            endSemScore: cats.endSem == null ? null : cats.endSem.toFixed(2),
+            projectScore: cats.project == null ? null : cats.project.toFixed(2),
+            portfolioScore: cats.portfolio == null ? null : cats.portfolio.toFixed(2),
+            weightedTotal: total == null ? null : total.toFixed(2),
+            asgnWeightUsed: weights.asgn,
+            midSemWeightUsed: weights.midSem,
+            endSemWeightUsed: weights.endSem,
+            projectWeightUsed: weights.project,
+            portfolioWeightUsed: weights.portfolio,
+            // A scanned portfolio is still human-written → manual (spec §4.1).
+            portfolioManual: cats.portfolio != null,
+            status,
+            compiledByUserId: actor.id ?? undefined,
+            compiledAt: new Date(),
+            updatedAt: new Date(),
+          };
+          await tx
+            .insert(seniorScoreLedger)
+            .values({
+              schoolId: school.id,
+              studentId,
+              subjectId: d.subjectId,
+              periodId: d.periodId,
+              ...row,
+            })
+            .onConflictDoUpdate({
+              target: [
+                seniorScoreLedger.schoolId,
+                seniorScoreLedger.studentId,
+                seniorScoreLedger.subjectId,
+                seniorScoreLedger.periodId,
+              ],
+              set: row,
+            });
+          n++;
+        }
+
+        // Commit summary — path_used lives here (no ledger column exists; single migration 0041
+        // is denominators + reason enum only). Never carries the image or a reference to it (B9/G1).
+        await recordAudit(tx, {
+          schoolId: school.id,
+          actorUserId: actor.id ?? undefined,
+          actorRole: actor.role,
+          actionType: "updated",
+          entityType: "senior_score_ledger",
+          entityId: d.subjectId,
+          after: {
+            periodId: d.periodId,
+            rows: n,
+            pathUsed: d.origin,
+            corrections: corrections.length,
+          },
+          reason: "Scan verified & committed (Path B)",
+        });
+        // One before/after row per correction, carrying the reason code (Kofi Q4 / B9).
+        for (const c of corrections) {
+          await recordAudit(tx, {
+            schoolId: school.id,
+            actorUserId: actor.id ?? undefined,
+            actorRole: actor.role,
+            actionType: "updated",
+            entityType: "senior_score_ledger",
+            entityId: c.studentId,
+            before: { category: c.cat, value: c.before },
+            after: { category: c.cat, value: c.after },
+            reason: c.note ? `${c.code}: ${c.note}` : c.code,
+          });
+        }
+        return { ok: true, saved: n };
+      },
+    );
+    if (outcome.ok) {
+      safeRevalidate(LEDGER_PATH);
+      safeRevalidate(SCAN_PATH);
+    }
+    return outcome;
+  } catch {
+    return { ok: false, error: "Could not commit the scan. Please try again." };
   }
 }

--- a/omnischools/lib/env.ts
+++ b/omnischools/lib/env.ts
@@ -19,6 +19,11 @@ const schema = z.object({
   NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().optional(),
   SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
 
+  // Claude Vision — score-ledger scan extraction (Path B / Item 4). Server-only (NOT
+  // NEXT_PUBLIC): the base64 photo is sent to Claude from our own API route, never the
+  // client. Absent in dev/CI → the extractor falls back to the deterministic stub.
+  ANTHROPIC_API_KEY: z.string().optional(),
+
   // SMS / email providers (stubbed until credentials exist)
   HUBTEL_CLIENT_ID: z.string().optional(),
   HUBTEL_CLIENT_SECRET: z.string().optional(),

--- a/omnischools/lib/ocr/claude.ts
+++ b/omnischools/lib/ocr/claude.ts
@@ -1,0 +1,177 @@
+import type {
+  ScanExtraction,
+  ExtractInput,
+  LedgerExtractor,
+} from "./index";
+
+/**
+ * Claude-Vision ledger extractor (Path B real engine). Dormant unless ANTHROPIC_API_KEY is set —
+ * getLedgerExtractor() dynamically imports this module only then, so dev/CI never load it and the
+ * key never reaches a client bundle. Follows the house portability discipline (like lib/sms →
+ * Hubtel): the vendor is called over plain `fetch`, never a vendor SDK, so this file is the only
+ * place that knows the wire shape — a Sonnet 5 upgrade later is a one-constant swap (owner ruling 1).
+ *
+ * Request shape (verified against the Anthropic Messages API for Haiku 4.5, `anthropic-version:
+ * 2023-06-01`): structured output is obtained with a FORCED tool call — a single tool whose
+ * `input_schema` is our grid shape + `tool_choice: {type:"tool"}` — the GA, model-agnostic way to
+ * constrain output. (The salvaged WIP used `output_config` + `thinking:{type:"adaptive"}`; neither
+ * is a valid Messages-API field, so both were dropped. Haiku 4.5 needs no thinking to transcribe a
+ * grid, and forcing a tool is incompatible with extended thinking anyway.)
+ *
+ * The image is transient: it is read from the in-memory data URL, sent once, and never stored or
+ * logged (G1–G4) — this module holds no reference to it after the request resolves.
+ */
+
+/** The one place the model id lives. Swap to `claude-sonnet-5` post-go-live — no other change. */
+const MODEL = "claude-haiku-4-5-20251001";
+const MESSAGES_URL = "https://api.anthropic.com/v1/messages";
+const TOOL_NAME = "record_ledger_grid";
+
+/** One extracted cell: a number (0–100+ raw, scaled downstream) or null (blank), plus 0–1 confidence. */
+const CELL_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["value", "confidence"],
+  properties: {
+    value: { type: ["number", "null"] },
+    confidence: { type: "number", minimum: 0, maximum: 1 },
+  },
+} as const;
+
+/** The whole grid: one row per handwritten line, with the name read + a best-guess student id. */
+const EXTRACTION_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["rows"],
+  properties: {
+    rows: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["readName", "studentId", "cells"],
+        properties: {
+          readName: { type: "string" },
+          studentId: { type: ["string", "null"] },
+          cells: {
+            type: "object",
+            additionalProperties: false,
+            required: ["asgn", "midSem", "endSem", "project", "portfolio"],
+            properties: {
+              asgn: CELL_SCHEMA,
+              midSem: CELL_SCHEMA,
+              endSem: CELL_SCHEMA,
+              project: CELL_SCHEMA,
+              portfolio: CELL_SCHEMA,
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+/** Split a `data:<mime>;base64,<data>` URL into the parts the Messages API image block needs. */
+function parseDataUrl(dataUrl: string): { mediaType: string; data: string } {
+  const m = /^data:(image\/[a-zA-Z0-9.+-]+);base64,(.+)$/.exec(dataUrl);
+  if (!m) throw new Error("Ledger extract: image must be a base64 image data URL");
+  return { mediaType: m[1], data: m[2] };
+}
+
+function buildPrompt(roster: ExtractInput["roster"]): string {
+  const list = roster.map((r) => `- ${r.id}: ${r.name}`).join("\n");
+  return [
+    "This is a photograph of a paper score-ledger page for one class and subject.",
+    "Each student row has five handwritten score columns, in this order:",
+    "1) assignments / class exercises, 2) mid-semester exam, 3) end-of-semester exam,",
+    "4) project work, 5) portfolio.",
+    "",
+    "Return one object per handwritten row. For each row:",
+    "- readName: the handwritten student name exactly as you read it (e.g. 'A. Boateng').",
+    "- studentId: your best-guess id from this class roster (format `id: name`), or null if",
+    "  you are not confident which student it is. Do NOT guess a student when the name is",
+    "  abbreviated and could match more than one — return null and let the teacher confirm.",
+    list,
+    "",
+    "For each of the five cells give:",
+    "- value: the number you read, or null if the cell is blank, crossed out, or unreadable.",
+    "  Do NOT guess — null is correct for unreadable.",
+    "- confidence: your confidence in that value from 0 to 1 (use a low value, e.g. below 0.6,",
+    "  whenever the digit is smudged, ambiguous, or inferred).",
+  ].join("\n");
+}
+
+interface ToolUseBlock {
+  type: string;
+  name?: string;
+  input?: unknown;
+}
+interface MessagesResponse {
+  content?: ToolUseBlock[];
+  stop_reason?: string;
+  error?: { message?: string };
+}
+
+export class ClaudeLedgerExtractor implements LedgerExtractor {
+  constructor(private readonly apiKey: string) {}
+
+  async extract(input: ExtractInput): Promise<ScanExtraction> {
+    const { mediaType, data } = parseDataUrl(input.imageDataUrl);
+
+    const res = await fetch(MESSAGES_URL, {
+      method: "POST",
+      headers: {
+        "x-api-key": this.apiKey,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        max_tokens: 8000,
+        tools: [
+          {
+            name: TOOL_NAME,
+            description:
+              "Record the extracted five-category score grid, one entry per handwritten row.",
+            input_schema: EXTRACTION_SCHEMA,
+          },
+        ],
+        tool_choice: { type: "tool", name: TOOL_NAME },
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "image", source: { type: "base64", media_type: mediaType, data } },
+              { type: "text", text: buildPrompt(input.roster) },
+            ],
+          },
+        ],
+      }),
+    });
+
+    if (!res.ok) {
+      const body = (await res.json().catch(() => null)) as MessagesResponse | null;
+      // Never echo the request (it carries the image) — only the vendor's error text.
+      throw new Error(
+        `Ledger extract: Claude request failed (HTTP ${res.status}${
+          body?.error?.message ? `: ${body.error.message}` : ""
+        })`,
+      );
+    }
+
+    const payload = (await res.json()) as MessagesResponse;
+    if (payload.stop_reason === "refusal") {
+      throw new Error("Ledger extract: request was declined by the model");
+    }
+
+    // Forced tool_choice → the grid arrives as the tool_use block's already-parsed `input`.
+    const block = (payload.content ?? []).find(
+      (b) => b.type === "tool_use" && b.name === TOOL_NAME,
+    );
+    const parsed = block?.input as ScanExtraction | undefined;
+    if (!parsed || !Array.isArray(parsed.rows)) {
+      throw new Error("Ledger extract: model returned no grid");
+    }
+    return parsed;
+  }
+}

--- a/omnischools/lib/ocr/claude.ts
+++ b/omnischools/lib/ocr/claude.ts
@@ -11,12 +11,15 @@ import type {
  * Hubtel): the vendor is called over plain `fetch`, never a vendor SDK, so this file is the only
  * place that knows the wire shape — a Sonnet 5 upgrade later is a one-constant swap (owner ruling 1).
  *
- * Request shape (verified against the Anthropic Messages API for Haiku 4.5, `anthropic-version:
- * 2023-06-01`): structured output is obtained with a FORCED tool call — a single tool whose
- * `input_schema` is our grid shape + `tool_choice: {type:"tool"}` — the GA, model-agnostic way to
- * constrain output. (The salvaged WIP used `output_config` + `thinking:{type:"adaptive"}`; neither
- * is a valid Messages-API field, so both were dropped. Haiku 4.5 needs no thinking to transcribe a
- * grid, and forcing a tool is incompatible with extended thinking anyway.)
+ * Request shape (verified against the Anthropic Messages API + the claude-api reference for Haiku
+ * 4.5, `anthropic-version: 2023-06-01`): structured output is a FORCED, STRICT tool call — a single
+ * tool whose `input_schema` is our grid shape + `tool_choice: {type:"tool"}` + `strict:true` — a GA,
+ * model-agnostic way to constrain output that Haiku 4.5 supports (`strict` guarantees the grid
+ * validates against the schema). `output_config: {format:{type:"json_schema"}}` is also valid on
+ * Haiku 4.5 and would work; the forced tool is chosen for provider-neutrality. The salvaged WIP set
+ * `thinking:{type:"adaptive"}` — a Claude-4.6+ feature Haiku 4.5 does NOT support (Haiku 4.5 uses
+ * `{type:"enabled", budget_tokens}` and has no `effort`) — so thinking is dropped: transcription
+ * needs none.
  *
  * The image is transient: it is read from the in-memory data URL, sent once, and never stored or
  * logged (G1–G4) — this module holds no reference to it after the request resolves.
@@ -134,6 +137,7 @@ export class ClaudeLedgerExtractor implements LedgerExtractor {
             description:
               "Record the extracted five-category score grid, one entry per handwritten row.",
             input_schema: EXTRACTION_SCHEMA,
+            strict: true,
           },
         ],
         tool_choice: { type: "tool", name: TOOL_NAME },

--- a/omnischools/lib/ocr/index.ts
+++ b/omnischools/lib/ocr/index.ts
@@ -1,0 +1,67 @@
+import { env } from "@/lib/env";
+
+/**
+ * Ledger scan-extraction abstraction (Path B, spec §4.2 / INCR-2). Feature code calls
+ * `getLedgerExtractor()` and never a vendor SDK directly — a portability discipline, like
+ * lib/sms (both call the vendor over plain fetch behind this interface). The real engine is
+ * Claude Vision (Haiku 4.5, activated when ANTHROPIC_API_KEY is set); otherwise a deterministic
+ * dev stub lets the whole verify-first flow run with no credentials or cost.
+ *
+ * The image is TRANSIENT (owner ruling 3 / G1–G4): it is passed in-flight to the extractor and
+ * never persisted — no table, no column, no bucket, no temp file, no log. These types describe
+ * only the extracted NUMBERS + confidences that come back; they are plain lib types (not tied to
+ * any DB row) precisely because nothing about the scan is stored.
+ */
+
+/** One extracted cell: the number the model read (null = blank/unreadable) + its 0–1 confidence. */
+export interface ExtractedCell {
+  value: number | null;
+  confidence: number;
+}
+
+/** One extracted ledger row: the handwritten name the model read (for teacher roster-confirm —
+ * Kofi Q5), its best-guess student id (may be null / wrong — never trusted for an ambiguous
+ * name), and the five raw category reads. */
+export interface ExtractedRow {
+  readName: string;
+  studentId: string | null;
+  cells: {
+    asgn: ExtractedCell;
+    midSem: ExtractedCell;
+    endSem: ExtractedCell;
+    project: ExtractedCell;
+    portfolio: ExtractedCell;
+  };
+}
+
+export interface ScanExtraction {
+  rows: ExtractedRow[];
+}
+
+export interface ExtractorRosterEntry {
+  id: string;
+  name: string;
+}
+
+export interface ExtractInput {
+  /** data: URL of the photographed ledger page — held only in memory, never persisted. */
+  imageDataUrl: string;
+  /** The class roster — Omnischools knows it, so the extractor proposes name→student mappings. */
+  roster: ExtractorRosterEntry[];
+}
+
+export interface LedgerExtractor {
+  /** Extract the five-category grid from a ledger photo, with a confidence per cell. */
+  extract(input: ExtractInput): Promise<ScanExtraction>;
+}
+
+/** Resolve the extractor: Claude Vision if configured, else the deterministic dev stub. */
+export async function getLedgerExtractor(): Promise<LedgerExtractor> {
+  const key = env.ANTHROPIC_API_KEY;
+  if (key) {
+    const { ClaudeLedgerExtractor } = await import("./claude");
+    return new ClaudeLedgerExtractor(key);
+  }
+  const { StubLedgerExtractor } = await import("./stub");
+  return new StubLedgerExtractor();
+}

--- a/omnischools/lib/ocr/stub.ts
+++ b/omnischools/lib/ocr/stub.ts
@@ -1,0 +1,40 @@
+import type { ScanExtraction, ExtractedCell, ExtractInput, LedgerExtractor } from "./index";
+
+/**
+ * Deterministic dev/stub extractor — fabricates a plausible five-category grid from the roster
+ * (it does not read the image; that is the real Claude engine's job). Deterministic per student
+ * so a re-scan is stable, and it deliberately produces a spread of confidences — including some
+ * low-confidence and blank cells — so the verify-first UI can be built and demoed with no
+ * credentials. The image is never touched or stored (transient guarantee holds in the stub too).
+ */
+function hash(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0;
+  return Math.abs(h);
+}
+
+export class StubLedgerExtractor implements LedgerExtractor {
+  async extract(input: ExtractInput): Promise<ScanExtraction> {
+    const cell = (studentId: string, salt: number): ExtractedCell => {
+      const h = hash(`${studentId}:${salt}`);
+      // Every ~11th cell is an unreadable blank (low confidence) — the teacher fills it.
+      if (h % 11 === 0) return { value: null, confidence: 0.35 };
+      const value = 45 + (h % 50); // 45..94, a realistic score spread
+      const confidence = Math.round((0.6 + ((h >> 4) % 40) / 100) * 100) / 100; // 0.60..0.99
+      return { value, confidence };
+    };
+    return {
+      rows: input.roster.map((r) => ({
+        readName: r.name,
+        studentId: r.id,
+        cells: {
+          asgn: cell(r.id, 1),
+          midSem: cell(r.id, 2),
+          endSem: cell(r.id, 3),
+          project: cell(r.id, 4),
+          portfolio: cell(r.id, 5),
+        },
+      })),
+    };
+  }
+}

--- a/omnischools/lib/score-ledger/compute.test.ts
+++ b/omnischools/lib/score-ledger/compute.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from "vitest";
 import {
   SYSTEM_DEFAULT_WEIGHTS,
+  SYSTEM_DEFAULT_DENOMINATORS,
   MAX_PERCENT,
   resolveWeights,
+  resolveDenominators,
   percent,
   exceedsMax,
   meanPercent,
@@ -12,6 +14,7 @@ import {
   provisionalTotal,
   computedStatus,
   type CategoryScores,
+  type CategoryDenominators,
   type EventMark,
 } from "./compute";
 
@@ -29,6 +32,39 @@ describe("resolveWeights", () => {
   it("falls back to the system constant when neither exists", () => {
     expect(resolveWeights(null, null)).toEqual(W);
     expect(resolveWeights(undefined, undefined)).toEqual(W);
+  });
+});
+
+describe("resolveDenominators (A · denominator resolution)", () => {
+  const subj: CategoryDenominators = {
+    asgn: 100,
+    midSem: 100,
+    endSem: 100,
+    project: 100,
+    portfolio: 20,
+  };
+  const school: CategoryDenominators = {
+    asgn: 100,
+    midSem: 100,
+    endSem: 100,
+    project: 100,
+    portfolio: 10,
+  };
+  it("A4 prefers the per-subject override over the school default", () => {
+    expect(resolveDenominators(subj, school)).toBe(subj);
+  });
+  it("falls back to the school default when there is no subject row", () => {
+    expect(resolveDenominators(null, school)).toBe(school);
+  });
+  it("A3 falls back to the system 100s when neither row exists (never inflates)", () => {
+    expect(resolveDenominators(null, null)).toEqual(SYSTEM_DEFAULT_DENOMINATORS);
+    expect(SYSTEM_DEFAULT_DENOMINATORS).toEqual({
+      asgn: 100,
+      midSem: 100,
+      endSem: 100,
+      project: 100,
+      portfolio: 100,
+    });
   });
 });
 

--- a/omnischools/lib/score-ledger/compute.test.ts
+++ b/omnischools/lib/score-ledger/compute.test.ts
@@ -13,6 +13,7 @@ import {
   weightedTotalComplete,
   provisionalTotal,
   computedStatus,
+  parseCategoryCell,
   type CategoryScores,
   type CategoryDenominators,
   type EventMark,
@@ -256,3 +257,34 @@ describe("allCategoriesPresent / computedStatus", () => {
     expect(allCategoriesPresent({ ...full, midSem: null })).toBe(false);
   });
 });
+
+// ------------------------------------ Kofi Owner-Option-A: one 0–999.99 bound for all 3 paths
+describe("parseCategoryCell (A8–A11 · unified bonus bound)", () => {
+  it("A8/A11 accepts a bonus mark >100 (11/10 portfolio → 110) — commits, not rejected", () => {
+    expect(parseCategoryCell("110")).toBe(110);
+    // The full Path-B chain: raw 11 under a /10 denom scales to 110, then parses to 110.
+    expect(parseCategoryCell(String(scaleTo110()))).toBe(110);
+  });
+  it("A11 same value parses identically regardless of path (B/C share this one bound)", () => {
+    expect(parseCategoryCell("73")).toBe(73);
+    expect(parseCategoryCell("73.5")).toBe(73.5);
+  });
+  it("A10 rejects negative and non-numeric", () => {
+    expect(parseCategoryCell("-1")).toBe("invalid");
+    expect(parseCategoryCell("abc")).toBe("invalid");
+  });
+  it("A10 rejects above the numeric(5,2) ceiling; caps live in the scaler (MAX_PERCENT)", () => {
+    expect(parseCategoryCell("1000")).toBe("invalid");
+    expect(parseCategoryCell(String(MAX_PERCENT))).toBe(MAX_PERCENT);
+  });
+  it("blank → null (never 0), and rounds to 2dp", () => {
+    expect(parseCategoryCell("")).toBeNull();
+    expect(parseCategoryCell("  ")).toBeNull();
+    expect(parseCategoryCell("80.005")).toBe(80.01);
+  });
+});
+
+/** raw 11 under a /10 denominator → 110 (the A8 bonus that used to be rejected at commit). */
+function scaleTo110(): number {
+  return percent(11, 10)!;
+}

--- a/omnischools/lib/score-ledger/compute.ts
+++ b/omnischools/lib/score-ledger/compute.ts
@@ -117,6 +117,22 @@ export function exceedsMax(rawMark: number | null, maxMark: number): boolean {
 }
 
 /**
+ * Parse one hand-entered / scanned category cell string: "" → null; a 0–MAX_PERCENT number →
+ * round2; anything else → "invalid". THE single 0–999.99 category bound shared by all three
+ * capture paths (Path A saveAssessmentScores, Path C saveDirectLedgerScores, Path B
+ * commitScanLedger) so they can never disagree — Kofi Owner-Option-A: a bonus mark (category
+ * >100, e.g. 11/10 portfolio → 110) commits, the UI soft-warns; negatives and non-numbers are
+ * rejected; the 999.99 ceiling is the numeric(5,2) overflow guard.
+ */
+export function parseCategoryCell(v: string): number | null | "invalid" {
+  const t = v.trim();
+  if (t === "") return null;
+  const n = Number(t);
+  if (!Number.isFinite(n) || n < 0 || n > MAX_PERCENT) return "invalid";
+  return round2(n);
+}
+
+/**
  * Mean of the non-null event percentages (blank cells excluded, not treated as 0 —
  * Kofi Q2). Equal-weight mean is the default; weight-by-max-mark is deferred (spec §4.1,
  * Kofi Q5). Returns null when there are no events or every event is blank.

--- a/omnischools/lib/score-ledger/compute.ts
+++ b/omnischools/lib/score-ledger/compute.ts
@@ -25,6 +25,32 @@ export const SYSTEM_DEFAULT_WEIGHTS: CategoryWeights = {
   portfolio: 15,
 };
 
+/**
+ * The five per-category scan denominators (Path B / Item 4). A raw number the extractor read
+ * is interpreted against its category's denominator before it becomes the 0–100 stored value:
+ * raw 8 under a /10 portfolio denominator → 80. Same shape and resolution as the weights.
+ */
+export interface CategoryDenominators {
+  asgn: number;
+  midSem: number;
+  endSem: number;
+  project: number;
+  portfolio: number;
+}
+
+/**
+ * System fallback denominators — all 100 (identity). An unconfigured category never inflates
+ * a mark (raw 8 under /100 → 8); only a smaller configured denominator scales up. The fallback
+ * is deliberately the largest sane denominator so a missing config can never over-award.
+ */
+export const SYSTEM_DEFAULT_DENOMINATORS: CategoryDenominators = {
+  asgn: 100,
+  midSem: 100,
+  endSem: 100,
+  project: 100,
+  portfolio: 100,
+};
+
 /** The four categories Path A auto-compiles from events; portfolio is entered manually. */
 export type ComputableCategory = "ASSIGNMENT" | "MID_SEM_EXAM" | "END_SEM_EXAM" | "PROJECT";
 
@@ -54,6 +80,19 @@ export function resolveWeights(
   schoolDefaultRow: CategoryWeights | null | undefined,
 ): CategoryWeights {
   return subjectRow ?? schoolDefaultRow ?? SYSTEM_DEFAULT_WEIGHTS;
+}
+
+/**
+ * Resolve the five scan denominators for a (school × subject) — identical precedence to
+ * resolveWeights (subject override → school default → system 100), fed the SAME two
+ * ref_assessment_weights rows the weight resolver already fetched (the denominators are
+ * columns on those very rows, so no extra query). Pure — Kofi Q1b / Wells §5 handoff.
+ */
+export function resolveDenominators(
+  subjectRow: CategoryDenominators | null | undefined,
+  schoolDefaultRow: CategoryDenominators | null | undefined,
+): CategoryDenominators {
+  return subjectRow ?? schoolDefaultRow ?? SYSTEM_DEFAULT_DENOMINATORS;
 }
 
 /**

--- a/omnischools/lib/score-ledger/scan-diff.test.ts
+++ b/omnischools/lib/score-ledger/scan-diff.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { MAX_PERCENT } from "./compute";
+import { ledgerCorrectionReasonEnum } from "@/db/schema/_enums";
 import {
   LOW_CONF_FLAG,
   LOW_CONF_FLOOR,
@@ -7,7 +8,11 @@ import {
   scaleExtractedCell,
   diffCell,
   reasonRequiredForCommit,
+  removalRejectsReGraded,
   mapRosterRows,
+  REASON_LABELS,
+  SCORE_DOWN_REASON_CODES,
+  REMOVAL_REASON_CODES,
   type BandedCell,
   type RosterStudent,
 } from "./scan-diff";
@@ -124,6 +129,44 @@ describe("reasonRequiredForCommit (B8 · the authoritative server check, Q4)", (
   it("unchanged / keep-old needs NO reason", () => {
     expect(reasonRequiredForCommit(70, 70)).toBe(false);
     expect(reasonRequiredForCommit(null, null)).toBe(false);
+  });
+});
+
+// ------------------------------- Q2 · a removed score can't be re-graded (server teeth, Kofi Q2)
+describe("removalRejectsReGraded (Q2-c…f · server teeth)", () => {
+  it("Q2-c/Q2-d removal (82 → blank) with RE_GRADED → rejected (blocked, server-recomputed)", () => {
+    expect(removalRejectsReGraded(82, null, "RE_GRADED")).toBe(true);
+  });
+  it("Q2-e removal with TRANSCRIPTION_ERROR or OTHER → allowed", () => {
+    expect(removalRejectsReGraded(82, null, "TRANSCRIPTION_ERROR")).toBe(false);
+    expect(removalRejectsReGraded(82, null, "OTHER")).toBe(false);
+  });
+  it("Q2-a/b score-down (76 → 73) with RE_GRADED → allowed (pre-baked default stays)", () => {
+    expect(removalRejectsReGraded(76, 73, "RE_GRADED")).toBe(false);
+  });
+  it("Q2-f score-up / blank→filled are never removals → never gated by this rule", () => {
+    expect(removalRejectsReGraded(71, 74, "RE_GRADED")).toBe(false);
+    expect(removalRejectsReGraded(null, 64, "RE_GRADED")).toBe(false);
+  });
+  it("a removal excludes RE_GRADED from the picker; a re-grade yields a score, not a blank", () => {
+    expect(REMOVAL_REASON_CODES).not.toContain("RE_GRADED");
+    expect(SCORE_DOWN_REASON_CODES).toContain("RE_GRADED");
+  });
+});
+
+// ------------------------------------------------------------ Dex-1 · reason codes can't drift
+describe("reason codes stay in lockstep with the DB enum (Dex-1)", () => {
+  it("REASON_LABELS keys are exactly ledger_correction_reason's values", () => {
+    expect(Object.keys(REASON_LABELS).sort()).toEqual(
+      [...ledgerCorrectionReasonEnum.enumValues].sort(),
+    );
+  });
+  it("keeps the three locked codes", () => {
+    expect([...ledgerCorrectionReasonEnum.enumValues].sort()).toEqual([
+      "OTHER",
+      "RE_GRADED",
+      "TRANSCRIPTION_ERROR",
+    ]);
   });
 });
 

--- a/omnischools/lib/score-ledger/scan-diff.test.ts
+++ b/omnischools/lib/score-ledger/scan-diff.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from "vitest";
+import { MAX_PERCENT } from "./compute";
+import {
+  LOW_CONF_FLAG,
+  LOW_CONF_FLOOR,
+  bandCell,
+  scaleExtractedCell,
+  diffCell,
+  reasonRequiredForCommit,
+  mapRosterRows,
+  type BandedCell,
+  type RosterStudent,
+} from "./scan-diff";
+
+const banded = (value: number | null, band: BandedCell["band"] = "ACCEPTED"): BandedCell => ({
+  band,
+  value,
+});
+
+// ---------------------------------------------------------------- A · denominator scaling
+describe("scaleExtractedCell (A · denominator scaling)", () => {
+  it("A1 portfolio /10, raw 8 → 80", () => {
+    expect(scaleExtractedCell(8, 10)).toBe(80);
+  });
+  it("A2 assignment /100, raw 72 → 72", () => {
+    expect(scaleExtractedCell(72, 100)).toBe(72);
+  });
+  it("A3 fallback /100 never inflates: raw 8 → 8", () => {
+    expect(scaleExtractedCell(8, 100)).toBe(8);
+  });
+  it("A5 /10 raw 850 → capped at MAX_PERCENT, no overflow", () => {
+    expect(scaleExtractedCell(850, 10)).toBe(MAX_PERCENT);
+  });
+  it("A6 raw blank → null, not 0", () => {
+    expect(scaleExtractedCell(null, 10)).toBeNull();
+  });
+  it("A7 non-positive denominator → null (defence in depth behind the CHECK)", () => {
+    expect(scaleExtractedCell(8, 0)).toBeNull();
+    expect(scaleExtractedCell(8, -10)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------- C · confidence bands
+describe("bandCell (C · confidence bands, Q2)", () => {
+  it("C1 ≥0.85 → ACCEPTED, value kept", () => {
+    expect(bandCell(80, 0.85)).toEqual({ band: "ACCEPTED", value: 80 });
+    expect(bandCell(80, 0.99)).toEqual({ band: "ACCEPTED", value: 80 });
+  });
+  it("C2 [0.60,0.85) → LOW_CONF, value kept but must be reviewed", () => {
+    expect(bandCell(80, 0.6)).toEqual({ band: "LOW_CONF", value: 80 });
+    expect(bandCell(80, 0.84)).toEqual({ band: "LOW_CONF", value: 80 });
+  });
+  it("C3 <0.60 → BLANK, the sub-floor guess is dropped (never a possibly-wrong number)", () => {
+    expect(bandCell(80, 0.59)).toEqual({ band: "BLANK", value: null });
+    expect(bandCell(80, 0)).toEqual({ band: "BLANK", value: null });
+  });
+  it("a blank read is BLANK regardless of confidence", () => {
+    expect(bandCell(null, 0.99)).toEqual({ band: "BLANK", value: null });
+  });
+  it("the band thresholds are the ruled constants", () => {
+    expect(LOW_CONF_FLAG).toBe(0.85);
+    expect(LOW_CONF_FLOOR).toBe(0.6);
+  });
+});
+
+// ---------------------------------------------------------------- B · four diff cases
+describe("diffCell (B · four diff cases, Q3)", () => {
+  it("B1 committed blank + extracted ≥0.85 → SILENT_ACCEPT (gold, no reason)", () => {
+    const d = diffCell(null, banded(64, "ACCEPTED"));
+    expect(d.kind).toBe("SILENT_ACCEPT");
+    expect(d.reasonRequired).toBe(false);
+    expect(d.forcesReview).toBe(false);
+    expect(d.severity).toBe("gold");
+  });
+  it("B2 committed == extracted → UNCHANGED, no flag", () => {
+    expect(diffCell(70, banded(70)).kind).toBe("UNCHANGED");
+    expect(diffCell(null, banded(null, "BLANK")).kind).toBe("UNCHANGED");
+  });
+  it("B3 76 → 73 → SCORE_DOWN, reason required, warn", () => {
+    const d = diffCell(76, banded(73));
+    expect(d.kind).toBe("SCORE_DOWN");
+    expect(d.reasonRequired).toBe(true);
+    expect(d.forcesReview).toBe(true);
+    expect(d.severity).toBe("warn");
+  });
+  it("B4 71 → 74 @≥0.85 → REVIEW, NO reason", () => {
+    const d = diffCell(71, banded(74, "ACCEPTED"));
+    expect(d.kind).toBe("REVIEW");
+    expect(d.reasonRequired).toBe(false);
+    expect(d.forcesReview).toBe(true);
+  });
+  it("B5 82 → blank → GONE_MISSING, never auto-nulls (terra, forces review)", () => {
+    const d = diffCell(82, banded(null, "BLANK"));
+    expect(d.kind).toBe("GONE_MISSING");
+    expect(d.forcesReview).toBe(true);
+    expect(d.severity).toBe("terra");
+  });
+  it("B6 71 → 74 @0.60–0.85 → REVIEW (forced, not silent)", () => {
+    const d = diffCell(71, banded(74, "LOW_CONF"));
+    expect(d.kind).toBe("REVIEW");
+    expect(d.forcesReview).toBe(true);
+  });
+  it("B7 blank → val @0.60–0.85 → REVIEW, not SILENT_ACCEPT (low-conf overrides)", () => {
+    const d = diffCell(null, banded(64, "LOW_CONF"));
+    expect(d.kind).toBe("REVIEW");
+    expect(d.forcesReview).toBe(true);
+    expect(d.severity).toBe("warn");
+  });
+});
+
+describe("reasonRequiredForCommit (B8 · the authoritative server check, Q4)", () => {
+  it("score-down needs a reason", () => {
+    expect(reasonRequiredForCommit(76, 73)).toBe(true);
+  });
+  it("Case-D keep-blank (committed → blank) needs a reason", () => {
+    expect(reasonRequiredForCommit(82, null)).toBe(true);
+  });
+  it("score-up needs NO reason", () => {
+    expect(reasonRequiredForCommit(71, 74)).toBe(false);
+  });
+  it("blank → filled needs NO reason", () => {
+    expect(reasonRequiredForCommit(null, 64)).toBe(false);
+  });
+  it("unchanged / keep-old needs NO reason", () => {
+    expect(reasonRequiredForCommit(70, 70)).toBe(false);
+    expect(reasonRequiredForCommit(null, null)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------- D · roster mapping
+describe("mapRosterRows (D · roster mapping, Q5)", () => {
+  const roster: RosterStudent[] = [
+    { id: "akwasi", firstName: "Akwasi", lastName: "Boateng" },
+    { id: "abena", firstName: "Abena", lastName: "Boateng" },
+    { id: "ama", firstName: "Ama", lastName: "Asante" },
+    { id: "daniel", firstName: "Daniel", lastName: "Owusu" },
+  ];
+
+  it("D1 'A. Boateng' with Akwasi + Abena → ambiguous, blocks, no auto-pick", () => {
+    const res = mapRosterRows([{ readName: "A. Boateng", studentId: "akwasi" }], roster);
+    expect(res.rows[0].status).toBe("ambiguous");
+    expect(res.ok).toBe(false);
+  });
+  it("D2 a name matching no active student → unmapped, no commit until resolved", () => {
+    const res = mapRosterRows([{ readName: "K. Mensah" }], roster);
+    expect(res.rows[0].status).toBe("unmapped");
+    expect(res.ok).toBe(false);
+  });
+  it("D4 two rows → the same student → duplicate, blocks", () => {
+    const res = mapRosterRows(
+      [{ readName: "Ama Asante" }, { readName: "Ama Asante" }],
+      roster,
+    );
+    expect(res.duplicateStudentIds).toContain("ama");
+    expect(res.ok).toBe(false);
+  });
+  it("D5 unambiguous full names → all mapped, commit proceeds", () => {
+    const res = mapRosterRows(
+      [
+        { readName: "Akwasi Boateng" },
+        { readName: "Ama Asante" },
+        { readName: "D. Owusu" },
+      ],
+      roster,
+    );
+    expect(res.rows.map((r) => r.status)).toEqual(["mapped", "mapped", "mapped"]);
+    expect(res.ok).toBe(true);
+  });
+});

--- a/omnischools/lib/score-ledger/scan-diff.ts
+++ b/omnischools/lib/score-ledger/scan-diff.ts
@@ -1,0 +1,215 @@
+/**
+ * Path B (scan-and-extract) diff + scale + confidence engine — pure, no DB, no I/O, no React
+ * (SHS_SCORE_LEDGER_SPEC Item 4 / INCR-2, Kofi Q1b/Q2/Q3/Q5). Mirrors compute.ts: the same
+ * functions drive the client verify UI (flags, low-conf shading) AND the server commit's
+ * reason-required validation, so the two can never diverge. Nothing here is a DB trigger.
+ *
+ * The image never reaches this module — it takes already-extracted numbers + confidences and
+ * compares them against the currently-committed senior_score_ledger cell (Q1: diff-against-
+ * committed; there is no version/upload table).
+ */
+import { percent } from "./compute";
+
+// Confidence bands (owner ruling 6 — named + retunable). ≥ FLAG accepted · [FLOOR,FLAG) shown
+// but must be reviewed · < FLOOR dropped to blank (never show a possibly-wrong number).
+export const LOW_CONF_FLAG = 0.85;
+export const LOW_CONF_FLOOR = 0.6;
+
+export type CellBand = "ACCEPTED" | "LOW_CONF" | "BLANK";
+
+export interface BandedCell {
+  band: CellBand;
+  /** The value to seed the grid with — null when blank OR when a sub-floor guess is dropped. */
+  value: number | null;
+}
+
+/**
+ * Band one extracted cell by its confidence (Kofi Q2 / C1–C3). `value` is the already-scaled
+ * 0–100 number (see scaleExtractedCell) or null for a blank read.
+ *  - value null                → BLANK (nothing read)
+ *  - confidence ≥ 0.85         → ACCEPTED (seed the value, no marker)
+ *  - 0.60 ≤ confidence < 0.85  → LOW_CONF (seed the value, must be reviewed before commit)
+ *  - confidence < 0.60         → BLANK, value dropped (never surface a sub-floor guess — C3)
+ */
+export function bandCell(value: number | null, confidence: number): BandedCell {
+  if (value == null) return { band: "BLANK", value: null };
+  if (confidence >= LOW_CONF_FLAG) return { band: "ACCEPTED", value };
+  if (confidence >= LOW_CONF_FLOOR) return { band: "LOW_CONF", value };
+  return { band: "BLANK", value: null };
+}
+
+/**
+ * Scale one raw extracted number to the 0–100 stored scale by its category denominator
+ * (Kofi Q1b / A1–A7). Delegates to compute.percent, which already returns null on a blank or
+ * non-positive denominator and caps at MAX_PERCENT (999.99) so a pathological read can never
+ * overflow numeric(5,2). raw 8 under /10 → 80; raw 72 under /100 → 72; raw blank → null.
+ */
+export function scaleExtractedCell(raw: number | null, denominator: number): number | null {
+  return percent(raw, denominator);
+}
+
+// The four diff cases (Kofi Q3 / §7.2) plus the no-change case. Severity maps to the surface
+// flag colours: gold = expected/low-stakes, warn = review, terra = highest (gone missing).
+export type DiffKind =
+  | "UNCHANGED" // committed == extracted, or both blank — no flag
+  | "SILENT_ACCEPT" // committed blank → filled at ≥0.85 — commits with no action/reason
+  | "REVIEW" // a change that must be acknowledged but needs no reason (score-up / low-conf change / blank→filled low-conf)
+  | "SCORE_DOWN" // committed → lower value — must be confirmed WITH a reason
+  | "GONE_MISSING"; // committed present → extracted blank — highest severity, never auto-nulled
+
+export interface CellDiff {
+  kind: DiffKind;
+  /** True when accepting the *extracted* value at this cell requires a reason code (score-down). */
+  reasonRequired: boolean;
+  /** True when the cell cannot be silently committed — the teacher must act (Kofi Q3). */
+  forcesReview: boolean;
+  severity: "none" | "gold" | "warn" | "terra";
+}
+
+const UNCHANGED: CellDiff = {
+  kind: "UNCHANGED",
+  reasonRequired: false,
+  forcesReview: false,
+  severity: "none",
+};
+
+/**
+ * Classify one cell: the committed 0–100 value vs the banded extracted cell (Kofi Q3 / B1–B9).
+ * Low-confidence overrides silent-accept (B6/B7): a blank→filled or any change that is low-conf
+ * is forced to REVIEW, never silent. A committed score going to blank is GONE_MISSING and is
+ * never auto-nulled (B5).
+ */
+export function diffCell(committed: number | null, extracted: BandedCell): CellDiff {
+  const ev = extracted.value;
+  const lowConf = extracted.band === "LOW_CONF";
+
+  if (committed == null) {
+    if (ev == null) return UNCHANGED; // both blank
+    // blank → filled
+    if (lowConf) {
+      // B7: not a silent-accept — low-conf forces review.
+      return { kind: "REVIEW", reasonRequired: false, forcesReview: true, severity: "warn" };
+    }
+    // B1: silent-accept.
+    return { kind: "SILENT_ACCEPT", reasonRequired: false, forcesReview: false, severity: "gold" };
+  }
+
+  // committed present
+  if (ev == null) {
+    // B5: score went missing — highest severity, never auto-null.
+    return { kind: "GONE_MISSING", reasonRequired: false, forcesReview: true, severity: "terra" };
+  }
+  if (ev === committed) return UNCHANGED; // B2
+  if (ev < committed) {
+    // B3: score-down — confirm WITH a reason. Compound low-conf (B6) is still a score-down.
+    return { kind: "SCORE_DOWN", reasonRequired: true, forcesReview: true, severity: "warn" };
+  }
+  // ev > committed — score-up. B4: review, NO reason. B6: low-conf still forces review.
+  return { kind: "REVIEW", reasonRequired: false, forcesReview: true, severity: "warn" };
+}
+
+/**
+ * The authoritative server-side check (Kofi Q4 / B8): does committing this FINAL value over the
+ * committed value require a reason code? Reason is mandatory ONLY on a score-down and on a
+ * Case-D keep-blank (committed → blank). Never on a score-up, a blank→filled, or unchanged.
+ * The commit action recomputes this from what the teacher actually submitted — it does not trust
+ * a client flag, and it needs no extraction/image to decide.
+ */
+export function reasonRequiredForCommit(
+  committed: number | null,
+  final: number | null,
+): boolean {
+  if (committed == null) return false; // was blank → up/new, never a reason
+  if (final == null) return true; // committed → blank = keep-blank / gone-missing (Case D)
+  return final < committed; // score-down
+}
+
+// ------------------------------------------------------------- roster mapping (Kofi Q5 / D1–D5)
+
+export interface RosterStudent {
+  id: string;
+  firstName: string;
+  lastName: string;
+}
+
+/** One extracted row before it is confirmed to a student: the handwritten name the model read,
+ * plus its best-guess student id (may be wrong or absent — never trusted for an ambiguous name). */
+export interface ExtractedNameRow {
+  readName: string;
+  studentId?: string | null;
+}
+
+export type RowMapping =
+  | { status: "mapped"; studentId: string }
+  | { status: "ambiguous"; candidateIds: string[] } // >1 roster student fits the name — must confirm
+  | { status: "unmapped" }; // no active student fits — map by hand or discard
+
+export interface RosterMappingResult {
+  rows: RowMapping[];
+  /** Student ids that two or more rows resolved to — a right mark on the wrong student (D4). */
+  duplicateStudentIds: string[];
+  /** True only when every row maps to exactly one active student and no student is doubled (D5). */
+  ok: boolean;
+}
+
+const norm = (s: string) =>
+  s
+    .toLowerCase()
+    .replace(/[.,]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+/** Roster students whose name plausibly fits a handwritten read (last name + first initial). */
+function candidatesFor(readName: string, roster: RosterStudent[]): string[] {
+  const tokens = norm(readName).split(" ").filter(Boolean);
+  if (tokens.length === 0) return [];
+  const last = tokens[tokens.length - 1];
+  const firstTok = tokens[0];
+  const firstInitial = firstTok[0];
+  return roster
+    .filter((r) => {
+      if (norm(r.lastName) !== last) return false;
+      const rf = norm(r.firstName);
+      // "Akwasi" matches full "akwasi"; "A." (abbreviated) matches on the initial.
+      return firstTok.length === 1 ? rf.startsWith(firstInitial) : rf === firstTok;
+    })
+    .map((r) => r.id);
+}
+
+/**
+ * Propose a name→student mapping for extracted rows and flag every ambiguity (Kofi Q5 / D1–D5).
+ * Never auto-picks an ambiguous name: a read that fits two roster students (e.g. "A. Boateng"
+ * with Akwasi AND Abena on the roster) is `ambiguous` and blocks commit until the teacher picks.
+ * A read that fits none is `unmapped`. Two rows resolving to the same student is a duplicate.
+ * The model's own studentId guess is honoured ONLY when the name is unambiguous.
+ */
+export function mapRosterRows(
+  rows: ExtractedNameRow[],
+  roster: RosterStudent[],
+): RosterMappingResult {
+  const byId = new Set(roster.map((r) => r.id));
+  const mapped: RowMapping[] = rows.map((row) => {
+    const candidates = candidatesFor(row.readName, roster);
+    if (candidates.length === 1) return { status: "mapped", studentId: candidates[0] };
+    if (candidates.length > 1) return { status: "ambiguous", candidateIds: candidates };
+    // No name match — accept an explicit, in-roster model guess only if it is unambiguous,
+    // otherwise leave unmapped for the teacher.
+    if (row.studentId && byId.has(row.studentId)) {
+      return { status: "mapped", studentId: row.studentId };
+    }
+    return { status: "unmapped" };
+  });
+
+  // D4: two rows → one student.
+  const seen = new Map<string, number>();
+  for (const m of mapped) {
+    if (m.status === "mapped") seen.set(m.studentId, (seen.get(m.studentId) ?? 0) + 1);
+  }
+  const duplicateStudentIds = Array.from(seen.entries())
+    .filter(([, n]) => n > 1)
+    .map(([id]) => id);
+
+  const ok =
+    mapped.every((m) => m.status === "mapped") && duplicateStudentIds.length === 0;
+  return { rows: mapped, duplicateStudentIds, ok };
+}

--- a/omnischools/lib/score-ledger/scan-diff.ts
+++ b/omnischools/lib/score-ledger/scan-diff.ts
@@ -124,6 +124,37 @@ export function reasonRequiredForCommit(
   return final < committed; // score-down
 }
 
+// -------------------------------------------------- correction reason codes (Kofi Q2/Q4, Dex-1)
+// Client-safe label metadata for the three locked reason codes. This is the ONE list the diff UI
+// renders from; scan-diff.test locks its keys to ledgerCorrectionReasonEnum (the DB source of
+// truth) and lib/actions/score-ledger derives its Zod domain from that same enum, so the DB enum,
+// the server Zod domain, and this UI list can never drift (Dex-1). Kept here (a pure, client-safe
+// lib) rather than importing the pgEnum so drizzle never lands in the client bundle.
+export type ReasonCode = "RE_GRADED" | "TRANSCRIPTION_ERROR" | "OTHER";
+export const REASON_LABELS: Record<ReasonCode, string> = {
+  RE_GRADED: "Re-graded",
+  TRANSCRIPTION_ERROR: "Transcription error",
+  OTHER: "Other (add a note)",
+};
+// A score-down pre-bakes RE_GRADED (§7.3 — the surface's `Keep 73 · re-graded` primary). A
+// removal (committed → blank) can NEVER be a re-grade — a re-grade yields a score, not a blank —
+// so RE_GRADED is excluded and there is no default; the teacher must actively pick (Kofi Q2).
+export const SCORE_DOWN_REASON_CODES: ReasonCode[] = ["RE_GRADED", "TRANSCRIPTION_ERROR", "OTHER"];
+export const REMOVAL_REASON_CODES: ReasonCode[] = ["TRANSCRIPTION_ERROR", "OTHER"];
+
+/**
+ * Server teeth for the removal reason (Kofi Q2 / Q2-c…e). A removal (committed present → final
+ * blank) submitted with RE_GRADED is incoherent and must be rejected — recomputed server-side
+ * from committed-vs-final, never trusting the client default. A score-down keeps RE_GRADED.
+ */
+export function removalRejectsReGraded(
+  committed: number | null,
+  final: number | null,
+  code: string,
+): boolean {
+  return committed != null && final == null && code === "RE_GRADED";
+}
+
 // ------------------------------------------------------------- roster mapping (Kofi Q5 / D1–D5)
 
 export interface RosterStudent {


### PR DESCRIPTION
## Score Ledger Item 4 · Path B (INCR-2)

A teacher photographs their handwritten paper ledger → Claude Vision (Haiku 4.5) extracts the five-category grid → the teacher verifies in-session → commit to `senior_score_ledger`. **The image is never persisted** — it lives only in the browser + in-flight to Claude, and is discarded on commit.

### What's in it
- **OCR client** behind a `LedgerExtractor` interface (`lib/ocr/`): Haiku 4.5 over plain `fetch`, forced + `strict` tool for schema-valid extraction, model id a single constant (→ Sonnet 5 is a one-line swap). Dynamically imported so the key never bundles client-side; a deterministic stub for dev/CI.
- **Diff + scale engine** (`lib/score-ledger/scan-diff.ts`, pure functions + vitest): the four diff cases, confidence bands (≥0.85 / 0.60–0.85 / <0.60), low-confidence-overrides-silent-accept, roster row→student mapping (teacher-confirmed, never auto-picks an ambiguous name), per-category denominator scaling.
- **Verification UI** (`components/senior/scan-workspace.tsx`), extract API route (`app/api/senior/ledger-extract/route.ts`, server-held `ANTHROPIC_API_KEY`), `commitScanLedger` server action.
- **Schema (migration 0041):** 5 per-category denominator columns on the existing `ref_assessment_weights` + a `ledger_correction_reason` enum. **No new table.**

### Owner rulings baked in
- **Transient image** — never stored (no bucket, no `image_ref`, no upload table).
- **Bonus marks allowed** — one 0–999.99 category bound unified across all three capture paths (A/B/C); an 11/10 portfolio read commits as 110 with a soft-warn, never a hard block.
- **Gone-missing keep-blank** requires an *active* reason (`TRANSCRIPTION_ERROR`/`OTHER`+note) — a removal can't be "re-graded" (enforced server-side); a score-down keeps the pre-baked `RE_GRADED` default.
- Model **Haiku 4.5** now, revisit Sonnet 5 after go-live.

### Gates (all green)
- **Quinn (QA)** ✅ — `pnpm build` + typecheck + lint clean, **81/81 vitest** (acceptance A–H + the A8–A11 bonus and Q2 removal deltas); highest-risk math (denominator scaling, roster misattribution, tenant isolation) verified by read.
- **Dex (architecture/portability)** ✅ — provider swappable, no Vercel lock-in, engine is pure lib (not a DB trigger), no server/client leak.
- **Sarah (security)** ✅ — image-never-persists proven by tree-wide trace, key server-only, tenant isolation, **prod-RLS parity** (no new tenant table → nothing to hand-paste).
- Live round-trip proven end-to-end (real `commitScanLedger` over HTTP with the stub extractor).

### Deploy
Prod needs migration **0041** (the enum + 5 denominator columns + CHECK) via the normal migrate flow or `db/sql/prod-paste-0041-ledger-denominators.sql`. **No new RLS to paste** — no tenant table was added.

### Non-blocking follow-ups
- Optional dedicated removal reason code (`ENTERED_IN_ERROR`/`SCORE_VOIDED`) — `TRANSCRIPTION_ERROR`/`OTHER`+note suffice today.
- Pre-existing (from #138): `SENIOR_LEDGER_ROLES` includes `VICE_HEADMASTER_ACADEMIC`, so a VHM can commit/see scores on the *edit* surface; the completion-only rule targets the separate progress view.
- STPSHS export + report-card surfaces (Item 8+) will need to tolerate bonus totals >100 when built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)