### PR TITLE
fix(db): reorder migration 0033 so tenant_uk UNIQUE precedes composite FKs

### DIFF
--- a/omnischools/DEPLOY.md
+++ b/omnischools/DEPLOY.md
@@ -34,7 +34,7 @@ Run as the project's `postgres` user so the RLS bypass role is granted to it.
 ```bash
 # point at prod just for these commands (do NOT commit this value)
 export DATABASE_URL="<DIRECT_URL>"
-pnpm db:migrate        # creates all tables (migrations 0000–0006)
+pnpm db:migrate        # creates all tables (migrations 0000–0045)
 pnpm db:policies       # enables/forces RLS + tenant policies + app/admin roles
 pnpm db:seed           # optional: seeds the Asankrangwa demo school
 ```

--- a/omnischools/README.md
+++ b/omnischools/README.md
@@ -23,7 +23,7 @@ Sentry/PostHog. Local dev uses **Docker Postgres**; production uses **Supabase P
 pnpm install
 cp .env.example .env.local        # local defaults already point at Docker Postgres
 pnpm db:up                        # start Docker Postgres (docker-compose.yml)
-pnpm db:setup                     # push schema + apply RLS policies + seed Asankrangwa SHS
+pnpm db:setup                     # run migrations + apply RLS policies + seed Asankrangwa SHS
 pnpm dev                          # http://localhost:3000
 ```
 

--- a/omnischools/db/migrations/0033_flowery_vector.sql
+++ b/omnischools/db/migrations/0033_flowery_vector.sql
@@ -64,49 +64,94 @@ ALTER TABLE "timetable_slot" DROP CONSTRAINT "timetable_slot_class_id_class_id_f
 --> statement-breakpoint
 ALTER TABLE "inbox_message" DROP CONSTRAINT "inbox_message_conversation_id_conversation_id_fk";
 --> statement-breakpoint
-ALTER TABLE "student_guardian" ADD CONSTRAINT "student_guardian_school_id_student_id_students_school_id_id_fk" FOREIGN KEY ("school_id","student_id") REFERENCES "public"."students"("school_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "students" ADD CONSTRAINT "students_school_id_class_id_class_school_id_id_fk" FOREIGN KEY ("school_id","class_id") REFERENCES "public"."class"("school_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "admission_application" ADD CONSTRAINT "admission_application_school_id_student_id_students_school_id_id_fk" FOREIGN KEY ("school_id","student_id") REFERENCES "public"."students"("school_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "admission_document" ADD CONSTRAINT "admission_document_school_id_application_id_admission_application_school_id_id_fk" FOREIGN KEY ("school_id","application_id") REFERENCES "public"."admission_application"("school_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "invoice_line_item" ADD CONSTRAINT "invoice_line_item_school_id_invoice_id_invoice_school_id_id_fk" FOREIGN KEY ("school_id","invoice_id") REFERENCES "public"."invoice"("school_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "invoice_line_item" ADD CONSTRAINT "invoice_line_item_school_id_fee_category_id_fee_category_school_id_id_fk" FOREIGN KEY ("school_id","fee_category_id") REFERENCES "public"."fee_category"("school_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "invoice" ADD CONSTRAINT "invoice_school_id_student_id_students_school_id_id_fk" FOREIGN KEY ("school_id","student_id") REFERENCES "public"."students"("school_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "invoice" ADD CONSTRAINT "invoice_school_id_period_id_academic_period_school_id_period_id_fk" FOREIGN KEY ("school_id","period_id") REFERENCES "public"."academic_period"("school_id","period_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "payment_allocation" ADD CONSTRAINT "payment_allocation_school_id_payment_id_payment_school_id_id_fk" FOREIGN KEY ("school_id","payment_id") REFERENCES "public"."payment"("school_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "payment_allocation" ADD CONSTRAINT "payment_allocation_school_id_invoice_id_invoice_school_id_id_fk" FOREIGN KEY ("school_id","invoice_id") REFERENCES "public"."invoice"("school_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "payment" ADD CONSTRAINT "payment_school_id_student_id_students_school_id_id_fk" FOREIGN KEY ("school_id","student_id") REFERENCES "public"."students"("school_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "receipt" ADD CONSTRAINT "receipt_school_id_payment_id_payment_school_id_id_fk" FOREIGN KEY ("school_id","payment_id") REFERENCES "public"."payment"("school_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "receipt" ADD CONSTRAINT "receipt_school_id_student_id_students_school_id_id_fk" FOREIGN KEY ("school_id","student_id") REFERENCES "public"."students"("school_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "discount_tier" ADD CONSTRAINT "discount_tier_school_id_discount_id_discount_school_id_id_fk" FOREIGN KEY ("school_id","discount_id") REFERENCES "public"."discount"("school_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "fee_structure_item" ADD CONSTRAINT "fee_structure_item_school_id_fee_structure_id_fee_structure_school_id_id_fk" FOREIGN KEY ("school_id","fee_structure_id") REFERENCES "public"."fee_structure"("school_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "invoice_discount_application" ADD CONSTRAINT "invoice_discount_application_school_id_invoice_id_invoice_school_id_id_fk" FOREIGN KEY ("school_id","invoice_id") REFERENCES "public"."invoice"("school_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "invoice_discount_application" ADD CONSTRAINT "invoice_discount_application_school_id_student_id_students_school_id_id_fk" FOREIGN KEY ("school_id","student_id") REFERENCES "public"."students"("school_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "invoice_discount_application" ADD CONSTRAINT "invoice_discount_application_school_id_discount_id_discount_school_id_id_fk" FOREIGN KEY ("school_id","discount_id") REFERENCES "public"."discount"("school_id","id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "attendance_correction" ADD CONSTRAINT "attendance_correction_school_id_attendance_record_id_attendance_record_school_id_id_fk" FOREIGN KEY ("school_id","attendance_record_id") REFERENCES "public"."attendance_record"("school_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "attendance_record" ADD CONSTRAINT "attendance_record_school_id_student_id_students_school_id_id_fk" FOREIGN KEY ("school_id","student_id") REFERENCES "public"."students"("school_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "attendance_record" ADD CONSTRAINT "attendance_record_school_id_class_id_class_school_id_id_fk" FOREIGN KEY ("school_id","class_id") REFERENCES "public"."class"("school_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "gradebook_column_score" ADD CONSTRAINT "gradebook_column_score_school_id_column_id_gradebook_column_school_id_id_fk" FOREIGN KEY ("school_id","column_id") REFERENCES "public"."gradebook_column"("school_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "gradebook_column_score" ADD CONSTRAINT "gradebook_column_score_school_id_student_id_students_school_id_id_fk" FOREIGN KEY ("school_id","student_id") REFERENCES "public"."students"("school_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "gradebook_column" ADD CONSTRAINT "gradebook_column_school_id_class_id_class_school_id_id_fk" FOREIGN KEY ("school_id","class_id") REFERENCES "public"."class"("school_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "gradebook_column" ADD CONSTRAINT "gradebook_column_school_id_subject_id_subject_school_id_id_fk" FOREIGN KEY ("school_id","subject_id") REFERENCES "public"."subject"("school_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "gradebook_column" ADD CONSTRAINT "gradebook_column_school_id_period_id_academic_period_school_id_period_id_fk" FOREIGN KEY ("school_id","period_id") REFERENCES "public"."academic_period"("school_id","period_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "gradebook_score" ADD CONSTRAINT "gradebook_score_school_id_student_id_students_school_id_id_fk" FOREIGN KEY ("school_id","student_id") REFERENCES "public"."students"("school_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "gradebook_score" ADD CONSTRAINT "gradebook_score_school_id_subject_id_subject_school_id_id_fk" FOREIGN KEY ("school_id","subject_id") REFERENCES "public"."subject"("school_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "gradebook_score" ADD CONSTRAINT "gradebook_score_school_id_period_id_academic_period_school_id_period_id_fk" FOREIGN KEY ("school_id","period_id") REFERENCES "public"."academic_period"("school_id","period_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "report_card" ADD CONSTRAINT "report_card_school_id_student_id_students_school_id_id_fk" FOREIGN KEY ("school_id","student_id") REFERENCES "public"."students"("school_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "report_card" ADD CONSTRAINT "report_card_school_id_period_id_academic_period_school_id_period_id_fk" FOREIGN KEY ("school_id","period_id") REFERENCES "public"."academic_period"("school_id","period_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "timetable_slot" ADD CONSTRAINT "timetable_slot_school_id_class_id_class_school_id_id_fk" FOREIGN KEY ("school_id","class_id") REFERENCES "public"."class"("school_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "inbox_message" ADD CONSTRAINT "inbox_message_school_id_conversation_id_conversation_school_id_id_fk" FOREIGN KEY ("school_id","conversation_id") REFERENCES "public"."conversation"("school_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "academic_period" ADD CONSTRAINT "academic_period_tenant_uk" UNIQUE("school_id","period_id");--> statement-breakpoint
-ALTER TABLE "class" ADD CONSTRAINT "class_tenant_uk" UNIQUE("school_id","id");--> statement-breakpoint
-ALTER TABLE "students" ADD CONSTRAINT "students_tenant_uk" UNIQUE("school_id","id");--> statement-breakpoint
-ALTER TABLE "admission_application" ADD CONSTRAINT "admission_application_tenant_uk" UNIQUE("school_id","id");--> statement-breakpoint
-ALTER TABLE "fee_category" ADD CONSTRAINT "fee_category_tenant_uk" UNIQUE("school_id","id");--> statement-breakpoint
-ALTER TABLE "invoice" ADD CONSTRAINT "invoice_tenant_uk" UNIQUE("school_id","id");--> statement-breakpoint
-ALTER TABLE "payment" ADD CONSTRAINT "payment_tenant_uk" UNIQUE("school_id","id");--> statement-breakpoint
-ALTER TABLE "discount" ADD CONSTRAINT "discount_tenant_uk" UNIQUE("school_id","id");--> statement-breakpoint
-ALTER TABLE "fee_structure" ADD CONSTRAINT "fee_structure_tenant_uk" UNIQUE("school_id","id");--> statement-breakpoint
-ALTER TABLE "attendance_record" ADD CONSTRAINT "attendance_record_tenant_uk" UNIQUE("school_id","id");--> statement-breakpoint
-ALTER TABLE "gradebook_column" ADD CONSTRAINT "gradebook_column_tenant_uk" UNIQUE("school_id","id");--> statement-breakpoint
-ALTER TABLE "subject" ADD CONSTRAINT "subject_tenant_uk" UNIQUE("school_id","id");--> statement-breakpoint
+ALTER TABLE "academic_period" ADD CONSTRAINT "academic_period_tenant_uk" UNIQUE("school_id","period_id");
+--> statement-breakpoint
+ALTER TABLE "class" ADD CONSTRAINT "class_tenant_uk" UNIQUE("school_id","id");
+--> statement-breakpoint
+ALTER TABLE "students" ADD CONSTRAINT "students_tenant_uk" UNIQUE("school_id","id");
+--> statement-breakpoint
+ALTER TABLE "admission_application" ADD CONSTRAINT "admission_application_tenant_uk" UNIQUE("school_id","id");
+--> statement-breakpoint
+ALTER TABLE "fee_category" ADD CONSTRAINT "fee_category_tenant_uk" UNIQUE("school_id","id");
+--> statement-breakpoint
+ALTER TABLE "invoice" ADD CONSTRAINT "invoice_tenant_uk" UNIQUE("school_id","id");
+--> statement-breakpoint
+ALTER TABLE "payment" ADD CONSTRAINT "payment_tenant_uk" UNIQUE("school_id","id");
+--> statement-breakpoint
+ALTER TABLE "discount" ADD CONSTRAINT "discount_tenant_uk" UNIQUE("school_id","id");
+--> statement-breakpoint
+ALTER TABLE "fee_structure" ADD CONSTRAINT "fee_structure_tenant_uk" UNIQUE("school_id","id");
+--> statement-breakpoint
+ALTER TABLE "attendance_record" ADD CONSTRAINT "attendance_record_tenant_uk" UNIQUE("school_id","id");
+--> statement-breakpoint
+ALTER TABLE "gradebook_column" ADD CONSTRAINT "gradebook_column_tenant_uk" UNIQUE("school_id","id");
+--> statement-breakpoint
+ALTER TABLE "subject" ADD CONSTRAINT "subject_tenant_uk" UNIQUE("school_id","id");
+--> statement-breakpoint
 ALTER TABLE "conversation" ADD CONSTRAINT "conversation_tenant_uk" UNIQUE("school_id","id");
+--> statement-breakpoint
+ALTER TABLE "student_guardian" ADD CONSTRAINT "student_guardian_school_id_student_id_students_school_id_id_fk" FOREIGN KEY ("school_id","student_id") REFERENCES "public"."students"("school_id","id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "students" ADD CONSTRAINT "students_school_id_class_id_class_school_id_id_fk" FOREIGN KEY ("school_id","class_id") REFERENCES "public"."class"("school_id","id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "admission_application" ADD CONSTRAINT "admission_application_school_id_student_id_students_school_id_id_fk" FOREIGN KEY ("school_id","student_id") REFERENCES "public"."students"("school_id","id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "admission_document" ADD CONSTRAINT "admission_document_school_id_application_id_admission_application_school_id_id_fk" FOREIGN KEY ("school_id","application_id") REFERENCES "public"."admission_application"("school_id","id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "invoice_line_item" ADD CONSTRAINT "invoice_line_item_school_id_invoice_id_invoice_school_id_id_fk" FOREIGN KEY ("school_id","invoice_id") REFERENCES "public"."invoice"("school_id","id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "invoice_line_item" ADD CONSTRAINT "invoice_line_item_school_id_fee_category_id_fee_category_school_id_id_fk" FOREIGN KEY ("school_id","fee_category_id") REFERENCES "public"."fee_category"("school_id","id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "invoice" ADD CONSTRAINT "invoice_school_id_student_id_students_school_id_id_fk" FOREIGN KEY ("school_id","student_id") REFERENCES "public"."students"("school_id","id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "invoice" ADD CONSTRAINT "invoice_school_id_period_id_academic_period_school_id_period_id_fk" FOREIGN KEY ("school_id","period_id") REFERENCES "public"."academic_period"("school_id","period_id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "payment_allocation" ADD CONSTRAINT "payment_allocation_school_id_payment_id_payment_school_id_id_fk" FOREIGN KEY ("school_id","payment_id") REFERENCES "public"."payment"("school_id","id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "payment_allocation" ADD CONSTRAINT "payment_allocation_school_id_invoice_id_invoice_school_id_id_fk" FOREIGN KEY ("school_id","invoice_id") REFERENCES "public"."invoice"("school_id","id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "payment" ADD CONSTRAINT "payment_school_id_student_id_students_school_id_id_fk" FOREIGN KEY ("school_id","student_id") REFERENCES "public"."students"("school_id","id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "receipt" ADD CONSTRAINT "receipt_school_id_payment_id_payment_school_id_id_fk" FOREIGN KEY ("school_id","payment_id") REFERENCES "public"."payment"("school_id","id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "receipt" ADD CONSTRAINT "receipt_school_id_student_id_students_school_id_id_fk" FOREIGN KEY ("school_id","student_id") REFERENCES "public"."students"("school_id","id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "discount_tier" ADD CONSTRAINT "discount_tier_school_id_discount_id_discount_school_id_id_fk" FOREIGN KEY ("school_id","discount_id") REFERENCES "public"."discount"("school_id","id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "fee_structure_item" ADD CONSTRAINT "fee_structure_item_school_id_fee_structure_id_fee_structure_school_id_id_fk" FOREIGN KEY ("school_id","fee_structure_id") REFERENCES "public"."fee_structure"("school_id","id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "invoice_discount_application" ADD CONSTRAINT "invoice_discount_application_school_id_invoice_id_invoice_school_id_id_fk" FOREIGN KEY ("school_id","invoice_id") REFERENCES "public"."invoice"("school_id","id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "invoice_discount_application" ADD CONSTRAINT "invoice_discount_application_school_id_student_id_students_school_id_id_fk" FOREIGN KEY ("school_id","student_id") REFERENCES "public"."students"("school_id","id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "invoice_discount_application" ADD CONSTRAINT "invoice_discount_application_school_id_discount_id_discount_school_id_id_fk" FOREIGN KEY ("school_id","discount_id") REFERENCES "public"."discount"("school_id","id") ON DELETE restrict ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "attendance_correction" ADD CONSTRAINT "attendance_correction_school_id_attendance_record_id_attendance_record_school_id_id_fk" FOREIGN KEY ("school_id","attendance_record_id") REFERENCES "public"."attendance_record"("school_id","id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "attendance_record" ADD CONSTRAINT "attendance_record_school_id_student_id_students_school_id_id_fk" FOREIGN KEY ("school_id","student_id") REFERENCES "public"."students"("school_id","id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "attendance_record" ADD CONSTRAINT "attendance_record_school_id_class_id_class_school_id_id_fk" FOREIGN KEY ("school_id","class_id") REFERENCES "public"."class"("school_id","id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "gradebook_column_score" ADD CONSTRAINT "gradebook_column_score_school_id_column_id_gradebook_column_school_id_id_fk" FOREIGN KEY ("school_id","column_id") REFERENCES "public"."gradebook_column"("school_id","id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "gradebook_column_score" ADD CONSTRAINT "gradebook_column_score_school_id_student_id_students_school_id_id_fk" FOREIGN KEY ("school_id","student_id") REFERENCES "public"."students"("school_id","id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "gradebook_column" ADD CONSTRAINT "gradebook_column_school_id_class_id_class_school_id_id_fk" FOREIGN KEY ("school_id","class_id") REFERENCES "public"."class"("school_id","id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "gradebook_column" ADD CONSTRAINT "gradebook_column_school_id_subject_id_subject_school_id_id_fk" FOREIGN KEY ("school_id","subject_id") REFERENCES "public"."subject"("school_id","id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "gradebook_column" ADD CONSTRAINT "gradebook_column_school_id_period_id_academic_period_school_id_period_id_fk" FOREIGN KEY ("school_id","period_id") REFERENCES "public"."academic_period"("school_id","period_id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "gradebook_score" ADD CONSTRAINT "gradebook_score_school_id_student_id_students_school_id_id_fk" FOREIGN KEY ("school_id","student_id") REFERENCES "public"."students"("school_id","id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "gradebook_score" ADD CONSTRAINT "gradebook_score_school_id_subject_id_subject_school_id_id_fk" FOREIGN KEY ("school_id","subject_id") REFERENCES "public"."subject"("school_id","id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "gradebook_score" ADD CONSTRAINT "gradebook_score_school_id_period_id_academic_period_school_id_period_id_fk" FOREIGN KEY ("school_id","period_id") REFERENCES "public"."academic_period"("school_id","period_id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "report_card" ADD CONSTRAINT "report_card_school_id_student_id_students_school_id_id_fk" FOREIGN KEY ("school_id","student_id") REFERENCES "public"."students"("school_id","id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "report_card" ADD CONSTRAINT "report_card_school_id_period_id_academic_period_school_id_period_id_fk" FOREIGN KEY ("school_id","period_id") REFERENCES "public"."academic_period"("school_id","period_id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "timetable_slot" ADD CONSTRAINT "timetable_slot_school_id_class_id_class_school_id_id_fk" FOREIGN KEY ("school_id","class_id") REFERENCES "public"."class"("school_id","id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "inbox_message" ADD CONSTRAINT "inbox_message_school_id_conversation_id_conversation_school_id_id_fk" FOREIGN KEY ("school_id","conversation_id") REFERENCES "public"."conversation"("school_id","id") ON DELETE cascade ON UPDATE no action;


### PR DESCRIPTION
## Problem
From an **empty** database, `pnpm db:migrate` (and `db:setup`) rolls back to **0 tables** and exits 1 with no visible error.

- The real failing migration is **`0033_flowery_vector.sql`** (the composite-tenant-FK refactor) — *not* ~0011 as previously assumed.
- drizzle generated it with all 33 `ADD ... FOREIGN KEY (school_id, x) REFERENCES <t>(school_id, id)` statements **before** the 13 `ADD ... UNIQUE(school_id, id)` (`*_tenant_uk`) targets they require. Postgres rejects the first composite FK to `students`: `there is no unique constraint matching given keys for referenced table "students"`.
- `drizzle-kit migrate` runs the whole batch in one transaction and **swallows the error** — only the harmless `identifier … will be truncated` NOTICEs (from attendance-era tables) print, which is what made it look like a "~0011 / attendance era" failure.

This never surfaced in normal work because the dev DB is built via `db:push` (final schema, no replay), and prod applies each migration incrementally onto existing state (never from empty).

## Fix
Pure reorder of 0033: the 13 `*_tenant_uk` UNIQUE `ADD CONSTRAINT`s now come **before** the 33 composite FK `ADD CONSTRAINT`s (DROPs stay first). Same 79-statement set, identical final schema, valid dependency order. `_journal.json` and meta snapshots are untouched, so DBs that already applied 0033 (prod) will **not** re-run it.

## Verification
From-empty `pnpm db:migrate` against a throwaway Postgres:
- exits 0, applies all **46 migrations (0000–0045)**
- produces **71 tables**, equivalent to the `db:push`-built dev DB (**71 tables / 176 FKs / 112 uniques / 38 enums** on both)

## Notes
- This re-applies an earlier fix (`01ea27e`, on the never-merged branch `fix/migrate-0033-fk-ordering`) — the original was orphaned and never reached `main`, so every feature branch kept rediscovering the break. **Any future `db:generate` of the composite-FK migration will reintroduce FK-before-UNIQUE ordering** — verify ordering after a regen.
- Also corrects two now-inaccurate docs: README `db:setup` comment (`push schema` → `run migrations`) and DEPLOY.md migrate range (`0000–0006` → `0000–0045`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)