### PR TITLE
fix: revive 8 dead unique-violation checks (Drizzle .cause unwrapping)

### DIFF
--- a/omnischools/docs/OWNER-TODO.md
+++ b/omnischools/docs/OWNER-TODO.md
@@ -1,0 +1,149 @@
+# Owner TODO — actions only you can do before go-live
+
+Everything here is assigned to **you**, not to the build loop. It is work that needs your credentials,
+your data, your judgement, or your eyes on a real browser. Items already queued for me to build in a
+later increment are deliberately **not** listed.
+
+Last updated: 2026-07-20 (after INCR-17b + the 23505 retrofit).
+
+---
+
+## MUST DO — go-live is unsafe without these
+
+### 1. Verify every prod RLS paste has actually been applied
+**Why it matters:** `db:policies` only configures local dev. On prod, RLS is applied **only** by hand-pasting
+`db/sql/prod-paste-*.sql`. A single missed file means those tables have **no tenant isolation on prod** —
+one school reads another school's children's data. This is the highest-severity item on the list.
+
+There are **27** paste files (`prod-paste-0029-*` … `prod-paste-0054-*`). You've been running them per
+increment, but nothing has verified the full set end-to-end.
+
+**How to check (run on prod, expect ZERO rows):**
+```sql
+-- Any tenant table (has school_id) that is missing FORCE RLS or its policy:
+SELECT c.relname,
+       c.relrowsecurity  AS rls_enabled,
+       c.relforcerowsecurity AS rls_forced,
+       (SELECT count(*) FROM pg_policy p WHERE p.polrelid = c.oid) AS policies
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+ WHERE n.nspname = 'public' AND c.relkind = 'r'
+   AND EXISTS (SELECT 1 FROM pg_attribute a
+                WHERE a.attrelid = c.oid AND a.attname = 'school_id' AND NOT a.attisdropped)
+   AND (NOT c.relrowsecurity OR NOT c.relforcerowsecurity
+        OR (SELECT count(*) FROM pg_policy p WHERE p.polrelid = c.oid) = 0);
+```
+Anything returned is a leaking table — paste the matching `prod-paste-*.sql` for it.
+
+> Note: global reference tables (`universities`, `university_programmes`, `benchmark_reference`) are
+> *correctly* `ENABLE` without `FORCE` and without a policy. They hold no tenant data. The query above
+> only flags tables that have a `school_id`, so it won't false-positive on those.
+
+---
+
+### 2. One manual check before ship — click the WASSCE target write flow in a real browser
+Neither I nor Quinn had a browser-driving tool available, so the **write path was verified at the action
+boundary only** (role gates, real constraint dispatch, audit writes, tenant re-validation) plus the read
+path end-to-end. The actual click was never performed.
+
+**Do this once:** open a candidate's readiness page → **§6 University match** →
+- click **"+ Add programme"** and tag a programme → confirm the tile appears with the right tier badge,
+- change a target's rank to first choice → confirm the badge flips to **TARGET**,
+- **remove** a target → confirm it disappears and the header tally re-counts.
+
+Also worth an eyeball while you're there: the roster avatar tint on the WASSCE registration page. It had
+been silently missing since INCR-16 (a Tailwind scanning gap fixed in INCR-17b) and has never been seen
+rendered.
+
+---
+
+### 3. Run the PWA phase-2 offline self-verify (Score Ledger Item 9)
+Cannot be automated in a node test runner — it needs a real device/browser with DevTools. Checklist:
+1. Go offline → enter a full class's scores → **close and reopen the app while still offline** → scores
+   present and **gold** (held), none showing as saved.
+2. Reconnect → auto-flush → all green; flush a second time → **no duplicate rows**.
+3. Enter a deliberately invalid score → **red** → close/reopen → **still red**.
+4. Log out teacher A → A's pending scores and rosters gone from **both** IndexedDB and the SW cache.
+5. Log in teacher B on the same tablet → B sees **none** of A's held scores.
+
+---
+
+### 4. Supply the real data that is currently placeholder
+These render to parents/teachers as if authoritative. All are seeded snapshots or constants right now.
+
+| Item | Current state | What's needed |
+|---|---|---|
+| WAEC **national** benchmark figures | seeded constant | real published figures |
+| **Regional** benchmark | seeded, marked `DIRECTIONAL` (± 4–5 pp) | real figures, or keep it explicitly directional |
+| Mock **predictive-accuracy** figure (73–82%) | display constant, shown publicly | confirm the number + who updates it annually |
+| **University cut-offs** | published **2025** snapshot, 16 programmes, each stamped with its year | refresh for the live admission cycle before parents rely on it |
+
+---
+
+### 5. Decide on Hubtel SMS — nothing sends until you provision it
+Every SMS chain is built and wired but **degrades to console**: boarding late-return/overdue reminders,
+exeat notifications, visiting-day notices, and the WASSCE parent-acknowledgement OTP. No real message has
+ever been sent and no credentials exist.
+
+**To go live:** provision `HUBTEL_CLIENT_ID` / `HUBTEL_CLIENT_SECRET`. **Until you do, treat any feature
+described as "notifies the parent" as not actually notifying anyone.** Tell me before you provision —
+there's one code change I want to land first (moving the overdue-chain sends outside their DB transaction)
+so a slow SMS gateway can't hold a transaction open.
+
+---
+
+### 6. Provide the real brand mark
+The Omnischools-branded paper ledger book (Score Ledger Item 6) ships with a placeholder mark. It prints
+and goes home with students, so it needs the real asset before anything is printed at scale.
+
+---
+
+## SHOULD DO — decisions I need from you (none block the current build)
+
+### 7. Boarding: enable the 3× fee penalty → invoice write?
+Deliberately **stubbed** at your instruction ("build all of INCR-13 except the invoice write"). The
+deboardinization ladder computes the penalty but **writes no invoice**. Decide whether it should post to
+billing for real, and I'll wire it.
+
+### 8. Confirm the university cut-off source
+I defaulted to a **seeded published snapshot** as global reference (updatable per admission cycle, like the
+benchmark figures) because it ships without an external dependency and stays portable. The alternatives
+were school-entered, or a licensed/maintained dataset feed. Say the word if you'd rather switch.
+
+### 9. Admission-accurate aggregate — refine or leave?
+The projection uses the **pure best-3-cores** rule (matches the spec and the surface's own visualizer).
+Real Ghanaian *university admission* fixes **English + Core Maths as mandatory** cores. These differ only
+when English or Core Maths is a candidate's *worst* core — not the case in any demo data. The concern is
+already encoded as a **prerequisite** (every programme requires credits in both), so the practical risk is
+small. Decide if you want the stricter variant for cut-off matching.
+
+### 10. Boarding visiting day: public tokenised parent RSVP link?
+Deferred earlier. Today visiting-day RSVPs are **staff-entered**. A public tokenised link would let parents
+RSVP themselves — a different security surface (public endpoint, token lifetime) that needs your call.
+
+### 11. Marketing copy honesty
+`components/marketing/faq.tsx` still says **"offline-first"**. That claim is on the forbidden list for the
+shipped PWA (single-device, sync-on-reconnect — *not* offline-first, *not* multi-device). It predates this
+work and wasn't touched. Tell me the wording you want and I'll change it.
+
+### 12. Sync the design mockups in `Surfaces/`
+Those files are yours and untracked, and two have drifted from what shipped:
+- `schoolup-shs-score-ledger-pwa.html` — the Phase-2 roadmap card still reads "later · trigger = real
+  demand"; it **ships now**. The section meta and honesty caption need the same graduation.
+- `schoolup-wassce-subject-teacher.html` — a **"Mark Mock 3 papers"** button contradicts the ratified
+  two-mock model ("we stop at two"); recommend relabelling to Mock 2.
+
+### 13. Consider CI for the migration chain
+There is **no CI that replays migrations from empty**. Ordering bugs are therefore invisible until a prod
+deploy or a fresh onboarding — this has already bitten once (migration 0033 emitted foreign keys before the
+unique constraints they referenced, and drizzle swallowed the error). I verify each new migration against a
+throwaway database by hand, but that only covers migrations I author. A CI job running
+`db:migrate` from empty would catch it permanently.
+
+---
+
+## Standing process note
+
+**Every future increment that adds a tenant table produces a new `prod-paste-*.sql` that you must paste on
+prod by hand.** It is not automated and not covered by CI. If you ever merge an increment without running
+its paste, that increment's tables leak across schools until you do.

--- a/omnischools/lib/actions/boarding-config.ts
+++ b/omnischools/lib/actions/boarding-config.ts
@@ -9,7 +9,7 @@
  */
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
-import { withSchool } from "@/lib/db/rls";
+import { withSchool, isUniqueViolation } from "@/lib/db/rls";
 import { recordAudit } from "@/lib/db/audit";
 import { requireSchool, resolveActor } from "@/lib/auth/server";
 import { getCurrentUser } from "@/lib/auth";
@@ -233,7 +233,7 @@ export async function createCalendarEvent(input: unknown): Promise<Result> {
     safeRevalidate(PROGRAMME_PATH);
     return { ok: true };
   } catch (err) {
-    if (err && typeof err === "object" && (err as { code?: string }).code === "23505") {
+    if (isUniqueViolation(err)) {
       return { ok: false, error: "An event of that type already exists on that date." };
     }
     return { ok: false, error: "Could not add the calendar event." };
@@ -296,7 +296,7 @@ export async function updateCalendarEvent(input: unknown): Promise<Result> {
     safeRevalidate(PROGRAMME_PATH);
     return { ok: true };
   } catch (err) {
-    if (err && typeof err === "object" && (err as { code?: string }).code === "23505") {
+    if (isUniqueViolation(err)) {
       return { ok: false, error: "An event of that type already exists on that date." };
     }
     return { ok: false, error: "Could not update the calendar event." };
@@ -409,7 +409,7 @@ export async function updateHouse(input: unknown): Promise<Result> {
     safeRevalidate(PROGRAMME_PATH);
     return { ok: true };
   } catch (err) {
-    if (err && typeof err === "object" && (err as { code?: string }).code === "23505") {
+    if (isUniqueViolation(err)) {
       return { ok: false, error: "Another House already uses that name." };
     }
     return { ok: false, error: "Could not save the House." };
@@ -467,7 +467,7 @@ export async function addDormitory(input: unknown): Promise<Result> {
     safeRevalidate(PROGRAMME_PATH);
     return { ok: true };
   } catch (err) {
-    if (err && typeof err === "object" && (err as { code?: string }).code === "23505") {
+    if (isUniqueViolation(err)) {
       return { ok: false, error: "That House already has a dormitory with that name." };
     }
     return { ok: false, error: "Could not provision the dormitory." };

--- a/omnischools/lib/actions/boarding-exeat.ts
+++ b/omnischools/lib/actions/boarding-exeat.ts
@@ -1,7 +1,7 @@
 "use server";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
-import { withSchool } from "@/lib/db/rls";
+import { withSchool, isUniqueViolation } from "@/lib/db/rls";
 import { recordAudit } from "@/lib/db/audit";
 import { requireSchool, resolveActor, type ActiveSchool } from "@/lib/auth/server";
 import { getCurrentUser, type AppUser } from "@/lib/auth";
@@ -231,7 +231,11 @@ export async function requestExeat(input: unknown): Promise<ExeatResult> {
       safeRevalidate(EXEAT_PATH);
       return { ok: true, refCode: out.refCode };
     } catch (err) {
-      if (err && typeof err === "object" && (err as { code?: string }).code === "23505") continue;
+      // A ref-code collision is the EXPECTED failure this loop exists to retry. MUST go through
+      // `isUniqueViolation`: Drizzle wraps the driver error and hangs the real PostgresError off
+      // `.cause`, so reading `.code` off the THROWN error always missed — which made this retry
+      // dead code and hard-failed exeat creation on any collision.
+      if (isUniqueViolation(err)) continue;
       throw err;
     }
   }

--- a/omnischools/lib/actions/boarding.ts
+++ b/omnischools/lib/actions/boarding.ts
@@ -1,7 +1,7 @@
 "use server";
 import { and, eq, isNull, ne } from "drizzle-orm";
 import { z } from "zod";
-import { withSchool } from "@/lib/db/rls";
+import { withSchool, isUniqueViolation } from "@/lib/db/rls";
 import { recordAudit } from "@/lib/db/audit";
 import { requireSchool, resolveActor } from "@/lib/auth/server";
 import { getCurrentUser } from "@/lib/auth";
@@ -173,11 +173,14 @@ export async function reassignBunk(input: unknown): Promise<Result> {
     safeRevalidate(`/senior/boarding/houses/${outcome.houseId}/roster`);
     return { ok: true };
   } catch (err) {
-    // A lost race for the bunk trips the partial unique `uniq_student_current_bunk` (SQLSTATE 23505,
-    // which postgres.js surfaces on `.code`) → whole-tx rollback; that's the one expected failure, so
-    // surface the honest "just taken" (AC D2). Any OTHER error (connection drop, unrelated constraint)
-    // is genuinely unexpected — don't mask it as a bunk conflict; rethrow so it's logged/surfaced.
-    if (err && typeof err === "object" && (err as { code?: string }).code === "23505") {
+    // A lost race for the bunk trips the partial unique `uniq_student_current_bunk` (SQLSTATE 23505)
+    // → whole-tx rollback; that's the one expected failure, so surface the honest "just taken" (AC D2).
+    // Any OTHER error (connection drop, unrelated constraint) is genuinely unexpected — don't mask it
+    // as a bunk conflict; rethrow so it's logged/surfaced.
+    // MUST go through `isUniqueViolation`: Drizzle wraps the driver error and hangs the real
+    // PostgresError off `.cause`, so reading `.code` off the THROWN error always missed and this
+    // expected race threw instead of returning the message.
+    if (isUniqueViolation(err)) {
       return { ok: false, error: REASSIGN_MESSAGES.bunk_occupied };
     }
     throw err;

--- a/omnischools/lib/actions/onboarding.ts
+++ b/omnischools/lib/actions/onboarding.ts
@@ -452,8 +452,12 @@ export async function onboardSchool(input: unknown): Promise<OnboardResult> {
     // Match on the unwrapped SQLSTATE/constraint, NOT the thrown error's message: Drizzle's wrapper
     // message is only "Failed query: …" — "duplicate key" and the constraint name live on `.cause`,
     // so the old string match never fired and this degraded to the generic error.
+    // Match the NAMED constraint only (verified against pg_constraint). Deliberately no bare
+    // `code === "23505"` fallback: this transaction also creates classes, subjects, roles, fees and
+    // payment methods, so a duplicate in any of those would otherwise be reported as a GES-code clash
+    // and send the admin down the wrong path. An unrelated dupe gets the honest generic message below.
     const pg = pgError(err);
-    if (pg.constraint === "ref_school_ges_code_unique" || pg.code === "23505") {
+    if (pg.constraint === "ref_school_ges_code_unique") {
       return { ok: false, error: "A school with this GES code already exists." };
     }
     return { ok: false, error: "Could not complete onboarding. Please try again." };

--- a/omnischools/lib/actions/onboarding.ts
+++ b/omnischools/lib/actions/onboarding.ts
@@ -10,7 +10,7 @@ import {
   defaultFees,
   DEFAULT_PAYMENT_METHODS,
 } from "@/lib/onboarding";
-import { withoutTenantScope } from "@/lib/db/rls";
+import { withoutTenantScope, pgError } from "@/lib/db/rls";
 import { recordAudit } from "@/lib/db/audit";
 import { normalizeGhanaPhone } from "@/lib/auth";
 import { sendSms } from "@/lib/sms";
@@ -449,8 +449,11 @@ export async function onboardSchool(input: unknown): Promise<OnboardResult> {
     };
   } catch (err) {
     captureError(err, { action: "onboardSchool", gesCode: d.gesCode });
-    const msg = String((err as Error)?.message ?? err);
-    if (msg.includes("ref_school_ges_code_unique") || msg.includes("duplicate key")) {
+    // Match on the unwrapped SQLSTATE/constraint, NOT the thrown error's message: Drizzle's wrapper
+    // message is only "Failed query: …" — "duplicate key" and the constraint name live on `.cause`,
+    // so the old string match never fired and this degraded to the generic error.
+    const pg = pgError(err);
+    if (pg.constraint === "ref_school_ges_code_unique" || pg.code === "23505") {
       return { ok: false, error: "A school with this GES code already exists." };
     }
     return { ok: false, error: "Could not complete onboarding. Please try again." };

--- a/omnischools/lib/actions/whatsapp-templates.ts
+++ b/omnischools/lib/actions/whatsapp-templates.ts
@@ -109,8 +109,10 @@ export async function saveTemplate(input: unknown): Promise<Result> {
     // message is only "Failed query: …" — "duplicate key" and the constraint name live on `.cause`,
     // so the old string match never fired. (The `locked` check above stays message-based: that error
     // is thrown by our own code, not the driver, so it is not wrapped.)
+    // Constraint name verified against pg_constraint — it is ..._per_school, NOT ..._name. (The old
+    // code got away with `msg.includes("uniq_whatsapp_template_name")` because a substring matched.)
     const pg = pgError(e);
-    if (pg.constraint === "uniq_whatsapp_template_name" || pg.code === "23505") {
+    if (pg.constraint === "uniq_whatsapp_template_name_per_school" || pg.code === "23505") {
       return { ok: false, error: "A template with this name already exists." };
     }
     return { ok: false, error: "Could not save the template." };

--- a/omnischools/lib/actions/whatsapp-templates.ts
+++ b/omnischools/lib/actions/whatsapp-templates.ts
@@ -1,7 +1,7 @@
 "use server";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
-import { withSchool } from "@/lib/db/rls";
+import { withSchool, pgError } from "@/lib/db/rls";
 import { requireSchool, resolveActor, assertWriteAccess } from "@/lib/auth/server";
 import { recordAudit } from "@/lib/db/audit";
 import { safeRevalidate } from "@/lib/revalidate";
@@ -105,7 +105,12 @@ export async function saveTemplate(input: unknown): Promise<Result> {
     if (msg.includes("locked")) {
       return { ok: false, error: "Submitted templates can't be edited — duplicate it as a new version." };
     }
-    if (msg.includes("uniq_whatsapp_template_name") || msg.includes("duplicate key")) {
+    // Match on the unwrapped SQLSTATE/constraint, NOT the thrown error's message: Drizzle's wrapper
+    // message is only "Failed query: …" — "duplicate key" and the constraint name live on `.cause`,
+    // so the old string match never fired. (The `locked` check above stays message-based: that error
+    // is thrown by our own code, not the driver, so it is not wrapped.)
+    const pg = pgError(e);
+    if (pg.constraint === "uniq_whatsapp_template_name" || pg.code === "23505") {
       return { ok: false, error: "A template with this name already exists." };
     }
     return { ok: false, error: "Could not save the template." };

--- a/omnischools/lib/db/pg-error.test.ts
+++ b/omnischools/lib/db/pg-error.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { pgError, isUniqueViolation } from "./pg-error";
+
+/**
+ * These tests pin the REAL shapes observed from drizzle-orm + postgres.js against the dev DB, because
+ * this bug class was silently live across six call sites for months and is invisible to `next build`,
+ * typecheck, and lint — the broken checks compile and read plausibly, they just never fire.
+ *
+ * Observed by probing an actual duplicate insert:
+ *   thrown ctor            : DrizzleQueryError
+ *   thrown .code           : undefined
+ *   thrown .message        : 'Failed query: INSERT INTO probe_uk VALUES (1)\nparams: '
+ *   cause  ctor            : PostgresError
+ *   cause  .code           : '23505'
+ *   cause  .constraint_name: 'probe_uk_name'
+ */
+
+/** The exact wrapper shape drizzle throws — the regression that made six call sites dead code. */
+function drizzleWrapped(code: string, constraint?: string): Error {
+  const pgErr = Object.assign(new Error(`duplicate key value violates unique constraint "${constraint}"`), {
+    code,
+    constraint_name: constraint,
+  });
+  return Object.assign(new Error("Failed query: INSERT INTO x VALUES (1)\nparams: "), { cause: pgErr });
+}
+
+describe("pgError — unwrapping Drizzle's wrapped driver errors", () => {
+  it("finds a unique violation through the wrapper (THE regression)", () => {
+    const err = drizzleWrapped("23505", "uniq_student_current_bunk");
+    // What the six broken call sites read, and why they never fired:
+    expect((err as { code?: string }).code).toBeUndefined();
+    expect(String(err.message)).not.toContain("duplicate key");
+    // What the helper reads:
+    expect(isUniqueViolation(err)).toBe(true);
+    expect(pgError(err)).toEqual({ code: "23505", constraint: "uniq_student_current_bunk" });
+  });
+
+  it("still works if the driver error is NOT wrapped (degrades gracefully both directions)", () => {
+    const bare = Object.assign(new Error("dupe"), { code: "23505", constraint_name: "uniq_x" });
+    expect(isUniqueViolation(bare)).toBe(true);
+    expect(pgError(bare).constraint).toBe("uniq_x");
+  });
+
+  it("survives an extra wrapping layer", () => {
+    const deeper = Object.assign(new Error("outer"), { cause: drizzleWrapped("23505", "uniq_y") });
+    expect(isUniqueViolation(deeper)).toBe(true);
+  });
+
+  it("does NOT misreport other Postgres errors as unique violations", () => {
+    const fk = drizzleWrapped("23503", "some_fk"); // foreign-key violation
+    expect(isUniqueViolation(fk)).toBe(false);
+    expect(pgError(fk).code).toBe("23503"); // still classified, just not as 23505
+  });
+
+  it("returns a unique violation with no constraint name when the driver omits it", () => {
+    const noConstraint = Object.assign(new Error("outer"), {
+      cause: Object.assign(new Error("dupe"), { code: "23505" }),
+    });
+    expect(isUniqueViolation(noConstraint)).toBe(true);
+    expect(pgError(noConstraint).constraint).toBeUndefined();
+  });
+
+  it("is safe on non-errors and never throws", () => {
+    for (const junk of [null, undefined, "23505", 42, {}, new Error("plain"), []]) {
+      expect(() => pgError(junk)).not.toThrow();
+      expect(isUniqueViolation(junk)).toBe(false);
+    }
+  });
+
+  it("terminates on a cyclic cause chain", () => {
+    const a = new Error("a") as Error & { cause?: unknown };
+    const b = new Error("b") as Error & { cause?: unknown };
+    a.cause = b;
+    b.cause = a; // cycle
+    expect(() => pgError(a)).not.toThrow();
+    expect(isUniqueViolation(a)).toBe(false);
+  });
+
+  it("stops at the documented depth cap rather than walking unbounded", () => {
+    // 6 hops deep — beyond the cap of 5, so deliberately NOT found.
+    let err: unknown = Object.assign(new Error("pg"), { code: "23505" });
+    for (let i = 0; i < 6; i++) err = Object.assign(new Error(`wrap${i}`), { cause: err });
+    expect(isUniqueViolation(err)).toBe(false);
+  });
+});

--- a/omnischools/lib/db/pg-error.ts
+++ b/omnischools/lib/db/pg-error.ts
@@ -1,0 +1,52 @@
+/**
+ * Postgres error classification — PURE (no driver import), so it is unit-testable and client-safe.
+ * Re-exported from `lib/db/rls.ts`, which is where callers import it from.
+ *
+ * WHY THIS EXISTS. Drizzle wraps every driver failure in a `DrizzleQueryError` whose own `.message` is
+ * only `"Failed query: <sql>\nparams: …"` and whose `.code` is `undefined`; the real `PostgresError`
+ * — carrying `code` ("23505") and `constraint_name` — hangs off `.cause`. So BOTH of the obvious
+ * checks silently never fire against the thrown error:
+ *
+ *     (err as {code?}).code === "23505"          // ← undefined on the wrapper
+ *     String(err.message).includes("duplicate key") // ← wrapper message has no such text
+ *
+ * Every unique-violation check in this repo was written one of those two ways and was therefore dead:
+ * a bunk-race returned a throw instead of "just taken", and an exeat ref-code retry loop could never
+ * retry. Always classify through `pgError`/`isUniqueViolation`.
+ *
+ * Deliberately structural (duck-typed on `.code`/`.constraint_name`/`.cause`) rather than
+ * `instanceof DrizzleQueryError`: no Drizzle import, no private API, and it degrades gracefully in
+ * BOTH directions — if Drizzle stops wrapping, the fields are found at depth 0; if it adds a layer,
+ * the walk absorbs it.
+ *
+ * ponytail: `constraint_name` is postgres.js's field name (node-postgres uses `.constraint`). `code`
+ * is universal, so a driver swap degrades constraint-SPECIFIC messages to the generic branch rather
+ * than crashing. Add the alias if a driver swap ever happens.
+ */
+
+/** How many `.cause` hops to follow. Real wrap depth is 1; 5 is headroom without unbounded walking. */
+const MAX_CAUSE_DEPTH = 5;
+
+/**
+ * Unwrap a thrown query error to the underlying Postgres fields, however deeply it was wrapped.
+ * Returns empty fields for anything that isn't a Postgres error (never throws, terminates on cycles).
+ */
+export function pgError(err: unknown): { code?: string; constraint?: string } {
+  let cur: unknown = err;
+  for (let i = 0; i < MAX_CAUSE_DEPTH && cur != null && typeof cur === "object"; i++) {
+    const e = cur as { code?: unknown; constraint_name?: unknown; cause?: unknown };
+    if (typeof e.code === "string") {
+      return {
+        code: e.code,
+        constraint: typeof e.constraint_name === "string" ? e.constraint_name : undefined,
+      };
+    }
+    cur = e.cause;
+  }
+  return {};
+}
+
+/** True when the error is a Postgres unique violation (SQLSTATE 23505), however deeply it was wrapped. */
+export function isUniqueViolation(err: unknown): boolean {
+  return pgError(err).code === "23505";
+}

--- a/omnischools/lib/db/rls.ts
+++ b/omnischools/lib/db/rls.ts
@@ -18,32 +18,12 @@ export async function withSchool<T>(
 }
 
 /**
- * Unwrap a thrown query error to the underlying PostgresError fields.
- *
- * Drizzle wraps every driver failure in a `DrizzleQueryError` and hangs the real `PostgresError` off
- * `.cause`, so an `(err as {code?}).code === "23505"` check against the THROWN error silently misses and
- * a constraint violation degrades to the generic "please try again" instead of its own message. Always
- * inspect through this helper. The cause chain is walked (depth-capped) so it survives another wrap.
+ * Postgres error classification lives in the PURE `./pg-error` module (no driver import, so it is
+ * unit-tested in `lib/db/pg-error.test.ts`). Re-exported here because every caller already imports the
+ * db seam from `@/lib/db/rls` — see that module for WHY reading `.code`/`.message` off the thrown
+ * error silently misses.
  */
-export function pgError(err: unknown): { code?: string; constraint: string | undefined } {
-  let cur: unknown = err;
-  for (let i = 0; i < 5 && cur != null && typeof cur === "object"; i++) {
-    const e = cur as { code?: unknown; constraint_name?: unknown; cause?: unknown };
-    if (typeof e.code === "string") {
-      return {
-        code: e.code,
-        constraint: typeof e.constraint_name === "string" ? e.constraint_name : undefined,
-      };
-    }
-    cur = e.cause;
-  }
-  return { code: undefined, constraint: undefined };
-}
-
-/** True when the error is a Postgres unique violation (SQLSTATE 23505), however deeply it was wrapped. */
-export function isUniqueViolation(err: unknown): boolean {
-  return pgError(err).code === "23505";
-}
+export { pgError, isUniqueViolation } from "./pg-error";
 
 /**
  * Escalated, RLS-bypassing work (onboarding, identity lookups, ETL, admin jobs).


### PR DESCRIPTION
## What was broken

Drizzle wraps every driver failure in a `DrizzleQueryError`. Probing a real duplicate insert against the dev DB:

```
thrown ctor    : DrizzleQueryError
thrown .code   : undefined
thrown .message: "Failed query: INSERT INTO probe_uk VALUES (1)\nparams: "
cause  .code   : "23505"
cause  .message: 'duplicate key value violates unique constraint "probe_uk_name"'
```

The real `PostgresError` — carrying `code` and `constraint_name` — hangs off `.cause`. So **both** idioms used in this repo silently never fired:

```ts
(err as {code?}).code === "23505"              // undefined on the wrapper
String(err.message).includes("duplicate key")  // wrapper message has no such text
```

Every unique-violation check in the codebase was written one of those two ways. All 8 were dead. This is invisible to `build`, `typecheck` and `lint` — the checks compile and read plausibly, they just never run.

## Two were live user-facing defects

1. **`boarding-exeat.ts`** — the check guards a ref-code-collision **retry loop**, so the retry was dead code and exeat creation hard-threw on any collision. Quinn proved the fix against a real forced duplicate on `uniq_exeat_ref_code`.
2. **`boarding.ts`** — a lost bunk race **threw** instead of returning "bunk just taken" (AC D2), defeating the behavior its own comment documents. Quinn verified the catch can't over-reach: `bunk_allocation` has no other unique constraint, so `uniq_student_current_bunk` is the only reachable 23505.

Cosmetic (friendly message → generic): `boarding-config.ts` ×4, `onboarding.ts`, `whatsapp-templates.ts`. The last two matched on the **wrapper message**, so they needed constraint-name matching rather than a code swap.

## Also in this PR

- **Extracted the classifier to a pure `lib/db/pg-error.ts`** — it was trapped behind a driver import in `rls.ts`, so any test would open a real DB connection. `rls.ts` re-exports it, so **no call site's import changed**.
- **8 regression tests** pinning the real wrapper shape, plus graceful-degradation, other-SQLSTATE, cyclic-`cause`, and depth-cap cases. This bug class sat live for months precisely because nothing could catch it.
- **Post-review fixes (Quinn):** the whatsapp constraint is `uniq_whatsapp_template_name_per_school` — the old code matched it by *substring*, and converting to `===` silently killed that branch. Also dropped the bare `|| code === "23505"` fallback in `onboarding.ts`: that transaction creates classes, subjects, roles, fees and payment methods, so an unrelated duplicate was being reported as a GES-code clash. Every constraint literal in `lib/` was then swept against `pg_constraint` + `pg_indexes` — all present.

## Verification
`pnpm test` **391/391** · `typecheck` clean · `lint` clean · clean `pnpm build` exit 0 · **Quinn: GREEN** (verified against the live driver with real forced collisions, not mocks).

No schema change, no migration, **no prod-paste needed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)