### PR TITLE
fix(students): show subject scores on the student profile before a report card exists

### DIFF
--- a/omnischools/app/(app)/students/[id]/page.tsx
+++ b/omnischools/app/(app)/students/[id]/page.tsx
@@ -186,17 +186,43 @@ export default async function StudentDetailPage(props: { params: Promise<{ id: s
         .limit(8),
     ]);
 
-    // Per-subject scores for the latest card's period (or current term if a card exists).
-    const scorePeriodId = latestCard[0]?.periodId ?? null;
+    // Which period's per-subject scores to show. Prefer the latest report card's period;
+    // otherwise fall back to the most recent period this student actually has scores in —
+    // scores are entered well before a report card is generated, and the school may also be
+    // between terms (so "the current term" can be null and is not a usable fallback).
+    const [latestScored] = latestCard[0]
+      ? []
+      : await tx
+          .select({ periodId: gradebookScores.periodId })
+          .from(gradebookScores)
+          .innerJoin(
+            academicPeriod,
+            and(
+              eq(academicPeriod.periodId, gradebookScores.periodId),
+              eq(academicPeriod.schoolId, gradebookScores.schoolId),
+            ),
+          )
+          .where(
+            and(
+              eq(gradebookScores.schoolId, school.id),
+              eq(gradebookScores.studentId, student.id),
+            ),
+          )
+          .orderBy(desc(academicPeriod.academicYear), desc(academicPeriod.periodNumber))
+          .limit(1);
+
+    const scorePeriodId = latestCard[0]?.periodId ?? latestScored?.periodId ?? null;
     const scores = scorePeriodId
       ? await tx
           .select({
             subject: subjects.name,
             total: gradebookScores.total,
             grade: gradebookScores.grade,
+            periodLabel: academicPeriod.periodLabel,
           })
           .from(gradebookScores)
           .innerJoin(subjects, eq(gradebookScores.subjectId, subjects.id))
+          .leftJoin(academicPeriod, eq(gradebookScores.periodId, academicPeriod.periodId))
           .where(
             and(
               eq(gradebookScores.schoolId, school.id),
@@ -412,21 +438,29 @@ export default async function StudentDetailPage(props: { params: Promise<{ id: s
           )
         }
       >
-        {!card ? (
-          <Muted>No report card generated yet.</Muted>
+        {!card && scores.length === 0 ? (
+          <Muted>No scores or report card recorded yet.</Muted>
         ) : (
           <>
-            <div className="mb-4 flex flex-wrap items-baseline gap-x-3 gap-y-1">
-              <span className="font-display text-3xl font-semibold text-navy">
-                {card.overallGrade ?? "—"}
-              </span>
-              <span className="text-sm text-navy-2">
-                {card.overallTotal != null ? `${num(card.overallTotal).toFixed(1)} overall` : "no overall total"}
-              </span>
-              <span className="text-[11px] uppercase tracking-wide text-navy-3">
-                {card.periodLabel ?? "latest term"}
-              </span>
-            </div>
+            {card ? (
+              <div className="mb-4 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                <span className="font-display text-3xl font-semibold text-navy">
+                  {card.overallGrade ?? "—"}
+                </span>
+                <span className="text-sm text-navy-2">
+                  {card.overallTotal != null ? `${num(card.overallTotal).toFixed(1)} overall` : "no overall total"}
+                </span>
+                <span className="text-[11px] uppercase tracking-wide text-navy-3">
+                  {card.periodLabel ?? "latest term"}
+                </span>
+              </div>
+            ) : (
+              // Scores exist but no report card has been generated — show them anyway, labelled.
+              <div className="mb-4 text-[11px] uppercase tracking-wide text-navy-3">
+                {scores[0]?.periodLabel ?? "latest term"} · scores entered, report card not generated
+                yet
+              </div>
+            )}
             {scores.length === 0 ? (
               <Muted>No subject scores recorded for this period.</Muted>
             ) : (


### PR DESCRIPTION
**Reported:** [Akosua Boateng's profile](https://omnischools.vercel.app/students/9a78462f-6517-4d1f-b944-dfd9382bb2e8) shows no scores, though her gradebook holds a Maths score.

**Confirmed on prod.** She has a `gradebook_score` row — Mathematics, Term 1 2025/26, class 80 / exam 89 → **total 84.5, grade A** — and **zero `report_card` rows**.

## Root cause
Both halves of the Performance section were gated on a generated report card:

```ts
const scorePeriodId = latestCard[0]?.periodId ?? null;      // null when there's no card
const scores = scorePeriodId ? await tx.select(...) : [];   // ...so scores were never queried
```

…and the subject table was nested inside the `card ? … : …` branch, so even fetched scores couldn't render. Since scores are entered well before a report card is generated, **every un-carded student** showed "No report card generated yet" and nothing else — hiding real marks.

## Fix
- **Fall back to the most recent period the student actually has scores in.** The file's own comment intended "current term" as the fallback, but that isn't usable here: the current-term query requires *today* to fall inside a term window, and this school is between terms (Term 1 ran 2026-04-01 → 2026-06-20, today is past it), so `term` is `undefined`. A naive current-term fallback would still have shown nothing.
- **Render the per-subject table independently of the card.** With no card, the period is labelled `"<term> · scores entered, report card not generated yet"`.
- The genuine empty case now reads **"No scores or report card recorded yet"** instead of the misleading "No report card generated yet".

The report-card summary block is unchanged when a card does exist.

## Verification
Reproduced on dev (identical condition — scores present, no report cards):
- **Before:** "No report card generated yet", no scores.
- **After:** subject table renders real values — Chemistry **70.5 (B3)**, Mathematics **67.5 (C4)** — under the "scores entered, report card not generated yet" label.
- A student with no scores at all still shows the empty state (checked separately).

`typecheck` · `lint` · **383 tests** · `next build` — all green.

Independent of #162 (reports); branched off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)