### PR TITLE
chore(security): patch 3 dev-only dependency advisories + read-only prod-RLS verifier

### DIFF
--- a/omnischools/db/sql/verify-prod-rls.sql
+++ b/omnischools/db/sql/verify-prod-rls.sql
@@ -1,0 +1,149 @@
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- VERIFY PROD RLS — READ-ONLY. Safe to run on production. Makes NO changes (SELECT only).
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+--
+-- WHY THIS EXISTS
+--   `db:policies` only configures LOCAL DEV. On prod, RLS is applied solely by hand-pasting the
+--   `db/sql/prod-paste-*.sql` files (28 of them as of INCR-20). A single missed paste means those
+--   tables have NO tenant isolation on prod — one school reads another school's children's data.
+--
+--   Do NOT try to verify "did I run file 0042?" — provenance is unknowable after the fact. Verify
+--   the OUTCOME instead: is every tenant table isolated RIGHT NOW. That is strictly stronger than
+--   a checklist, and it is exactly the check that caught `student_health_record` sitting with RLS
+--   off since migration 0036 (found on dev during INCR-19a).
+--
+-- HOW TO USE
+--   Open the Supabase SQL editor on the PROD project. Run QUERY 1. Then run QUERY 2.
+--   (Run them one at a time — the editor shows only the last result set.)
+--
+--   QUERY 1 returns ONE ROW PER PROBLEM.  ► ZERO ROWS = PASS. ◄
+--   Anything returned is a live misconfiguration; paste the matching prod-paste file, then re-run.
+--
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+
+
+-- ─────────────────────────────────────────────────────────────────────────────────────────────
+-- QUERY 1 — THE PROBLEM REPORT.  Zero rows = every check passed.
+-- ─────────────────────────────────────────────────────────────────────────────────────────────
+WITH tt AS (
+  -- Every TENANT table = a real table in `public` carrying a school_id column.
+  SELECT c.oid,
+         c.relname,
+         c.relrowsecurity      AS rls_on,
+         c.relforcerowsecurity AS rls_forced
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = 'public'
+     AND c.relkind = 'r'
+     AND EXISTS (SELECT 1 FROM pg_attribute a
+                  WHERE a.attrelid = c.oid
+                    AND a.attname  = 'school_id'
+                    AND NOT a.attisdropped)
+),
+p AS (
+  SELECT polrelid, polname, polpermissive FROM pg_policy
+),
+glob AS (
+  -- Global reference tables hold NO tenant data. They are CORRECTLY bare-ENABLE:
+  -- RLS on, FORCE off, zero policies. (Owner stays exempt; the Data API is denied.)
+  SELECT c.oid,
+         c.relname,
+         c.relrowsecurity      AS rls_on,
+         c.relforcerowsecurity AS rls_forced,
+         (SELECT count(*) FROM pg_policy x WHERE x.polrelid = c.oid) AS npol
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = 'public'
+     AND c.relkind = 'r'
+     AND c.relname IN ('benchmark_reference', 'universities', 'university_programmes')
+)
+
+-- A · TENANT ISOLATION — the headline leak check.
+--     A table here is readable across schools, or readable by the owner role despite RLS.
+SELECT 'A · tenant isolation'::text AS check_name,
+       tt.relname::text             AS object,
+       concat_ws(' · ',
+         CASE WHEN NOT tt.rls_on     THEN 'RLS NOT ENABLED — table is fully cross-tenant readable' END,
+         CASE WHEN NOT tt.rls_forced THEN 'FORCE missing — the table owner bypasses RLS entirely'  END,
+         CASE WHEN NOT EXISTS (SELECT 1 FROM p WHERE p.polrelid = tt.oid AND p.polname = 'tenant_isolation')
+              THEN 'no tenant_isolation policy' END,
+         CASE WHEN EXISTS (SELECT 1 FROM p WHERE p.polrelid = tt.oid AND p.polname = 'tenant_isolation'
+                             AND NOT p.polpermissive)
+              THEN 'tenant_isolation is RESTRICTIVE (it must be PERMISSIVE)' END
+       )::text AS problem
+  FROM tt
+ WHERE NOT tt.rls_on
+    OR NOT tt.rls_forced
+    OR NOT EXISTS (SELECT 1 FROM p WHERE p.polrelid = tt.oid AND p.polname = 'tenant_isolation')
+    OR EXISTS     (SELECT 1 FROM p WHERE p.polrelid = tt.oid AND p.polname = 'tenant_isolation'
+                     AND NOT p.polpermissive)
+
+UNION ALL
+
+-- B · PARENT BOUNDARY (INCR-19a, prod-paste-0055) — the per-user parent scope.
+--     Every FORCE-RLS tenant table must carry either `parent_scope` (the small readable set) or
+--     `parent_deny` (everything else). Both MUST be RESTRICTIVE: Postgres OR's permissive policies
+--     together, so a PERMISSIVE parent policy would OR with tenant_isolation and hand a claimed
+--     parent the entire school.
+SELECT 'B · parent boundary'::text,
+       tt.relname::text,
+       concat_ws(' · ',
+         CASE WHEN NOT EXISTS (SELECT 1 FROM p WHERE p.polrelid = tt.oid
+                                 AND p.polname IN ('parent_deny', 'parent_scope'))
+              THEN 'neither parent_deny nor parent_scope — a claimed parent can read this table' END,
+         CASE WHEN EXISTS (SELECT 1 FROM p WHERE p.polrelid = tt.oid
+                             AND p.polname IN ('parent_deny', 'parent_scope')
+                             AND p.polpermissive)
+              THEN 'parent policy is PERMISSIVE — must be RESTRICTIVE, or it ORs with tenant_isolation and leaks the whole school' END
+       )::text
+  FROM tt
+ WHERE tt.rls_forced
+   AND ( NOT EXISTS (SELECT 1 FROM p WHERE p.polrelid = tt.oid
+                       AND p.polname IN ('parent_deny', 'parent_scope'))
+      OR EXISTS     (SELECT 1 FROM p WHERE p.polrelid = tt.oid
+                       AND p.polname IN ('parent_deny', 'parent_scope')
+                       AND p.polpermissive) )
+
+UNION ALL
+
+-- C · GLOBAL REFERENCE TABLES — must be ENABLE only (no FORCE, no policy).
+--     A FORCE or a stray policy here breaks legitimate global reads.
+SELECT 'C · global reference'::text,
+       g.relname::text,
+       concat_ws(' · ',
+         CASE WHEN NOT g.rls_on THEN 'RLS NOT ENABLED' END,
+         CASE WHEN g.rls_forced THEN 'FORCE is set — global tables must NOT be forced' END,
+         CASE WHEN g.npol > 0   THEN g.npol || ' policy/policies present — global tables must have none' END
+       )::text
+  FROM glob g
+ WHERE NOT g.rls_on OR g.rls_forced OR g.npol > 0
+
+ ORDER BY 1, 2;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────────────────────
+-- QUERY 2 — CONFIDENCE SUMMARY. Run separately. Confirms the check above actually saw your data
+-- (a zero-row PASS is only meaningful if `tenant_tables` is a plausible number, not 0).
+-- Reference shape as of INCR-20: ~87 tenant tables, 9 with parent_scope, the rest parent_deny,
+-- 3 global reference tables. Exact counts grow each increment — the ratios are what matter.
+-- ─────────────────────────────────────────────────────────────────────────────────────────────
+WITH tt AS (
+  SELECT c.oid, c.relrowsecurity AS rls_on, c.relforcerowsecurity AS rls_forced
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = 'public' AND c.relkind = 'r'
+     AND EXISTS (SELECT 1 FROM pg_attribute a
+                  WHERE a.attrelid = c.oid AND a.attname = 'school_id' AND NOT a.attisdropped)
+)
+SELECT (SELECT count(*) FROM tt)                                                  AS tenant_tables,
+       (SELECT count(*) FROM tt WHERE rls_on AND rls_forced)                      AS fully_forced,
+       (SELECT count(*) FROM tt t JOIN pg_policy p ON p.polrelid = t.oid
+         WHERE p.polname = 'tenant_isolation')                                    AS with_tenant_isolation,
+       (SELECT count(*) FROM tt t JOIN pg_policy p ON p.polrelid = t.oid
+         WHERE p.polname = 'parent_scope')                                        AS parent_readable,
+       (SELECT count(*) FROM tt t JOIN pg_policy p ON p.polrelid = t.oid
+         WHERE p.polname = 'parent_deny')                                         AS parent_denied,
+       (SELECT count(*) FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE n.nspname = 'public' AND c.relkind = 'r'
+           AND c.relname IN ('benchmark_reference','universities','university_programmes')
+           AND c.relrowsecurity AND NOT c.relforcerowsecurity)                    AS global_ok;

--- a/omnischools/docs/OWNER-TODO.md
+++ b/omnischools/docs/OWNER-TODO.md
@@ -4,7 +4,8 @@ Everything here is assigned to **you**, not to the build loop. It is work that n
 your data, your judgement, or your eyes on a real browser. Items already queued for me to build in a
 later increment are deliberately **not** listed.
 
-Last updated: 2026-07-21 (after INCR-19a — parent identity + per-user RLS boundary).
+Last updated: 2026-07-21 (after INCR-20 — Module 4.3 WASSCE readiness complete, PR #170 merged).
+Note: INCR-19b and INCR-20 added **no** new `prod-paste-*.sql` — the paste count in item 1 still stands at 28.
 
 ---
 
@@ -63,6 +64,12 @@ rendered.
 **And (INCR-19a):** on a student profile → guardian list, click **"Invite to parent portal"**. No browser
 tool here could drive it end-to-end; the writes it performs (the invite, and the guardian→user stamp on
 accept) are proven by the DB deny-suite, but the button-to-action path itself was never clicked.
+
+**And (INCR-19b):** log in as a **real claimed parent** and eyeball the portal at `/wassce`. No tool here
+could drive an authenticated-parent browser session (dev-bypass is ADMIN; no persistent seeded claimed
+parent), so the data path is proven only by the rolled-back-fixture boundary script + copy tests. Confirm
+while you're there that the parent sees **no** cohort-tier band vocabulary on screen *or* in the downloaded
+statement PDF, and that the acknowledgement line reads "recorded by the school · confirmed by phone".
 
 ---
 

--- a/omnischools/docs/OWNER-TODO.md
+++ b/omnischools/docs/OWNER-TODO.md
@@ -24,7 +24,16 @@ increment, but nothing has verified the full set end-to-end.
 > **off on dev**. Prod turned out safe (you confirmed `prod-paste-0036` was run), but that was luck of
 > discipline, not a guarantee. The query below is exactly what surfaces this class of gap. Run it.
 
-**How to check (run on prod, expect ZERO rows):**
+**▶ Use the script: `db/sql/verify-prod-rls.sql`** (read-only, `SELECT` only, safe on prod). Open the
+Supabase SQL editor on the **prod** project and run its **Query 1** (problem report — *zero rows = pass*),
+then **Query 2** (confidence summary — proves the check actually saw your data; a zero-row pass means
+nothing if it scanned zero tables). The script checks three things, two of which the inline query below
+does *not*: that `tenant_isolation` is PERMISSIVE, that every forced tenant table carries a **RESTRICTIVE**
+`parent_scope`/`parent_deny` (a PERMISSIVE one would OR with `tenant_isolation` and expose the whole
+school to a claimed parent), and that the 3 global reference tables are bare-ENABLE. Validated against dev:
+0 problems, 87 tenant tables, 9 parent-readable + 78 denied, 3 global.
+
+**Quick inline version (the headline leak check only — run on prod, expect ZERO rows):**
 ```sql
 -- Any tenant table (has school_id) that is missing FORCE RLS or its policy:
 SELECT c.relname,
@@ -73,12 +82,22 @@ statement PDF, and that the acknowledgement line reads "recorded by the school �
 
 ---
 
-### 3. Patch the 3 high-severity dependency vulnerabilities
+### 3. Patch the 3 high-severity dependency vulnerabilities — ✅ FIXED, awaiting merge
+**Resolved in `6ff15c3`.** All three were transitive **dev-only** advisories under `eslint` /
+`eslint-config-next` (`brace-expansion` ×2 DoS, `js-yaml` quadratic CPU) — none shipped in the production
+bundle, so the practical exposure was a DoS against your own linter. Fixed with pnpm `overrides` pinning
+`brace-expansion` to 1.1.16 / 5.0.7 and `js-yaml` ≥4.3.0. `pnpm audit` is now clean; lint, 485 tests, and
+the production build all pass. **The GitHub badge will not clear until this merges to `main`** (Dependabot
+rescans the lockfile there). Root cause is `eslint: "^8"`; the permanent fix is ESLint 9, but that is a
+flat-config migration and not worth it for three dev-only advisories.
+
+<details><summary>Original item</summary>
 GitHub Dependabot flags **3 high** vulnerabilities on `main` (`github.com/Omnischools/omnischools/security/dependabot`).
 None were introduced by the senior-tier work — they're in the existing dependency tree — but they should be
 triaged and patched before go-live. Run `pnpm audit`, review each, and bump the affected packages (or apply
 Dependabot's suggested PRs). Flagging here because it's a standing security item, not something the build loop
 resolves on its own.
+</details>
 
 ---
 

--- a/omnischools/package.json
+++ b/omnischools/package.json
@@ -85,7 +85,10 @@
       "@next/eslint-plugin-next>glob": "10.5.0",
       "@esbuild-kit/core-utils>esbuild": "0.25.12",
       "tsx>esbuild": "0.28.1",
-      "vite>esbuild": "0.28.1"
+      "vite>esbuild": "0.28.1",
+      "brace-expansion@<1.1.16": "^1.1.16",
+      "brace-expansion@>=3.0.0 <5.0.7": ">=5.0.7",
+      "js-yaml@>=4.0.0 <4.3.0": ">=4.3.0"
     }
   }
 }

--- a/omnischools/pnpm-lock.yaml
+++ b/omnischools/pnpm-lock.yaml
@@ -10,6 +10,9 @@ overrides:
   '@esbuild-kit/core-utils>esbuild': 0.25.12
   tsx>esbuild: 0.28.1
   vite>esbuild: 0.28.1
+  brace-expansion@<1.1.16: ^1.1.16
+  brace-expansion@>=3.0.0 <5.0.7: '>=5.0.7'
+  js-yaml@>=4.0.0 <4.3.0: '>=4.3.0'
 
 importers:
 
@@ -1288,11 +1291,11 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -2074,8 +2077,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@5.2.1:
+    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -3232,7 +3235,7 @@ snapshots:
       globals: 13.24.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 5.2.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -3997,12 +4000,12 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  brace-expansion@1.1.15:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4514,7 +4517,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 4.2.0
+      js-yaml: 5.2.1
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -4900,7 +4903,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@5.2.1:
     dependencies:
       argparse: 2.0.1
 
@@ -5025,11 +5028,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 1.1.16
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
Two owner-TODO items, closed. No application code touched — no migration, no schema, no runtime dependency change.

## 1. The 3 high dependabot advisories → clean
All three were **transitive and dev-only**, under `eslint` / `eslint-config-next`: `brace-expansion` ×2 (DoS) and `js-yaml` (quadratic CPU). None ship in the production bundle — the practical exposure was a DoS against our own linter.

Fixed with pnpm `overrides`. One subtlety worth noting: `pnpm audit --fix` emitted an **unbounded** `brace-expansion@<1.1.16` → `>=1.1.16`, which over-bumped the v1 chain to **5.0.6** — landing it back inside the *second* advisory's range (3 → 1 remaining). Pinned to `^1.1.16` instead, so minimatch v3 stays on the patched 1.x line it was written for.

- `pnpm audit` → **No known vulnerabilities**
- `pnpm lint` exit 0 · **485/485 tests** · `pnpm build` exit 0

The GitHub badge clears once this lands on `main` (Dependabot rescans the lockfile there). Root cause is `eslint: "^8"`; the permanent fix is ESLint 9 (flat-config migration) — not worth it for three dev-only advisories.

## 2. `db/sql/verify-prod-rls.sql` — verifying the 28 prod pastes
`db:policies` only configures dev; prod RLS is applied solely by hand-pasting `prod-paste-*.sql`. A missed paste means those tables have **no tenant isolation on prod**.

This script verifies the **outcome** rather than provenance — "is every tenant table isolated right now", not "did I run file 0042". Strictly stronger than a checklist, and it's the check that caught `student_health_record` sitting with RLS off since 0036.

`SELECT`-only, safe on prod. Query 1 = problem report (**zero rows = pass**); Query 2 = confidence summary, so a zero-row pass can't be mistaken for a query that scanned zero tables.

Checks: **A** tenant isolation (ENABLE + FORCE + `tenant_isolation` present *and* PERMISSIVE) · **B** parent boundary (every forced tenant table carries `parent_scope`/`parent_deny` *and* they are **RESTRICTIVE** — a permissive one would OR with `tenant_isolation` and expose the whole school to a claimed parent) · **C** global reference tables bare-ENABLE.

Validated against dev: **0 problems; 87 tenant tables, 87 forced, 87 with `tenant_isolation`; 9 parent-readable + 78 denied; 3 global** — the 9/78 split independently matches the INCR-19a gate record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)