### PR TITLE
fix(senior): Path A batch atomicity + refresh 3 stale score-ledger assertions

### DIFF
--- a/omnischools/lib/actions/score-ledger.ts
+++ b/omnischools/lib/actions/score-ledger.ts
@@ -414,15 +414,17 @@ export async function saveAssessmentScores(input: unknown): Promise<SaveMarksRes
     return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid scores." };
   }
   const d = parsed.data;
-  // Reject out-of-range marks up front with a clear message, so a bad entry can never
-  // reach the DB as a numeric(5,2) overflow that surfaces as the generic catch (Quinn MAJOR).
+  // Validate + parse EVERY mark up front through the SAME parseCategoryCell the other two
+  // capture paths use, so all three agree on one 0–MAX_PERCENT bound (compute.ts). A bad cell
+  // REJECTS the whole batch here, before the transaction opens — it is never silently dropped
+  // while its neighbours commit and the teacher is told "Saved N marks" (partial-write bug).
+  const parsedMarks: { assessmentId: string; studentId: string; value: number | null }[] = [];
   for (const s of d.scores) {
-    const t = s.raw.trim();
-    if (t === "") continue;
-    const num = Number(t);
-    if (Number.isFinite(num) && (num < 0 || num > 999.99)) {
-      return { ok: false, error: "Each mark must be between 0 and 999.99." };
+    const value = parseCategoryCell(s.raw);
+    if (value === "invalid") {
+      return { ok: false, error: "Each mark must be a number between 0 and 999.99." };
     }
+    parsedMarks.push({ assessmentId: s.assessmentId, studentId: s.studentId, value });
   }
   const closed = await closedPeriodError(school.id, d.periodId);
   if (closed) return { ok: false, error: closed };
@@ -445,31 +447,28 @@ export async function saveAssessmentScores(input: unknown): Promise<SaveMarksRes
       const validIds = new Set(valid.map((v) => v.id));
 
       let n = 0;
-      for (const s of d.scores) {
-        if (!validIds.has(s.assessmentId)) continue;
-        const trimmed = s.raw.trim();
-        if (trimmed === "") {
+      for (const { assessmentId, studentId, value: num } of parsedMarks) {
+        if (!validIds.has(assessmentId)) continue;
+        if (num == null) {
           await tx
             .delete(seniorAssessmentScores)
             .where(
               and(
                 eq(seniorAssessmentScores.schoolId, school.id),
-                eq(seniorAssessmentScores.assessmentId, s.assessmentId),
-                eq(seniorAssessmentScores.studentId, s.studentId),
+                eq(seniorAssessmentScores.assessmentId, assessmentId),
+                eq(seniorAssessmentScores.studentId, studentId),
               ),
             );
           n++;
           continue;
         }
-        const num = Number(trimmed);
-        // Non-negative and finite; over-max (bonus) is allowed — the UI soft-warns (Kofi Q3).
-        if (!Number.isFinite(num) || num < 0) continue;
+        // Over-max (bonus) is allowed — the UI soft-warns (Kofi Q3).
         await tx
           .insert(seniorAssessmentScores)
           .values({
             schoolId: school.id,
-            assessmentId: s.assessmentId,
-            studentId: s.studentId,
+            assessmentId,
+            studentId,
             rawMark: num.toFixed(2),
             updatedByUserId: actor.id ?? undefined,
             updatedAt: new Date(),

--- a/omnischools/scripts/verify-score-ledger.ts
+++ b/omnischools/scripts/verify-score-ledger.ts
@@ -86,9 +86,19 @@ async function main() {
   });
   check("direct entry refused before path is DIRECT_ENTRY", !guard.ok);
 
-  // setLedgerPath rejects Path B (not built).
-  const scanReject = await setLedgerPath({ ...ctx, path: "SCAN_EXTRACT" });
-  check("setLedgerPath rejects SCAN_EXTRACT (Path B)", !scanReject.ok);
+  // Path B SHIPPED in INCR-2 (commitScanLedger + /senior/score-ledger/scan), so setLedgerPath
+  // must ACCEPT SCAN_EXTRACT — the scan page, the extract route and the commit action all gate
+  // on the context being on that path. What stays load-bearing is the cross-path guard: while a
+  // context is on Path B, Path C direct entry must still be refused.
+  const setB = await setLedgerPath({ ...ctx, path: "SCAN_EXTRACT" });
+  check("setLedgerPath → SCAN_EXTRACT ok (Path B shipped)", setB.ok, setB.ok ? "" : setB.error);
+  const directOnB = await saveDirectLedgerScores({
+    ...ctx,
+    scores: [
+      { studentId: s1.studentId, asgn: "80", midSem: "70", endSem: "60", project: "90", portfolio: "85" },
+    ],
+  });
+  check("direct entry refused while the context is on Path B", !directOnB.ok);
 
   // Switch to Path C.
   const setC = await setLedgerPath({ ...ctx, path: "DIRECT_ENTRY" });
@@ -125,11 +135,14 @@ async function main() {
   );
 
   // ATOMICITY (the MAJOR): a batch with one out-of-range cell must commit NOTHING.
+  // NB the bound is 0–MAX_PERCENT (999.99), not 0–100: INCR-2 deliberately widened all three
+  // capture paths to allow bonus marks (Kofi Owner-Option-A), so 150 is a LEGAL score. The
+  // fixture must therefore breach the real ceiling to exercise the rejection.
   const bad = await saveDirectLedgerScores({
     ...ctx,
     scores: [
       { studentId: s1.studentId, asgn: "10", midSem: "10", endSem: "10", project: "10", portfolio: "10" },
-      { studentId: s2.studentId, asgn: "150", midSem: "", endSem: "", project: "", portfolio: "" },
+      { studentId: s2.studentId, asgn: "1500", midSem: "", endSem: "", project: "", portfolio: "" },
     ],
   });
   const r1After = await ledgerRow(s1.studentId, subjectId, periodId);
@@ -139,6 +152,48 @@ async function main() {
     Number(r1After?.weightedTotal) === 72.75,
     `${r1After?.weightedTotal}`,
   );
+
+  // Same batch-level rejection for a NON-NUMERIC cell — Number("abc") is NaN, which the old
+  // `Number.isFinite(num) && …` pre-pass let slip through to be silently dropped mid-loop.
+  const junk = await saveDirectLedgerScores({
+    ...ctx,
+    scores: [
+      { studentId: s1.studentId, asgn: "20", midSem: "20", endSem: "20", project: "20", portfolio: "20" },
+      { studentId: s2.studentId, asgn: "abc", midSem: "", endSem: "", project: "", portfolio: "" },
+    ],
+  });
+  const r1Junk = await ledgerRow(s1.studentId, subjectId, periodId);
+  check("non-numeric batch rejected", !junk.ok);
+  check(
+    "atomicity: non-numeric batch committed nothing (s1 still 72.75)",
+    Number(r1Junk?.weightedTotal) === 72.75,
+    `${r1Junk?.weightedTotal}`,
+  );
+
+  // A bonus mark (>100, ≤999.99) is LEGAL on Path C and must commit — the other half of the
+  // Owner-Option-A ruling, pinned so the bound can't silently narrow back to 100.
+  const bonus = await saveDirectLedgerScores({
+    ...ctx,
+    scores: [
+      { studentId: s2.studentId, asgn: "110", midSem: "", endSem: "", project: "", portfolio: "" },
+    ],
+  });
+  const r2Bonus = await ledgerRow(s2.studentId, subjectId, periodId);
+  check(
+    "bonus category score (110) commits",
+    bonus.ok && Number(r2Bonus?.asgnScore) === 110,
+    `${r2Bonus?.asgnScore}`,
+  );
+
+  // Restore s1 to the 72.75 baseline the Path A assertions below assume nothing about, and
+  // s2 to its partial state — keeps this block side-effect-free for the rest of the run.
+  await saveDirectLedgerScores({
+    ...ctx,
+    scores: [
+      { studentId: s1.studentId, asgn: "80", midSem: "70", endSem: "60", project: "90", portfolio: "85" },
+      { studentId: s2.studentId, asgn: "80", midSem: "", endSem: "", project: "", portfolio: "" },
+    ],
+  });
 
   // Roster filter: a studentId outside the class is ignored, not written, not counted.
   const stranger = await createStudent({ firstName: "Not", lastName: "Inclass", sex: "MALE" });
@@ -208,6 +263,39 @@ async function main() {
     "Path A complete → 72.75, COMPLETE",
     Number(rA2?.weightedTotal) === 72.75 && rA2?.status === "COMPLETE",
     `${rA2?.weightedTotal}/${rA2?.status}`,
+  );
+
+  // Path A batch atomicity (the real partial-write defect). A non-numeric cell used to slip the
+  // pre-pass (Number("abc") is NaN, so the `Number.isFinite(num) && …` guard never fired) and was
+  // then silently `continue`d mid-loop — its neighbours committed and the teacher saw
+  // "Saved N marks". The batch must now be refused whole, with the sibling mark unwritten.
+  const badA = await saveAssessmentScores({
+    ...ctx,
+    scores: [
+      { assessmentId: a.id, studentId: s3.studentId, raw: "55" },
+      { assessmentId: mid.id, studentId: s3.studentId, raw: "abc" },
+    ],
+  });
+  const rA3 = await ledgerRow(s3.studentId, subjectId, periodId);
+  check("Path A non-numeric batch rejected", !badA.ok);
+  check(
+    "Path A atomicity: sibling mark in the rejected batch NOT written (asgn still 80)",
+    Number(rA3?.asgnScore) === 80,
+    `${rA3?.asgnScore}`,
+  );
+  const overA = await saveAssessmentScores({
+    ...ctx,
+    scores: [
+      { assessmentId: a.id, studentId: s3.studentId, raw: "55" },
+      { assessmentId: mid.id, studentId: s3.studentId, raw: "1500" },
+    ],
+  });
+  const rA4 = await ledgerRow(s3.studentId, subjectId, periodId);
+  check("Path A out-of-range batch rejected", !overA.ok);
+  check(
+    "Path A atomicity: sibling mark in the out-of-range batch NOT written (asgn still 80)",
+    Number(rA4?.asgnScore) === 80,
+    `${rA4?.asgnScore}`,
   );
 
   // ---------- Item 3: VHM progress (enumerate from assignments) ----------


### PR DESCRIPTION
## Summary

`pnpm db:verify-score-ledger` had 3 failing assertions. Root-causing them found **one real defect — but not the one the failures pointed at.**

- **The reported "silent partial write" is not in Path C.** Path C atomicity is intact and always was. Two of the three failures were **stale test fixtures** that rotted when a later owner ruling deliberately changed the score bound.
- **A real partial write did exist — in Path A**, which the failing assertions never covered. That is fixed here at the root.

No schema, migration, or seed change. No seed data deleted.

## The 2 "atomicity" failures — stale fixture, not a defect

`saveDirectLedgerScores` already validates **every** cell in a pre-pass *before* the transaction opens, and `withSchool` is a real `db.transaction`.

The fixture used `150` as its "out of range" value. That was invalid under the original 0–100 bound, but 0cfda47 (INCR-2) deliberately widened all three capture paths to `0–MAX_PERCENT` (999.99) per the **Kofi Owner-Option-A** ruling to allow bonus marks. `150` is now a **legal** score — so the batch was correctly accepted, and s1's `10.00` was a *correct save*, not a leaked partial write.

Proven against the dev DB **before changing anything**:

| probe | result |
|---|---|
| genuinely out-of-range cell (`1500`) in row 2 | batch refused, s1 untouched at 72.75, neighbour row never created |
| non-numeric cell (`abc`) in row 2 | batch refused, s1 untouched |
| forced mid-transaction DB error inside `withSchool` | rolled back, row unchanged |

## The 3rd failure — assertion predates shipped code

`setLedgerPath rejects SCAN_EXTRACT (Path B)` was written when Path B did not exist. Path B **shipped** in 57a53ae: `commitScanLedger`, `/senior/score-ledger/scan` and `/api/senior/ledger-extract` all gate on the context being `SCAN_EXTRACT`, so making `setLedgerPath` refuse it would break shipped Path B end to end.

Retargeted at what is still load-bearing: the path is settable, **and** Path C direct entry stays refused while a context is on Path B.

## The real defect — Path A silent partial write

`saveAssessmentScores`' pre-pass guarded:

```ts
if (Number.isFinite(num) && (num < 0 || num > 999.99)) return { ok: false, … }
```

A non-numeric cell makes `Number()` return `NaN`, so `isFinite` is false and **the guard never fires**. The value then reached the write loop, hit `if (!Number.isFinite(num) || num < 0) continue` and was **silently dropped — while its neighbours in the same batch committed** and the grid told the teacher `Saved N marks`.

That is the silent partial write, and it contradicted `compute.ts`'s own docstring claiming `parseCategoryCell` is the one bound shared by all three paths (Path A never used it).

**Fixed at the root:** Path A's pre-pass now parses every mark through the shared `parseCategoryCell` and refuses the whole batch on any bad cell, before the transaction opens — identical in shape to Paths B and C. The divergent in-loop re-parse and its silent `continue` are **deleted**, so the loop consumes already-validated values and the three paths can no longer disagree.

## Regression coverage — 20 → 26 assertions

- Path A non-numeric batch refused + sibling mark NOT written ← **fails pre-fix**
- Path A out-of-range batch refused + sibling mark NOT written ← **fails pre-fix**
- Path C non-numeric batch refused, commits nothing
- Path C out-of-range fixture repaired to breach the real 999.99 ceiling
- bonus `110` commits — pins the widened bound so it can't silently narrow back to 100
- Path B settable + Path C refused while on Path B

The pure 0–999.99 bound was already pinned in `compute.test.ts` (A8–A11); the gap was integration-level, which is where the new assertions sit.

## Gates

All run on this branch's tree (clean worktree off `main`, fresh `pnpm install`):

- `pnpm db:verify-score-ledger` — **26/26**
- `pnpm test` — **536/536**
- `pnpm exec tsc --noEmit` — clean
- `pnpm lint` — clean (one pre-existing unrelated warning in `lib/wassce/cohort-data.ts`, present on `main`)
- `pnpm build` — compiled successfully

## Note for the owner

Both changed files are **byte-identical between `origin/main` and `senior-feat`**, confirming this is a pre-existing Module 4.1 defect independent of the INCR-22 sickbay work — so this branches off `main` directly rather than stacking on `senior-feat`.

While working, the `senior-live` worktree was being edited concurrently by another session. Nothing from that WIP is in this PR — the diff is exactly the two files above, verified against the pushed remote head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
