### PR TITLE
SECURITY: a claimed parent could read any student's health record

### DIFF
--- a/omnischools/app/(app)/layout.tsx
+++ b/omnischools/app/(app)/layout.tsx
@@ -6,12 +6,18 @@ import { PwaSession } from "@/components/pwa-session";
 
 /**
  * The staff-only guard is NOT here — it is inside `requireSchool()`, which this layout and all 82
- * pages under it already call. That placement is deliberate and was arrived at the hard way: a
- * redirect thrown from a LAYOUT does not stop the page rendering. Layouts and pages render in
- * parallel, so the page's own queries still run and its payload is still streamed; a production
- * build served a 307 to `/wassce` whose body nonetheless carried the student's allergies,
- * conditions and medications. The navigation was blocked and the bytes were not.
- * Guarding inside `requireSchool` puts the check in each page's OWN render, before its own reads.
+ * pages under it already call.
+ *
+ * The distinction is narrow and worth stating precisely, because getting it wrong sends you down a
+ * very expensive road. A redirect thrown from a **LAYOUT** does not stop the page: layouts and pages
+ * render in parallel, so the page's own queries still run and its payload is still streamed. A
+ * redirect thrown from the **page's own render, awaited before its own fetch**, does stop it — that
+ * is ordinary sequential control flow. So the guard belongs in the function every page awaits first,
+ * not in the shell around them.
+ *
+ * (Verified by Sarah on PR #176: with the guard in `requireSchool`, all 63 static routes here return
+ * a bare error shell to a non-staff session, including `students/[id]/edit`, which fetches the same
+ * health record and carries no data-layer guard of its own.)
  */
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
   const { school, user } = await requireSchool();

--- a/omnischools/app/(app)/layout.tsx
+++ b/omnischools/app/(app)/layout.tsx
@@ -5,8 +5,9 @@ import { SignOutButton } from "@/components/app/sign-out-button";
 import { PwaSession } from "@/components/pwa-session";
 
 /**
- * The staff-only guard is NOT here — it is inside `requireSchool()`, which this layout and all 82
- * pages under it already call.
+ * The staff-only guard is NOT here — it is inside `requireSchool()`, which this layout and every one
+ * of the 82 pages under it reaches: 61 call it directly, 20 through `requireSchoolRole` (which
+ * delegates to it), and `settings/academic/promotion` through `previewPromotion()`.
  *
  * The distinction is narrow and worth stating precisely, because getting it wrong sends you down a
  * very expensive road. A redirect thrown from a **LAYOUT** does not stop the page: layouts and pages

--- a/omnischools/app/(app)/layout.tsx
+++ b/omnischools/app/(app)/layout.tsx
@@ -4,6 +4,15 @@ import { AppSidebar } from "@/components/app/sidebar";
 import { SignOutButton } from "@/components/app/sign-out-button";
 import { PwaSession } from "@/components/pwa-session";
 
+/**
+ * The staff-only guard is NOT here — it is inside `requireSchool()`, which this layout and all 82
+ * pages under it already call. That placement is deliberate and was arrived at the hard way: a
+ * redirect thrown from a LAYOUT does not stop the page rendering. Layouts and pages render in
+ * parallel, so the page's own queries still run and its payload is still streamed; a production
+ * build served a 307 to `/wassce` whose body nonetheless carried the student's allergies,
+ * conditions and medications. The navigation was blocked and the bytes were not.
+ * Guarding inside `requireSchool` puts the check in each page's OWN render, before its own reads.
+ */
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
   const { school, user } = await requireSchool();
   const sessionId = await getSessionId();

--- a/omnischools/app/(app)/students/[id]/page.tsx
+++ b/omnischools/app/(app)/students/[id]/page.tsx
@@ -235,12 +235,21 @@ export default async function StudentDetailPage(props: { params: Promise<{ id: s
           .orderBy(asc(subjects.name))
       : [];
 
-    // 🔴 NOT FETCHED for a non-staff reader — deliberately a DATA decision, not a control-flow one.
-    // `requireSchool()` already refuses non-staff, but a redirect thrown from a Server Component
-    // does NOT stop the render: a production build served a 307 to /wassce whose body still carried
-    // this student's allergies, conditions and medications, live-rendered (proven by changing the
-    // value and seeing the NEW one appear in the redirect body). Navigation was blocked; disclosure
-    // was not. A row that is never selected cannot be streamed, whatever the control flow does.
+    // NOT fetched for a non-staff reader. DEFENCE IN DEPTH, not the load-bearing control — say so
+    // plainly, because the honest scope of this line matters to whoever reads it next.
+    //
+    // `requireSchool()` is the actual fix: it is awaited above, before this transaction opens, so a
+    // non-staff session never reaches here. Sarah proved that on PR #176 via the natural experiment
+    // sitting next door — `students/[id]/edit` fetches this same health record, has NO guard like
+    // this one, and still serves zero bytes of it to a parent.
+    //
+    // This stays anyway, for the narrow reason that this is the most sensitive read on the page: it
+    // makes the disclosure impossible even if someone later hoists a fetch above the guard, or adds
+    // a render path that does not await it. It is NOT a pattern to copy onto the other 81 pages —
+    // the guard-ordering invariant test is what protects those.
+    //
+    // ⚠️ Still over-broad and tracked separately: every staff role reads these fields, and a read is
+    // not audited.
     const [health] = isStaff(user.roles)
       ? await tx
           .select()

--- a/omnischools/app/(app)/students/[id]/page.tsx
+++ b/omnischools/app/(app)/students/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { and, asc, desc, eq, gte, lte } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
+import { isStaff } from "@/lib/access";
 import { withSchool } from "@/lib/db/rls";
 import {
   students,
@@ -58,7 +59,7 @@ const pctToneOf = (p: number) => (p >= 90 ? "text-green" : p >= 70 ? "text-gold"
 
 export default async function StudentDetailPage(props: { params: Promise<{ id: string }> }) {
   const params = await props.params;
-  const { school } = await requireSchool();
+  const { school, user } = await requireSchool();
   const today = new Date().toISOString().slice(0, 10);
 
   const data = await withSchool(school.id, async (tx) => {
@@ -234,10 +235,18 @@ export default async function StudentDetailPage(props: { params: Promise<{ id: s
           .orderBy(asc(subjects.name))
       : [];
 
-    const [health] = await tx
-      .select()
-      .from(studentHealthRecords)
-      .where(eq(studentHealthRecords.studentId, student.id));
+    // 🔴 NOT FETCHED for a non-staff reader — deliberately a DATA decision, not a control-flow one.
+    // `requireSchool()` already refuses non-staff, but a redirect thrown from a Server Component
+    // does NOT stop the render: a production build served a 307 to /wassce whose body still carried
+    // this student's allergies, conditions and medications, live-rendered (proven by changing the
+    // value and seeing the NEW one appear in the redirect body). Navigation was blocked; disclosure
+    // was not. A row that is never selected cannot be streamed, whatever the control flow does.
+    const [health] = isStaff(user.roles)
+      ? await tx
+          .select()
+          .from(studentHealthRecords)
+          .where(eq(studentHealthRecords.studentId, student.id))
+      : [];
 
     return { student, term, guardians, attRecs, invs, pays, latestCard, notes, activity, scores, health };
   });

--- a/omnischools/app/api/senior/readiness-statement/[id]/route.ts
+++ b/omnischools/app/api/senior/readiness-statement/[id]/route.ts
@@ -21,7 +21,11 @@ export const dynamic = "force-dynamic";
  * owns the statement (ownership proven under withParentScope before any render); STUDENT/TEACHER denied.
  */
 export async function GET(_req: Request, props: { params: Promise<{ id: string }> }) {
-  const { school } = await requireSchool();
+  // The ONE deliberate non-staff caller: a PARENT may fetch their own child's statement (INCR-19b),
+  // with ownership proven under `withParentScope` below before anything renders. `requireSchool` is
+  // staff-only by default, so this opt-in is what keeps that shipped parent feature working — and it
+  // is greppable precisely so a second one cannot appear without being noticed.
+  const { school } = await requireSchool({ allowNonStaff: true });
 
   const user = await getCurrentUser();
   if (!user) return new Response("Forbidden", { status: 403 });

--- a/omnischools/lib/auth/app-shell-guard.test.ts
+++ b/omnischools/lib/auth/app-shell-guard.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { cwd } from "node:process";
+import { isStaff } from "@/lib/access";
+
+/**
+ * `requireSchool()` is staff-only — a regression guard for a LIVE PII leak.
+ *
+ * It authenticated and resolved an active school but performed NO role check, and 62 of the 82 pages
+ * under `app/(app)` are gated by nothing else. Accepting a PARENT invite creates a real
+ * `role_assignment`, so a claimed parent held an active school, passed the gate, and could open
+ * `students/[id]` — blood group, allergies, conditions, medications, emergency contact.
+ *
+ * Two findings are baked into these assertions, both learned by getting it wrong first:
+ *
+ *  1. THE GUARD CANNOT LIVE IN THE LAYOUT. A redirect thrown from a layout does not stop the page
+ *     rendering — layouts and pages render in parallel. A production build served a 307 to /wassce
+ *     whose body still carried the health data. The check must sit where each page's own render
+ *     calls it, before its own queries.
+ *  2. ASSERT THE EXPRESSION, NEVER THE NAME. An earlier version compared `indexOf("getSessionId")`,
+ *     which matched the IMPORT and passed however late the gate ran — the same trap as INCR-22c's
+ *     ADV-3, reproduced inside the test written to prevent it.
+ */
+const SERVER = "lib/auth/server.ts";
+const src = () => readFileSync(resolve(cwd(), SERVER), "utf8");
+const GATE = /if\s*\(\s*!opts\?\.allowNonStaff\s*&&\s*!\s*isStaff\s*\(\s*user\.roles\s*\)\s*\)/;
+
+describe("requireSchool is staff-only by default", () => {
+  it("carries the isStaff gate", () => {
+    expect(src()).toMatch(GATE);
+  });
+
+  it("the gate runs before requireSchool returns — not after the caller has its school", () => {
+    const s = src();
+    const body = s.slice(s.indexOf("export async function requireSchool"));
+    const gate = body.search(GATE);
+    expect(gate, "requireSchool must carry the staff gate").toBeGreaterThan(-1);
+    // The CALL SITE / statement, never a bare identifier that would also match an import.
+    expect(gate).toBeLessThan(body.indexOf("return { user, school };"));
+  });
+
+  it("never redirects into app/(app) — /dashboard would loop", () => {
+    const s = src();
+    const body = s.slice(
+      s.indexOf("export async function requireSchool"),
+      s.indexOf("export async function requireSchoolRole"),
+    );
+    // Pull every string literal out of every redirect(...) in this function. Deliberately not a
+    // clever regex over the argument shape: `includes("PARENT")` contains a `)`.
+    const targets = [...body.matchAll(/redirect\(([\s\S]*?)\);/g)].flatMap((m) =>
+      [...m[1].matchAll(/"(\/[^"]*)"/g)].map((lit) => lit[1]),
+    );
+    expect(targets.length).toBeGreaterThan(0);
+    const inAppShell = readdirSync(resolve(cwd(), "app/(app)"), { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => `/${e.name}`);
+    for (const t of targets) {
+      expect(inAppShell, `redirect target ${t} is inside (app) and would loop`).not.toContain(t);
+    }
+  });
+
+  it("EXACTLY ONE caller opts out, and it is the parent's own statement PDF", () => {
+    // The opt-out is the shipped INCR-19b parent reader, which proves ownership under
+    // withParentScope before rendering. A second one appearing silently is the regression.
+    const roots = ["app", "lib", "components", "features"];
+    const hits: string[] = [];
+    const walk = (dir: string) => {
+      for (const e of readdirSync(resolve(cwd(), dir), { withFileTypes: true })) {
+        const p = `${dir}/${e.name}`;
+        if (e.isDirectory()) walk(p);
+        else if (/\.tsx?$/.test(e.name) && !/\.test\.tsx?$/.test(e.name)) {
+          if (readFileSync(resolve(cwd(), p), "utf8").includes("allowNonStaff: true")) hits.push(p);
+        }
+      }
+    };
+    for (const r of roots) walk(r);
+    expect(hits).toEqual(["app/api/senior/readiness-statement/[id]/route.ts"]);
+  });
+});
+
+describe("isStaff has the polarity a shell guard needs", () => {
+  // Fail-OPEN for unknown roles, fail-CLOSED for the two known non-staff ones. Across 104 call sites
+  // that is the safe direction: a newly-added staff role still works, rather than the bursar being
+  // locked out on Monday morning.
+  it("STUDENT-only and PARENT-only sessions are not staff", () => {
+    expect(isStaff(["PARENT"])).toBe(false);
+    expect(isStaff(["STUDENT"])).toBe(false);
+    expect(isStaff(["STUDENT", "PARENT"])).toBe(false);
+    expect(isStaff([])).toBe(false);
+  });
+
+  it("a staff member who is ALSO a parent passes — common, and must keep working", () => {
+    expect(isStaff(["TEACHER", "PARENT"])).toBe(true);
+    expect(isStaff(["PARENT", "MATRON"])).toBe(true);
+  });
+
+  it("every known staff role passes, and an unknown role is admitted rather than locked out", () => {
+    for (const r of [
+      "ADMIN",
+      "HEADMASTER",
+      "VICE_HEADMASTER_ACADEMIC",
+      "TEACHER",
+      "FORM_MASTER",
+      "HOUSEMASTER",
+      "BURSAR",
+      "ACCOUNTANT",
+      "DEAN_OF_BOARDING",
+      "MATRON",
+    ]) {
+      expect(isStaff([r]), r).toBe(true);
+    }
+    expect(isStaff(["SOME_FUTURE_ROLE"])).toBe(true);
+  });
+});

--- a/omnischools/lib/auth/app-shell-guard.test.ts
+++ b/omnischools/lib/auth/app-shell-guard.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { readFileSync, readdirSync } from "node:fs";
+import { readFileSync, readdirSync, existsSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 import { cwd } from "node:process";
 import { isStaff } from "@/lib/access";
@@ -21,10 +21,26 @@ import { isStaff } from "@/lib/access";
  *  2. ASSERT THE EXPRESSION, NEVER THE NAME. An earlier version compared `indexOf("getSessionId")`,
  *     which matched the IMPORT and passed however late the gate ran — the same trap as INCR-22c's
  *     ADV-3, reproduced inside the test written to prevent it.
+ *  3. ASSERT THE CONSEQUENCE, NOT ONLY THE CONDITION — and read code, never comments. Both found on
+ *     PR #176 by gate review, and both are the SAME trap one level deeper than (1) and (2):
+ *       · Quinn kept the pinned `if` and deleted its `redirect`. The leak reopens in full and all
+ *         668 tests stay green. So `GATE` now spans the condition THROUGH the redirect it must cause.
+ *       · Dex found the sweep below matching guard/read names inside PROSE. A file whose docblock
+ *         mentions `requireSchool()` above a genuinely unguarded read would certify clean — a false
+ *         PASS, the dangerous direction. Everything here now reads comment-stripped source.
  */
 const SERVER = "lib/auth/server.ts";
-const src = () => readFileSync(resolve(cwd(), SERVER), "utf8");
-const GATE = /if\s*\(\s*!opts\?\.allowNonStaff\s*&&\s*!\s*isStaff\s*\(\s*user\.roles\s*\)\s*\)/;
+
+/**
+ * Strip comments so every assertion below matches CODE. `(?<!:)` keeps `https://…` inside a string
+ * from swallowing the rest of its line — that would silently erase a real `withSchool(` and turn the
+ * sweep's "no tenant read here" skip into exactly the false pass this exists to stop.
+ */
+const stripComments = (s: string) => s.replace(/\/\*[\s\S]*?\*\/|(?<!:)\/\/.*$/gm, "");
+const src = () => stripComments(readFileSync(resolve(cwd(), SERVER), "utf8"));
+// Condition THROUGH consequence: a gate that tests the right thing and then does nothing is not a gate.
+const GATE =
+  /if\s*\(\s*!opts\?\.allowNonStaff\s*&&\s*!\s*isStaff\s*\(\s*user\.roles\s*\)\s*\)\s*\{\s*redirect\s*\(/;
 
 describe("requireSchool is staff-only by default", () => {
   it("carries the isStaff gate", () => {
@@ -63,18 +79,29 @@ describe("requireSchool is staff-only by default", () => {
   it("EXACTLY ONE caller opts out, and it is the parent's own statement PDF", () => {
     // The opt-out is the shipped INCR-19b parent reader, which proves ownership under
     // withParentScope before rendering. A second one appearing silently is the regression.
-    const roots = ["app", "lib", "components", "features"];
+    //
+    // Match the BARE IDENTIFIER, not `allowNonStaff: true`. Quinn reproduced the gap: a second caller
+    // written `{ allowNonStaff: OPEN }` (or spread from a config) passed every test here. To set the
+    // flag at all the identifier must appear in source, so this closes essentially the whole gap —
+    // and a non-literal RHS is strictly MORE suspicious than `true`, not less.
+    const roots = ["app", "lib", "components", "features", "hooks", "middleware.ts"];
     const hits: string[] = [];
+    const scan = (p: string) => {
+      if (p === SERVER) return; // the definition itself
+      if (!/\.tsx?$/.test(p) || /\.test\.tsx?$/.test(p)) return;
+      if (stripComments(readFileSync(resolve(cwd(), p), "utf8")).includes("allowNonStaff")) hits.push(p);
+    };
     const walk = (dir: string) => {
       for (const e of readdirSync(resolve(cwd(), dir), { withFileTypes: true })) {
         const p = `${dir}/${e.name}`;
         if (e.isDirectory()) walk(p);
-        else if (/\.tsx?$/.test(e.name) && !/\.test\.tsx?$/.test(e.name)) {
-          if (readFileSync(resolve(cwd(), p), "utf8").includes("allowNonStaff: true")) hits.push(p);
-        }
+        else scan(p);
       }
     };
-    for (const r of roots) walk(r);
+    for (const r of roots) {
+      if (!existsSync(resolve(cwd(), r))) continue;
+      statSync(resolve(cwd(), r)).isDirectory() ? walk(r) : scan(r);
+    }
     expect(hits).toEqual(["app/api/senior/readiness-statement/[id]/route.ts"]);
   });
 });
@@ -90,6 +117,13 @@ describe("requireSchool is staff-only by default", () => {
  * So: every page and API route that opens a tenant read must await a `require*` guard FIRST. A file
  * that performs no tenant read has nothing to guard and passes trivially — that also covers the
  * pages which delegate to a lib function that guards internally.
+ *
+ * KNOWN BLIND SPOT, measured rather than assumed (Dex, PR #176): of 91 swept targets, 63 contain a
+ * tenant read and are genuinely checked; 28 contain none and pass trivially. Of those 28, 26 carry a
+ * guard anyway, one is `app/api/cron/health/route.ts` (no session, no tenant read — correctly
+ * invisible), and one is the promotion page, which delegates to `previewPromotion()` and is guarded
+ * inside it. So nothing is currently hiding there — but a page reading through a `-data.ts` helper
+ * under `lib` that takes a `schoolId` and opens its own transaction WOULD be invisible to this sweep.
  *
  * This is deliberately cheap and blunt. It passes today; its whole value is failing the day someone
  * adds a route that reads before it checks.
@@ -118,7 +152,8 @@ describe("every tenant read is preceded by an auth guard", () => {
 
   it("finds the routes it claims to check (the sweep is not vacuous)", () => {
     // If a refactor moves these, this test must fail loudly rather than pass over an empty set.
-    expect(targets.length).toBeGreaterThan(60);
+    // 91 today; pinned close enough to notice a mass move rather than merely a total wipe-out.
+    expect(targets.length).toBeGreaterThan(85);
   });
 
   /**
@@ -132,7 +167,7 @@ describe("every tenant read is preceded by an auth guard", () => {
     const offenders: string[] = [];
     for (const p of targets) {
       if (SECRET_AUTHED.includes(p)) continue;
-      const src = readFileSync(resolve(cwd(), p), "utf8");
+      const src = stripComments(readFileSync(resolve(cwd(), p), "utf8"));
       const read = src.search(TENANT_READ);
       if (read === -1) continue; // no tenant read here — nothing to guard
       const guard = src.search(GUARD);
@@ -141,13 +176,24 @@ describe("every tenant read is preceded by an auth guard", () => {
     expect(offenders, "these read tenant data before (or without) an auth guard").toEqual([]);
   });
 
-  it("every secret-authed exemption actually checks its secret, before reading", () => {
+  it("every secret-authed exemption actually checks its secret, REFUSES, and does both before reading", () => {
     // The exemption must be earned. This is what stops the list becoming a way to opt out of the
     // invariant: an entry that stops verifying its secret fails here rather than passing silently.
+    //
+    // Deliberately NOT pinned to `!==`. The earlier version required that exact comparison, so
+    // swapping in `crypto.timingSafeEqual` — strictly better — would have failed (Dex). A test that
+    // penalises the safer implementation gets worked around instead of updated. What must hold is
+    // only: the condition consults the secret, and the block REFUSES.
     for (const p of SECRET_AUTHED) {
-      const src = readFileSync(resolve(cwd(), p), "utf8");
-      const check = src.search(/if\s*\(\s*!env\.\w*SECRET\w*\s*\|\|\s*\w+\s*!==\s*env\.\w*SECRET\w*\s*\)/);
-      expect(check, `${p}: expected a fail-closed shared-secret check`).toBeGreaterThan(-1);
+      const src = stripComments(readFileSync(resolve(cwd(), p), "utf8"));
+      const m = /if\s*\([\s\S]{0,200}?env\.\w*SECRET\w*[\s\S]{0,200}?\)\s*\{/.exec(src);
+      expect(m, `${p}: expected a shared-secret check consulting env.*SECRET*`).not.toBeNull();
+      const check = m!.index;
+      // Quinn kept the `if` and deleted its 401: the webhook opened completely, suite stayed green.
+      expect(
+        src.slice(check, check + 300),
+        `${p}: the secret check must FAIL CLOSED — refuse with 401/403`,
+      ).toMatch(/\b40[13]\b/);
       const read = src.search(TENANT_READ);
       if (read !== -1) expect(check, `${p}: secret check must precede the tenant read`).toBeLessThan(read);
     }

--- a/omnischools/lib/auth/app-shell-guard.test.ts
+++ b/omnischools/lib/auth/app-shell-guard.test.ts
@@ -79,6 +79,81 @@ describe("requireSchool is staff-only by default", () => {
   });
 });
 
+/**
+ * 🔴 THE GUARD-ORDERING INVARIANT — the thing that actually keeps the other 81 pages safe.
+ *
+ * Sarah's ruling on PR #176: the residual risk was never "61 pages leak" — they do not, because a
+ * redirect awaited in a page's OWN render stops that page before its own fetch. The risk is that
+ * *nothing enforced* the property making them safe. Page 83, or one fetch hoisted above a guard,
+ * silently reopens the hole that let a claimed parent read a child's medications.
+ *
+ * So: every page and API route that opens a tenant read must await a `require*` guard FIRST. A file
+ * that performs no tenant read has nothing to guard and passes trivially — that also covers the
+ * pages which delegate to a lib function that guards internally.
+ *
+ * This is deliberately cheap and blunt. It passes today; its whole value is failing the day someone
+ * adds a route that reads before it checks.
+ */
+const TENANT_READ = /\b(withSchool|withParentScope|withoutTenantScope|withStaffScope)\s*\(/;
+const GUARD = /\b(requireSchool|requireSchoolRole|requireParent|requireUser)\s*\(/;
+
+function filesUnder(dir: string, match: RegExp): string[] {
+  const out: string[] = [];
+  const walk = (d: string) => {
+    for (const e of readdirSync(resolve(cwd(), d), { withFileTypes: true })) {
+      const p = `${d}/${e.name}`;
+      if (e.isDirectory()) walk(p);
+      else if (match.test(e.name)) out.push(p);
+    }
+  };
+  walk(dir);
+  return out;
+}
+
+describe("every tenant read is preceded by an auth guard", () => {
+  const targets = [
+    ...filesUnder("app/(app)", /^page\.tsx$/),
+    ...filesUnder("app/api", /^route\.ts$/),
+  ];
+
+  it("finds the routes it claims to check (the sweep is not vacuous)", () => {
+    // If a refactor moves these, this test must fail loudly rather than pass over an empty set.
+    expect(targets.length).toBeGreaterThan(60);
+  });
+
+  /**
+   * Machine-to-machine routes have no user session by design. They are exempt from the `require*`
+   * rule and subject to a stricter one instead (below): the shared-secret check must be the FIRST
+   * thing the handler does. The list is explicit so adding one is a deliberate act, not a drift.
+   */
+  const SECRET_AUTHED = ["app/api/inbox/inbound/route.ts"];
+
+  it("no page or route opens a tenant transaction before awaiting a guard", () => {
+    const offenders: string[] = [];
+    for (const p of targets) {
+      if (SECRET_AUTHED.includes(p)) continue;
+      const src = readFileSync(resolve(cwd(), p), "utf8");
+      const read = src.search(TENANT_READ);
+      if (read === -1) continue; // no tenant read here — nothing to guard
+      const guard = src.search(GUARD);
+      if (guard === -1 || guard > read) offenders.push(p);
+    }
+    expect(offenders, "these read tenant data before (or without) an auth guard").toEqual([]);
+  });
+
+  it("every secret-authed exemption actually checks its secret, before reading", () => {
+    // The exemption must be earned. This is what stops the list becoming a way to opt out of the
+    // invariant: an entry that stops verifying its secret fails here rather than passing silently.
+    for (const p of SECRET_AUTHED) {
+      const src = readFileSync(resolve(cwd(), p), "utf8");
+      const check = src.search(/if\s*\(\s*!env\.\w*SECRET\w*\s*\|\|\s*\w+\s*!==\s*env\.\w*SECRET\w*\s*\)/);
+      expect(check, `${p}: expected a fail-closed shared-secret check`).toBeGreaterThan(-1);
+      const read = src.search(TENANT_READ);
+      if (read !== -1) expect(check, `${p}: secret check must precede the tenant read`).toBeLessThan(read);
+    }
+  });
+});
+
 describe("isStaff has the polarity a shell guard needs", () => {
   // Fail-OPEN for unknown roles, fail-CLOSED for the two known non-staff ones. Across 104 call sites
   // that is the safe direction: a newly-added staff role still works, rather than the bursar being

--- a/omnischools/lib/auth/server.ts
+++ b/omnischools/lib/auth/server.ts
@@ -10,6 +10,7 @@ import {
   pathAllowedForFinance,
   FINANCE_HOME,
   hasAnyRole,
+  isStaff,
 } from "@/lib/access";
 
 export interface ActiveSchool {
@@ -96,10 +97,54 @@ export async function requireUser(): Promise<AppUser> {
 }
 
 /** For app pages: ensure a user AND a resolvable school, else redirect. */
-export async function requireSchool(): Promise<{ user: AppUser; school: ActiveSchool }> {
+/**
+ * 🔴 STAFF-ONLY BY DEFAULT. This closes a live PII leak, and the placement is the whole point.
+ *
+ * WHAT WAS WRONG. This function authenticated and resolved an active school but performed NO role
+ * check, and 62 of the 82 pages under `app/(app)` are gated by nothing else. Accepting a PARENT
+ * invite creates a real `role_assignment` (`lib/actions/invites.ts`), so a claimed parent held an
+ * active school, passed this gate, and could open `students/[id]` — blood group, allergies,
+ * conditions, medications, emergency contact — plus admissions, attendance and billing.
+ * Demonstrated end-to-end against a production build with a PARENT session: HTTP 200 carrying the
+ * data.
+ *
+ * WHY THE 19a PARENT BOUNDARY DID NOT CATCH IT — and why it was not at fault. It binds through
+ * `withParentScope`, which sets `app.current_parent_user`. Staff pages read under `withSchool`, so
+ * that GUC is unset and `parent_deny`'s permit-by-default clause (`pu IS NULL OR …`) lets the row
+ * through. Proven against the live DB as the non-superuser role: school-GUC-only read the health
+ * record, parent-GUC-set read zero. The boundary is sound; a parent standing on a staff route never
+ * met it. (This is exactly the polarity hazard Kofi flagged when specifying the chronic-register
+ * boundary as deny-by-default.)
+ *
+ * WHY HERE AND NOT IN THE LAYOUT. A redirect thrown from a layout does not stop the page rendering —
+ * layouts and pages render in parallel. A production build served a 307 whose body still carried the
+ * health data. Every page calls this function in its OWN render, before its own queries, so this is
+ * the seam where a refusal actually prevents the read.
+ *
+ * WHY `isStaff` RATHER THAN AN ALLOW-LIST. `isStaff` is false only for the two roles KNOWN to be
+ * non-staff and true for everything else, so an unfamiliar or newly-added staff role is admitted
+ * rather than locked out. For a guard covering 104 call sites that polarity is the safe one: the
+ * failure mode is "a new role still works", never "the bursar cannot log in on Monday". A staff
+ * member who is also a parent — common — holds a staff role and passes, correctly; roles are
+ * active-school-scoped since #167, so this means "staff HERE, now".
+ *
+ * `allowNonStaff` is the ONE deliberate exception: `app/api/senior/readiness-statement/[id]` serves
+ * a parent their own child's PDF (INCR-19b), proving ownership under `withParentScope` before it
+ * renders. It is opt-IN and greppable precisely so a second one cannot appear by accident.
+ * `requireParent()` does not route through here, so the parent portal is unaffected.
+ */
+export async function requireSchool(
+  opts?: { allowNonStaff?: boolean },
+): Promise<{ user: AppUser; school: ActiveSchool }> {
   const user = await requireUser();
   const school = await getActiveSchool(user);
   if (!school) redirect("/start");
+  if (!opts?.allowNonStaff && !isStaff(user.roles)) {
+    // A parent has somewhere to be; a student-only session has no portal yet, and `/start` is the
+    // honest landing rather than a staff page they cannot use. Neither target is inside `app/(app)`,
+    // which would loop.
+    redirect(user.roles.includes("PARENT") ? "/wassce" : "/start");
+  }
   // Finance-only staff (Accountant/Bursar) are confined to the billing sections.
   // Runs on every app page (and its server actions) via this shared guard; the path
   // comes from the middleware-stamped `x-pathname` header.


### PR DESCRIPTION
🔴 **Live on `main`.** A claimed parent could read any student's blood group, allergies, conditions, medications and emergency contact. Found while mapping the INCR-23 chronic register — the register could not claim "admin-private" while this page said otherwise.

## The chain, each link verified

- `requireSchool()` authenticated and resolved an active school but performed **no role check** — and **62 of the 82 pages** under `app/(app)` are gated by nothing else.
- Accepting a PARENT invite creates a real `role_assignment` (`lib/actions/invites.ts:223`), so a claimed parent **held** an active school and passed that gate.
- `students/[id]` renders the health record behind exactly that gate.
- The page reads under `withSchool`, so `app.current_parent_user` is never set and the 19a parent boundary never applies.

**Demonstrated end-to-end on a production build** with a PARENT session: HTTP 200 carrying the allergy, condition and medication tokens.

## The 19a boundary was not at fault
It binds through `withParentScope`. Staff pages read under `withSchool`, so that GUC is unset and `parent_deny`'s permit-by-default clause lets the row through. Proven against the live DB as the non-superuser role — school-GUC-only reads the health row, parent-GUC-set reads zero. The boundary is sound; **a parent standing on a staff route simply never met it.** (This is the polarity hazard Kofi flagged hours earlier when specifying the chronic-register boundary as deny-by-default — here in its live form.)

## Two fixes, because the first was not sufficient

**1. `requireSchool()` is staff-only by default.** One greppable opt-in (`allowNonStaff`), used solely by the INCR-19b parent statement PDF, which proves ownership under `withParentScope` before rendering. `requireParent()` doesn't route through `requireSchool`, so the parent portal is unaffected. `isStaff` is fail-**open** for unknown roles and fail-**closed** only for STUDENT/PARENT — across 104 call sites the failure mode must be *"a new role still works"*, never *"the bursar can't log in on Monday"*. A teacher who is also a parent holds a staff role and passes, correctly.

**2. The health record is not FETCHED for a non-staff reader — and this is the one that actually closes it.** A `redirect()` thrown from a Server Component blocks **navigation but not disclosure**: layouts and pages render in parallel, and a production build served a 307 to `/wassce` whose body *still carried the data*, live-rendered. I proved it was live rather than cached by changing the stored value and watching the **new** one appear in the redirect body. A row that is never selected cannot be streamed, whatever the control flow does.

The guard was deliberately **not** left in `app/(app)/layout.tsx` for that reason; the layout now documents why.

## Verification
`tsc` clean · **665 tests** · lint clean · production build clean. Production HTTP both directions: **PARENT → 307 with zero health tokens in the body**; **ADMIN → 200 with the data**, `/dashboard` still reachable. The new guard tests are mutation-proven — neutering the gate turns 2 red. Dev DB fixture restored.

## ⚠️ Still needs a considered answer (not in this PR)
A redirect from `requireSchool` does **not** stop the other 61 unguarded pages rendering and streaming their payloads to a non-staff session — admissions, attendance, billing. This PR closes the health-data disclosure specifically, which is the acute one. The general case deserves a designed answer rather than a third rushed attempt, and I'd like Sarah's view on the shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)