### PR TITLE
fix(security): staff administration is ADMIN/HEADMASTER-only (live privilege escalation)

### DIFF
--- a/omnischools/app/(app)/staff/[id]/page.tsx
+++ b/omnischools/app/(app)/staff/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { and, asc, count, eq, notInArray } from "drizzle-orm";
 import { requireSchool } from "@/lib/auth/server";
+import { hasAnyRole, STAFF_ADMIN_ROLES } from "@/lib/access";
 import { withSchool } from "@/lib/db/rls";
 import {
   users,
@@ -81,8 +82,14 @@ const initialsOf = (full: string) => {
 
 export default async function StaffDetailPage(props: { params: Promise<{ id: string }> }) {
   const params = await props.params;
-  const { school } = await requireSchool();
+  const { school, user } = await requireSchool();
   const today = new Date().toISOString().slice(0, 10);
+  // A staff DIRECTORY is legitimately staff-wide — names, roles, classes. PAY IS NOT. The list view
+  // at /staff/compensation was gated and this detail view was not, so the same salary, SSNIT and PAYE
+  // stayed one click away on any colleague's row (Dex, PR #177). Gated here rather than on the whole
+  // page so the directory keeps working: the query is NEVER ISSUED for a non-administrator, so there
+  // is no row to leak into the payload whatever the JSX does.
+  const canAdmin = hasAnyRole(user.roles, STAFF_ADMIN_ROLES);
 
   const data = await withSchool(school.id, async (tx) => {
     // The user must hold ≥1 non-student/parent role at this school to be staff here.
@@ -136,16 +143,18 @@ export default async function StaffDetailPage(props: { params: Promise<{ id: str
           ),
         )
         .limit(1),
-      tx
-        .select()
-        .from(staffCompensation)
-        .where(
-          and(
-            eq(staffCompensation.schoolId, school.id),
-            eq(staffCompensation.userId, staffUser.id),
-          ),
-        )
-        .limit(1),
+      canAdmin
+        ? tx
+            .select()
+            .from(staffCompensation)
+            .where(
+              and(
+                eq(staffCompensation.schoolId, school.id),
+                eq(staffCompensation.userId, staffUser.id),
+              ),
+            )
+            .limit(1)
+        : [],
       tx
         .select({ id: classes.id, name: classes.name, level: classes.level })
         .from(classes)
@@ -389,75 +398,79 @@ export default async function StaffDetailPage(props: { params: Promise<{ id: str
         )}
       </Section>
 
+      {/* 🔴 Pay is NOT directory data. `canAdmin` also stops the query above from being issued,
+          so a non-administrator has no compensation row to render in the first place. */}
       {/* ── 05 · Compensation ──────────────────────────────────── */}
-      <Section
-        num="05"
-        title="Compensation"
-        right={
-          <StaffCompensationEdit
-            userId={staffUser.id}
-            hasRecord={!!compensation}
-            variant="secondary"
-            initial={
-              compensation
-                ? {
-                    salaryStatus: compensation.salaryStatus,
-                    monthlyAmount: compMonthly ? String(compMonthly) : "",
-                    payMethod: compensation.payMethod,
-                    payCadence: compensation.payCadence,
-                    ssnitDeduction: compSsnit ? String(compSsnit) : "",
-                    payeDeduction: compPaye ? String(compPaye) : "",
-                    effectiveFrom: compensation.effectiveFrom ?? "",
-                    notes: compensation.notes ?? "",
-                  }
-                : EMPTY_COMPENSATION
-            }
-          />
-        }
-      >
-        {!compensation ? (
-          <Muted>No compensation set — use Set compensation.</Muted>
-        ) : (
-          <dl className="grid grid-cols-1 gap-px overflow-hidden rounded-lg border border-border bg-border sm:grid-cols-2">
-            <Field
-              label="Salary status"
-              value={COMP_STATUS_LABEL[compensation.salaryStatus] ?? compensation.salaryStatus}
-            />
-            <Field label="Monthly amount" value={ghs(compMonthly)} mono />
-            <Field
-              label="Pay method"
-              value={`${COMP_METHOD_LABEL[compensation.payMethod] ?? compensation.payMethod} · ${
-                compensation.payCadence === "TERMLY" ? "Termly" : "Monthly"
-              }`}
-            />
-            <Field
-              label="SSNIT"
-              value={compSsnit > 0 ? ghs(compSsnit) : "—"}
-              mono={compSsnit > 0}
-            />
-            <Field
-              label="PAYE"
-              value={compPaye > 0 ? ghs(compPaye) : "—"}
-              mono={compPaye > 0}
-            />
-            <Field label="Net" value={ghs(compNet)} mono />
-            <Field
-              label="Effective from"
-              value={compensation.effectiveFrom ? fmtDob(compensation.effectiveFrom) : null}
-            />
-            <Field
-              label="Tenure"
-              value={
-                firstStart
-                  ? `${yearsSince(firstStart, today)} ${
-                      yearsSince(firstStart, today) === 1 ? "year" : "years"
-                    }`
-                  : null
+      {canAdmin && (
+        <Section
+          num="05"
+          title="Compensation"
+          right={
+            <StaffCompensationEdit
+              userId={staffUser.id}
+              hasRecord={!!compensation}
+              variant="secondary"
+              initial={
+                compensation
+                  ? {
+                      salaryStatus: compensation.salaryStatus,
+                      monthlyAmount: compMonthly ? String(compMonthly) : "",
+                      payMethod: compensation.payMethod,
+                      payCadence: compensation.payCadence,
+                      ssnitDeduction: compSsnit ? String(compSsnit) : "",
+                      payeDeduction: compPaye ? String(compPaye) : "",
+                      effectiveFrom: compensation.effectiveFrom ?? "",
+                      notes: compensation.notes ?? "",
+                    }
+                  : EMPTY_COMPENSATION
               }
             />
-          </dl>
-        )}
-      </Section>
+          }
+        >
+          {!compensation ? (
+            <Muted>No compensation set — use Set compensation.</Muted>
+          ) : (
+            <dl className="grid grid-cols-1 gap-px overflow-hidden rounded-lg border border-border bg-border sm:grid-cols-2">
+              <Field
+                label="Salary status"
+                value={COMP_STATUS_LABEL[compensation.salaryStatus] ?? compensation.salaryStatus}
+              />
+              <Field label="Monthly amount" value={ghs(compMonthly)} mono />
+              <Field
+                label="Pay method"
+                value={`${COMP_METHOD_LABEL[compensation.payMethod] ?? compensation.payMethod} · ${
+                  compensation.payCadence === "TERMLY" ? "Termly" : "Monthly"
+                }`}
+              />
+              <Field
+                label="SSNIT"
+                value={compSsnit > 0 ? ghs(compSsnit) : "—"}
+                mono={compSsnit > 0}
+              />
+              <Field
+                label="PAYE"
+                value={compPaye > 0 ? ghs(compPaye) : "—"}
+                mono={compPaye > 0}
+              />
+              <Field label="Net" value={ghs(compNet)} mono />
+              <Field
+                label="Effective from"
+                value={compensation.effectiveFrom ? fmtDob(compensation.effectiveFrom) : null}
+              />
+              <Field
+                label="Tenure"
+                value={
+                  firstStart
+                    ? `${yearsSince(firstStart, today)} ${
+                        yearsSince(firstStart, today) === 1 ? "year" : "years"
+                      }`
+                    : null
+                }
+              />
+            </dl>
+          )}
+        </Section>
+      )}
     </div>
   );
 }

--- a/omnischools/app/(app)/staff/compensation/page.tsx
+++ b/omnischools/app/(app)/staff/compensation/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { and, asc, eq, notInArray, sql } from "drizzle-orm";
-import { requireSchool } from "@/lib/auth/server";
+import { requireSchoolRole } from "@/lib/auth/server";
+import { STAFF_ADMIN_ROLES } from "@/lib/access";
 import { withSchool } from "@/lib/db/rls";
 import {
   users,
@@ -59,8 +60,13 @@ type CompRow = {
   effectiveFrom: string | null;
 };
 
+/**
+ * Every colleague's salary, SSNIT and PAYE. This was gated by `requireSchool()` alone — i.e. any
+ * staff member — so a teacher could read the whole school's payroll. The write side
+ * (`saveStaffCompensation`) had the same gap and is now closed at the action.
+ */
 export default async function StaffCompensationPage() {
-  const { school } = await requireSchool();
+  const { school } = await requireSchoolRole(STAFF_ADMIN_ROLES);
   const today = new Date().toISOString().slice(0, 10);
 
   const { rows, compRows, profileRows, tenureRows, activeStudents } = await withSchool(

--- a/omnischools/lib/access.ts
+++ b/omnischools/lib/access.ts
@@ -26,7 +26,7 @@ export const FINANCE_ROLES = ["ACCOUNTANT", "BURSAR"];
  * /staff, find their own row and become Administrator in three clicks.
  *
  * Deliberately narrow. Widening it is a decision about who may mint administrators, not a
- * convenience tweak; `VICE_HEADMASTER_ADMIN` is the obvious candidate if a school asks.
+ * convenience tweak; `VICE_HEADMASTER_ACADEMIC` is the obvious candidate if a school asks.
  */
 export const STAFF_ADMIN_ROLES = [
   "ADMIN",

--- a/omnischools/lib/access.ts
+++ b/omnischools/lib/access.ts
@@ -15,6 +15,25 @@ import type { KnownAppRole } from "@/lib/auth";
 export const FINANCE_ROLES = ["ACCOUNTANT", "BURSAR"];
 
 /**
+ * 🔴 Who may administer STAFF — create, edit, delete, set pay, and above all ASSIGN ROLES.
+ *
+ * This is the school's authorization root. `role_assignment` is the table every other guard in the
+ * product reads (`requireSchool`→`isStaff`, `requireSchoolRole`, `isFinanceOnly`, and the sickbay
+ * clinical boundary's `chronic_clinical_role`), so an actor who can write it can grant themselves
+ * anything downstream. Before this group existed, every action in `lib/actions/staff.ts` was gated
+ * by `requireSchool()` alone — which since PR #176 means "authenticated + is staff" — and `ADMIN` is
+ * on the same assignable list that /staff renders for every row, so ANY staff member could open
+ * /staff, find their own row and become Administrator in three clicks.
+ *
+ * Deliberately narrow. Widening it is a decision about who may mint administrators, not a
+ * convenience tweak; `VICE_HEADMASTER_ADMIN` is the obvious candidate if a school asks.
+ */
+export const STAFF_ADMIN_ROLES = [
+  "ADMIN",
+  "HEADMASTER",
+] as const satisfies readonly KnownAppRole[];
+
+/**
  * Senior (SHS) tier role groups. The score ledger is a teaching surface (teachers + form
  * masters + academic leadership); the Vice Headmaster progress view is management-only
  * (Admin, Headmaster, Vice Headmaster Academic). STUDENT / PARENT never reach either.

--- a/omnischools/lib/actions/invites.ts
+++ b/omnischools/lib/actions/invites.ts
@@ -9,7 +9,7 @@ import { sendSms } from "@/lib/sms";
 import { sendEmail } from "@/lib/email";
 import { safeRevalidate } from "@/lib/revalidate";
 import { resolveRole, roleLabel } from "@/lib/staff-roles";
-import { isStaff } from "@/lib/access";
+import { isStaff, hasAnyRole, STAFF_ADMIN_ROLES } from "@/lib/access";
 import { isParentRole, parentInviteError } from "@/lib/parent/claim";
 import { resolveParentInviteTargetTx, stampGuardianUserId } from "@/lib/parent/parent-data";
 import { invites, users, roles, roleAssignments } from "@/db/schema";
@@ -79,6 +79,20 @@ export async function createInvite(input: unknown): Promise<Result & { token?: s
     if (!d.phone || d.phone.length < 7) return { ok: false, error: "A phone number is required" };
     phone = normalizeGhanaPhone(d.phone);
     fullName = d.fullName.trim();
+  }
+
+  // 🔴 NO MINTING PRIVILEGE YOU DO NOT HOLD. An invite creates a real `role_assignment`, so this is
+  // the SECOND door onto the escalation `assertAnyRole(STAFF_ADMIN_ROLES)` closes in `staff.ts` —
+  // and it needs no interception to walk through: `createInvite` returns the token to its caller and
+  // `acceptInvite` requires no session. Reproduced end-to-end on a production build by Quinn: a
+  // TEACHER invited "ADMIN" **to their own phone number**, accepted it, and `onConflictDoNothing` on
+  // `users.phone` stapled ADMIN onto their existing account — two calls, no SMS, no crafted session.
+  //
+  // Scoped to the role being MINTED rather than gating the whole action, because a Form Master
+  // inviting a teacher is a legitimate workflow and inviting an administrator is not. The `isStaff`
+  // check above stays: it answers "may you invite at all", this answers "may you invite THIS".
+  if (hasAnyRole([role.code], STAFF_ADMIN_ROLES) && !hasAnyRole(user.roles, STAFF_ADMIN_ROLES)) {
+    return { ok: false, error: "Only an administrator can invite an administrator." };
   }
 
   const token = crypto.randomUUID().replace(/-/g, "").slice(0, 24);

--- a/omnischools/lib/actions/invites.ts
+++ b/omnischools/lib/actions/invites.ts
@@ -81,18 +81,27 @@ export async function createInvite(input: unknown): Promise<Result & { token?: s
     fullName = d.fullName.trim();
   }
 
-  // 🔴 NO MINTING PRIVILEGE YOU DO NOT HOLD. An invite creates a real `role_assignment`, so this is
-  // the SECOND door onto the escalation `assertAnyRole(STAFF_ADMIN_ROLES)` closes in `staff.ts` —
-  // and it needs no interception to walk through: `createInvite` returns the token to its caller and
-  // `acceptInvite` requires no session. Reproduced end-to-end on a production build by Quinn: a
-  // TEACHER invited "ADMIN" **to their own phone number**, accepted it, and `onConflictDoNothing` on
-  // `users.phone` stapled ADMIN onto their existing account — two calls, no SMS, no crafted session.
+  // 🔴 A STAFF INVITE IS THE SAME CAPABILITY AS `addStaff` — create a user and grant them a role at
+  // this school — so it takes the SAME gate. This is the second door onto the escalation, and it
+  // needs no interception: `createInvite` returns the token to its caller by design, and
+  // `acceptInvite` requires no session. Quinn reproduced it end-to-end on a production build — a
+  // TEACHER invited a privileged role **to their own phone number**, accepted it, and
+  // `onConflictDoNothing` on `users.phone` stapled the role onto their existing account.
   //
-  // Scoped to the role being MINTED rather than gating the whole action, because a Form Master
-  // inviting a teacher is a legitimate workflow and inviting an administrator is not. The `isStaff`
-  // check above stays: it answers "may you invite at all", this answers "may you invite THIS".
-  if (hasAnyRole([role.code], STAFF_ADMIN_ROLES) && !hasAnyRole(user.roles, STAFF_ADMIN_ROLES)) {
-    return { ok: false, error: "Only an administrator can invite an administrator." };
+  // My first fix blocked only ADMIN/HEADMASTER, justified by "a Form Master inviting a teacher is
+  // legitimate". Dex checked: **that surface does not exist.** Both staff callers of this action are
+  // on `/staff` (now admin-only), and the only other caller is the parent invite. So the carve-out
+  // defended a workflow with no UI while leaving MATRON (clinical write), VICE_HEADMASTER_ACADEMIC
+  // (the WASSCE freeze co-signer), DEAN_OF_BOARDING and the finance roles mintable by any teacher —
+  // the identical two-call exploit, one role over.
+  //
+  // PARENT invites stay staff-wide: teachers issue them from /students, and a parent invite grants
+  // no staff privilege (its phone/name come from the stored guardian row, never caller free-text).
+  const canInvite = isParentRole(d.role)
+    ? isStaff(user.roles)
+    : hasAnyRole(user.roles, STAFF_ADMIN_ROLES);
+  if (!canInvite) {
+    return { ok: false, error: "Only an administrator can invite staff." };
   }
 
   const token = crypto.randomUUID().replace(/-/g, "").slice(0, 24);

--- a/omnischools/lib/actions/staff-authz.test.ts
+++ b/omnischools/lib/actions/staff-authz.test.ts
@@ -33,30 +33,74 @@ const stripComments = (s: string) => s.replace(/\/\*[\s\S]*?\*\/|(?<!:)\/\/.*$/g
 const read = (p: string) => stripComments(readFileSync(resolve(cwd(), p), "utf8"));
 
 const GUARD = /\bassertAnyRole\s*\(\s*STAFF_ADMIN_ROLES\s*\)/;
-const TENANT_READ = /\bwithSchool\s*\(/;
+/**
+ * Deliberately WIDER than `withSchool(` — Quinn shipped a `grantRoleBackdoor` using
+ * `withoutTenantScope` that typechecked, built, passed all 675 tests, and handed a TEACHER `ADMIN`
+ * on a production build. `withoutTenantScope` is not a strawman: it is the idiom `invites.ts` and
+ * `onboarding.ts` already use for the very `role_assignment` writes that ARE the escalation.
+ */
+const TENANT_READ = /\b(withSchool|withoutTenantScope|withParentScope|withStaffScope|db)\s*[.(]/;
+/** Every export of a `"use server"` module is remotely callable — arrow consts included. */
+const EXPORTED_FN = /^export (?:async function (\w+)|const (\w+)\s*=\s*async)/gm;
+const EXPECTED = [
+  "addStaff",
+  "importStaff",
+  "saveStaffProfile",
+  "updateStaff",
+  "deleteStaff",
+  "deleteStaffBulk",
+  "assignStaffRole",
+  "removeStaffRole",
+  "saveStaffCompensation",
+];
 
 describe("every staff mutator is gated to STAFF_ADMIN_ROLES", () => {
   const src = () => read(ACTIONS);
+  const exportsOf = (s: string) =>
+    [...s.matchAll(EXPORTED_FN)].map((m) => ({ name: m[1] ?? m[2], i: m.index! }));
 
-  it("finds the mutators it claims to check (the sweep is not vacuous)", () => {
-    const names = [...src().matchAll(/^export async function (\w+)/gm)].map((m) => m[1]);
-    // 9 today. If a refactor moves or renames them this must fail loudly, not pass over an empty set.
-    expect(names).toContain("assignStaffRole");
-    expect(names.length).toBeGreaterThanOrEqual(9);
+  it("the mutator list is EXACT — a tenth action is a change to this file, not a silent addition", () => {
+    // `toContain` + `>= 9` licensed exactly what it should have caught: Quinn added a 10th export
+    // and every assertion stayed green. An allow-list makes a new action fail until someone rules
+    // on whether it may be called by a non-administrator.
+    expect(exportsOf(src()).map((e) => e.name).sort()).toEqual([...EXPECTED].sort());
   });
 
-  it("no mutator opens a tenant transaction before asserting the role", () => {
+  it("no mutator touches the database before asserting the role", () => {
     const s = src();
-    const marks = [...s.matchAll(/^export async function (\w+)/gm)];
+    const marks = exportsOf(s);
     const offenders: string[] = [];
     marks.forEach((m, i) => {
-      const body = s.slice(m.index!, i + 1 < marks.length ? marks[i + 1].index! : s.length);
+      const body = s.slice(m.i, i + 1 < marks.length ? marks[i + 1].i : s.length);
       const guard = body.search(GUARD);
-      const tenantRead = body.search(TENANT_READ);
-      if (tenantRead === -1) return; // nothing to guard
-      if (guard === -1 || guard > tenantRead) offenders.push(m[1]);
+      const read = body.search(TENANT_READ);
+      // NO "nothing to guard" SKIP. An exported server action whose data access this sweep cannot
+      // recognise is an OFFENDER, not a pass — the old `if (read === -1) return` was the hatch
+      // Quinn's backdoor walked through. Unrecognised shape ⇒ someone must look at it.
+      if (guard === -1 || read === -1 || guard > read) offenders.push(m.name);
     });
     expect(offenders, "these mutate staff data without first asserting the role").toEqual([]);
+  });
+
+  it("the guard is a real call, not a locally-rebound no-op", () => {
+    // `const assertAnyRole = async () => {}` above the mutators satisfies a name-shaped check.
+    const s = src();
+    expect(s, "assertAnyRole must come from the auth seam").toMatch(
+      /import\s*\{[^}]*\bassertAnyRole\b[^}]*\}\s*from\s*"@\/lib\/auth\/server"/,
+    );
+    expect(s, "assertAnyRole must not be shadowed by a local binding").not.toMatch(
+      /(?:const|let|var|function)\s+assertAnyRole\b/,
+    );
+  });
+
+  it("the guard is unconditional — a gate behind an `if` or a flag is not a gate", () => {
+    const s = src();
+    for (const m of [...s.matchAll(new RegExp(GUARD, "g"))]) {
+      const line = s.slice(s.lastIndexOf("\n", m.index!) + 1, m.index! + m[0].length);
+      expect(line.trim(), "the role assertion must not be conditional").toMatch(
+        /^await assertAnyRole\(STAFF_ADMIN_ROLES\)/,
+      );
+    }
   });
 
   it("assertAnyRole REFUSES — the condition is not enough, it must throw", () => {
@@ -68,6 +112,42 @@ describe("every staff mutator is gated to STAFF_ADMIN_ROLES", () => {
     expect(decl, "assertAnyRole must THROW when the check fails").toMatch(
       /if\s*\([\s\S]*?\)\s*\{[\s\S]*?\bthrow\b/,
     );
+  });
+});
+
+describe("the other two doors onto role_assignment", () => {
+  /**
+   * Quinn reverted the compensation page to its exact pre-fix form and all 675 tests stayed green —
+   * `app-shell-guard.test.ts` included, because `requireSchool` IS a guard and #176's sweep is
+   * satisfied by the vulnerable version. Half the shipped fix had no regression coverage at all.
+   */
+  it("the payroll page requires STAFF_ADMIN_ROLES, before it reads", () => {
+    const s = read("app/(app)/staff/compensation/page.tsx");
+    const guard = s.search(/requireSchoolRole\(\s*STAFF_ADMIN_ROLES\s*\)/);
+    expect(guard, "salaries, SSNIT and PAYE must not be readable by any staff member").toBeGreaterThan(-1);
+    const readAt = s.search(TENANT_READ);
+    if (readAt !== -1) expect(guard).toBeLessThan(readAt);
+  });
+
+  /**
+   * The second door, reproduced live by Quinn: `createInvite` accepted an arbitrary role string,
+   * RETURNED the token to its caller, and `acceptInvite` needs no session — so a TEACHER invited
+   * `ADMIN` to their own phone, accepted it, and `onConflictDoNothing` on `users.phone` stapled the
+   * role onto their existing account. Closing `staff.ts` alone left the escalation fully open.
+   */
+  it("createInvite refuses to mint a role the actor does not hold", () => {
+    const s = read("lib/actions/invites.ts");
+    const fn = s.slice(s.indexOf("export async function createInvite"));
+    const body = fn.slice(0, fn.indexOf("\nexport "));
+    const check = body.search(
+      /hasAnyRole\(\s*\[\s*role\.code\s*\]\s*,\s*STAFF_ADMIN_ROLES\s*\)\s*&&\s*!\s*hasAnyRole\(\s*user\.roles\s*,\s*STAFF_ADMIN_ROLES\s*\)/,
+    );
+    expect(check, "an invite creates a real role_assignment — minting admin needs admin").toBeGreaterThan(-1);
+    // Consequence, not just condition (the PR #176 lesson): the check must REFUSE.
+    expect(body.slice(check, check + 220)).toMatch(/return\s*\{\s*ok:\s*false/);
+    // …and it must refuse BEFORE the invite row is written.
+    const write = body.search(/tx\.insert\(invites\)/);
+    if (write !== -1) expect(check).toBeLessThan(write);
   });
 });
 

--- a/omnischools/lib/actions/staff-authz.test.ts
+++ b/omnischools/lib/actions/staff-authz.test.ts
@@ -164,12 +164,21 @@ describe("the other two doors onto role_assignment", () => {
       const s = stripComments(readFileSync(p, "utf8"));
       const query = s.search(/\.from\(\s*staffCompensation\s*\)/);
       if (query === -1) continue; // this page never queries pay — nothing to gate
-      // `await` is required: `requireSchoolRole(...)` unawaited throws inside a floating promise and
-      // the page renders anyway (Dex). No type-aware lint rule catches that here.
-      const proof = s.search(
-        /await requireSchoolRole\(\s*STAFF_ADMIN_ROLES\s*\)|hasAnyRole\(\s*user\.roles\s*,\s*STAFF_ADMIN_ROLES\s*\)/,
-      );
-      if (proof === -1 || proof > query) offenders.push(p.slice(p.indexOf("app/")));
+      // Shape A — the whole page is gated. `await` is required: `requireSchoolRole(...)` unawaited
+      // throws inside a floating promise and the page renders anyway (Dex), and no type-aware lint
+      // rule catches that here.
+      const paged = s.search(/await requireSchoolRole\(\s*STAFF_ADMIN_ROLES\s*\)/);
+      if (paged !== -1 && paged < query) continue;
+
+      // Shape B — the query itself is conditional. Pin the guard's USE AT THE QUERY, not merely its
+      // declaration somewhere in the file. Replacing `canAdmin ? tx.select()…` with `true ? …` left
+      // `const canAdmin = hasAnyRole(...)` sitting untouched above and satisfied the old check — the
+      // same "assert the expression, never the name" trap this file was written to stop, one level up.
+      const decl = /const (\w+)\s*=\s*hasAnyRole\(\s*user\.roles\s*,\s*STAFF_ADMIN_ROLES\s*\)/.exec(s);
+      const nearQuery = s.slice(Math.max(0, query - 200), query);
+      if (!decl || !new RegExp(`\\b${decl[1]}\\b`).test(nearQuery)) {
+        offenders.push(p.slice(p.indexOf("app/")));
+      }
     }
     expect(offenders, "salaries, SSNIT and PAYE must not be readable by any staff member").toEqual([]);
   });
@@ -193,9 +202,15 @@ describe("the other two doors onto role_assignment", () => {
     expect(check, "an invite creates a real role_assignment — minting staff needs admin").toBeGreaterThan(-1);
     // Consequence, not just condition (the PR #176 lesson): the check must REFUSE.
     expect(body.slice(check, check + 260)).toMatch(/if\s*\(\s*!canInvite\s*\)\s*\{[\s\S]{0,120}?return\s*\{\s*ok:\s*false/);
-    // Unconditional — base indent, nested inside nothing. The staff.ts sweep learned this; this
-    // describe had not inherited it, so a dead outer `if` disabled the check with the text intact.
-    expect(body.slice(body.lastIndexOf("\n", check) + 1, check + 20)).toMatch(/^ {2}const canInvite/);
+    // Unconditional — pin the REFUSAL's indent, not the const's. A dead outer `if (…) if (!canInvite)`
+    // leaves the const at base indent and the pinned text intact while disabling the check entirely;
+    // pinning `if (!canInvite)` to exactly two spaces makes the dangling wrapper visible.
+    const refusal = body.search(/if\s*\(\s*!canInvite\s*\)/);
+    expect(refusal, "createInvite must refuse when canInvite is false").toBeGreaterThan(-1);
+    expect(
+      body.slice(body.lastIndexOf("\n", refusal) + 1, refusal + 18),
+      "the refusal must sit at the function's base indent, nested inside nothing",
+    ).toMatch(/^ {2}if \(!canInvite\)/);
     // …and it must refuse BEFORE the invite row is written. No `if (write !== -1)` escape hatch:
     // this file forbids skip-hatches and then contained two of them.
     const write = body.search(/tx\.insert\(invites\)/);

--- a/omnischools/lib/actions/staff-authz.test.ts
+++ b/omnischools/lib/actions/staff-authz.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { resolve } from "node:path";
 import { cwd } from "node:process";
 import { hasAnyRole, STAFF_ADMIN_ROLES } from "@/lib/access";
@@ -40,8 +40,14 @@ const GUARD = /\bassertAnyRole\s*\(\s*STAFF_ADMIN_ROLES\s*\)/;
  * `onboarding.ts` already use for the very `role_assignment` writes that ARE the escalation.
  */
 const TENANT_READ = /\b(withSchool|withoutTenantScope|withParentScope|withStaffScope|db)\s*[.(]/;
-/** Every export of a `"use server"` module is remotely callable — arrow consts included. */
-const EXPORTED_FN = /^export (?:async function (\w+)|const (\w+)\s*=\s*async)/gm;
+/**
+ * Every export of a `"use server"` module is remotely callable — arrow consts and DEFAULT exports
+ * included. Dex shipped an `export default async function grantAdminBackdoor` that matched neither
+ * earlier branch, so it was invisible to both the exact-list check and the body sweep: a fully
+ * ungated, self-service ADMIN grant with all 11 tests green.
+ */
+const EXPORTED_FN =
+  /^export (?:default\s+async function (\w+)|async function (\w+)|const (\w+)\s*=\s*async)/gm;
 const EXPECTED = [
   "addStaff",
   "importStaff",
@@ -57,7 +63,13 @@ const EXPECTED = [
 describe("every staff mutator is gated to STAFF_ADMIN_ROLES", () => {
   const src = () => read(ACTIONS);
   const exportsOf = (s: string) =>
-    [...s.matchAll(EXPORTED_FN)].map((m) => ({ name: m[1] ?? m[2], i: m.index! }));
+    [...s.matchAll(EXPORTED_FN)].map((m) => ({ name: m[1] ?? m[2] ?? m[3], i: m.index! }));
+
+  it("exposes no re-exports — a barrel would smuggle in actions this sweep never reads", () => {
+    expect(src(), "`export {` / `export *` put a callable action outside this file").not.toMatch(
+      /^export\s*(?:\{|\*)/m,
+    );
+  });
 
   it("the mutator list is EXACT — a tenth action is a change to this file, not a silent addition", () => {
     // `toContain` + `>= 9` licensed exactly what it should have caught: Quinn added a 10th export
@@ -93,13 +105,20 @@ describe("every staff mutator is gated to STAFF_ADMIN_ROLES", () => {
     );
   });
 
-  it("the guard is unconditional — a gate behind an `if` or a flag is not a gate", () => {
+  it("the guard is unconditional — a gate behind an `if`, a flag or a block is not a gate", () => {
+    // INDENTATION, not the matched line. My first version sliced back to the start of the guard's own
+    // line, so `if (process.env.NODE_ENV !== "test") {\n    await assertAnyRole(...)\n }` read as
+    // unconditional (Dex). A statement at the function body's base indent — exactly two spaces — is
+    // nested inside nothing, which kills every wrapping variant at once instead of one at a time.
     const s = src();
-    for (const m of [...s.matchAll(new RegExp(GUARD, "g"))]) {
-      const line = s.slice(s.lastIndexOf("\n", m.index!) + 1, m.index! + m[0].length);
-      expect(line.trim(), "the role assertion must not be conditional").toMatch(
-        /^await assertAnyRole\(STAFF_ADMIN_ROLES\)/,
-      );
+    const all = [...s.matchAll(new RegExp(GUARD, "g"))];
+    expect(all.length, "the guard must appear once per mutator").toBe(EXPECTED.length);
+    for (const m of all) {
+      const from = s.lastIndexOf("\n", m.index!) + 1;
+      expect(
+        s.slice(from, m.index! + m[0].length),
+        "the role assertion must sit at the function's base indent, nested inside nothing",
+      ).toMatch(/^ {2}await assertAnyRole\(STAFF_ADMIN_ROLES\)/);
     }
   });
 
@@ -121,12 +140,38 @@ describe("the other two doors onto role_assignment", () => {
    * `app-shell-guard.test.ts` included, because `requireSchool` IS a guard and #176's sweep is
    * satisfied by the vulnerable version. Half the shipped fix had no regression coverage at all.
    */
-  it("the payroll page requires STAFF_ADMIN_ROLES, before it reads", () => {
-    const s = read("app/(app)/staff/compensation/page.tsx");
-    const guard = s.search(/requireSchoolRole\(\s*STAFF_ADMIN_ROLES\s*\)/);
-    expect(guard, "salaries, SSNIT and PAYE must not be readable by any staff member").toBeGreaterThan(-1);
-    const readAt = s.search(TENANT_READ);
-    if (readAt !== -1) expect(guard).toBeLessThan(readAt);
+  /**
+   * SWEEP every /staff surface that touches the table — not one hardcoded path. The first version
+   * pinned `/staff/compensation` alone, and `/staff/[id]` served the SAME salary, SSNIT and PAYE one
+   * click away on any colleague's row, falsifying this very test's message (Dex). Two legal shapes:
+   * gate the whole page, or never issue the query.
+   */
+  it("no /staff surface reads staffCompensation without proving STAFF_ADMIN_ROLES first", () => {
+    const dir = resolve(cwd(), "app/(app)/staff");
+    const pages: string[] = [];
+    const walk = (d: string) => {
+      for (const e of readdirSync(d, { withFileTypes: true })) {
+        const p = `${d}/${e.name}`;
+        if (e.isDirectory()) walk(p);
+        else if (e.name.endsWith(".tsx")) pages.push(p);
+      }
+    };
+    walk(dir);
+    expect(pages.length, "the /staff sweep found no pages").toBeGreaterThan(3);
+
+    const offenders: string[] = [];
+    for (const p of pages) {
+      const s = stripComments(readFileSync(p, "utf8"));
+      const query = s.search(/\.from\(\s*staffCompensation\s*\)/);
+      if (query === -1) continue; // this page never queries pay — nothing to gate
+      // `await` is required: `requireSchoolRole(...)` unawaited throws inside a floating promise and
+      // the page renders anyway (Dex). No type-aware lint rule catches that here.
+      const proof = s.search(
+        /await requireSchoolRole\(\s*STAFF_ADMIN_ROLES\s*\)|hasAnyRole\(\s*user\.roles\s*,\s*STAFF_ADMIN_ROLES\s*\)/,
+      );
+      if (proof === -1 || proof > query) offenders.push(p.slice(p.indexOf("app/")));
+    }
+    expect(offenders, "salaries, SSNIT and PAYE must not be readable by any staff member").toEqual([]);
   });
 
   /**
@@ -135,19 +180,27 @@ describe("the other two doors onto role_assignment", () => {
    * `ADMIN` to their own phone, accepted it, and `onConflictDoNothing` on `users.phone` stapled the
    * role onto their existing account. Closing `staff.ts` alone left the escalation fully open.
    */
-  it("createInvite refuses to mint a role the actor does not hold", () => {
+  it("a STAFF invite takes the same gate as addStaff; only PARENT invites stay staff-wide", () => {
     const s = read("lib/actions/invites.ts");
     const fn = s.slice(s.indexOf("export async function createInvite"));
     const body = fn.slice(0, fn.indexOf("\nexport "));
+    // Scoping this to ADMIN/HEADMASTER left MATRON (clinical write), VICE_HEADMASTER_ACADEMIC (the
+    // WASSCE freeze co-signer), DEAN_OF_BOARDING and the finance roles mintable by any teacher — the
+    // identical two-call exploit, one role over. The branch closes all of them with one rule.
     const check = body.search(
-      /hasAnyRole\(\s*\[\s*role\.code\s*\]\s*,\s*STAFF_ADMIN_ROLES\s*\)\s*&&\s*!\s*hasAnyRole\(\s*user\.roles\s*,\s*STAFF_ADMIN_ROLES\s*\)/,
+      /const canInvite = isParentRole\(d\.role\)\s*\?\s*isStaff\(user\.roles\)\s*:\s*hasAnyRole\(\s*user\.roles\s*,\s*STAFF_ADMIN_ROLES\s*\)/,
     );
-    expect(check, "an invite creates a real role_assignment — minting admin needs admin").toBeGreaterThan(-1);
+    expect(check, "an invite creates a real role_assignment — minting staff needs admin").toBeGreaterThan(-1);
     // Consequence, not just condition (the PR #176 lesson): the check must REFUSE.
-    expect(body.slice(check, check + 220)).toMatch(/return\s*\{\s*ok:\s*false/);
-    // …and it must refuse BEFORE the invite row is written.
+    expect(body.slice(check, check + 260)).toMatch(/if\s*\(\s*!canInvite\s*\)\s*\{[\s\S]{0,120}?return\s*\{\s*ok:\s*false/);
+    // Unconditional — base indent, nested inside nothing. The staff.ts sweep learned this; this
+    // describe had not inherited it, so a dead outer `if` disabled the check with the text intact.
+    expect(body.slice(body.lastIndexOf("\n", check) + 1, check + 20)).toMatch(/^ {2}const canInvite/);
+    // …and it must refuse BEFORE the invite row is written. No `if (write !== -1)` escape hatch:
+    // this file forbids skip-hatches and then contained two of them.
     const write = body.search(/tx\.insert\(invites\)/);
-    if (write !== -1) expect(check).toBeLessThan(write);
+    expect(write, "createInvite must still write the invite row").toBeGreaterThan(-1);
+    expect(check).toBeLessThan(write);
   });
 });
 

--- a/omnischools/lib/actions/staff-authz.test.ts
+++ b/omnischools/lib/actions/staff-authz.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { cwd } from "node:process";
+import { hasAnyRole, STAFF_ADMIN_ROLES } from "@/lib/access";
+import { STAFF_ROLES } from "@/lib/staff-roles";
+
+/**
+ * 🔴 Staff administration is ADMIN/HEADMASTER-only — a regression guard for a LIVE privilege
+ * escalation.
+ *
+ * Every mutator in `lib/actions/staff.ts` was gated by `requireSchool()` alone, which since PR #176
+ * means "authenticated + is staff" and nothing more. `ADMIN` is on the same assignable list that
+ * `/staff` renders for every row, so ANY staff member — a teacher, a librarian, a sports master —
+ * could open /staff, find their own row and make themselves Administrator in three clicks. No
+ * crafted request, no SQL. `saveStaffCompensation` and the compensation page leaked the school's
+ * whole payroll by the same gap.
+ *
+ * `role_assignment` is the authorization ROOT: `requireSchool`→`isStaff`, `requireSchoolRole`,
+ * `isFinanceOnly` and the sickbay clinical boundary all read it. An actor who can write it can grant
+ * themselves anything downstream — which is why this file pins the guard rather than trusting it.
+ *
+ * Three lessons from the PR #176 gate are baked in, each learned by getting it wrong first:
+ *  1. ASSERT THE CALL, NEVER THE NAME — a bare identifier also matches the import.
+ *  2. ASSERT THE CONSEQUENCE, NOT ONLY THE CONDITION — Quinn kept a pinned `if` and deleted the
+ *     `redirect` inside it; the leak reopened and every test stayed green. So test 3 below pins that
+ *     `assertAnyRole`'s check actually THROWS.
+ *  3. READ CODE, NOT COMMENTS — a docblock naming the guard must never satisfy the guard check.
+ */
+const ACTIONS = "lib/actions/staff.ts";
+const SERVER = "lib/auth/server.ts";
+const stripComments = (s: string) => s.replace(/\/\*[\s\S]*?\*\/|(?<!:)\/\/.*$/gm, "");
+const read = (p: string) => stripComments(readFileSync(resolve(cwd(), p), "utf8"));
+
+const GUARD = /\bassertAnyRole\s*\(\s*STAFF_ADMIN_ROLES\s*\)/;
+const TENANT_READ = /\bwithSchool\s*\(/;
+
+describe("every staff mutator is gated to STAFF_ADMIN_ROLES", () => {
+  const src = () => read(ACTIONS);
+
+  it("finds the mutators it claims to check (the sweep is not vacuous)", () => {
+    const names = [...src().matchAll(/^export async function (\w+)/gm)].map((m) => m[1]);
+    // 9 today. If a refactor moves or renames them this must fail loudly, not pass over an empty set.
+    expect(names).toContain("assignStaffRole");
+    expect(names.length).toBeGreaterThanOrEqual(9);
+  });
+
+  it("no mutator opens a tenant transaction before asserting the role", () => {
+    const s = src();
+    const marks = [...s.matchAll(/^export async function (\w+)/gm)];
+    const offenders: string[] = [];
+    marks.forEach((m, i) => {
+      const body = s.slice(m.index!, i + 1 < marks.length ? marks[i + 1].index! : s.length);
+      const guard = body.search(GUARD);
+      const tenantRead = body.search(TENANT_READ);
+      if (tenantRead === -1) return; // nothing to guard
+      if (guard === -1 || guard > tenantRead) offenders.push(m[1]);
+    });
+    expect(offenders, "these mutate staff data without first asserting the role").toEqual([]);
+  });
+
+  it("assertAnyRole REFUSES — the condition is not enough, it must throw", () => {
+    // The exact mutation that defeated the PR #176 guard: keep the `if`, delete its consequence.
+    const body = read(SERVER);
+    const fn = body.slice(body.indexOf("export async function assertAnyRole"));
+    const decl = fn.slice(0, fn.indexOf("\n}"));
+    expect(decl, "assertAnyRole must test the roles").toMatch(/!\s*hasAnyRole\s*\(/);
+    expect(decl, "assertAnyRole must THROW when the check fails").toMatch(
+      /if\s*\([\s\S]*?\)\s*\{[\s\S]*?\bthrow\b/,
+    );
+  });
+});
+
+describe("STAFF_ADMIN_ROLES has the polarity an authorization root needs", () => {
+  // hasAnyRole is the predicate assertAnyRole actually calls, so this is the real logic, not a proxy.
+  it("admits exactly the two administrator roles", () => {
+    expect(hasAnyRole(["ADMIN"], STAFF_ADMIN_ROLES)).toBe(true);
+    expect(hasAnyRole(["HEADMASTER"], STAFF_ADMIN_ROLES)).toBe(true);
+  });
+
+  it("refuses every other assignable staff role — including the ones that look senior", () => {
+    const admin = new Set<string>(STAFF_ADMIN_ROLES);
+    const others = STAFF_ROLES.map((r) => r.code).filter((c) => !admin.has(c));
+    expect(others.length).toBeGreaterThan(10); // the list is real, not empty
+    for (const role of others) {
+      expect(hasAnyRole([role], STAFF_ADMIN_ROLES), `${role} must not administer staff`).toBe(false);
+    }
+  });
+
+  it("refuses non-staff and empty sessions", () => {
+    expect(hasAnyRole(["TEACHER", "MATRON", "HOUSEMASTER"], STAFF_ADMIN_ROLES)).toBe(false);
+    expect(hasAnyRole(["PARENT"], STAFF_ADMIN_ROLES)).toBe(false);
+    expect(hasAnyRole([], STAFF_ADMIN_ROLES)).toBe(false);
+  });
+
+  it("an administrator who also teaches still administers", () => {
+    expect(hasAnyRole(["TEACHER", "ADMIN"], STAFF_ADMIN_ROLES)).toBe(true);
+  });
+});

--- a/omnischools/lib/actions/staff.ts
+++ b/omnischools/lib/actions/staff.ts
@@ -3,7 +3,8 @@ import { and, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 import { withSchool } from "@/lib/db/rls";
 import { recordAudit } from "@/lib/db/audit";
-import { requireSchool, resolveActor } from "@/lib/auth/server";
+import { requireSchool, resolveActor, assertAnyRole } from "@/lib/auth/server";
+import { STAFF_ADMIN_ROLES } from "@/lib/access";
 import { normalizeGhanaPhone } from "@/lib/auth";
 import { sendSms } from "@/lib/sms";
 import { sendEmail } from "@/lib/email";
@@ -147,6 +148,7 @@ const AddStaffSchema = z.object({
 
 export async function addStaff(input: unknown): Promise<Result> {
   const { school } = await requireSchool();
+  await assertAnyRole(STAFF_ADMIN_ROLES);
   const parsed = AddStaffSchema.safeParse(input);
   if (!parsed.success) {
     return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };
@@ -206,6 +208,7 @@ export async function importStaff(
   input: unknown,
 ): Promise<Result & { created?: number; invited?: number }> {
   const { school } = await requireSchool();
+  await assertAnyRole(STAFF_ADMIN_ROLES);
   const parsed = ImportStaffSchema.safeParse(input);
   if (!parsed.success) {
     return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid import" };
@@ -316,6 +319,7 @@ const SaveStaffProfileSchema = z.object({
 
 export async function saveStaffProfile(input: unknown): Promise<Result> {
   const { school } = await requireSchool();
+  await assertAnyRole(STAFF_ADMIN_ROLES);
   const parsed = SaveStaffProfileSchema.safeParse(input);
   if (!parsed.success) {
     return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };
@@ -353,6 +357,7 @@ const UpdateStaffSchema = z.object({
 
 export async function updateStaff(input: unknown): Promise<Result> {
   const { school } = await requireSchool();
+  await assertAnyRole(STAFF_ADMIN_ROLES);
   const parsed = UpdateStaffSchema.safeParse(input);
   if (!parsed.success) {
     return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };
@@ -463,6 +468,7 @@ const DeleteStaffSchema = z.object({ userId: z.string().uuid() });
 
 export async function deleteStaff(input: unknown): Promise<Result> {
   const { school } = await requireSchool();
+  await assertAnyRole(STAFF_ADMIN_ROLES);
   const parsed = DeleteStaffSchema.safeParse(input);
   if (!parsed.success) return { ok: false, error: "Invalid input" };
   const actor = await resolveActor(school.id);
@@ -497,6 +503,7 @@ export async function deleteStaffBulk(
   input: unknown,
 ): Promise<Result & { deleted?: number }> {
   const { school } = await requireSchool();
+  await assertAnyRole(STAFF_ADMIN_ROLES);
   const parsed = DeleteStaffBulkSchema.safeParse(input);
   if (!parsed.success) return { ok: false, error: "Select at least one staff member" };
   const ids = Array.from(new Set(parsed.data.userIds));
@@ -532,6 +539,7 @@ const AssignSchema = z.object({
 
 export async function assignStaffRole(input: unknown): Promise<Result> {
   const { school } = await requireSchool();
+  await assertAnyRole(STAFF_ADMIN_ROLES);
   const parsed = AssignSchema.safeParse(input);
   if (!parsed.success) return { ok: false, error: "Invalid input" };
   const role = resolveRole(parsed.data.role);
@@ -564,6 +572,7 @@ const RemoveSchema = z.object({ assignmentId: z.string().uuid() });
 
 export async function removeStaffRole(input: unknown): Promise<Result> {
   const { school } = await requireSchool();
+  await assertAnyRole(STAFF_ADMIN_ROLES);
   const parsed = RemoveSchema.safeParse(input);
   if (!parsed.success) return { ok: false, error: "Invalid input" };
   const actor = await resolveActor(school.id);
@@ -638,6 +647,7 @@ const SaveCompensationSchema = z.object({
 /** Upsert the current compensation record for a staff member at this school. */
 export async function saveStaffCompensation(input: unknown): Promise<Result> {
   const { school } = await requireSchool();
+  await assertAnyRole(STAFF_ADMIN_ROLES);
   const parsed = SaveCompensationSchema.safeParse(input);
   if (!parsed.success) {
     return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };


### PR DESCRIPTION
## The defect

Every mutator in `lib/actions/staff.ts` was gated by `requireSchool()` alone — which since #176 means **"authenticated + is staff"** and nothing more. `ADMIN` is on the same assignable list that `/staff` renders for every row.

**So any staff member — a teacher, a librarian, a sports master — could open `/staff`, find their own row, and make themselves Administrator.** Three clicks. No crafted request, no SQL.

`role_assignment` is the authorization root: `requireSchool`→`isStaff`, `requireSchoolRole`, `isFinanceOnly` and the sickbay clinical boundary's `chronic_clinical_role` all read it. An actor who can write it can grant themselves anything downstream.

Found by Sarah while security-reviewing INCR-23's third RLS boundary — as a way to defeat it by self-assigning `MATRON`. The wider consequence is full administrative takeover of the tenant, plus bulk staff deletion and payroll write access.

Same seam as #176, one layer up: #176 correctly made `requireSchool()` mean *is staff*; a **role-management** surface needs *is an administrator*, and nothing supplied it.

## The fix

`STAFF_ADMIN_ROLES = [ADMIN, HEADMASTER]`, asserted in all nine mutators before their first tenant read: `addStaff`, `importStaff`, `saveStaffProfile`, `updateStaff`, `deleteStaff`, `deleteStaffBulk`, `assignStaffRole`, `removeStaffRole`, `saveStaffCompensation`.

Also gates `/staff/compensation`, which exposed **every colleague's salary, SSNIT and PAYE** to any staff member. Reuses the existing `assertAnyRole` seam and the established role-group idiom — no new mechanism.

## Regression guard

`lib/actions/staff-authz.test.ts` pins the invariant rather than the instance, carrying all three lessons from the #176 gate:

- every mutator asserts the role **before** its first `withSchool(`
- **the consequence, not only the condition** — `assertAnyRole` must actually `throw` (the exact mutation that defeated the #176 guard: keep the `if`, delete its body)
- **code, not comments** — a docblock naming the guard must never satisfy the check
- the real predicate tested for real: every non-admin `STAFF_ROLES` entry is refused

**Mutation-proven, each fixture verified applied before its result was trusted:** guard removed → RED · guard present but moved *after* the read → RED · guard name left only in a comment → RED · `TEACHER` added to the group → RED · `throw` replaced with `return` → RED.

## Not fixed here

`settings.ts`, `billing.ts` and `invites.ts` have no role gate either — real, but not privilege escalation. Ticketed separately. The sickbay and boarding action files **do** guard (`authorizeClinicalWrite`, `holdsMatronRole`, `BOARDING_ROLES`); a narrow grep made them look bare.

## Gates

`typecheck 0` · **675 tests, 40 files** · `lint 0` · clean production build. No migration, no prod-paste SQL.

Not yet reviewed by Quinn or Dex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)