### PR TITLE
test(security): one source-shape dialect, and the 91-page sweep loses its skip-hatch

### DIFF
--- a/omnischools/lib/actions/staff-authz.test.ts
+++ b/omnischools/lib/actions/staff-authz.test.ts
@@ -3,6 +3,7 @@ import { readFileSync, readdirSync } from "node:fs";
 import { resolve } from "node:path";
 import { cwd } from "node:process";
 import { hasAnyRole, STAFF_ADMIN_ROLES } from "@/lib/access";
+import { stripComments, readCode, TENANT_READ } from "@/lib/test-utils/source-shape";
 import { STAFF_ROLES } from "@/lib/staff-roles";
 
 /**
@@ -29,17 +30,9 @@ import { STAFF_ROLES } from "@/lib/staff-roles";
  */
 const ACTIONS = "lib/actions/staff.ts";
 const SERVER = "lib/auth/server.ts";
-const stripComments = (s: string) => s.replace(/\/\*[\s\S]*?\*\/|(?<!:)\/\/.*$/gm, "");
-const read = (p: string) => stripComments(readFileSync(resolve(cwd(), p), "utf8"));
+const read = readCode;
 
 const GUARD = /\bassertAnyRole\s*\(\s*STAFF_ADMIN_ROLES\s*\)/;
-/**
- * Deliberately WIDER than `withSchool(` — Quinn shipped a `grantRoleBackdoor` using
- * `withoutTenantScope` that typechecked, built, passed all 675 tests, and handed a TEACHER `ADMIN`
- * on a production build. `withoutTenantScope` is not a strawman: it is the idiom `invites.ts` and
- * `onboarding.ts` already use for the very `role_assignment` writes that ARE the escalation.
- */
-const TENANT_READ = /\b(withSchool|withoutTenantScope|withParentScope|withStaffScope|db)\s*[.(]/;
 /**
  * Every export of a `"use server"` module is remotely callable — arrow consts and DEFAULT exports
  * included. Dex shipped an `export default async function grantAdminBackdoor` that matched neither

--- a/omnischools/lib/auth/app-shell-guard.test.ts
+++ b/omnischools/lib/auth/app-shell-guard.test.ts
@@ -3,6 +3,14 @@ import { readFileSync, readdirSync, existsSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 import { cwd } from "node:process";
 import { isStaff } from "@/lib/access";
+import {
+  TENANT_READ,
+  GUARD,
+  filesUnder,
+  guardBefore,
+  readCode,
+  stripComments,
+} from "@/lib/test-utils/source-shape";
 
 /**
  * `requireSchool()` is staff-only — a regression guard for a LIVE PII leak.
@@ -31,13 +39,7 @@ import { isStaff } from "@/lib/access";
  */
 const SERVER = "lib/auth/server.ts";
 
-/**
- * Strip comments so every assertion below matches CODE. `(?<!:)` keeps `https://…` inside a string
- * from swallowing the rest of its line — that would silently erase a real `withSchool(` and turn the
- * sweep's "no tenant read here" skip into exactly the false pass this exists to stop.
- */
-const stripComments = (s: string) => s.replace(/\/\*[\s\S]*?\*\/|(?<!:)\/\/.*$/gm, "");
-const src = () => stripComments(readFileSync(resolve(cwd(), SERVER), "utf8"));
+const src = () => readCode(SERVER);
 // Condition THROUGH consequence: a gate that tests the right thing and then does nothing is not a gate.
 const GATE =
   /if\s*\(\s*!opts\?\.allowNonStaff\s*&&\s*!\s*isStaff\s*\(\s*user\.roles\s*\)\s*\)\s*\{\s*redirect\s*\(/;
@@ -114,36 +116,20 @@ describe("requireSchool is staff-only by default", () => {
  * *nothing enforced* the property making them safe. Page 83, or one fetch hoisted above a guard,
  * silently reopens the hole that let a claimed parent read a child's medications.
  *
- * So: every page and API route that opens a tenant read must await a `require*` guard FIRST. A file
- * that performs no tenant read has nothing to guard and passes trivially — that also covers the
- * pages which delegate to a lib function that guards internally.
+ * So: every page and API route that opens a tenant read must await a `require*` guard FIRST.
  *
- * KNOWN BLIND SPOT, measured rather than assumed (Dex, PR #176): of 91 swept targets, 63 contain a
- * tenant read and are genuinely checked; 28 contain none and pass trivially. Of those 28, 26 carry a
- * guard anyway, one is `app/api/cron/health/route.ts` (no session, no tenant read — correctly
- * invisible), and one is the promotion page, which delegates to `previewPromotion()` and is guarded
- * inside it. So nothing is currently hiding there — but a page reading through a `-data.ts` helper
- * under `lib` that takes a `schoolId` and opens its own transaction WOULD be invisible to this sweep.
+ * 🔴 THE "NOTHING TO GUARD" SKIP IS GONE (PR #180). It used to say: a file with no recognised tenant
+ * read passes trivially. Dex measured the cost of that on PR #176 — 28 of 91 targets passed without
+ * being checked at all — and Quinn then PROVED it exploitable on the sibling guard by shipping a
+ * `grantRoleBackdoor` that used `withoutTenantScope`: it typechecked, built, passed the whole suite,
+ * and handed a TEACHER `ADMIN` on a production build. A file whose data access the sweep cannot
+ * RECOGNISE is exactly the case a backdoor falls into, so it can no longer be the case that passes
+ * silently.
  *
- * This is deliberately cheap and blunt. It passes today; its whole value is failing the day someone
- * adds a route that reads before it checks.
+ * The rule now: reach the database ⇒ guard first. Appear not to reach it ⇒ STILL carry a guard, or be
+ * named in `NO_DB_ACCESS` by a human who looked. Of the 28, 26 already carried a guard and pass
+ * unchanged; the two that did not are named below with their reasons.
  */
-const TENANT_READ = /\b(withSchool|withParentScope|withoutTenantScope|withStaffScope)\s*\(/;
-const GUARD = /\b(requireSchool|requireSchoolRole|requireParent|requireUser)\s*\(/;
-
-function filesUnder(dir: string, match: RegExp): string[] {
-  const out: string[] = [];
-  const walk = (d: string) => {
-    for (const e of readdirSync(resolve(cwd(), d), { withFileTypes: true })) {
-      const p = `${d}/${e.name}`;
-      if (e.isDirectory()) walk(p);
-      else if (match.test(e.name)) out.push(p);
-    }
-  };
-  walk(dir);
-  return out;
-}
-
 describe("every tenant read is preceded by an auth guard", () => {
   const targets = [
     ...filesUnder("app/(app)", /^page\.tsx$/),
@@ -163,17 +149,37 @@ describe("every tenant read is preceded by an auth guard", () => {
    */
   const SECRET_AUTHED = ["app/api/inbox/inbound/route.ts"];
 
-  it("no page or route opens a tenant transaction before awaiting a guard", () => {
+  /**
+   * The two targets that reach no database AND hold no session guard. Named, not skipped — each has
+   * to be justifiable out loud, and a third appearing is a diff line someone must defend.
+   *  · the promotion page delegates to `previewPromotion()`, which calls `requireSchool()` itself
+   *    (`lib/actions/promotion.ts`) — guarded, just not in the file.
+   *  · the cron health check has no session and no tenant data by design.
+   */
+  const NO_DB_ACCESS = [
+    "app/(app)/settings/academic/promotion/page.tsx",
+    "app/api/cron/health/route.ts",
+  ];
+
+  it("no page or route touches the database before awaiting a guard", () => {
     const offenders: string[] = [];
     for (const p of targets) {
-      if (SECRET_AUTHED.includes(p)) continue;
-      const src = stripComments(readFileSync(resolve(cwd(), p), "utf8"));
-      const read = src.search(TENANT_READ);
-      if (read === -1) continue; // no tenant read here — nothing to guard
-      const guard = src.search(GUARD);
-      if (guard === -1 || guard > read) offenders.push(p);
+      if (SECRET_AUTHED.includes(p) || NO_DB_ACCESS.includes(p)) continue;
+      const v = guardBefore(readCode(p));
+      if (!v.ok) offenders.push(`${p} (${v.why})`);
     }
     expect(offenders, "these read tenant data before (or without) an auth guard").toEqual([]);
+  });
+
+  it("the NO_DB_ACCESS exemptions are still earned — none of them has grown a database read", () => {
+    // An exemption that silently starts querying is the failure this list would otherwise cause.
+    for (const p of NO_DB_ACCESS) {
+      expect(targets, `${p} is exempted but no longer swept`).toContain(p);
+      expect(
+        readCode(p),
+        `${p} now reaches the database — it must guard, or leave this list`,
+      ).not.toMatch(TENANT_READ);
+    }
   });
 
   it("every secret-authed exemption actually checks its secret, REFUSES, and does both before reading", () => {
@@ -185,7 +191,7 @@ describe("every tenant read is preceded by an auth guard", () => {
     // penalises the safer implementation gets worked around instead of updated. What must hold is
     // only: the condition consults the secret, and the block REFUSES.
     for (const p of SECRET_AUTHED) {
-      const src = stripComments(readFileSync(resolve(cwd(), p), "utf8"));
+      const src = readCode(p);
       const m = /if\s*\([\s\S]{0,200}?env\.\w*SECRET\w*[\s\S]{0,200}?\)\s*\{/.exec(src);
       expect(m, `${p}: expected a shared-secret check consulting env.*SECRET*`).not.toBeNull();
       const check = m!.index;
@@ -195,7 +201,8 @@ describe("every tenant read is preceded by an auth guard", () => {
         `${p}: the secret check must FAIL CLOSED — refuse with 401/403`,
       ).toMatch(/\b40[13]\b/);
       const read = src.search(TENANT_READ);
-      if (read !== -1) expect(check, `${p}: secret check must precede the tenant read`).toBeLessThan(read);
+      expect(read, `${p}: this route is exempted because it READS under a shared secret`).toBeGreaterThan(-1);
+      expect(check, `${p}: secret check must precede the tenant read`).toBeLessThan(read);
     }
   });
 });

--- a/omnischools/lib/test-utils/source-shape.ts
+++ b/omnischools/lib/test-utils/source-shape.ts
@@ -1,0 +1,91 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { cwd } from "node:process";
+
+/**
+ * Shared primitives for the repo's SOURCE-SHAPE security guards.
+ *
+ * These tests assert that code has a given *shape* — a guard call before a tenant read — rather than
+ * a behaviour. That is the right instrument for an invariant about ordering across ~90 files (a
+ * behavioural version needs a fixture, a DB and a session per role, and gets abandoned within two
+ * increments), but it only works if every guard reads the source the same way.
+ *
+ * It exists because they did NOT. Three copies of `stripComments` drifted, and `TENANT_READ` was
+ * defined twice with the WIDER one on the SMALLER sweep: `staff-authz.test.ts` (9 actions) learned
+ * from Quinn's `withoutTenantScope` backdoor and widened; `app-shell-guard.test.ts` (91 pages) kept
+ * the narrow one and the `if (read === -1) continue` hatch that backdoor walked through. A hardening
+ * has to land once, in one place, or the guard with ten times the blast radius is the one left stale.
+ *
+ * `lib/sickbay/board-copy.test.ts` deliberately keeps its own stripper: it strips MARKUP from surface
+ * HTML for a copy-fidelity check, which is a different job with different edge cases.
+ */
+
+/**
+ * Strip comments so an assertion matches CODE.
+ *
+ * Two lessons are baked in, both from real false passes:
+ *  · Dex found `app/api/senior/readiness-statement/[id]/route.ts` matching `withParentScope` inside
+ *    PROSE. A file whose docblock names a guard above a genuinely unguarded read certified clean —
+ *    a false PASS, the dangerous direction.
+ *  · `(?<!:)` keeps `https://…` inside a string literal from swallowing the rest of its line. Without
+ *    it the stripper erases a real `withSchool(` and turns "no tenant read here" into exactly the
+ *    silent skip this module exists to remove.
+ */
+export const stripComments = (s: string): string =>
+  s.replace(/\/\*[\s\S]*?\*\/|(?<!:)\/\/.*$/gm, "");
+
+/** Read a repo-relative path as comment-stripped source. */
+export const readCode = (p: string): string =>
+  stripComments(readFileSync(resolve(cwd(), p), "utf8"));
+
+/**
+ * Anything that reaches the database.
+ *
+ * Deliberately wider than the four `with*` helpers, and matching `.` as well as `(`. Quinn shipped a
+ * `grantRoleBackdoor` using `withoutTenantScope` that typechecked, built, passed the whole suite and
+ * handed a TEACHER `ADMIN` on a production build — `withoutTenantScope` is not a strawman, it is the
+ * idiom `invites.ts` and `onboarding.ts` already use for the `role_assignment` writes that ARE the
+ * escalation. `db` catches nothing today (measured: 0 of 91); it is there so a page reaching past the
+ * RLS helpers to the raw driver — which would be UNTENANTED, worse than merely unguarded — is visible
+ * the day someone writes one.
+ */
+export const TENANT_READ =
+  /\b(withSchool|withParentScope|withoutTenantScope|withStaffScope|db)\s*[.(]/;
+
+/** The session guards. Every one of them resolves identity before returning. */
+export const GUARD = /\b(requireSchool|requireSchoolRole|requireParent|requireUser)\s*\(/;
+
+/** Walk a directory, returning repo-relative paths whose basename matches. */
+export function filesUnder(dir: string, match: RegExp): string[] {
+  const out: string[] = [];
+  const walk = (d: string) => {
+    for (const e of readdirSync(resolve(cwd(), d), { withFileTypes: true })) {
+      const p = `${d}/${e.name}`;
+      if (e.isDirectory()) walk(p);
+      else if (match.test(e.name)) out.push(p);
+    }
+  };
+  walk(dir);
+  return out;
+}
+
+export type GuardVerdict =
+  | { ok: true; why: "guarded" | "no-db-access-but-guarded" }
+  | { ok: false; why: "reads-before-guard" | "reads-unguarded" | "no-guard-at-all" };
+
+/**
+ * Does this source prove a guard runs before it touches the database?
+ *
+ * 🔴 THERE IS NO "NOTHING TO GUARD" SKIP, and that absence is the whole point. The previous form —
+ * `if (read === -1) continue` — meant a file whose data access the sweep could not RECOGNISE passed
+ * silently, which is precisely the case a new backdoor falls into. A file that reaches the database
+ * must guard first; a file that appears not to reach it must STILL carry a guard, or be named in an
+ * explicit exemption list by a human who looked at it.
+ */
+export function guardBefore(code: string): GuardVerdict {
+  const read = code.search(TENANT_READ);
+  const guard = code.search(GUARD);
+  if (guard === -1) return { ok: false, why: read === -1 ? "no-guard-at-all" : "reads-unguarded" };
+  if (read === -1) return { ok: true, why: "no-db-access-but-guarded" };
+  return guard < read ? { ok: true, why: "guarded" } : { ok: false, why: "reads-before-guard" };
+}


### PR DESCRIPTION
Dex's follow-up from #177. No production code changes — this hardens the guards themselves.

## The problem

Three copies of `stripComments` had drifted, and `TENANT_READ` was defined twice **with the wider one on the smaller sweep**:

- `staff-authz.test.ts` (9 actions) learned from Quinn's `withoutTenantScope` backdoor and widened.
- `app-shell-guard.test.ts` (**91 pages**) kept the narrow regex *and* the `if (read === -1) continue` hatch that the same backdoor walked through.

The lesson had been learned twice on the small file and never reached the guard with ten times the blast radius.

## The hatch

It used to say: a file with no recognised tenant read passes trivially. **A file whose data access the sweep cannot *recognise* is exactly the case a backdoor falls into** — Quinn proved that on the sibling guard by shipping a `grantRoleBackdoor` using `withoutTenantScope` that typechecked, built, passed the whole suite, and handed a TEACHER `ADMIN` on a production build.

Measured before changing anything: of 91 targets, **28** had no recognised read and passed unchecked. **26 already carry a guard** and pass unchanged. The **2** that don't are now named in `NO_DB_ACCESS` with their reasons — the promotion page guards inside `previewPromotion()`, and the cron health check has no session by design. A second test proves those exemptions stay earned by failing if either grows a database read. The secret-authed exemption had its own `if (read !== -1)` escape; that's gone too.

`TENANT_READ` also now matches `db.` — measured as catching **0 of 91** today, and included so a page reaching past the RLS helpers to the raw driver (which would be *untenanted*, worse than merely unguarded) is visible the day someone writes one.

## Verification

Fixtures created and verified non-empty before each run:

| mutation | result |
|---|---|
| page with no recognised read and no guard — **the newly-closed hatch** | **RED** `(no-guard-at-all)` |
| the same page **with** a guard — the control 26 real files depend on | **GREEN** |
| raw `db.` driver access, unguarded | **RED** `(reads-unguarded)` |
| a `NO_DB_ACCESS` exemption grows a database read | **RED** |

`typecheck 0` · **696 tests, 42 files** · `lint 0` · clean production build.

## Deliberately not consolidated

`lib/sickbay/board-copy.test.ts` keeps its own stripper: it strips **markup** from surface HTML for a copy-fidelity check — a different job with different edge cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)