### PR TITLE
docs(legal): Ghana Act 843 Privacy Policy + Terms of Service (drafts) + footer fix

### DIFF
--- a/omnischools/app/(marketing)/privacy/page.tsx
+++ b/omnischools/app/(marketing)/privacy/page.tsx
@@ -179,11 +179,7 @@ const sections: Section[] = [
         personal data is transferred outside Ghana for storage and processing. We rely on the
         provider&rsquo;s contractual and technical safeguards for that transfer, consistent with the
         cross-border-transfer provisions of Act 843. If we change where data is hosted, we will
-        update this policy.{" "}
-        <span className="text-navy-3">
-          [Note for review: any public claim that data is &ldquo;resident in Ghana&rdquo; must be
-          reconciled with EU hosting before launch.]
-        </span>
+        update this policy.
       </p>
     ),
   },

--- a/omnischools/app/(marketing)/privacy/page.tsx
+++ b/omnischools/app/(marketing)/privacy/page.tsx
@@ -3,63 +3,339 @@ import Link from "next/link";
 
 export const metadata: Metadata = {
   title: "Privacy Policy",
-  description: "How Omnischools collects, uses and protects school data.",
+  description: "How Omnischools collects, uses and protects school data under Ghana's Data Protection Act, 2012 (Act 843).",
 };
 
-const sections: { h: string; p: string }[] = [
+// Document metadata — bump VERSION and EFFECTIVE_DATE when the copy is revised.
+const EFFECTIVE_DATE = "20 July 2026";
+const VERSION = "Draft v0.1 — pending legal review";
+
+const CONTACT_EMAIL = "hello@omnischools.gh";
+
+type Section = { h: string; id?: string; body: React.ReactNode };
+
+const sections: Section[] = [
   {
-    h: "1. What we collect",
-    p: "To run a school we store the records you enter — student and guardian details, staff profiles, classes and subjects, attendance, grades, fees and payments, and communications sent through the platform. We also collect basic account data (name, phone, role) for the people who sign in.",
+    h: "1. Who we are, and our two roles",
+    body: (
+      <>
+        <p>
+          Omnischools is a school-management platform operated by [LEGAL ENTITY NAME], a company
+          registered in Ghana (registration no. [COMPANY REG NO.]), of [REGISTERED OFFICE ADDRESS]
+          (&ldquo;Omnischools&rdquo;, &ldquo;we&rdquo;, &ldquo;us&rdquo;). This policy explains how
+          personal data is handled on the platform. It is written to align with Ghana&rsquo;s Data
+          Protection Act, 2012 (Act 843).
+        </p>
+        <p className="mt-2">
+          We act in <strong>two different roles</strong>, and your rights depend on which applies:
+        </p>
+        <ul className="mt-2 list-disc space-y-1 pl-5">
+          <li>
+            <strong>As a data processor</strong>, for the records a school enters about its
+            students, guardians and applicants. The <em>school</em> is the data controller — it
+            decides what to collect and why, and it is responsible for having a lawful basis. We
+            process that data <em>only</em> on the school&rsquo;s instructions, to provide the
+            service.
+          </li>
+          <li>
+            <strong>As a data controller</strong>, for a narrower set of data we decide the purposes
+            of ourselves: the account details of staff who sign in (name, phone, email, role),
+            platform usage and security logs, and enquiries submitted through our marketing or demo
+            forms.
+          </li>
+        </ul>
+      </>
+    ),
   },
   {
-    h: "2. How we use it",
-    p: "Data is used solely to provide the service to your school: showing your records, generating report cards and invoices, sending the SMS and messages you initiate, and producing the reports you ask for. We do not sell your data or use it for advertising.",
+    h: "2. The data we handle, and whose it is",
+    body: (
+      <>
+        <p>
+          A school&rsquo;s use of Omnischools involves the following categories of personal data.
+          Much of it concerns <strong>children</strong>, and some of it is{" "}
+          <strong>sensitive</strong> (health and financial information).
+        </p>
+        <ul className="mt-2 list-disc space-y-1 pl-5">
+          <li>
+            <strong>Students (minors):</strong> name, date of birth, sex, student ID, class,
+            programme, enrolment status and boarding/residency details.
+          </li>
+          <li>
+            <strong>Student health records (sensitive):</strong> blood group, allergies, chronic
+            conditions, current medications, and an emergency contact — where a school chooses to
+            record them.
+          </li>
+          <li>
+            <strong>Guardians / parents:</strong> name, relationship, phone number and email.
+          </li>
+          <li>
+            <strong>Applicants:</strong> the details submitted on an admission application (child
+            and guardian) and any supporting-document references.
+          </li>
+          <li>
+            <strong>Academic records:</strong> attendance (including reason codes such as medical or
+            excused), gradebook scores, report cards and, for senior schools, the score ledger.
+          </li>
+          <li>
+            <strong>Financial records:</strong> invoices, payments, receipts and discounts recorded
+            against a student.
+          </li>
+          <li>
+            <strong>Staff:</strong> profile details (which may include date of birth, gender,
+            address, emergency contact and qualifications) and, where a school uses it, compensation
+            information (salary, SSNIT and PAYE figures).
+          </li>
+          <li>
+            <strong>Communications:</strong> the phone numbers, message content and delivery logs of
+            SMS and in-app messages a school sends or receives through the platform.
+          </li>
+          <li>
+            <strong>Account &amp; security data (we control):</strong> the name, phone, email and
+            role of each user who signs in, and audit logs of actions taken — which include the
+            actor, timestamp, and the IP address and browser (user-agent) of the request.
+          </li>
+        </ul>
+      </>
+    ),
   },
   {
-    h: "3. Tenant isolation",
-    p: "Each school's data is logically isolated. Row-level security ensures one school can never read or write another school's records. Staff only see the data their role grants within their own school.",
+    h: "3. How and why we use it",
+    body: (
+      <p>
+        We use this data solely to provide the service to your school: to display your records,
+        generate report cards, invoices and receipts, send the SMS and messages you initiate,
+        produce the reports you request, authenticate the people who sign in, and keep the platform
+        secure. <strong>We do not sell your data, and we do not use it for advertising.</strong> We
+        do not use the personal data a school enters to train artificial-intelligence models.
+      </p>
+    ),
   },
   {
-    h: "4. Guardians & minors",
-    p: "Much of the data concerns children. Schools are responsible for having a lawful basis to enter student data. Guardians can be invited to view their own child's records; they do not see other students.",
+    h: "4. The service providers we share data with",
+    body: (
+      <>
+        <p>
+          To run the platform we rely on a small number of trusted providers (&ldquo;sub-processors&rdquo;).
+          Each receives only the data it needs for its function, and only to help us deliver the
+          service:
+        </p>
+        <div className="mt-3 overflow-x-auto">
+          <table className="w-full min-w-[520px] border-collapse text-left text-[13px]">
+            <thead>
+              <tr className="border-b border-border text-[11px] uppercase tracking-wide text-navy-3">
+                <th className="py-2 pr-4 font-semibold">Provider</th>
+                <th className="py-2 pr-4 font-semibold">Purpose</th>
+                <th className="py-2 font-semibold">Data shared</th>
+              </tr>
+            </thead>
+            <tbody className="align-top text-navy-2">
+              <tr className="border-b border-border">
+                <td className="py-2 pr-4 font-semibold text-navy">Supabase</td>
+                <td className="py-2 pr-4">Database, authentication and file storage</td>
+                <td className="py-2">All platform data; phone numbers for sign-in (hosted in the EU — see section 5)</td>
+              </tr>
+              <tr className="border-b border-border">
+                <td className="py-2 pr-4 font-semibold text-navy">Vercel</td>
+                <td className="py-2 pr-4">Application hosting</td>
+                <td className="py-2">Processes requests to the platform; does not retain your records</td>
+              </tr>
+              <tr className="border-b border-border">
+                <td className="py-2 pr-4 font-semibold text-navy">Hubtel (and the SMS provider for sign-in codes)</td>
+                <td className="py-2 pr-4">Delivering SMS messages and one-time sign-in codes</td>
+                <td className="py-2">Recipient phone number and the message content being sent</td>
+              </tr>
+              <tr className="border-b border-border">
+                <td className="py-2 pr-4 font-semibold text-navy">Resend</td>
+                <td className="py-2 pr-4">Sending transactional email (e.g. staff invitations)</td>
+                <td className="py-2">Recipient email address and message content</td>
+              </tr>
+              <tr className="border-b border-border">
+                <td className="py-2 pr-4 font-semibold text-navy">Anthropic</td>
+                <td className="py-2 pr-4">Reading handwritten score sheets a teacher photographs, to transcribe the marks</td>
+                <td className="py-2">The photograph and class roster, sent for that single transcription; the image is not stored by us or retained for model training</td>
+              </tr>
+              <tr>
+                <td className="py-2 pr-4 font-semibold text-navy">Error &amp; usage analytics</td>
+                <td className="py-2 pr-4">Diagnosing faults and understanding usage (only if enabled)</td>
+                <td className="py-2">Not currently enabled; when enabled, would carry error context and usage events, not your student records</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p className="mt-3 text-[13px] text-navy-3">
+          We keep this list current; we will give schools notice before adding a sub-processor that
+          materially changes how data is handled.
+        </p>
+      </>
+    ),
   },
   {
-    h: "5. SMS & communications",
-    p: "When you send messages, the recipient's phone number is shared with our SMS provider only to deliver that message. Message content you compose is stored so you have a record of what was sent.",
+    h: "5. Where your data is stored, and cross-border transfer",
+    body: (
+      <p>
+        Your data is currently hosted by Supabase in a data centre in the{" "}
+        <strong>European Union (London region)</strong>, chosen for proximity to Ghana. This means
+        personal data is transferred outside Ghana for storage and processing. We rely on the
+        provider&rsquo;s contractual and technical safeguards for that transfer, consistent with the
+        cross-border-transfer provisions of Act 843. If we change where data is hosted, we will
+        update this policy.{" "}
+        <span className="text-navy-3">
+          [Note for review: any public claim that data is &ldquo;resident in Ghana&rdquo; must be
+          reconciled with EU hosting before launch.]
+        </span>
+      </p>
+    ),
   },
   {
-    h: "6. Retention & export",
-    p: "We keep your data for as long as your school uses Omnischools, plus any period set by your retention policy. You can export your records at any time, and request deletion when you leave the platform.",
+    h: "6. Children&rsquo;s data and lawful basis",
+    body: (
+      <p>
+        Much of the data on the platform concerns children. Because we act as a{" "}
+        <strong>processor</strong> for that data, each school is responsible for having a lawful
+        basis to collect and enter it — including obtaining parental or guardian consent where the
+        law requires it — and for telling parents how their child&rsquo;s data is used. We handle
+        children&rsquo;s data only as needed to provide the service to the school. Guardians can be
+        invited to view their own child&rsquo;s records; they cannot see other students.
+      </p>
+    ),
   },
   {
-    h: "7. Security",
-    p: "Data is encrypted in transit. Access is limited to authorised staff and audited. We follow reasonable measures to protect against unauthorised access, consistent with Ghana's Data Protection Act.",
+    h: "7. Your rights under Act 843",
+    id: "data-protection",
+    body: (
+      <>
+        <p>
+          Under Ghana&rsquo;s Data Protection Act, 2012 (Act 843), individuals have rights over their
+          personal data, including the right to be informed, to access their data, to correct
+          inaccurate data, to object to processing, and to request deletion.
+        </p>
+        <p className="mt-2">
+          Because a school is usually the data <strong>controller</strong> for student, guardian and
+          staff records, requests about that data are normally directed to the school, and we will
+          assist the school in responding. For data we control (your sign-in account and enquiries
+          you send us), you can contact us directly at{" "}
+          <a href={`mailto:${CONTACT_EMAIL}`} className="font-semibold text-gold hover:underline">
+            {CONTACT_EMAIL}
+          </a>
+          .
+        </p>
+        <p className="mt-2">
+          You may also lodge a complaint with Ghana&rsquo;s Data Protection Commission, the
+          supervisory authority for Act 843. Our data-protection contact is [DPO / CONTACT NAME], and
+          our registration with the Data Protection Commission is [DPC REGISTRATION NUMBER — or
+          &ldquo;in progress&rdquo;].
+        </p>
+      </>
+    ),
   },
   {
-    h: "8. Contact",
-    p: "Privacy questions or data requests can be sent to hello@omnischools.gh.",
+    h: "8. Retention, deletion and export",
+    body: (
+      <p>
+        We keep your data for as long as your school uses Omnischools. Each school can set a
+        retention preference in its settings; today that preference is{" "}
+        <strong>recorded for compliance but not yet enforced automatically</strong> — automatic
+        purging is planned for a future release, and until then nothing is deleted on a schedule. You
+        can export your key records (students, staff and fee structures) to CSV at any time, and you
+        can ask us to delete your data when you leave the platform. When a school&rsquo;s account is
+        closed, its records — including students, guardians, health, financial, academic,
+        communications and audit data — are removed.
+      </p>
+    ),
+  },
+  {
+    h: "9. How we protect your data",
+    body: (
+      <>
+        <p>
+          We design the platform to keep each school&rsquo;s data separate and to limit who can see
+          what:
+        </p>
+        <ul className="mt-2 list-disc space-y-1 pl-5">
+          <li>
+            <strong>Strict tenant isolation.</strong> Every school&rsquo;s records are separated at
+            the database level using row-level security, enforced so that a query without the correct
+            school context returns nothing rather than another school&rsquo;s data. Records are also
+            keyed so that a reference across two schools is not structurally possible.
+          </li>
+          <li>
+            <strong>Role-based access.</strong> Staff see only what their role allows within their own
+            school; finance roles are confined to billing, and students and parents cannot reach staff
+            areas.
+          </li>
+          <li>
+            <strong>Auditing.</strong> Changes are recorded in an append-only audit log capturing who
+            did what and when.
+          </li>
+          <li>
+            <strong>Encryption in transit.</strong> Data is encrypted while travelling between your
+            device and the platform. Data at rest is protected by the encryption our hosting provider
+            applies at the storage layer.{" "}
+            <span className="text-navy-3">
+              We do not currently apply additional field-level encryption to individual columns such
+              as health or salary data.
+            </span>
+          </li>
+        </ul>
+        <p className="mt-2">
+          No system can be guaranteed perfectly secure, but we take reasonable measures to protect
+          against unauthorised access, consistent with Act 843.
+        </p>
+      </>
+    ),
+  },
+  {
+    h: "10. Cookies and sessions",
+    body: (
+      <p>
+        When you sign in, we use a session cookie to keep you signed in. It is necessary for the
+        service to work and is not used for advertising or cross-site tracking.
+      </p>
+    ),
+  },
+  {
+    h: "11. Changes and contact",
+    body: (
+      <p>
+        We may update this policy as the platform evolves; we will communicate material changes to
+        school administrators. Privacy questions or data requests can be sent to{" "}
+        <a href={`mailto:${CONTACT_EMAIL}`} className="font-semibold text-gold hover:underline">
+          {CONTACT_EMAIL}
+        </a>
+        .
+      </p>
+    ),
   },
 ];
 
 export default function PrivacyPage() {
   return (
     <main className="mx-auto max-w-content px-6 py-16">
-      <div className="mb-3 text-[11px] font-bold uppercase tracking-[0.18em] text-gold">
-        Legal
-      </div>
+      <div className="mb-3 text-[11px] font-bold uppercase tracking-[0.18em] text-gold">Legal</div>
       <h1 className="font-display text-4xl font-semibold text-navy">
         Privacy <em className="not-italic text-gold [font-style:italic]">Policy.</em>
       </h1>
       <p className="mt-3 max-w-2xl text-sm text-navy-3">
-        How school data is collected, used and protected on Omnischools. This is a starting
-        template — replace with your reviewed legal copy before launch.
+        How school data is collected, used and protected on Omnischools, under Ghana&rsquo;s Data
+        Protection Act, 2012 (Act 843).
       </p>
+      <p className="mt-2 text-[12px] text-navy-3">
+        Effective {EFFECTIVE_DATE} · {VERSION}
+      </p>
+
+      <div className="mt-6 max-w-2xl rounded-lg border border-gold-soft bg-gold-bg px-4 py-3 text-[13px] leading-relaxed text-navy-2">
+        <strong>Draft for review — not legal advice.</strong> This is a working draft grounded in how
+        the platform operates. It must be reviewed by a qualified Ghanaian lawyer, and registration
+        with the Data Protection Commission confirmed, before it is published. Bracketed [ ] items
+        are placeholders to be completed.
+      </div>
 
       <div className="mt-10 space-y-7">
         {sections.map((s) => (
-          <section key={s.h}>
+          <section key={s.h} id={s.id}>
             <h2 className="font-display text-lg font-semibold text-navy">{s.h}</h2>
-            <p className="mt-1.5 max-w-2xl text-sm leading-relaxed text-navy-2">{s.p}</p>
+            <div className="mt-1.5 max-w-2xl text-sm leading-relaxed text-navy-2">{s.body}</div>
           </section>
         ))}
       </div>

--- a/omnischools/app/(marketing)/terms/page.tsx
+++ b/omnischools/app/(marketing)/terms/page.tsx
@@ -3,63 +3,194 @@ import Link from "next/link";
 
 export const metadata: Metadata = {
   title: "Terms of Service",
-  description: "The terms governing your use of Omnischools.",
+  description: "The terms governing a school's use of Omnischools.",
 };
 
-const sections: { h: string; p: string }[] = [
+// Document metadata — bump VERSION and EFFECTIVE_DATE when the copy is revised.
+const EFFECTIVE_DATE = "20 July 2026";
+const VERSION = "Draft v0.1 — pending legal review";
+
+const CONTACT_EMAIL = "hello@omnischools.gh";
+
+type Section = { h: string; body: React.ReactNode };
+
+const sections: Section[] = [
   {
     h: "1. Agreement",
-    p: "By creating a school on Omnischools and using the platform, the school and its authorised users agree to these Terms of Service. If you are accepting on behalf of a school, you confirm you are authorised to bind that school.",
+    body: (
+      <p>
+        These Terms of Service are a contract between [LEGAL ENTITY NAME] (&ldquo;Omnischools&rdquo;,
+        &ldquo;we&rdquo;, &ldquo;us&rdquo;), a company registered in Ghana, and the school that
+        creates an account (&ldquo;you&rdquo;, &ldquo;your school&rdquo;). By creating a school on
+        Omnischools and using the platform, your school and its authorised users agree to these
+        Terms. If you are accepting on behalf of a school, you confirm you are authorised to bind
+        that school.
+      </p>
+    ),
   },
   {
-    h: "2. Your account",
-    p: "Each user signs in with their own phone number and credentials. You are responsible for keeping access credentials secure and for activity carried out under your account. Notify us promptly of any unauthorised use.",
+    h: "2. Your account and security",
+    body: (
+      <p>
+        Each user signs in with their own phone number, using a one-time code or a password. You are
+        responsible for keeping sign-in credentials secure, for ensuring only appropriate staff have
+        accounts, and for activity carried out under your school&rsquo;s accounts. Notify us promptly
+        of any unauthorised use.
+      </p>
+    ),
   },
   {
     h: "3. Acceptable use",
-    p: "You agree to use Omnischools only for the lawful administration of your school — managing students, staff, fees, attendance, grades and communications. You will not misuse the platform, attempt to access other schools' data, or interfere with its operation.",
+    body: (
+      <p>
+        You agree to use Omnischools only for the lawful administration of your school — managing
+        students, staff, fees, attendance, grades and communications. You will not misuse the
+        platform, attempt to access another school&rsquo;s data, send unlawful or unsolicited
+        messages, or interfere with the platform&rsquo;s operation or security.
+      </p>
+    ),
   },
   {
-    h: "4. Your data",
-    p: "Your school owns the records it enters. We process them on your behalf to provide the service, under the Privacy Policy. Each school's data is isolated from every other school's. You may export your data at any time.",
+    h: "4. Your data and our role",
+    body: (
+      <p>
+        Your school owns the records it enters. For the data your school enters about students,
+        guardians and applicants, your school is the data controller and we act as your{" "}
+        <strong>data processor</strong> — we process that data only to provide the service, as set
+        out in the{" "}
+        <Link href="/privacy" className="font-semibold text-gold hover:underline">
+          Privacy Policy
+        </Link>
+        . Each school&rsquo;s data is isolated from every other school&rsquo;s. You may export your
+        data at any time.
+      </p>
+    ),
   },
   {
-    h: "5. Fees & billing",
-    p: "Fee structures, amounts and payment channels you configure are yours to set and collect. Omnischools facilitates record-keeping and, where enabled, payment reconciliation; it is not a party to the fees owed between a school and its parents.",
+    h: "5. Subscription and fees",
+    body: (
+      <>
+        <p>
+          Omnischools is offered on a freemium basis. New schools begin with a 30-day free trial, and
+          a free tier remains available. Paid tiers are charged per student for each academic period
+          (per term, or per semester for senior schools), billed at the start of the period, with no
+          setup fee and no per-user minimum. Prices are as shown on our pricing page and may change on
+          reasonable notice.
+        </p>
+        <p className="mt-2">
+          You can cancel at any time; your paid features continue until the end of the period you have
+          paid for. Fees are exclusive of any taxes or levies that may apply. If a payment for a paid
+          tier is not made when due, we may suspend paid features after notice, while leaving your
+          data available for export. Subscription payments to Omnischools are made by [SUBSCRIPTION
+          PAYMENT METHOD — placeholder].
+        </p>
+      </>
+    ),
   },
   {
-    h: "6. Availability",
-    p: "We work to keep Omnischools available and accurate, but the service is provided on an “as is” basis. We are not liable for indirect or consequential loss arising from use of the platform, to the extent permitted by Ghanaian law.",
+    h: "6. School and parent fees are separate",
+    body: (
+      <p>
+        The fee structures, amounts and payment channels your school configures for its own parents
+        are yours to set and collect. Omnischools facilitates record-keeping and, where enabled,
+        reconciliation of payments made through a Bank of Ghana-licensed payment gateway; it is{" "}
+        <strong>not a party</strong> to the fees owed between a school and its parents, and is not
+        responsible for collecting them.
+      </p>
+    ),
   },
   {
-    h: "7. Changes",
-    p: "We may update these terms as the platform evolves. Material changes will be communicated to school administrators. Continued use after a change constitutes acceptance.",
+    h: "7. Automated transcription of score sheets",
+    body: (
+      <p>
+        Where a teacher photographs a handwritten score sheet, the platform may use a third-party
+        artificial-intelligence service to transcribe the marks. The image is sent for that single
+        transcription and is not stored by us afterwards. You are responsible for checking transcribed
+        scores before they are relied upon.
+      </p>
+    ),
   },
   {
-    h: "8. Contact",
-    p: "Questions about these terms can be sent to hello@omnischools.gh.",
+    h: "8. Availability and liability",
+    body: (
+      <p>
+        We work to keep Omnischools available and accurate, but the service is provided on an
+        &ldquo;as is&rdquo; and &ldquo;as available&rdquo; basis, without warranties of any kind. To
+        the fullest extent permitted by Ghanaian law, we are not liable for indirect, incidental or
+        consequential loss arising from use of the platform, and our total liability is limited to the
+        fees your school paid to us in the twelve months before the claim.
+      </p>
+    ),
+  },
+  {
+    h: "9. Suspension and termination",
+    body: (
+      <p>
+        Either party may end this agreement. You may stop using the platform and close your account at
+        any time. We may suspend or terminate access for a serious or repeated breach of these Terms,
+        or for non-payment of a paid tier, giving reasonable notice where practicable. On termination
+        you will have a reasonable window to export your data before it is removed.
+      </p>
+    ),
+  },
+  {
+    h: "10. Governing law and disputes",
+    body: (
+      <p>
+        These Terms are governed by the laws of the Republic of Ghana. The parties will try to resolve
+        any dispute amicably; failing that, the dispute is subject to the exclusive jurisdiction of
+        the courts of Ghana, sitting in [CITY / VENUE — placeholder].
+      </p>
+    ),
+  },
+  {
+    h: "11. Changes",
+    body: (
+      <p>
+        We may update these Terms as the platform evolves. Material changes will be communicated to
+        school administrators. Continued use after a change takes effect constitutes acceptance.
+      </p>
+    ),
+  },
+  {
+    h: "12. Contact",
+    body: (
+      <p>
+        Questions about these Terms can be sent to{" "}
+        <a href={`mailto:${CONTACT_EMAIL}`} className="font-semibold text-gold hover:underline">
+          {CONTACT_EMAIL}
+        </a>
+        .
+      </p>
+    ),
   },
 ];
 
 export default function TermsPage() {
   return (
     <main className="mx-auto max-w-content px-6 py-16">
-      <div className="mb-3 text-[11px] font-bold uppercase tracking-[0.18em] text-gold">
-        Legal
-      </div>
+      <div className="mb-3 text-[11px] font-bold uppercase tracking-[0.18em] text-gold">Legal</div>
       <h1 className="font-display text-4xl font-semibold text-navy">
         Terms of <em className="not-italic text-gold [font-style:italic]">Service.</em>
       </h1>
       <p className="mt-3 max-w-2xl text-sm text-navy-3">
-        A plain-language summary of how Omnischools may be used. This is a starting template —
-        replace with your reviewed legal copy before launch.
+        The terms governing your school&rsquo;s use of Omnischools.
       </p>
+      <p className="mt-2 text-[12px] text-navy-3">
+        Effective {EFFECTIVE_DATE} · {VERSION}
+      </p>
+
+      <div className="mt-6 max-w-2xl rounded-lg border border-gold-soft bg-gold-bg px-4 py-3 text-[13px] leading-relaxed text-navy-2">
+        <strong>Draft for review — not legal advice.</strong> This is a working draft grounded in how
+        the platform operates. It must be reviewed by a qualified Ghanaian lawyer before it is
+        published. Bracketed [ ] items are placeholders to be completed.
+      </div>
 
       <div className="mt-10 space-y-7">
         {sections.map((s) => (
           <section key={s.h}>
             <h2 className="font-display text-lg font-semibold text-navy">{s.h}</h2>
-            <p className="mt-1.5 max-w-2xl text-sm leading-relaxed text-navy-2">{s.p}</p>
+            <div className="mt-1.5 max-w-2xl text-sm leading-relaxed text-navy-2">{s.body}</div>
           </section>
         ))}
       </div>

--- a/omnischools/components/marketing/about.tsx
+++ b/omnischools/components/marketing/about.tsx
@@ -39,8 +39,8 @@ export function About() {
               </b>
               . It means the gradebook understands a WASSCE qualification rate, not just
               an American GPA. It means attendance can be taken on a phone with patchy
-              data and sync later. And it means the data stays in Ghana, governed by
-              Ghanaian law.
+              data and sync later. And it means your data is governed by Ghanaian law,
+              hosted in a secure data centre in the region closest to Ghana.
             </p>
             <p>
               Three products, one platform:{" "}

--- a/omnischools/components/marketing/faq.tsx
+++ b/omnischools/components/marketing/faq.tsx
@@ -17,7 +17,7 @@ const FAQS = [
   },
   {
     q: "Where is our school's data stored?",
-    a: "In data centres serving Ghana, governed by Ghana's Data Protection Act. We're registered with the Data Protection Commission, and named-record access — including by us, for support — is justification-gated and audit-logged.",
+    a: "In a secure data centre in the region closest to Ghana (currently the EU — London), governed by Ghana's Data Protection Act, 2012 (Act 843). Named-record access — including by us, for support — is justification-gated and audit-logged.",
   },
   {
     q: "Is there a discount for small schools?",

--- a/omnischools/components/marketing/footer.tsx
+++ b/omnischools/components/marketing/footer.tsx
@@ -21,9 +21,9 @@ const COLS = [
   {
     title: "Legal & trust",
     links: [
-      { href: "/legal/privacy", label: "Privacy policy" },
-      { href: "/legal/data-protection", label: "Data protection" },
-      { href: "/legal/terms", label: "Terms of service" },
+      { href: "/privacy", label: "Privacy policy" },
+      { href: "/privacy#data-protection", label: "Data protection" },
+      { href: "/terms", label: "Terms of service" },
     ],
   },
 ];

--- a/omnischools/docs/legal/privacy-policy.md
+++ b/omnischools/docs/legal/privacy-policy.md
@@ -1,0 +1,141 @@
+# Omnischools — Privacy Policy
+
+**Effective:** 20 July 2026 · **Version:** Draft v0.1 — pending legal review
+
+> **Draft for review — not legal advice.** This is a working draft grounded in how the
+> Omnischools platform actually operates (data model, sub-processors, security). It must be
+> reviewed by a qualified Ghanaian lawyer, and registration with the Data Protection Commission
+> confirmed, before it is published. Items in `[SQUARE BRACKETS]` are placeholders to be
+> completed by the business.
+
+This policy explains how personal data is handled on Omnischools. It is written to align with
+Ghana's **Data Protection Act, 2012 (Act 843)**.
+
+## 1. Who we are, and our two roles
+
+Omnischools is a school-management platform operated by `[LEGAL ENTITY NAME]`, a company
+registered in Ghana (registration no. `[COMPANY REG NO.]`), of `[REGISTERED OFFICE ADDRESS]`
+("Omnischools", "we", "us").
+
+We act in **two different roles**, and your rights depend on which applies:
+
+- **As a data processor** — for the records a school enters about its students, guardians and
+  applicants. The *school* is the data controller; it decides what to collect and why, and is
+  responsible for having a lawful basis. We process that data **only on the school's instructions**,
+  to provide the service.
+- **As a data controller** — for a narrower set of data whose purposes we decide ourselves: the
+  account details of staff who sign in (name, phone, email, role), platform usage and security logs,
+  and enquiries submitted through our marketing or demo forms.
+
+## 2. The data we handle, and whose it is
+
+A school's use of Omnischools involves the following categories. Much of it concerns **children**,
+and some is **sensitive** (health and financial information).
+
+- **Students (minors):** name, date of birth, sex, student ID, class, programme, enrolment status,
+  boarding/residency details.
+- **Student health records (sensitive):** blood group, allergies, chronic conditions, medications,
+  emergency contact — where a school records them.
+- **Guardians / parents:** name, relationship, phone, email.
+- **Applicants:** admission-application details (child and guardian) and supporting-document references.
+- **Academic records:** attendance (including reason codes such as medical/excused), gradebook
+  scores, report cards and, for senior schools, the score ledger.
+- **Financial records:** invoices, payments, receipts and discounts recorded against a student.
+- **Staff:** profile details (which may include date of birth, gender, address, emergency contact,
+  qualifications) and, where used, compensation information (salary, SSNIT, PAYE).
+- **Communications:** phone numbers, message content and delivery logs of SMS and in-app messages.
+- **Account & security data (we control):** the name, phone, email and role of each user who signs
+  in, and audit logs of actions taken — including the actor, timestamp, IP address and browser
+  (user-agent) of the request.
+
+## 3. How and why we use it
+
+We use this data solely to provide the service: to display your records, generate report cards,
+invoices and receipts, send the SMS and messages you initiate, produce the reports you request,
+authenticate users, and keep the platform secure. **We do not sell your data, and we do not use it
+for advertising.** We do not use the personal data a school enters to train AI models.
+
+## 4. The service providers we share data with
+
+We rely on a small number of trusted providers ("sub-processors"). Each receives only the data it
+needs, and only to help us deliver the service:
+
+| Provider | Purpose | Data shared |
+|---|---|---|
+| **Supabase** | Database, authentication, file storage | All platform data; phone numbers for sign-in (hosted in the EU — see §5) |
+| **Vercel** | Application hosting | Processes requests; does not retain your records |
+| **Hubtel** (and the SMS provider for sign-in codes) | Delivering SMS and one-time sign-in codes | Recipient phone number and message content |
+| **Resend** | Transactional email (e.g. staff invitations) | Recipient email and message content |
+| **Anthropic** | Transcribing photographed handwritten score sheets | The photograph and class roster, sent for a single transcription; the image is not stored by us or used for model training |
+| **Error & usage analytics** | Diagnosing faults, understanding usage (only if enabled) | Not currently enabled; when enabled, error context and usage events — not student records |
+
+We keep this list current and will notify schools before adding a sub-processor that materially
+changes how data is handled.
+
+## 5. Where your data is stored, and cross-border transfer
+
+Your data is currently hosted by Supabase in the **European Union (London region)**, chosen for
+proximity to Ghana. This means personal data is transferred outside Ghana for storage and
+processing. We rely on the provider's contractual and technical safeguards for that transfer,
+consistent with the cross-border-transfer provisions of Act 843. If we change where data is hosted,
+we will update this policy.
+
+> **[Reconcile before launch]** Any public claim that data is "resident in Ghana" (e.g. marketing
+> copy) must be reconciled with EU hosting, or the hosting changed.
+
+## 6. Children's data and lawful basis
+
+Much of the data concerns children. Because we act as a **processor** for that data, each school is
+responsible for having a lawful basis to collect and enter it — including obtaining parental or
+guardian consent where the law requires — and for informing parents how their child's data is used.
+Guardians can be invited to view only their own child's records.
+
+## 7. Your rights under Act 843 {#data-protection}
+
+Under the Data Protection Act, 2012 (Act 843), individuals have rights over their personal data,
+including the rights to be informed, to access, to correct inaccurate data, to object to processing,
+and to request deletion.
+
+Because a school is usually the **controller** for student, guardian and staff records, requests
+about that data are normally directed to the school, and we assist the school in responding. For
+data we control (your sign-in account and enquiries you send us), contact us at
+**hello@omnischools.gh**.
+
+You may also complain to Ghana's **Data Protection Commission**, the supervisory authority for Act
+843. Our data-protection contact is `[DPO / CONTACT NAME]`, and our registration with the Data
+Protection Commission is `[DPC REGISTRATION NUMBER — or "in progress"]`.
+
+## 8. Retention, deletion and export
+
+We keep your data for as long as your school uses Omnischools. Each school can set a retention
+preference in settings; today that preference is **recorded for compliance but not yet enforced
+automatically** — automatic purging is planned for a future release, and until then nothing is
+deleted on a schedule. You can export key records (students, staff, fee structures) to CSV at any
+time, and ask us to delete your data when you leave. When an account is closed, its records —
+students, guardians, health, financial, academic, communications and audit data — are removed.
+
+## 9. How we protect your data
+
+- **Strict tenant isolation** — every school's records are separated at the database level using
+  row-level security, enforced so a query without the correct school context returns nothing rather
+  than another school's data. Records are keyed so a cross-school reference is not structurally
+  possible.
+- **Role-based access** — staff see only what their role allows within their own school; finance
+  roles are confined to billing; students and parents cannot reach staff areas.
+- **Auditing** — changes are recorded in an append-only audit log (who, what, when).
+- **Encryption in transit** — data is encrypted between your device and the platform. Data at rest is
+  protected by the encryption our hosting provider applies at the storage layer. *We do not currently
+  apply additional field-level encryption to individual columns such as health or salary data.*
+
+No system is perfectly secure, but we take reasonable measures against unauthorised access,
+consistent with Act 843.
+
+## 10. Cookies and sessions
+
+When you sign in, we use a session cookie to keep you signed in. It is necessary for the service and
+is not used for advertising or cross-site tracking.
+
+## 11. Changes and contact
+
+We may update this policy as the platform evolves and will communicate material changes to school
+administrators. Privacy questions or data requests: **hello@omnischools.gh**.

--- a/omnischools/docs/legal/privacy-policy.md
+++ b/omnischools/docs/legal/privacy-policy.md
@@ -80,9 +80,6 @@ processing. We rely on the provider's contractual and technical safeguards for t
 consistent with the cross-border-transfer provisions of Act 843. If we change where data is hosted,
 we will update this policy.
 
-> **[Reconcile before launch]** Any public claim that data is "resident in Ghana" (e.g. marketing
-> copy) must be reconciled with EU hosting, or the hosting changed.
-
 ## 6. Children's data and lawful basis
 
 Much of the data concerns children. Because we act as a **processor** for that data, each school is

--- a/omnischools/docs/legal/terms-of-service.md
+++ b/omnischools/docs/legal/terms-of-service.md
@@ -1,0 +1,91 @@
+# Omnischools — Terms of Service
+
+**Effective:** 20 July 2026 · **Version:** Draft v0.1 — pending legal review
+
+> **Draft for review — not legal advice.** This is a working draft grounded in how the
+> Omnischools platform actually operates. It must be reviewed by a qualified Ghanaian lawyer before
+> it is published. Items in `[SQUARE BRACKETS]` are placeholders to be completed by the business.
+
+## 1. Agreement
+
+These Terms of Service are a contract between `[LEGAL ENTITY NAME]` ("Omnischools", "we", "us"), a
+company registered in Ghana, and the school that creates an account ("you", "your school"). By
+creating a school on Omnischools and using the platform, your school and its authorised users agree
+to these Terms. If you are accepting on behalf of a school, you confirm you are authorised to bind
+that school.
+
+## 2. Your account and security
+
+Each user signs in with their own phone number, using a one-time code or a password. You are
+responsible for keeping sign-in credentials secure, for ensuring only appropriate staff have
+accounts, and for activity under your school's accounts. Notify us promptly of any unauthorised use.
+
+## 3. Acceptable use
+
+You agree to use Omnischools only for the lawful administration of your school — managing students,
+staff, fees, attendance, grades and communications. You will not misuse the platform, attempt to
+access another school's data, send unlawful or unsolicited messages, or interfere with the
+platform's operation or security.
+
+## 4. Your data and our role
+
+Your school owns the records it enters. For the data your school enters about students, guardians and
+applicants, your school is the data controller and we act as your **data processor** — processing
+that data only to provide the service, as set out in the Privacy Policy. Each school's data is
+isolated from every other school's. You may export your data at any time.
+
+## 5. Subscription and fees
+
+Omnischools is offered on a **freemium** basis. New schools begin with a 30-day free trial, and a
+free tier remains available. Paid tiers are charged per student for each academic period (per term,
+or per semester for senior schools), billed at the start of the period, with no setup fee and no
+per-user minimum. Prices are as shown on our pricing page and may change on reasonable notice.
+
+You can cancel at any time; paid features continue until the end of the period you have paid for.
+Fees are exclusive of any applicable taxes or levies. If a payment for a paid tier is not made when
+due, we may suspend paid features after notice, while leaving your data available for export.
+Subscription payments to Omnischools are made by `[SUBSCRIPTION PAYMENT METHOD]`.
+
+## 6. School and parent fees are separate
+
+The fee structures, amounts and payment channels your school configures for its own parents are
+yours to set and collect. Omnischools facilitates record-keeping and, where enabled, reconciliation
+of payments made through a Bank of Ghana-licensed payment gateway; it is **not a party** to the fees
+owed between a school and its parents, and is not responsible for collecting them.
+
+## 7. Automated transcription of score sheets
+
+Where a teacher photographs a handwritten score sheet, the platform may use a third-party
+artificial-intelligence service to transcribe the marks. The image is sent for that single
+transcription and is not stored by us afterwards. You are responsible for checking transcribed scores
+before relying on them.
+
+## 8. Availability and liability
+
+We work to keep Omnischools available and accurate, but the service is provided on an "as is" and "as
+available" basis, without warranties of any kind. To the fullest extent permitted by Ghanaian law, we
+are not liable for indirect, incidental or consequential loss arising from use of the platform, and
+our total liability is limited to the fees your school paid to us in the twelve months before the
+claim.
+
+## 9. Suspension and termination
+
+Either party may end this agreement. You may stop using the platform and close your account at any
+time. We may suspend or terminate access for a serious or repeated breach of these Terms, or for
+non-payment of a paid tier, giving reasonable notice where practicable. On termination you will have
+a reasonable window to export your data before it is removed.
+
+## 10. Governing law and disputes
+
+These Terms are governed by the laws of the Republic of Ghana. The parties will try to resolve any
+dispute amicably; failing that, the dispute is subject to the exclusive jurisdiction of the courts of
+Ghana, sitting in `[CITY / VENUE]`.
+
+## 11. Changes
+
+We may update these Terms as the platform evolves. Material changes will be communicated to school
+administrators. Continued use after a change takes effect constitutes acceptance.
+
+## 12. Contact
+
+Questions about these Terms: **hello@omnischools.gh**.


### PR DESCRIPTION
Replaces the self-labelled placeholder `/terms` and `/privacy` copy with proper **drafts grounded in what the platform actually does** and in Ghana's **Data Protection Act, 2012 (Act 843)**. Delivered per an approved plan.

> ⚠️ **Not legal advice.** These are working drafts. Both pages carry a visible "review before publish" banner, an effective date, a version, and `[PLACEHOLDER]` tokens. **A qualified Ghanaian lawyer must review them, and DPC registration must be confirmed, before publishing.**

## Key decisions (confirmed with the owner)
- **Role:** Omnischools is a **data processor** for student/guardian data (schools are controllers); controller only for account/usage/billing data.
- **Law:** governed by the laws of **Ghana**; entity name/number left as `[PLACEHOLDER]`.
- **Commercial:** **freemium** (30-day trial, free tier, per-student per-period paid tiers).

## What's in the drafts
**Privacy Policy** — the two-role split; a data-category inventory (incl. children's, **health**, and **salary** data); a **sub-processor table** (Supabase EU-London, Vercel, Hubtel, Resend, Anthropic for score-sheet OCR, analytics-when-enabled); **cross-border-transfer** disclosure; **Act 843 rights** (with a `#data-protection` anchor); and honest retention + security sections.

**Terms of Service** — expanded from 8 to 12 sections: freemium subscription/fees, school↔parent fees disclaimer, AI/OCR transcription, availability/liability cap, suspension/termination, governing law = Ghana.

## Honesty pass — three things I would NOT assert (drafted to the code, flagged for you)
1. **Data residency:** the About page says data is "resident in Ghana," but hosting is Supabase **EU/London**. The policy discloses EU hosting + transfer, and flags the marketing claim to reconcile — it does not repeat it.
2. **DPC registration:** the FAQ says "we're registered with the Data Protection Commission," but that's an open internal to-do. The policy uses a `[DPC REGISTRATION — or "in progress"]` placeholder rather than asserting it.
3. **Encryption:** the old page said "encrypted in transit" only; the security section is accurate — TLS in transit, provider encryption at rest, and *explicitly not* field-level-encrypted (health/salary are plaintext columns).

## Also fixed
The footer's "Legal & trust" column linked to non-existent `/legal/privacy`, `/legal/data-protection`, `/legal/terms` (all 404). Repointed to `/privacy`, `/terms`, `/privacy#data-protection`.

## Structure
Pages keep the existing `sections.map(...)` render; the item type is widened from `{h, p: string}` to `{h, id?, body: ReactNode}` so a section can hold the table/lists/anchor — no UI redesign. A **markdown source of truth** is added under `docs/legal/` for the lawyer.

## Placeholders the owner must supply
Legal entity name + registration no.; registered office address; real phone; DPC registration status/number; DPO/contact name; court venue city; how schools pay Omnischools its subscription.

## Verification
`typecheck` · `lint` · `build` green; `/privacy` and `/terms` render (draft banner, sub-processor table, honesty phrases all confirmed on the rendered page); footer links resolve and `/legal/*` returns 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)