### PR TITLE
fix(dev): tailwind.config.ts require() -> ESM import (fixes next dev CSS 500)

### DIFF
--- a/omnischools/tailwind.config.ts
+++ b/omnischools/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 /**
  * Tailwind bound to Omnischools design tokens (styles/tokens.css).
@@ -105,6 +106,6 @@ const config: Config = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindcssAnimate],
 };
 export default config;


### PR DESCRIPTION
## fix(dev): tailwind.config.ts `require()` → ESM import

A one-line dev-experience fix. `tailwind.config.ts` loaded its plugin with `plugins: [require("tailwindcss-animate")]`. Under `next dev`'s ESM config worker, `require` is not defined, so it throws `ReferenceError: require is not defined` and **500s CSS-importing pages in development**. Production is unaffected — `next build` loads the config through PostCSS where the require worked, so Vercel deploys fine. This is a dev-experience bug, not a prod incident.

**Fix:** a top-level default import (`tailwindcss-animate` is a CommonJS module, so the default import is interop-safe):
```diff
+import tailwindcssAnimate from "tailwindcss-animate";
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindcssAnimate],
```

**Verified:**
- `pnpm typecheck` — clean.
- `pnpm build` — Compiled successfully, 16/16 static pages, exit 0 (the config still loads through PostCSS at build time).
- **`next dev`** — `/` and `/login` (both styled, tailwind-dependent) return **HTTP 200** with **zero** "require is not defined" in the dev log. That's the reported bug, fixed.

Pre-existing; surfaced by (and out of scope for) the react-pdf fix in PR #233. Standalone off `main`, no schema/dependency change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
