### PR TITLE
INCR-AUTH-OTP · OTP-mandatory first login + onboarding auto-sign-in + security headers

### DIFF
--- a/omnischools/.env.example
+++ b/omnischools/.env.example
@@ -34,3 +34,6 @@ AUTH_DEV_BYPASS=true
 # is MATRON-gated, so its UI and mutations are unreachable in dev without this. Read ONLY when
 # AUTH_DEV_BYPASS is true; unset = today's behaviour (ADMIN). Never set it in production.
 # AUTH_DEV_ROLES=MATRON
+# OTP-mandatory FIRST login (INCR-AUTH-OTP). Keep "false" until the prod Supabase SMS provider + "Confirm
+# phone" are on (DEPLOY.md §1 P1–P3), then set "true" (P4). Read ONLY when auth is live; inert in dev.
+AUTH_OTP_LIVE=false

--- a/omnischools/DEPLOY.md
+++ b/omnischools/DEPLOY.md
@@ -26,6 +26,18 @@ SMS/email behind `lib/{sms,email}`, jobs as HTTP POST + shared secret. Hosting t
 4. **Authentication → Providers → Phone** — enable, and attach an SMS provider
    (Twilio / MessageBird / Vonage) per Supabase docs. For first tests you can add test
    phone numbers with fixed OTPs under Auth → Phone.
+   > **⚠️ The OTP SMS provider is Supabase's own (Twilio/etc.), NOT `HUBTEL_*`.** Hubtel only
+   > sends our invite/reminder messages (`lib/sms`); setting `HUBTEL_*` does NOT make login OTP work.
+
+   **OTP-first-login rollout (INCR-AUTH-OTP) — do these IN ORDER, or you risk locking users out:**
+   - **P1.** Attach the Supabase Auth SMS provider (above).
+   - **P2.** Confirm a real test OTP actually delivers to a live Ghana number (MTN / Telecel / AirtelTigo).
+   - **P3.** **Authentication → Providers → Phone → enable "Confirm phone".** This is what makes GoTrue
+     refuse password login on an un-verified phone, so a first login MUST go through OTP. Before P3,
+     sign-ups auto-confirm (password login works, OTP degrades to console) — the safe no-lockout interim.
+   - **P4.** Set `AUTH_OTP_LIVE=true` (env table below) so the app shows the OTP-first flow. Set this LAST.
+
+   See `docs/senior/incr-auth-otp-first-login-ruling.md` §5. `AUTH_OTP_LIVE` stays `false` until P1–P3 are done.
 
 ## 2 · Apply schema + RLS to prod (run locally, once)
 Run from `omnischools/` with the **direct** connection string. These are safe on an empty DB.
@@ -53,6 +65,7 @@ Tip: `pnpm db:rls-test` against prod should pass (cross-tenant reads blocked).
    | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | anon key |
    | `SUPABASE_SERVICE_ROLE_KEY` | service_role key |
    | `AUTH_DEV_BYPASS` | `false`  ← flips on real phone-OTP auth |
+   | `AUTH_OTP_LIVE` | `false` until P1–P3 done, then `true`  ← OTP-mandatory first login (INCR-AUTH-OTP) |
    | `NEXT_PUBLIC_SITE_URL` | your Vercel URL (e.g. `https://omnischools.vercel.app`) |
    | `CRON_SECRET` | a long random string |
    | `HUBTEL_CLIENT_ID` / `_SECRET` / `_SENDER_ID` | optional (SMS goes live when set) |

--- a/omnischools/components/auth/login-form.tsx
+++ b/omnischools/components/auth/login-form.tsx
@@ -132,6 +132,13 @@ export function LoginForm({
         )
       ) : (
         <div className="space-y-3">
+          {/* Static first-login hint (INCR-AUTH-OTP §3) — never varies with whether the number exists or
+              is confirmed, so it leaks nothing (enumeration-safe). A brand-new account must verify by OTP
+              once (which confirms the phone); password sign-in works after that. */}
+          <p className="rounded-md bg-bg px-3 py-2 text-[12px] leading-relaxed text-navy-3">
+            <b className="text-navy-2">First time signing in?</b> Verify your number on the{" "}
+            <b className="text-navy-2">Phone OTP</b> tab first — your password works after that.
+          </p>
           <input
             className={fieldClass}
             type="tel"

--- a/omnischools/components/onboarding/wizard.tsx
+++ b/omnischools/components/onboarding/wizard.tsx
@@ -666,7 +666,7 @@ function PasswordStep({
 
 /* ----------------------------------------------------------------------- done */
 
-function DonePanel({
+export function DonePanel({
   result,
   schoolName,
 }: {
@@ -749,7 +749,7 @@ function DonePanel({
  * /dashboard (`verifyLogin`). The account already exists (tx committed before this renders), so a failed
  * send/verify never orphans anything — the "Go to sign in" link below reaches the same OTP tab at /login.
  */
-function OnboardingOtpFinish({ phone }: { phone: string }) {
+export function OnboardingOtpFinish({ phone }: { phone: string }) {
   const [code, setCode] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/omnischools/components/onboarding/wizard.tsx
+++ b/omnischools/components/onboarding/wizard.tsx
@@ -5,7 +5,7 @@
  * the `onboardSchool` action from tier defaults; the full multi-step version lives in
  * `full-wizard.tsx` (kept for the super-admin tenant-setup portal).
  */
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import {
@@ -747,7 +747,8 @@ export function DonePanel({
  * INCR-AUTH-OTP (Option A) · the done-phase auto-sign-in. Shown only when `otpLoginRequired()` is true.
  * Auto-sends ONE OTP on mount, then verify → confirms the phone + establishes the session + redirects to
  * /dashboard (`verifyLogin`). The account already exists (tx committed before this renders), so a failed
- * send/verify never orphans anything — the "Go to sign in" link below reaches the same OTP tab at /login.
+ * send/verify never orphans anything — DonePanel's always-present "Go to sign in" link reaches the same
+ * OTP tab at /login.
  */
 export function OnboardingOtpFinish({ phone }: { phone: string }) {
   const [code, setCode] = useState("");
@@ -755,9 +756,13 @@ export function OnboardingOtpFinish({ phone }: { phone: string }) {
   const [error, setError] = useState<string | null>(null);
   const [resent, setResent] = useState(false);
 
-  // One app-controlled send on mount. With Supabase "Confirm phone" ON, GoTrue may already have sent a
-  // code at sign-up — so the copy asks for the LATEST code rather than assuming this is the only one.
+  const sentRef = useRef(false);
+  // One app-controlled send on mount, guarded to fire EXACTLY once (React StrictMode double-invokes
+  // effects in dev). With Supabase "Confirm phone" ON, GoTrue may already have sent a code at sign-up —
+  // so the copy asks for the LATEST code rather than assuming this is the only one.
   useEffect(() => {
+    if (sentRef.current) return;
+    sentRef.current = true;
     void requestOtp(phone);
   }, [phone]);
 

--- a/omnischools/components/onboarding/wizard.tsx
+++ b/omnischools/components/onboarding/wizard.tsx
@@ -5,7 +5,7 @@
  * the `onboardSchool` action from tier defaults; the full multi-step version lives in
  * `full-wizard.tsx` (kept for the super-admin tenant-setup portal).
  */
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import {
@@ -21,6 +21,7 @@ import {
   type SchoolSubtype,
 } from "@/lib/onboarding";
 import { onboardSchool } from "@/lib/actions/onboarding";
+import { requestOtp, verifyLogin } from "@/lib/actions/auth";
 
 type Form = Partial<OnboardInput> & { subtype?: SchoolSubtype; confirmPassword?: string };
 
@@ -692,14 +693,20 @@ function DonePanel({
               we&apos;ll guide you through the rest from a checklist.
             </p>
           </div>
-          <Link
-            href="/login?accepted=1"
-            className="rounded-lg bg-gold px-6 py-3.5 text-sm font-bold text-navy transition-colors hover:brightness-95"
-          >
-            Sign in →
-          </Link>
+          {/* When OTP-first is live, the OTP card below is the sign-in action; else link to /login. */}
+          {!result.otpLive && (
+            <Link
+              href="/login?accepted=1"
+              className="rounded-lg bg-gold px-6 py-3.5 text-sm font-bold text-navy transition-colors hover:brightness-95"
+            >
+              Sign in →
+            </Link>
+          )}
         </div>
       </div>
+
+      {/* INCR-AUTH-OTP · auto-sign-in (Option A): verify the phone via OTP → confirms it + lands in /dashboard. */}
+      {result.otpLive && <OnboardingOtpFinish phone={result.adminPhone} />}
 
       <div className="mt-6">
         <div className="mb-3 font-display text-base font-medium text-navy">
@@ -732,6 +739,78 @@ function DonePanel({
         </Link>
         <p className="font-mono text-[11px] text-navy-3">school id · {result.schoolId}</p>
       </div>
+    </div>
+  );
+}
+
+/**
+ * INCR-AUTH-OTP (Option A) · the done-phase auto-sign-in. Shown only when `otpLoginRequired()` is true.
+ * Auto-sends ONE OTP on mount, then verify → confirms the phone + establishes the session + redirects to
+ * /dashboard (`verifyLogin`). The account already exists (tx committed before this renders), so a failed
+ * send/verify never orphans anything — the "Go to sign in" link below reaches the same OTP tab at /login.
+ */
+function OnboardingOtpFinish({ phone }: { phone: string }) {
+  const [code, setCode] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [resent, setResent] = useState(false);
+
+  // One app-controlled send on mount. With Supabase "Confirm phone" ON, GoTrue may already have sent a
+  // code at sign-up — so the copy asks for the LATEST code rather than assuming this is the only one.
+  useEffect(() => {
+    void requestOtp(phone);
+  }, [phone]);
+
+  async function verify() {
+    if (!code.trim()) return;
+    setBusy(true);
+    setError(null);
+    const res = await verifyLogin(phone, code.trim()); // redirects to /dashboard on success
+    setBusy(false);
+    if (res && !res.ok) setError(res.error);
+  }
+  async function resend() {
+    setResent(false);
+    setError(null);
+    await requestOtp(phone);
+    setResent(true);
+  }
+
+  return (
+    <div className="mt-5 rounded-xl border border-gold-soft bg-gold-bg px-6 py-5">
+      <div className="font-display text-base font-semibold text-navy">
+        Finish signing in — verify your number
+      </div>
+      <p className="mt-1 max-w-[520px] text-[13px] leading-relaxed text-navy-2">
+        We sent a one-time code to <b className="text-navy">{phone}</b>. Enter the latest code to confirm
+        your number and go straight to your dashboard. You&apos;ll be able to sign in with your password
+        after this.
+      </p>
+      <div className="mt-3 flex flex-wrap items-center gap-2.5">
+        <input
+          inputMode="numeric"
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && verify()}
+          placeholder="••••••"
+          className="w-40 rounded-md border border-border-2 bg-surface px-3 py-2.5 text-center font-mono text-lg tracking-[0.3em] text-navy outline-none focus:border-gold"
+        />
+        <button
+          onClick={verify}
+          disabled={busy}
+          className="rounded-lg bg-navy px-5 py-2.5 text-sm font-bold text-bg transition-colors hover:bg-navy-deep disabled:opacity-60"
+        >
+          {busy ? "Verifying…" : "Verify & go to dashboard"}
+        </button>
+        <button
+          type="button"
+          onClick={resend}
+          className="text-xs font-semibold text-navy-3 transition-colors hover:text-navy"
+        >
+          {resent ? "Code re-sent ✓" : "Resend code"}
+        </button>
+      </div>
+      {error && <p className="mt-2 text-sm text-terra">{error}</p>}
     </div>
   );
 }

--- a/omnischools/docs/senior/incr-auth-otp-first-login-ruling.md
+++ b/omnischools/docs/senior/incr-auth-otp-first-login-ruling.md
@@ -1,0 +1,77 @@
+# INCR-AUTH-OTP — Ruling: OTP-mandatory first login + auto-sign-in after onboarding
+
+**Steward:** Kofi (domain / spec) · **Status:** Ruled — buildable path. Owner said "proceed." One soft owner-preference flagged (§8), non-blocking.
+**Scope:** (a) OTP-mandatory FIRST login for every account; (b) auto-sign-in after onboarding.
+**Out of scope:** security headers/CSP (parallel); leaked-password + rate-limit (follow-up).
+**Directive (verbatim):** "keep SMS and OTP as mandatory for first time login. subsequent logins with phone would also require OTPs, passwords login however wouldn't. Also, add the auto-sign-in after onboarding."
+
+## 1 · The fork — RULED: **Option A** (reject B)
+
+Option A = the onboarding OTP-verify BOTH confirms the phone AND establishes the session (the "auto-sign-in" *is* the OTP-verified session). Rationale:
+
+1. **B contradicts the directive.** The directive says OTP is mandatory for "first time login" with no creator carve-out. B admin-confirms the creator so their first auth is a password with no OTP — the exact case forbidden. A makes every first auth (creator + invited) an OTP.
+2. **A is the lazier and safer change.** A keeps `createPasswordUser` on the existing anon `signUp` (unconfirmed phone, `lib/auth/index.ts:236-251`) and drops the held branch's admin path. B *adds* a service-role path + `SUPABASE_SERVICE_ROLE_KEY` dependency + a self-blessing "confirmed on create" state. Less code, no new privileged dependency, directive met.
+3. **A reuses a shipped pattern verbatim** — the L3 reset flow (`components/auth/reset-form.tsx`, `verifyResetOtp` at `lib/actions/auth.ts:129-136`) already does phone → `requestOtp` → verify (no redirect) → session → `/dashboard`.
+4. **A's costs are already paid** — live SMS is a hard precondition for the whole feature regardless (invited users need it), the OTP step is gated inert until SMS is live (§5), and it has a non-blocking escape (AC-07). No superior third option: skipping auto-sign-in fails part (b); OTP-verify + admin-confirm together is incoherent.
+
+## 2 · "First-time login" definition + enforcing signal
+
+**First-time login = the first authentication of an account whose Supabase phone is unconfirmed (`phone_confirmed_at == null`).** Enforcement is **GoTrue-native — do NOT add an app check, do NOT admin-confirm.** `createPasswordUser` creates the account via anon `signUp` → unconfirmed phone; with Supabase "Confirm phone" ON (precondition P3), GoTrue **refuses `signInWithPassword` on an unconfirmed phone**, so the first OTP is mandatory by construction. Once confirmed, password login is natively permitted. No app-level `phone_confirmed_at` pre-check (it needs a privileged admin lookup on the hot path and buys nothing over the native block). **Never admin-confirm** in any onboarding/accept/admin path — that single line, if crossed, silently voids the whole guarantee (it is what B and the held branch do). Dependency: the native block exists only when "Confirm phone" is ON — if OFF, `signUp` auto-confirms and the guarantee evaporates (hence P3, and the pre-SMS interim keeps it OFF as the safe no-lockout state).
+
+## 3 · Messaging (the real current defect) — enumeration-safe, no server branching
+
+Fix with **static UI copy only** (a state-dependent message would be an existence oracle — AC-S3): a persistent static hint on the Password tab (`components/auth/login-form.tsx`) — *"First time signing in? Verify your number on the Phone OTP tab first."*; the password-failure message stays the generic *"Invalid phone or password."* (optionally with the same static line appended, shown on every failure). Accept page + `?accepted=1` banner steer to the OTP tab. `passwordLogin`/`signInWithPassword` otherwise unchanged — the password tab stays OTP-free.
+
+## 4 · Per-question rulings
+
+- **4.1 Invited-user first login:** same rule. `acceptInvite` keeps anon `signUp` → unconfirmed. Accept already routes to `/login?accepted=1`, where the only working first login is the OTP tab. Already correct today; only §3 messaging changes. No admin-confirm.
+- **4.2 Subsequent logins:** Phone tab → OTP (unchanged). Password tab → NO OTP once confirmed (unchanged, stays single-factor).
+- **4.3 Auto-sign-in (Option A mechanics):** on `onboardSchool` success (done phase, `full-wizard.tsx:234-242`): **OTP-live ON** → auto-issue one `requestOtp` to the creator's effective admin phone (already computed at `full-wizard.tsx:225-231`), show the code step, `verifyLogin` → phone confirmed + session established → `/dashboard`. **OTP-live OFF / dev-bypass** → no OTP step, keep today's "school created — sign in" → `/login`. Impl note: with "Confirm phone" ON, GoTrue may already send a confirmation OTP at `signUp`; issue exactly ONE app-controlled `requestOtp` and tell the user to enter *the latest code* — Claude Code to verify send-at-signup on the live project.
+- **4.4 Failure mid-onboarding — must not orphan/block:** the school + account are created before the OTP step (tx committed, `signUp` ran), so the OTP step is purely additive and its failure can't roll back the school. Recovery = ordinary `/login` Phone-OTP tab (identical confirm-and-sign-in). The done phase MUST always render a persistent "Sign in later" → `/login` link (AC-07).
+
+## 5 · HARD PRECONDITION — SMS provider + safe rollout
+
+**Two SMS layers, do not confuse:** Supabase Auth SMS provider (Twilio/MessageBird/Vonage, DEPLOY.md §1.4) sends the **OTP** — this is the precondition; Hubtel/console `sendSms` (`lib/sms/index.ts`) sends our invite/reminder messages — `HUBTEL_*` has nothing to do with OTP.
+
+**New config — one fail-closed flag (no schema):** add `AUTH_OTP_LIVE` to `lib/env.ts` as `enum(["true","false"]).default("false")`, read only when `authIsLive()` is true; helper `otpLoginRequired()` = `authIsLive() && env.AUTH_OTP_LIVE`. It gates the app-visible pieces (onboarding OTP step §4.3, messaging §3); inert under dev-bypass; defaults OFF (fail closed, mirroring `AUTH_DEV_BYPASS` at `env.ts:49-52`). A separate flag is required because `authIsLive()` only means "Supabase auth wired" — not "SMS provider attached"; a prod with the URL set but no provider is `authIsLive()==true` yet OTP-undeliverable.
+
+**Owner deploy prerequisites, in this exact order:** P1 configure Supabase Auth SMS provider (DEPLOY.md §1.4) → P2 confirm a real test OTP delivers to a live Ghana number (MTN/Telecel/AirtelTigo) → P3 enable "Confirm phone" in Supabase Auth (turns ON the native block) → P4 set `AUTH_OTP_LIVE=true`. **Why safe/monotonic:** before P3, `signUp` auto-confirms so password login works for everyone and OTP console-degrades — no lockout; users confirmed before P3 stay confirmed; P1/P2 land SMS before P3 makes anyone depend on it; P4 last so the app only shows OTP-first once it can complete. DEPLOY.md must gain P3 + the `AUTH_OTP_LIVE` row.
+
+## 6 · Reconciliation with `fix/onboarding-auth-confirm` (held branch)
+
+This increment supersedes/merges it. **KEEP** the auto-sign-in *concept* (land the creator in the app). **DROP** the switch of `createPasswordUser` to the service-role ADMIN API with `phone_confirm:true` — `createPasswordUser` stays on anon `signUp`. **CHANGE** the auto-sign-in mechanism from `signInWithPassword` to OTP-verify (§4.3) — the held branch's password auto-sign-in only worked because it admin-confirmed. Net: take only the auto-sign-in idea; re-mechanise as OTP.
+
+## 7 · Schema / state — NONE
+
+No migration, no `ref_user` marker — **does not pull in Wells.** The signal is Supabase-owned (`phone_confirmed_at`). Only new state is the `AUTH_OTP_LIVE` env flag (config, not schema).
+
+## 8 · Owner open-call (soft, non-blocking)
+
+- **Invited-user auto-sign-in parity** (inline OTP on `acceptInvite`) is directive-silent — ruling: **defer** (out of scope); invited users keep accept → `/login?accepted=1` → OTP tab. Recommend a small follow-up if the owner wants parity.
+- **Onboarding OTP UX shape:** default inline OTP card on the done phase (faithful "auto-sign-in"); a primed-`/login` redirect is an acceptable lower-effort degradation but isn't truly auto. Default inline; owner-tweakable.
+
+## 9 · Acceptance criteria
+
+**Functional (Quinn)**
+- **AUTH-OTP-01** — Given a newly created account (creator or invitee) with `phone_confirmed_at==null` and "Confirm phone" ON, when it attempts password login with the correct password, the system must refuse and issue no session.
+- **AUTH-OTP-02** — Given the same unconfirmed account, when it completes `requestOtp`→`verifyLogin`, the system must confirm the phone AND establish a session AND land at `/dashboard`.
+- **AUTH-OTP-03** — Given `phone_confirmed_at!=null`, when it password-logs-in correctly, a session is issued with no OTP.
+- **AUTH-OTP-04** — Given any account, when it uses the Phone-OTP tab, an OTP is required (unchanged).
+- **AUTH-OTP-05** — Given onboarding OR invite-accept, when the account is created via `createPasswordUser`, it uses anon `signUp` (no admin API, no `phone_confirm:true`) and the phone is unconfirmed.
+- **AUTH-OTP-06** — Given `otpLoginRequired()` true and `onboardSchool` ok, when the wizard reaches done, it auto-issues one `requestOtp` to the creator's admin phone, shows the code step, and on verify redirects to `/dashboard`.
+- **AUTH-OTP-07** — Given the onboarding OTP step, when send/verify fails OR the user picks "sign in later," the school+account persist, a `/login` link is present, and the account is reachable via the `/login` OTP tab (no orphan/block).
+- **AUTH-OTP-08** — Given `otpLoginRequired()` false, when onboarding reaches done, NO OTP step shows and the terminal card links to `/login`.
+- **AUTH-OTP-09** — Given an accepted invite, when the user lands on `/login?accepted=1` and uses the OTP tab, first login succeeds; the Password tab is refused until confirmed; banner+hint steer to OTP.
+- **AUTH-OTP-10** — Given the Password tab, when it renders (and on password-login failure), a static first-login-OTP hint shows that does not vary with account existence/confirmation.
+- **AUTH-OTP-11** — Given this increment, when inspected, there is no new migration/`ref_user` marker; the only new config is `AUTH_OTP_LIVE` (`default "false"`, read only when `authIsLive()`).
+
+**Security (Sarah)**
+- **AUTH-OTP-S1** — No path (onboarding/accept/admin) sets `phone_confirmed_at`/auto-confirms without a real OTP verify; `createPasswordUser` uses no admin API/`phone_confirm:true`. A freshly created account MUST NOT password-login (grep + mutation).
+- **AUTH-OTP-S2** — No lockout: with `AUTH_OTP_LIVE=false`/"Confirm phone" OFF, password login stays available (auto-confirmed signups); the onboarding OTP step never blocks school creation (tx commits first); flipping the flag is gated behind P1–P4.
+- **AUTH-OTP-S3** — Enumeration-safety: the Password-tab error+hint are identical for unknown / registered-unconfirmed / wrong-password (no oracle); the OTP send path keeps neutral-always `{ok:true}` (INCR-38).
+- **AUTH-OTP-S4** — No admin-confirm backdoor: the held branch's `phone_confirm:true` is NOT present after merge; future service-role paths must not auto-confirm phones.
+- **AUTH-OTP-S5** — `AUTH_OTP_LIVE` absent/misspelled resolves false; under `AUTH_DEV_BYPASS=true`, `otpLoginRequired()` is false and no OTP step runs.
+- **AUTH-OTP-S6** — No regression: the reset fresh-proof gate (R276, `completePasswordReset`) and INCR-38 OTP enumeration guard remain intact.
+
+## 10 · Grounding index
+`components/auth/login-form.tsx`; `lib/actions/auth.ts:34-42` (`passwordLogin`), `:129-136` (`verifyResetOtp`); `lib/auth/index.ts:236-251` (`createPasswordUser`), `:179-201` (`signInWithPhone`/INCR-38), `:116-118` (`authIsLive`); `components/auth/reset-form.tsx`; `lib/actions/onboarding.ts:65-523`; `components/onboarding/full-wizard.tsx:225-242`; `lib/actions/invites.ts:194-300`; `components/auth/accept-form.tsx:30`; `lib/env.ts:49-52` (`AUTH_DEV_BYPASS`); `lib/sms/index.ts`; DEPLOY.md §1.4.

--- a/omnischools/lib/actions/onboarding.ts
+++ b/omnischools/lib/actions/onboarding.ts
@@ -12,7 +12,7 @@ import {
 } from "@/lib/onboarding";
 import { withoutTenantScope, pgError } from "@/lib/db/rls";
 import { recordAudit } from "@/lib/db/audit";
-import { normalizeGhanaPhone, createPasswordUser } from "@/lib/auth";
+import { normalizeGhanaPhone, createPasswordUser, otpLoginRequired } from "@/lib/auth";
 import { sendSms } from "@/lib/sms";
 import { sendEmail } from "@/lib/email";
 import { captureEvent, captureError } from "@/lib/observability";
@@ -504,6 +504,10 @@ export async function onboardSchool(input: unknown): Promise<OnboardResult> {
       schoolId: result.schoolId,
       academicYear,
       periodsCreated: result.periodsCreated,
+      // INCR-AUTH-OTP — Option A: the done phase auto-signs-in the creator via an OTP to this number
+      // (when otpLive). No server-side password sign-in, no admin-confirm.
+      adminPhone: result.adminPhone,
+      otpLive: otpLoginRequired(),
     };
   } catch (err) {
     captureError(err, { action: "onboardSchool", gesCode: d.gesCode });

--- a/omnischools/lib/auth/create-password-user-anon.test.ts
+++ b/omnischools/lib/auth/create-password-user-anon.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { readCode } from "@/lib/test-utils/source-shape";
+
+/**
+ * INCR-AUTH-OTP · AUTH-OTP-05 (KEY) — the whole guarantee rests on `createPasswordUser` staying on the
+ * anonymous `signUp` and NEVER admin-confirming a phone. If any onboarding/accept/admin path set
+ * `phone_confirm:true` (or used the service-role admin API to create the user), a brand-new account's
+ * phone would be confirmed on create and GoTrue would permit a password login with NO OTP — silently
+ * voiding OTP-first for every creator and invitee. This is a source-shape guard because the enforcing
+ * signal is GoTrue-owned (`phone_confirmed_at`), not observable from our code at runtime; the mutation
+ * demonstration (adding `phone_confirm` turns this file RED) is the proof it actually bites.
+ *
+ * `readCode` strips comments, so the docblocks in `lib/auth/index.ts` that MENTION "admin-confirm" /
+ * "phone_confirm" as the forbidden thing cannot self-trip the greps below.
+ */
+const AUTH = readCode("lib/auth/index.ts");
+const ONBOARD_ACTION = readCode("lib/actions/onboarding.ts");
+const INVITE_ACTION = readCode("lib/actions/invites.ts");
+
+/** The body of `createPasswordUser`, from its signature to the next top-level `export`. */
+function createPasswordUserBody(src: string): string {
+  const start = src.indexOf("export async function createPasswordUser");
+  expect(start, "createPasswordUser must exist in lib/auth/index.ts").toBeGreaterThan(-1);
+  const after = src.indexOf("\nexport ", start + 1);
+  return src.slice(start, after === -1 ? undefined : after);
+}
+
+describe("AUTH-OTP-05 · createPasswordUser uses anon signUp, never admin-confirm", () => {
+  const body = createPasswordUserBody(AUTH);
+
+  it("creates the account via anon signUp", () => {
+    expect(body).toContain("signUp");
+    // The credential is exactly { phone, password } — no confirm flags smuggled into the object.
+    expect(body).toContain(".signUp({");
+  });
+
+  it("MUTATION GUARD — no admin API, no phone/email auto-confirm anywhere in lib/auth", () => {
+    // These are the exact tokens a "confirm on create" regression introduces. Adding
+    // `phone_confirm: true` to the signUp call (or switching to `admin.createUser`) flips this RED.
+    expect(AUTH).not.toContain("phone_confirm");
+    expect(AUTH).not.toContain("email_confirm");
+    expect(AUTH).not.toContain("admin.createUser");
+    expect(AUTH).not.toContain(".admin.");
+    expect(AUTH).not.toContain("createAdminClient");
+    expect(AUTH).not.toContain("SUPABASE_SERVICE_ROLE_KEY");
+    // No service-role client is constructed in the auth seam at all.
+    expect(AUTH).not.toMatch(/service_role/i);
+  });
+
+  it("createPasswordUser body itself carries no confirm flag / admin path", () => {
+    expect(body).not.toContain("phone_confirm");
+    expect(body).not.toContain("admin");
+  });
+});
+
+describe("AUTH-OTP-05 · both onboarding AND invite-accept route through createPasswordUser", () => {
+  it("onboardSchool creates the credential via createPasswordUser", () => {
+    expect(ONBOARD_ACTION).toContain("createPasswordUser(adminPhone, d.password)");
+  });
+
+  it("acceptInvite creates the credential via createPasswordUser (no admin-confirm either)", () => {
+    expect(INVITE_ACTION).toContain("createPasswordUser(");
+    expect(INVITE_ACTION).not.toContain("phone_confirm");
+    expect(INVITE_ACTION).not.toContain("admin.createUser");
+  });
+});

--- a/omnischools/lib/auth/index.ts
+++ b/omnischools/lib/auth/index.ts
@@ -117,6 +117,17 @@ export function authIsLive(): boolean {
   return !env.AUTH_DEV_BYPASS && !!env.NEXT_PUBLIC_SUPABASE_URL;
 }
 
+/**
+ * INCR-AUTH-OTP — is OTP-first login ENFORCED (show the onboarding OTP step + first-login messaging)?
+ * True only when auth is live AND the owner has flipped `AUTH_OTP_LIVE` (P4) — which they do ONLY after
+ * the Supabase SMS provider + "Confirm phone" are on (P1–P3). Inert under dev-bypass. This gates the
+ * UI/flow ONLY; the actual "an unconfirmed phone cannot password-login" guarantee is GoTrue-native
+ * (Supabase "Confirm phone"), never an app check — we never admin-confirm a phone.
+ */
+export function otpLoginRequired(): boolean {
+  return authIsLive() && env.AUTH_OTP_LIVE;
+}
+
 /** Normalise Ghanaian phone numbers to E.164 (+233XXXXXXXXX). */
 export function normalizeGhanaPhone(input: string): string {
   const digits = input.replace(/[^\d+]/g, "");

--- a/omnischools/lib/auth/login-form-hint.test.ts
+++ b/omnischools/lib/auth/login-form-hint.test.ts
@@ -18,8 +18,9 @@ const AUTH_ACTIONS = readCode("lib/actions/auth.ts");
 const visible = (html: string) =>
   html
     .replace(/<[^>]*>/g, " ")
-    .replace(/&amp;/g, "&")
     .replace(/&apos;|&#x27;/g, "'")
+    // Ampersand LAST: unescaping &amp; before the named entities can double-unescape (CodeQL js/double-escaping).
+    .replace(/&amp;/g, "&")
     .replace(/\s+/g, " ")
     .trim();
 

--- a/omnischools/lib/auth/login-form-hint.test.ts
+++ b/omnischools/lib/auth/login-form-hint.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { readCode } from "@/lib/test-utils/source-shape";
+import { LoginForm } from "@/components/auth/login-form";
+
+/**
+ * INCR-AUTH-OTP · AUTH-OTP-10 — the Password tab shows a STATIC first-login hint that does not vary
+ * with account existence/confirmation (enumeration-safe). The hint only renders in the password tab,
+ * reached by a click that `renderToStaticMarkup` cannot simulate; the enforceable invariant is that it
+ * is a literal, not a value derived from account state, so it is proven at the SOURCE. The render half
+ * confirms the ONLY account-state-driven text on the page is the navigation banner (`?accepted=1` /
+ * `?reset=1`) — never an existence/confirmation oracle.
+ */
+const FORM = readCode("components/auth/login-form.tsx");
+const AUTH_ACTIONS = readCode("lib/actions/auth.ts");
+
+const visible = (html: string) =>
+  html
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&apos;|&#x27;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+
+describe("AUTH-OTP-10 · the first-login hint is a static literal (source)", () => {
+  it("the hint copy is present in the password branch", () => {
+    expect(FORM).toContain("First time signing in?");
+    expect(FORM).toContain("Phone OTP");
+    // It sits inside the password-tab branch (the `mode === \"password\"` else-arm), not the OTP tab.
+    expect(FORM).toContain('mode === "otp"');
+  });
+
+  it("the hint does NOT interpolate account state (no accepted/error/phone/password expression)", () => {
+    // Isolate the hint paragraph and prove it contains no `{…}` JSX expression at all — a pure literal.
+    const hintStart = FORM.indexOf("First time signing in?");
+    // The <p> opens shortly before the copy; grab a generous window around the paragraph.
+    const windowStart = FORM.lastIndexOf("<p", hintStart);
+    const windowEnd = FORM.indexOf("</p>", hintStart);
+    const hint = FORM.slice(windowStart, windowEnd);
+    expect(hint).not.toMatch(/\{[^}]*\b(accepted|reset|error|phone|password|exist|confirm)\b/i);
+  });
+});
+
+describe("AUTH-OTP-10 · the password-failure message is a single generic constant (source)", () => {
+  it("passwordLogin returns the same 'Invalid phone or password.' regardless of the reason", () => {
+    // One constant, used for BOTH the empty-input and the auth-failure branch — no unknown-vs-wrong
+    // -password oracle. (Enumeration-safety; the OTP send path is Sarah's INCR-38 territory.)
+    expect(AUTH_ACTIONS).toContain('"Invalid phone or password."');
+    expect(AUTH_ACTIONS).not.toMatch(/no such (account|user)|not found|unconfirmed|does not exist/i);
+  });
+});
+
+describe("AUTH-OTP-10 · rendered login page leaks no existence oracle", () => {
+  it("the accepted banner is the ONLY state signal, and it is a navigation flag, not account state", () => {
+    const withBanner = renderToStaticMarkup(createElement(LoginForm, { accepted: true }));
+    const noBanner = renderToStaticMarkup(createElement(LoginForm, { accepted: false }));
+    expect(visible(withBanner)).toContain("Account ready");
+    expect(visible(noBanner)).not.toContain("Account ready");
+    // Neither render (nor the reset variant) ever names an account's existence/confirmation state.
+    for (const html of [
+      withBanner,
+      noBanner,
+      renderToStaticMarkup(createElement(LoginForm, { reset: true })),
+    ]) {
+      expect(visible(html)).not.toMatch(/not found|no such|unconfirmed|does not exist|already registered/i);
+    }
+  });
+});

--- a/omnischools/lib/auth/otp-login-required.test.ts
+++ b/omnischools/lib/auth/otp-login-required.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+/**
+ * INCR-AUTH-OTP · AUTH-OTP-11 (+ notes for S5) — the OTP-first gate `otpLoginRequired()` and the
+ * fail-closed `AUTH_OTP_LIVE` env flag. `env` is parsed once at `@/lib/env` load from `process.env`,
+ * so each case stubs the three inputs, `vi.resetModules()`, then dynamically re-imports a fresh
+ * `@/lib/auth` (which pulls a fresh `@/lib/env`). No DB is touched — the helper is pure config logic.
+ *
+ * The gate is `authIsLive() && env.AUTH_OTP_LIVE`, i.e. `!AUTH_DEV_BYPASS && !!SUPABASE_URL && OTP_LIVE`.
+ * The ONLY combination that is true: bypass off + URL set + flag "true". Everything else is false —
+ * that is the "fail closed" guarantee: a forgotten/misset flag can never turn OTP-first ON.
+ */
+async function loadAuth(vars: { bypass?: string; url?: string; otp?: string }) {
+  vi.resetModules();
+  // undefined ⇒ unset the var ⇒ the zod `.default("false")` (or `.optional()`) governs.
+  vi.stubEnv("AUTH_DEV_BYPASS", vars.bypass);
+  vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", vars.url);
+  vi.stubEnv("AUTH_OTP_LIVE", vars.otp);
+  const auth = await import("@/lib/auth");
+  const { env } = await import("@/lib/env");
+  return { ...auth, env };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+const LIVE_URL = "https://project.supabase.co";
+
+describe("AUTH-OTP-11 · AUTH_OTP_LIVE defaults false (fail closed)", () => {
+  it("absent flag ⇒ env.AUTH_OTP_LIVE === false", async () => {
+    const { env } = await loadAuth({ bypass: "false", url: LIVE_URL, otp: undefined });
+    expect(env.AUTH_OTP_LIVE).toBe(false);
+  });
+
+  it('flag "false" ⇒ env.AUTH_OTP_LIVE === false', async () => {
+    const { env } = await loadAuth({ bypass: "false", url: LIVE_URL, otp: "false" });
+    expect(env.AUTH_OTP_LIVE).toBe(false);
+  });
+
+  it('flag "true" ⇒ env.AUTH_OTP_LIVE === true', async () => {
+    const { env } = await loadAuth({ bypass: "false", url: LIVE_URL, otp: "true" });
+    expect(env.AUTH_OTP_LIVE).toBe(true);
+  });
+});
+
+describe("AUTH-OTP-11 · otpLoginRequired() is true ONLY under live-auth + flag on", () => {
+  it("the single TRUE case: bypass off + URL set + flag true", async () => {
+    const { otpLoginRequired, authIsLive } = await loadAuth({
+      bypass: "false",
+      url: LIVE_URL,
+      otp: "true",
+    });
+    expect(authIsLive()).toBe(true);
+    expect(otpLoginRequired()).toBe(true);
+  });
+
+  it("flag off (default) with live auth ⇒ false", async () => {
+    const { otpLoginRequired } = await loadAuth({ bypass: "false", url: LIVE_URL, otp: undefined });
+    expect(otpLoginRequired()).toBe(false);
+  });
+
+  it('flag explicitly "false" with live auth ⇒ false', async () => {
+    const { otpLoginRequired } = await loadAuth({ bypass: "false", url: LIVE_URL, otp: "false" });
+    expect(otpLoginRequired()).toBe(false);
+  });
+
+  it("no Supabase URL ⇒ authIsLive false ⇒ otpLoginRequired false even with flag true", async () => {
+    const { otpLoginRequired, authIsLive } = await loadAuth({
+      bypass: "false",
+      url: undefined,
+      otp: "true",
+    });
+    expect(authIsLive()).toBe(false);
+    expect(otpLoginRequired()).toBe(false);
+  });
+});
+
+describe("AUTH-OTP-11 / S5 · inert under dev-bypass", () => {
+  it("AUTH_DEV_BYPASS=true ⇒ authIsLive false ⇒ otpLoginRequired false (flag & URL ignored)", async () => {
+    const { otpLoginRequired, authIsLive } = await loadAuth({
+      bypass: "true",
+      url: LIVE_URL,
+      otp: "true",
+    });
+    expect(authIsLive()).toBe(false);
+    expect(otpLoginRequired()).toBe(false);
+  });
+
+  it("all three unset (bare default) ⇒ everything false", async () => {
+    const { otpLoginRequired, authIsLive, env } = await loadAuth({});
+    expect(env.AUTH_OTP_LIVE).toBe(false);
+    expect(authIsLive()).toBe(false);
+    expect(otpLoginRequired()).toBe(false);
+  });
+});

--- a/omnischools/lib/env.ts
+++ b/omnischools/lib/env.ts
@@ -58,6 +58,19 @@ const schema = z.object({
   // It exists because the clinical module is MATRON-gated and the shim otherwise pins every dev
   // session to ADMIN, making the sickbay UI and every clinical mutation unreachable in dev.
   AUTH_DEV_ROLES: z.string().optional(),
+
+  // OTP-first-login enforcement toggle (INCR-AUTH-OTP). Defaults "false" — FAIL CLOSED: the app shows
+  // the OTP-first flow (onboarding OTP step + first-login messaging) ONLY once SMS is proven live on
+  // prod. Read ONLY when `authIsLive()` is true (see `otpLoginRequired`). It is SEPARATE from
+  // AUTH_DEV_BYPASS and from merely having the Supabase URL set: `authIsLive()` means "auth wired", NOT
+  // "SMS provider attached" — a prod with the URL but no provider is `authIsLive()==true` yet
+  // OTP-undeliverable, so enabling OTP-first there would lock everyone out. Owner sets this LAST (P4),
+  // after P1 Supabase SMS provider + P2 a real test OTP to a Ghana number + P3 Supabase "Confirm phone"
+  // ON. See docs/senior/incr-auth-otp-first-login-ruling.md §5.
+  AUTH_OTP_LIVE: z
+    .enum(["true", "false"])
+    .default("false")
+    .transform((v) => v === "true"),
 });
 
 export const env = schema.parse(process.env);

--- a/omnischools/lib/next-config-headers.test.ts
+++ b/omnischools/lib/next-config-headers.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import nextConfig from "@/next.config.mjs";
+
+/**
+ * INCR-AUTH-OTP (headers half) — `next.config.mjs` `headers()` must apply the enforced hardening set to
+ * every path, and ship CSP as **Report-Only by design** (a strict enforcing CSP on the App Router needs
+ * live tuning first). This asserts the shape: the enforced keys/values, the report-only CSP, and the
+ * ABSENCE of an enforcing `Content-Security-Policy` (flipping report-only → enforcing prematurely would
+ * break hydration/styled-jsx, so its absence is the correct state today).
+ */
+async function headerMap() {
+  const headersFn = nextConfig.headers;
+  if (!headersFn) throw new Error("next.config.mjs must define headers()");
+  const rules = await headersFn();
+  expect(Array.isArray(rules)).toBe(true);
+  expect(rules).toHaveLength(1);
+  const rule = rules[0];
+  expect(rule.source).toBe("/:path*"); // applied to every path
+  const map = new Map<string, string>();
+  for (const h of rule.headers) map.set(h.key, h.value);
+  return map;
+}
+
+describe("headers · enforced hardening set", () => {
+  it("HSTS pins HTTPS for two years incl. subdomains + preload", async () => {
+    const m = await headerMap();
+    expect(m.get("Strict-Transport-Security")).toBe(
+      "max-age=63072000; includeSubDomains; preload",
+    );
+  });
+
+  it("clickjacking + MIME-sniff + referrer + permissions are locked down", async () => {
+    const m = await headerMap();
+    expect(m.get("X-Frame-Options")).toBe("DENY");
+    expect(m.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(m.get("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
+    expect(m.get("Permissions-Policy")).toBe(
+      "camera=(), microphone=(), geolocation=(), browsing-topics=()",
+    );
+  });
+});
+
+describe("headers · CSP is Report-Only by design", () => {
+  it("ships Content-Security-Policy-Report-Only with the app allowlist", async () => {
+    const m = await headerMap();
+    const csp = m.get("Content-Security-Policy-Report-Only");
+    expect(csp, "report-only CSP header must be present").toBeTruthy();
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("base-uri 'self'");
+  });
+
+  it("does NOT ship an ENFORCING Content-Security-Policy (report-only until a deploy proves it)", async () => {
+    const m = await headerMap();
+    expect(m.has("Content-Security-Policy")).toBe(false);
+  });
+});

--- a/omnischools/lib/onboarding-done-panel-render.test.ts
+++ b/omnischools/lib/onboarding-done-panel-render.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { readCode } from "@/lib/test-utils/source-shape";
+import { DonePanel } from "@/components/onboarding/wizard";
+import type { OnboardResult } from "@/lib/onboarding";
+
+/**
+ * INCR-AUTH-OTP · AUTH-OTP-06/07/08 — the onboarding done phase. `DonePanel` renders the inline OTP
+ * auto-sign-in card (`OnboardingOtpFinish`) IFF `result.otpLive`; a `/login` "Go to sign in" link is
+ * ALWAYS present (both states), so a failed/skipped OTP can never orphan or block the just-created
+ * school. `renderToStaticMarkup` runs the component in node with no jsdom — effects (the mount-time
+ * `requestOtp`) do NOT fire, so the render proves the STRUCTURE (which card shows, which links exist);
+ * the auto-send-once + verify→/dashboard wiring is proven at the SOURCE below.
+ */
+const okResult = (otpLive: boolean): Extract<OnboardResult, { ok: true }> => ({
+  ok: true,
+  schoolId: "sch_123",
+  academicYear: "2025/26",
+  periodsCreated: 3,
+  adminPhone: "+233241234567",
+  otpLive,
+});
+
+const render = (otpLive: boolean) =>
+  renderToStaticMarkup(
+    createElement(DonePanel, { result: okResult(otpLive), schoolName: "St. Theresa's SHS" }),
+  );
+
+const visible = (html: string) =>
+  html
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&apos;|&#x27;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const LOGIN_HREF = 'href="/login?accepted=1"';
+
+describe("AUTH-OTP-06 · otpLive=true renders the inline OTP auto-sign-in card", () => {
+  const html = render(true);
+
+  it("shows the OTP finish card wired to the creator's admin phone", () => {
+    const text = visible(html);
+    expect(text).toContain("Finish signing in — verify your number");
+    expect(text).toContain("Verify & go to dashboard");
+    expect(text).toContain("+233241234567"); // the effective admin phone from result.adminPhone
+  });
+
+  it("hides the plain 'Sign in →' button (the OTP card IS the sign-in action)", () => {
+    // The top button is gated `!result.otpLive`; only the bottom 'Go to sign in' link remains.
+    expect(visible(html)).not.toContain("Sign in →");
+  });
+
+  it("STILL exposes a /login link (no orphan/block) — AUTH-OTP-07", () => {
+    expect(html).toContain(LOGIN_HREF);
+    expect(visible(html)).toContain("Go to sign in");
+  });
+});
+
+describe("AUTH-OTP-08 · otpLive=false renders NO OTP step, links to /login", () => {
+  const html = render(false);
+
+  it("does NOT render the OTP finish card", () => {
+    expect(visible(html)).not.toContain("Finish signing in");
+    expect(html).not.toContain("Verify & go to dashboard");
+  });
+
+  it("renders the plain 'Sign in →' terminal button to /login", () => {
+    expect(visible(html)).toContain("Sign in →");
+    expect(html).toContain(LOGIN_HREF);
+  });
+
+  it("also keeps the always-present 'Go to sign in' /login link", () => {
+    expect(visible(html)).toContain("Go to sign in");
+  });
+});
+
+describe("AUTH-OTP-07 · a /login link is present in BOTH otpLive states", () => {
+  it("both renders contain at least one href=/login?accepted=1", () => {
+    expect(render(true)).toContain(LOGIN_HREF);
+    expect(render(false)).toContain(LOGIN_HREF);
+  });
+});
+
+/**
+ * AUTH-OTP-06 wiring that a static render cannot exercise: the mount-time single `requestOtp`, and
+ * `verifyLogin` (which redirects to /dashboard on success). Proven at the source (comment-stripped).
+ */
+describe("AUTH-OTP-06 · OTP card auto-sends once on mount and verifies via verifyLogin (source)", () => {
+  const WIZARD = readCode("components/onboarding/wizard.tsx");
+
+  it("the done phase renders OnboardingOtpFinish exactly when result.otpLive", () => {
+    expect(WIZARD).toContain("result.otpLive && <OnboardingOtpFinish");
+    // and the plain Sign-in button is the else case (gated on NOT otpLive)
+    expect(WIZARD).toContain("!result.otpLive");
+  });
+
+  it("mounts one app-controlled requestOtp to the admin phone", () => {
+    const effStart = WIZARD.indexOf("useEffect(");
+    const effEnd = WIZARD.indexOf("}, [phone]);", effStart);
+    const effect = WIZARD.slice(effStart, effEnd);
+    expect(effect).toContain("requestOtp(phone)");
+    // exactly one requestOtp inside the mount effect (the second call lives in `resend`, outside it)
+    expect((effect.match(/requestOtp\(/g) ?? []).length).toBe(1);
+  });
+
+  it("verify calls verifyLogin(phone, code) — which redirects to /dashboard", () => {
+    expect(WIZARD).toContain("verifyLogin(phone, code.trim())");
+    // verifyLogin's /dashboard redirect lives in the action, not the component.
+    expect(readCode("lib/actions/auth.ts")).toMatch(/verifyLogin[\s\S]*redirect\("\/dashboard"\)/);
+  });
+});

--- a/omnischools/lib/onboarding-done-panel-render.test.ts
+++ b/omnischools/lib/onboarding-done-panel-render.test.ts
@@ -30,8 +30,9 @@ const render = (otpLive: boolean) =>
 const visible = (html: string) =>
   html
     .replace(/<[^>]*>/g, " ")
-    .replace(/&amp;/g, "&")
     .replace(/&apos;|&#x27;/g, "'")
+    // Ampersand LAST: unescaping &amp; before the named entities can double-unescape (CodeQL js/double-escaping).
+    .replace(/&amp;/g, "&")
     .replace(/\s+/g, " ")
     .trim();
 

--- a/omnischools/lib/onboarding.ts
+++ b/omnischools/lib/onboarding.ts
@@ -405,5 +405,15 @@ export const OnboardSchema = z.object({
 
 export type OnboardInput = z.infer<typeof OnboardSchema>;
 export type OnboardResult =
-  | { ok: true; schoolId: string; academicYear: string; periodsCreated: number }
+  | {
+      ok: true;
+      schoolId: string;
+      academicYear: string;
+      periodsCreated: number;
+      // INCR-AUTH-OTP — the creator's admin phone (for the done-phase auto-sign-in OTP) + whether the
+      // OTP-first flow is live. When `otpLive`, the wizard's done phase runs the OTP step; else it links
+      // to /login. `adminPhone` is the effective (post adminSameAsHead) number, already normalized.
+      adminPhone: string;
+      otpLive: boolean;
+    }
   | { ok: false; error: string };

--- a/omnischools/next.config.mjs
+++ b/omnischools/next.config.mjs
@@ -13,6 +13,53 @@ const nextConfig = {
   // image to sharp/libvips server-side.
   // Don't leak host-specific build details.
   poweredByHeader: false,
+  async headers() {
+    return [{ source: "/:path*", headers: securityHeaders }];
+  },
 };
+
+/**
+ * App-wide security headers (audit item #1 — XSS/clickjacking/transport hardening).
+ *
+ * The ENFORCED headers are all low-risk (they don't change what renders): HSTS pins HTTPS,
+ * X-Frame-Options + frame-ancestors block clickjacking, nosniff stops MIME sniffing, a tight
+ * Referrer-Policy stops path/PII leakage via Referer, and Permissions-Policy denies device APIs
+ * the app never uses.
+ *
+ * CSP ships in **Report-Only** first (`Content-Security-Policy-Report-Only`): a strict enforcing CSP
+ * on the Next.js App Router needs live tuning (inline hydration bootstrap, styled-jsx, the Supabase
+ * API/realtime origins) that must be observed on a real deploy before it can block. Report-Only never
+ * breaks a page — it only surfaces would-be violations in the browser console — so it's the safe way
+ * to converge on an enforcing policy. Promote to `Content-Security-Policy` once the console is clean.
+ * ponytail: report-only until a deploy proves the allowlist; flip the header name to enforce.
+ */
+const csp = [
+  "default-src 'self'",
+  // Next injects inline hydration/bootstrap scripts; no nonce middleware yet, so 'unsafe-inline'.
+  "script-src 'self' 'unsafe-inline'",
+  // Tailwind + styled-jsx emit inline styles.
+  "style-src 'self' 'unsafe-inline'",
+  // School logo/stamp are Supabase-storage <img>; data:/blob: for embedded assets.
+  "img-src 'self' data: blob: https://*.supabase.co",
+  "font-src 'self' data:",
+  // Supabase Auth/REST/Realtime (wss for realtime).
+  "connect-src 'self' https://*.supabase.co wss://*.supabase.co",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "object-src 'none'",
+].join("; ");
+
+const securityHeaders = [
+  { key: "Strict-Transport-Security", value: "max-age=63072000; includeSubDomains; preload" },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), browsing-topics=()",
+  },
+  { key: "Content-Security-Policy-Report-Only", value: csp },
+];
 
 export default nextConfig;


### PR DESCRIPTION
## INCR-AUTH-OTP · OTP-mandatory first login + onboarding auto-sign-in + security headers

Addresses the owner's auth directive ("SMS+OTP mandatory for first-time login; subsequent phone logins OTP; password logins OTP-free; add onboarding auto-sign-in") plus audit item #1 (security headers). Spec: `docs/senior/incr-auth-otp-first-login-ruling.md` (Kofi, AC AUTH-OTP-01..11 + S1..S6). Supersedes the held `fix/onboarding-auth-confirm` branch.

### ⚠️ Inert until the owner enables it
The new `AUTH_OTP_LIVE` flag **defaults to `false`**, so **merging changes nothing in prod**. The OTP-first flow turns on only after the deploy prerequisites, in order (now in DEPLOY.md §1):
1. Attach a Supabase **Auth SMS provider** (Twilio/etc.) — **not** `HUBTEL_*` (Hubtel is only invite/reminder SMS).
2. Confirm a real test OTP reaches a Ghana number.
3. Enable **"Confirm phone"** in Supabase Auth — the load-bearing switch that makes GoTrue refuse password login on an un-verified phone.
4. Set `AUTH_OTP_LIVE=true`.

Before step 3 there is **no lockout** (sign-ups auto-confirm, password login works, OTP degrades to console).

### (a) OTP-mandatory first login
- Enforcement is **GoTrue-native**, not an app check: with "Confirm phone" ON, an unconfirmed phone can't password-login, so a first login must go through OTP (which confirms the phone). `createPasswordUser` stays on plain `signUp` (unconfirmed) — **we never admin-confirm a phone** (that would let a first login skip OTP; it's exactly what the held branch did and this drops).
- A static, **enumeration-safe** hint on the Password tab steers first-timers to the OTP tab (identical regardless of whether the number exists/is confirmed).

### (b) Onboarding auto-sign-in (Option A)
- The wizard's done screen (`OnboardingOtpFinish`) auto-sends one OTP and verifies it — that single act **confirms the phone AND establishes the session**, landing the creator straight in `/dashboard`.
- Fail-safe: the school + account commit *before* the OTP step, and a `/login` fallback link renders unconditionally, so a failed/declined OTP never orphans or blocks the account.
- Gated by `otpLoginRequired()` = `authIsLive() && AUTH_OTP_LIVE`; when off (incl. all dev), the done screen keeps today's "Sign in →" link.

### (c) Security headers
- **Enforced:** HSTS, `X-Frame-Options: DENY` (clickjacking), `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy` (deny unused device APIs).
- **`Content-Security-Policy-Report-Only`** first (self + Supabase allowlist) — non-breaking, so it can be tuned on a real deploy before promoting to enforcing. No Vercel-specific config (portable).

### No schema
No migration, no `ref_user` marker (Wells not needed) — the signal is Supabase's `phone_confirmed_at`. The only new state is the `AUTH_OTP_LIVE` env flag.

### Gates
- **Quinn (QA) 🟢** — full suite **2000/2000** (+32), tsc/build green; 4 mutations RED'd incl. the KEY `phone_confirm:true` guard. The un-demoable OTP flow (dev-bypass makes it inert; real OTP needs live SMS) proven via source + `renderToStaticMarkup`.
- **Dex (architecture) ✅** — flag seam, wizard reuse of shipped `requestOtp`/`verifyLogin`, held-branch supersession, portable headers all sound. 2 LOWs folded (exactly-once OTP send guard; docblock).
- **Sarah (security + final) 🟢 CLEAR** — no phone auto-confirm on any path (the auth seam type has no `admin` member, so the admin-confirm backdoor is structurally unreachable — repo-wide grep for `phone_confirm`/`admin.createUser`/`admin.updateUserById` is clean); no lockout; enumeration-safe (static hint + generic error, INCR-38 neutral-always intact); `AUTH_OTP_LIVE` fail-closed; R276 reset-gate + INCR-38 untouched. Clickjacking enforced now via `X-Frame-Options: DENY`; report-only CSP correctly deferred. No prod-paste.

### Follow-up (tracked, not in this PR)
(d) Supabase leaked-password + complexity rules; (e) login/OTP rate-limit or CAPTCHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
