### PR TITLE
feat(auth): app-side password complexity rule (audit #5)

### DIFF
--- a/omnischools/components/auth/accept-form.tsx
+++ b/omnischools/components/auth/accept-form.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { acceptInvite } from "@/lib/actions/invites";
+import { passwordProblem } from "@/lib/password";
 
 const fieldClass =
   "w-full rounded-md border border-border-2 bg-bg px-3.5 py-2.5 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
@@ -15,8 +16,9 @@ export function AcceptForm({ token, contact }: { token: string; contact: string 
   const [error, setError] = useState<string | null>(null);
 
   async function submit() {
-    if (password.length < 8) {
-      setError("Password must be at least 8 characters.");
+    const problem = passwordProblem(password);
+    if (problem) {
+      setError(`${problem}.`);
       return;
     }
     if (password !== confirm) {

--- a/omnischools/components/auth/change-password-form.tsx
+++ b/omnischools/components/auth/change-password-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState } from "react";
 import { changeOwnPassword } from "@/lib/actions/auth";
+import { passwordProblem } from "@/lib/password";
 import { rekeySnapshots } from "@/lib/score-ledger/pwa-store";
 
 /**
@@ -21,14 +22,15 @@ export function ChangePasswordForm({ sessionId }: { sessionId?: string }) {
   const [error, setError] = useState<string | null>(null);
   const [done, setDone] = useState(false);
 
-  const tooShort = next.length > 0 && next.length < 8;
+  const pwProblem = next.length > 0 ? passwordProblem(next) : null;
   const mismatch = confirm.length > 0 && next !== confirm;
-  const canSubmit = !!current && next.length >= 8 && next === confirm && !busy;
+  const canSubmit = !!current && !passwordProblem(next) && next === confirm && !busy;
 
   async function submit() {
     setError(null);
     setDone(false);
-    if (next.length < 8) return setError("Password must be at least 8 characters");
+    const problem = passwordProblem(next);
+    if (problem) return setError(problem);
     if (next !== confirm) return setError("Passwords don't match.");
     setBusy(true);
     const res = await changeOwnPassword({ currentPassword: current, newPassword: next });
@@ -92,7 +94,7 @@ export function ChangePasswordForm({ sessionId }: { sessionId?: string }) {
         />
       </div>
 
-      {tooShort && <p className="text-[12px] text-terra">Password must be at least 8 characters.</p>}
+      {pwProblem && <p className="text-[12px] text-terra">{pwProblem}.</p>}
       {mismatch && <p className="text-[12px] text-terra">Passwords don&apos;t match.</p>}
       {error && <p className="text-sm text-terra">{error}</p>}
       {done && (

--- a/omnischools/components/auth/set-new-password.tsx
+++ b/omnischools/components/auth/set-new-password.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { completePasswordReset } from "@/lib/actions/auth";
+import { passwordProblem } from "@/lib/password";
 
 /**
  * INCR-36 (L3) — Step 3 of the reset flow: set a NEW password on the already-proven session (phone OTP
@@ -23,13 +24,14 @@ export function SetNewPassword({ redirectTo }: { redirectTo: string }) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const tooShort = next.length > 0 && next.length < 8;
+  const pwProblem = next.length > 0 ? passwordProblem(next) : null;
   const mismatch = confirm.length > 0 && next !== confirm;
-  const canSubmit = next.length >= 8 && next === confirm && !busy;
+  const canSubmit = !passwordProblem(next) && next === confirm && !busy;
 
   async function submit() {
     setError(null);
-    if (next.length < 8) return setError("Password must be at least 8 characters");
+    const problem = passwordProblem(next);
+    if (problem) return setError(problem);
     if (next !== confirm) return setError("Passwords don't match.");
     setBusy(true);
     const res = await completePasswordReset({ newPassword: next });
@@ -68,7 +70,7 @@ export function SetNewPassword({ redirectTo }: { redirectTo: string }) {
         />
       </div>
 
-      {tooShort && <p className="text-[12px] text-terra">Password must be at least 8 characters.</p>}
+      {pwProblem && <p className="text-[12px] text-terra">{pwProblem}.</p>}
       {mismatch && <p className="text-[12px] text-terra">Passwords don&apos;t match.</p>}
       {error && <p className="text-sm text-terra">{error}</p>}
 

--- a/omnischools/components/onboarding/wizard.tsx
+++ b/omnischools/components/onboarding/wizard.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/lib/onboarding";
 import { onboardSchool } from "@/lib/actions/onboarding";
 import { requestOtp, verifyLogin } from "@/lib/actions/auth";
+import { passwordProblem } from "@/lib/password";
 
 type Form = Partial<OnboardInput> & { subtype?: SchoolSubtype; confirmPassword?: string };
 
@@ -97,8 +98,8 @@ export function OnboardingWizard({ initialType }: { initialType?: CardId }) {
   };
   // Same policy as the invite/accept flow (min-8) + a confirm-match guard (R257b).
   const passwordError = (): string | null => {
-    if (!form.password || form.password.length < 8)
-      return "Password must be at least 8 characters";
+    const problem = passwordProblem(form.password ?? "");
+    if (problem) return problem;
     if (form.password !== form.confirmPassword) return "Passwords don't match.";
     return null;
   };
@@ -619,7 +620,7 @@ function PasswordStep({
 }) {
   const pw = f("password");
   const confirm = f("confirmPassword");
-  const tooShort = pw.length > 0 && pw.length < 8;
+  const pwProblem = pw.length > 0 ? passwordProblem(pw) : null;
   const mismatch = confirm.length > 0 && pw !== confirm;
   return (
     <div>
@@ -630,7 +631,7 @@ function PasswordStep({
         lede="Set a password so you can sign in. You can also sign in with your phone number via a one-time code — your choice each time."
       />
       <div className="max-w-[460px] space-y-4">
-        <Field label="Set a password" req help="At least 8 characters.">
+        <Field label="Set a password" req help="At least 8 characters, with a letter and a number.">
           <input
             className={inputCls(!!pw)}
             type="password"
@@ -650,9 +651,7 @@ function PasswordStep({
             autoComplete="new-password"
           />
         </Field>
-        {tooShort && (
-          <p className="text-[12px] text-terra">Password must be at least 8 characters.</p>
-        )}
+        {pwProblem && <p className="text-[12px] text-terra">{pwProblem}.</p>}
         {mismatch && <p className="text-[12px] text-terra">Passwords don&apos;t match.</p>}
         <div className="rounded-r-lg border-l-[3px] border-gold bg-gold-bg px-4 py-3 text-[12px] leading-relaxed text-navy-2">
           <b className="text-navy">Two ways to sign in.</b> After launch you can use this password

--- a/omnischools/components/onboarding/wizard.tsx
+++ b/omnischools/components/onboarding/wizard.tsx
@@ -96,7 +96,7 @@ export function OnboardingWizard({ initialType }: { initialType?: CardId }) {
     setError(null);
     setStep("identity");
   };
-  // Same policy as the invite/accept flow (min-8) + a confirm-match guard (R257b).
+  // Same policy as the invite/accept flow (shared passwordSchema) + a confirm-match guard (R257b).
   const passwordError = (): string | null => {
     const problem = passwordProblem(form.password ?? "");
     if (problem) return problem;

--- a/omnischools/lib/actions/auth.ts
+++ b/omnischools/lib/actions/auth.ts
@@ -11,6 +11,7 @@ import {
   getSessionId,
 } from "@/lib/auth";
 import { requireUser, resolveActor } from "@/lib/auth/server";
+import { passwordProblem } from "@/lib/password";
 import { withSchool } from "@/lib/db/rls";
 import { recordAudit } from "@/lib/db/audit";
 
@@ -59,8 +60,9 @@ export async function changeOwnPassword(input: {
 }): Promise<{ ok: boolean; error?: string; newSessionId?: string }> {
   const currentPassword = input?.currentPassword ?? "";
   const newPassword = input?.newPassword ?? "";
-  if (newPassword.length < 8) {
-    return { ok: false, error: "Password must be at least 8 characters" };
+  const pwProblem = passwordProblem(newPassword);
+  if (pwProblem) {
+    return { ok: false, error: pwProblem };
   }
   const user = await requireUser();
   // Prove the current password before changing it (blocks a walk-up attacker on an unlocked session).
@@ -154,8 +156,9 @@ export async function completePasswordReset(input: {
   newPassword: string;
 }): Promise<{ ok: boolean; error?: string }> {
   const newPassword = input?.newPassword ?? "";
-  if (newPassword.length < 8) {
-    return { ok: false, error: "Password must be at least 8 characters" };
+  const pwProblem = passwordProblem(newPassword);
+  if (pwProblem) {
+    return { ok: false, error: pwProblem };
   }
   const methods = await sessionAuthMethods();
   const passwordOnly = methods.length > 0 && methods.every((m) => m === "password");

--- a/omnischools/lib/actions/invites.ts
+++ b/omnischools/lib/actions/invites.ts
@@ -5,6 +5,7 @@ import { withSchool, withoutTenantScope } from "@/lib/db/rls";
 import { recordAudit } from "@/lib/db/audit";
 import { requireSchool, resolveActor } from "@/lib/auth/server";
 import { normalizeGhanaPhone, createPasswordUser } from "@/lib/auth";
+import { passwordSchema } from "@/lib/password";
 import { sendSms } from "@/lib/sms";
 import { sendEmail } from "@/lib/email";
 import { safeRevalidate } from "@/lib/revalidate";
@@ -188,7 +189,7 @@ export async function revokeInvite(input: unknown): Promise<Result> {
 // ----------------------------------------------------------------- accept
 const AcceptSchema = z.object({
   token: z.string().min(6),
-  password: z.string().min(8, "Password must be at least 8 characters"),
+  password: passwordSchema, // shared app-side policy (audit #5): min-8 + a letter + a number
 });
 
 export async function acceptInvite(input: unknown): Promise<Result> {

--- a/omnischools/lib/auth-l2a.test.ts
+++ b/omnischools/lib/auth-l2a.test.ts
@@ -30,10 +30,10 @@ describe("L2a · self change-password action", () => {
     expect(ACTION.indexOf("!reauth.ok")).toBeLessThan(ACTION.indexOf("updatePassword(newPassword)"));
   });
 
-  it("L2-3 · min-8 is enforced BEFORE any auth call", () => {
-    expect(ACTION).toContain("newPassword.length < 8");
+  it("L2-3 · the password policy is enforced BEFORE any auth call", () => {
+    expect(ACTION).toContain("passwordProblem(newPassword)");
     // scope to changeOwnPassword's own re-auth call (signInWithPassword( also appears in passwordLogin)
-    expect(ACTION.indexOf("newPassword.length < 8")).toBeLessThan(
+    expect(ACTION.indexOf("passwordProblem(newPassword)")).toBeLessThan(
       ACTION.indexOf("signInWithPassword(user.phone, currentPassword)"),
     );
   });

--- a/omnischools/lib/auth-l3.test.ts
+++ b/omnischools/lib/auth-l3.test.ts
@@ -60,10 +60,9 @@ describe("L3 · forgot-password", () => {
     expect(b).not.toContain("targetUserId");
   });
 
-  it("L3-11 · completePasswordReset enforces min-8", () => {
+  it("L3-11 · completePasswordReset enforces the password policy", () => {
     const b = body(ACTION, "completePasswordReset");
-    expect(b).toContain("newPassword.length < 8");
-    expect(b).toContain("Password must be at least 8 characters");
+    expect(b).toContain("passwordProblem(newPassword)");
   });
 
   it("L3-12 · completePasswordReset requires NO current password (distinct from changeOwnPassword)", () => {

--- a/omnischools/lib/auth/otp-login-required.test.ts
+++ b/omnischools/lib/auth/otp-login-required.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 
+// Each test does vi.resetModules() + a fresh dynamic re-import of the module graph; under full-suite
+// loader contention that occasionally exceeds the 5s default. Raise the file's timeout (no DB work here).
+vi.setConfig({ testTimeout: 20_000 });
+
 /**
  * INCR-AUTH-OTP · AUTH-OTP-11 (+ notes for S5) — the OTP-first gate `otpLoginRequired()` and the
  * fail-closed `AUTH_OTP_LIVE` env flag. `env` is parsed once at `@/lib/env` load from `process.env`,

--- a/omnischools/lib/onboarding-l1.test.ts
+++ b/omnischools/lib/onboarding-l1.test.ts
@@ -55,10 +55,11 @@ describe("L1 · the signup password step", () => {
     expect((WIZARD.match(/type="password"/g) ?? []).length).toBeGreaterThanOrEqual(2);
   });
 
-  it("L1-5 · min-8 enforced client (wizard) AND server (schema), identical message", () => {
-    expect(WIZARD).toContain("Password must be at least 8 characters");
-    expect(WIZARD).toMatch(/form\.password\.length < 8/);
-    expect(SCHEMA).toContain('password: z.string().min(8, "Password must be at least 8 characters")');
+  it("L1-5 · policy enforced client (wizard) AND server (schema) via the shared passwordProblem/passwordSchema", () => {
+    // Single-sourced in lib/password (audit #5: min-8 + a letter + a number). The behavioural proof is
+    // lib/password.test.ts; here we pin that both the client and the server route through it.
+    expect(WIZARD).toMatch(/passwordProblem\(/);
+    expect(SCHEMA).toContain("password: passwordSchema");
   });
 
   it("L1-6 · confirm-mismatch is blocked", () => {
@@ -67,12 +68,10 @@ describe("L1 · the signup password step", () => {
   });
 
   it("L1-7 · password is MANDATORY (schema required, launch guards empty)", () => {
-    // Required in the schema (not `.optional()`).
-    expect(SCHEMA).not.toMatch(
-      /password: z\.string\(\)\.min\(8, "Password must be at least 8 characters"\)\.optional/,
-    );
-    // Launch cannot proceed with an empty password.
-    expect(WIZARD).toContain("!form.password");
+    // Required in the schema (passwordSchema, not `.optional()`).
+    expect(SCHEMA).toContain("password: passwordSchema");
+    expect(SCHEMA).not.toMatch(/password: passwordSchema\.optional/);
+    // Launch cannot proceed with an empty password: passwordError → passwordProblem("") returns an error.
     expect(WIZARD).toMatch(/identityError\(\) \?\? passwordError\(\)/);
   });
 

--- a/omnischools/lib/onboarding.ts
+++ b/omnischools/lib/onboarding.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { passwordSchema } from "@/lib/password";
 
 // Shared onboarding constants/schema/types — importable by both the client wizard
 // and the "use server" action (a "use server" module may only export async functions).
@@ -390,8 +391,8 @@ export const OnboardSchema = z.object({
   adminPhone: z.string().min(7, "Your phone number is required").max(40),
   adminEmail: z.string().email().optional().or(z.literal("")),
   // INCR-33 (Module L / L1) — the owner sets a password at signup (mandatory, R257a), so they can sign
-  // in with either OTP or password. Same policy/message as the invite/accept flow (AcceptSchema min-8).
-  password: z.string().min(8, "Password must be at least 8 characters"),
+  // in with either OTP or password. Shared app-side policy (audit #5): min-8 + a letter + a number.
+  password: passwordSchema,
   // Staff step — who handles billing. "ADMIN" = the admin keeps full billing access
   // (combined); "ACCOUNTANT" = a separate Accountant role, invited below.
   billingHandler: z.enum(["ADMIN", "ACCOUNTANT"]).optional(),

--- a/omnischools/lib/password.test.ts
+++ b/omnischools/lib/password.test.ts
@@ -32,6 +32,10 @@ describe("password policy · min-8 + a letter + a number", () => {
     expect(passwordProblem("12345678")).toMatch(/letter/i);
   });
 
+  it("rejects an over-long password (> 128 chars)", () => {
+    expect(passwordProblem("a1".repeat(70))).toMatch(/at most 128/i); // 140 chars, letter+digit present
+  });
+
   it("passwordProblem returns null exactly when the schema passes (they agree)", () => {
     for (const pw of ["short", "12345678", "password", "abcd1234", "", "ok1"]) {
       expect(passwordProblem(pw) === null).toBe(passwordSchema.safeParse(pw).success);

--- a/omnischools/lib/password.test.ts
+++ b/omnischools/lib/password.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { passwordSchema, passwordProblem, PASSWORD_MIN } from "@/lib/password";
+
+/**
+ * Audit item #5 — the app-side password policy: min-8 + at least one letter + at least one number.
+ * This is the behavioural proof; the source-pin tests (onboarding-l1 / auth-l2a / auth-l3) only assert
+ * that the call sites route through this shared policy.
+ */
+describe("password policy · min-8 + a letter + a number", () => {
+  it("PASSWORD_MIN is 8", () => {
+    expect(PASSWORD_MIN).toBe(8);
+  });
+
+  it("accepts a compliant password (letters + a number, ≥8)", () => {
+    for (const ok of ["abcd1234", "Str0ngpass", "kwame2024", "passw0rd"]) {
+      expect(passwordProblem(ok)).toBeNull();
+      expect(passwordSchema.safeParse(ok).success).toBe(true);
+    }
+  });
+
+  it("rejects too-short (< 8), even with a letter and a number", () => {
+    expect(passwordProblem("ab12")).toMatch(/at least 8/i);
+    expect(passwordSchema.safeParse("a1b2c3").success).toBe(false);
+  });
+
+  it("rejects all-letters — no number (e.g. 'password')", () => {
+    expect(passwordProblem("password")).toMatch(/number/i);
+    expect(passwordProblem("onlyletters")).toMatch(/number/i);
+  });
+
+  it("rejects all-digits — no letter (e.g. '12345678')", () => {
+    expect(passwordProblem("12345678")).toMatch(/letter/i);
+  });
+
+  it("passwordProblem returns null exactly when the schema passes (they agree)", () => {
+    for (const pw of ["short", "12345678", "password", "abcd1234", "", "ok1"]) {
+      expect(passwordProblem(pw) === null).toBe(passwordSchema.safeParse(pw).success);
+    }
+  });
+});

--- a/omnischools/lib/password.ts
+++ b/omnischools/lib/password.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+/**
+ * App-side password policy (audit item #5) — THE single source of truth. Every signup / invite-accept /
+ * self-change / reset path validates through this, so the rule cannot drift across the ~10 call sites it
+ * used to be copy-pasted into.
+ *
+ * Rule: at least 8 characters AND at least one letter AND at least one number. This rejects the common
+ * weak passwords (all-letters like "password", all-digits like "12345678") without symbol-required
+ * friction for non-technical school admins. It is COMPLEMENTARY to Supabase's own min-length +
+ * leaked-password (HIBP) protection (Auth dashboard), which the deploy guide recommends enabling too —
+ * this is the app-enforced floor that holds regardless of the provider's settings.
+ */
+export const PASSWORD_MIN = 8;
+
+export const passwordSchema = z
+  .string()
+  .min(PASSWORD_MIN, `Password must be at least ${PASSWORD_MIN} characters`)
+  .regex(/\p{L}/u, "Password must include at least one letter")
+  .regex(/\d/, "Password must include at least one number");
+
+/**
+ * The first password-policy problem, or null if the password passes. For the imperative (non-Zod) call
+ * sites — the client forms' live/submit hints and the self-change / reset server actions.
+ */
+export function passwordProblem(pw: string): string | null {
+  const r = passwordSchema.safeParse(pw);
+  return r.success ? null : (r.error.issues[0]?.message ?? "Invalid password");
+}

--- a/omnischools/lib/password.ts
+++ b/omnischools/lib/password.ts
@@ -17,7 +17,10 @@ export const passwordSchema = z
   .string()
   .min(PASSWORD_MIN, `Password must be at least ${PASSWORD_MIN} characters`)
   .regex(/\p{L}/u, "Password must include at least one letter")
-  .regex(/\d/, "Password must include at least one number");
+  .regex(/\d/, "Password must include at least one number")
+  // Defense-in-depth cap (Sarah): the lone otherwise-unbounded string on these forms. GoTrue rejects
+  // >72-char passwords downstream anyway; this just bounds the input with a friendly message first.
+  .max(128, "Password must be at most 128 characters");
 
 /**
  * The first password-policy problem, or null if the password passes. For the imperative (non-Zod) call


### PR DESCRIPTION
## Password complexity rule (audit item #5, follow-up (d))

Follow-up to the auth audit — the app-enforced password floor. Previously the rule was a bare `min(8)` copy-pasted across ~10 sites (2 server schemas, 2 self-service actions, 4 client forms) with no complexity check. This single-sources it and adds complexity.

### The policy — `lib/password.ts` (single source of truth)
**At least 8 characters, with at least one letter and at least one number.** Rejects the common weak passwords (`password` — no number; `12345678` — no letter) without symbol-required friction for non-technical school admins. Complementary to Supabase's own leaked-password (HIBP) + length settings — this is the app floor that holds regardless of the provider config.

- `passwordSchema` (Zod) for the schema call sites; `passwordProblem(pw)` (thin `safeParse` wrapper) for the imperative ones.

### Enforced on every password-set path
Server (the boundary — a hand-crafted request can't bypass it):
- Signup — `OnboardSchema.password` (`lib/onboarding.ts`), re-validated in `onboardSchool`.
- Invite-accept — `AcceptSchema.password` (`lib/actions/invites.ts`), re-validated in `acceptInvite`.
- Self-change — `changeOwnPassword` and reset — `completePasswordReset` (`lib/actions/auth.ts`), guarded **before** the auth/`updatePassword` call.

Client (UX) — the four forms now show the *actual* problem live (e.g. "must include at least one number") instead of a length-only hint, using the same shared policy so the messages can't drift.

### Tests
- `lib/password.test.ts` (new, behavioural) — accepts compliant, rejects short / all-letters / all-digits; asserts `passwordProblem` and `passwordSchema` agree.
- Updated the 3 source-pin tests (`onboarding-l1`, `auth-l2a`, `auth-l3`) to assert the call sites route through the shared policy (the behaviour is proven in `password.test.ts`).
- One-line flake fix in `otp-login-required.test.ts` (an unrelated #243 test whose `vi.resetModules()` re-import tipped past the 5s default under the now-larger suite — raised its file timeout).

Full suite **2006 green**, tsc + `next build` green. No schema, no prod-paste. The only account-creation fixture (`scripts/verify-onboarding.ts`) is policy-compliant.

Gates: Dex + Sarah in review (QA self-covered by the behavioural test + updated source-pins + green suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
