### PR TITLE
docs(senior): sync L1/L2/L3 auth surface maps to shipped copy

### DIFF
--- a/omnischools/docs/senior/l1-signup-surface-map.md
+++ b/omnischools/docs/senior/l1-signup-surface-map.md
@@ -83,20 +83,38 @@ This is the existing, live set-password screen — port its exact field styling,
 - `fieldClass = "w-full rounded-md border border-border-2 bg-bg px-3.5 py-2.5 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface"`.
 - Labels verbatim: **`Set a password`**, **`Confirm password`** (title case, no help text on the accept screen; the wireframe adds the `*` required markers — keep them for signup).
 - Both inputs `type="password"`, submit-on-Enter (`onKeyDown … Enter`).
-- **Validation (reuse these exact strings):**
-  - `password.length < 8` → **`"Password must be at least 8 characters."`**
-  - `password !== confirm` → **`"Passwords don't match."`**
+- **Validation — single-sourced via `passwordProblem` (`lib/password.ts`, PR #244); do NOT re-hardcode:** the accept screen calls `passwordProblem(password)` and, on a non-null result, sets the error to `` `${problem}.` `` (a period is appended). The rule is **min 8 + at least one letter + at least one number (max 128)**; the messages, in check order, are:
+  - **`"Password must be at least 8 characters"`** (< 8)
+  - **`"Password must include at least one letter"`** (no letter)
+  - **`"Password must include at least one number"`** (no digit)
+  - **`"Password must be at most 128 characters"`** (> 128)
+  - then `password !== confirm` → **`"Passwords don't match."`**
   - Error render: `<p className="text-sm text-terra">…</p>`.
-- No strength meter, no complexity rules beyond min-8 — the accept screen has none; do not add one (YAGNI, and it would drift from the existing pattern).
+- No strength meter — the rule is exactly `passwordSchema` (min-8 + letter + number, max-128), single-sourced in `lib/password.ts`; do not add a meter or extra rules, and do not re-hardcode the strings.
 - Button: `w-full rounded-md bg-navy px-5 py-3 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-60`, label `Accept & continue →` / busy `Setting up…`.
 
 ### 3.2 Placement recommendation (design-faithful, minimal)
 The live wizard's `IdentityStep` already has a **"Your details · you sign in first"** sub-section (Full name / Phone (login) / Email — optional) followed by the Terms checkbox and the `Launch school →` CTA. The wireframe surface puts password/confirm **inside that same "Your details" block, right after the contact fields and before Terms.**
 
-- **Recommended: inline, inside "Your details"** — add a 2-col row `Set a password *` / `Confirm password *` between the phone/email grid and the Terms `<label>`. This is 1:1 with the authored precedent, keeps the flow at **2 steps** (no counter/pill changes), and reuses the AcceptForm validation. Use the live wizard's own `Field` + `inputCls` wrappers (see §4) so it matches the surrounding fields, not the accept-screen card exactly — i.e. `<Field label="Password" req help="At least 8 characters."><input type="password" className={inputCls(!!…)} /></Field>` and a confirm `<Field>`. Wire the two validators into `identityError()` before the existing `termsAccepted` check.
+- **Recommended: inline, inside "Your details"** — add a 2-col row `Set a password *` / `Confirm password *` between the phone/email grid and the Terms `<label>`. This is 1:1 with the authored precedent, keeps the flow at **2 steps** (no counter/pill changes), and reuses the AcceptForm validation. Use the live wizard's own `Field` + `inputCls` wrappers (see §4) so it matches the surrounding fields, not the accept-screen card exactly — i.e. `<Field label="Password" req help="At least 8 characters, with a letter and a number."><input type="password" className={inputCls(!!…)} /></Field>` and a confirm `<Field>`. Wire the two validators into `identityError()` before the existing `termsAccepted` check.
 - **Alternative: a literal 3rd step** ("Step 3 of 3 · Create your password", standalone like the accept card). Only take this if product wants password isolated from PII entry. If so, the implementer MUST also update: the two step-pill strings, the footer meta line, and the `"Step 1 of 2"/"Step 2 of 2"` counters to `… of 3`. **No authored surface shows this** — flag before choosing. Default to inline.
 
 Either way the password is validated **client-side before `onboardSchool`**, and `onboardSchool`/`OnboardSchema` must accept the new `adminPassword` value (schema field addition — Kofi/Claude Code's call, not mapped here).
+
+### 3.3 Done-phase OTP-finish step (INCR-AUTH-OTP / PR #243 — **gated by `AUTH_OTP_LIVE`**)
+
+Shipped after INCR-33: the wizard's **done phase** (`DonePanel`) branches on `result.otpLive` (= `otpLoginRequired()` = `authIsLive() && env.AUTH_OTP_LIVE`; default **OFF** — full behaviour in `docs/senior/incr-auth-otp-first-login-ruling.md`).
+
+- **OTP-first ON (`result.otpLive` true)** — the success card's gold `Sign in →` button is **hidden**, and an OTP-finish card (`OnboardingOtpFinish`) renders below it. It auto-issues exactly **one** `requestOtp(phone)` on mount, then verify → confirms the phone + establishes the session + redirects to `/dashboard` (`verifyLogin`).
+  - Container: `mt-5 rounded-xl border border-gold-soft bg-gold-bg px-6 py-5`.
+  - Heading (`font-display text-base font-semibold text-navy`): **"Finish signing in — verify your number"**
+  - Body (`text-[13px] leading-relaxed text-navy-2`): **"We sent a one-time code to {phone}. Enter the latest code to confirm your number and go straight to your dashboard. You'll be able to sign in with your password after this."**
+  - OTP input: placeholder **"••••••"**, `inputMode="numeric"`, `w-40 … text-center font-mono text-lg tracking-[0.3em]` (mono, like the login OTP field).
+  - Primary button (`bg-navy … text-bg`): **"Verify & go to dashboard"** / busy **"Verifying…"**
+  - Resend link (`text-xs font-semibold text-navy-3 hover:text-navy`): **"Resend code"** → **"Code re-sent ✓"**
+  - Error: `mt-2 text-sm text-terra`
+- **OTP-first OFF (`result.otpLive` false — the default)** — no OTP card; the success card keeps the gold **"Sign in →"** → `/login?accepted=1`.
+- **Always present (both states, AC-07 no-orphan escape)** — the terminal **"Go to sign in"** link → `/login?accepted=1` (`border border-border-2 bg-surface …`) plus the `school id · {schoolId}` mono line. The school + account are committed before the OTP step, so a failed send/verify never blocks — the same OTP tab at `/login` completes first login.
 
 ---
 
@@ -143,8 +161,10 @@ If password becomes a literal 3rd step, its own CTA should be the **navy** `Cont
 ## 5. INCR-33 change-list (the mechanical port)
 
 1. **Remove CSSPS** — delete the `CSSPS school code` `<Field>` from `IdentityStep` (`wizard.tsx` ~438–445); change that grid from `sm:grid-cols-3` to `sm:grid-cols-2` (GES code + Year founded remain). Leave `csspsCode` out of the submitted `form`; the optional schema key can stay or be dropped by the data owner. No review-row cleanup needed in the live "done" panel.
-2. **Add password** — inside `IdentityStep`'s "Your details · you sign in first" block, after the name/phone/email grid and before the Terms `<label>`, add a 2-col row of `Password *` + `Confirm password *` (`type="password"`, live `Field`/`inputCls` wrappers, help "At least 8 characters."). Add the two validators (`< 8` → "Password must be at least 8 characters."; mismatch → "Passwords don't match.") into `identityError()` ahead of the terms check. Reuse `AcceptForm`'s strings/rules exactly. Flow stays 2 steps.
+2. **Add password** — inside `IdentityStep`'s "Your details · you sign in first" block, after the name/phone/email grid and before the Terms `<label>`, add a 2-col row of `Password *` + `Confirm password *` (`type="password"`, live `Field`/`inputCls` wrappers, help "At least 8 characters, with a letter and a number."). Validate through the shared `passwordProblem` (`lib/password.ts`, PR #244) — min-8 + at least one letter + at least one number (max-128), surfaced as the failing-rule inline hint (`.`-suffixed) — plus mismatch → "Passwords don't match.", wired ahead of the terms check. Reuse `AcceptForm`'s rules exactly (same helper). Flow stays 2 steps.
 3. **PROPRIETOR role** — brief says **no visible wizard change**. The live wizard has **no role picker for the creator** (they become the ADMIN by construction), so nothing renders differently. The only authored place a self-role appears is the wireframe's `Your role` select (`Headmistress / Headmaster / Proprietor / IT lead / Other`) — a *different* surface not in the live flow. Registering PROPRIETOR is an RBAC/role-model addition (see `lib/access.ts`, `lib/staff-roles.ts`), out of my cartography scope — hand to Kofi/Sarah/Claude Code. Confirmed: **no signup UI element to map for this item.**
+
+4. **Done-phase OTP-finish (INCR-AUTH-OTP / PR #243 — gated by `AUTH_OTP_LIVE`)** — when `result.otpLive` is true, `DonePanel` hides the `Sign in →` button and renders `OnboardingOtpFinish` (auto-`requestOtp` on mount → **"Verify & go to dashboard"** → `/dashboard`); when false, the gold `Sign in →` → `/login?accepted=1` stays. The `Go to sign in` → `/login?accepted=1` link is always present (AC-07 no-orphan). Full copy/tokens in §3.3.
 
 ---
 
@@ -160,13 +180,14 @@ If password becomes a literal 3rd step, its own CTA should be the **navy** `Cont
 
 ## 7. Drift / notes log
 
-1. **Primary surface has no password step.** INCR-33's password step is *new design*, not a port — but it is fully constrained by (a) the wireframe precedent (fields, order, confirm rationale, `*` markers) and (b) the live `AcceptForm` (styling, labels, min-8 + match validation). Assemble from those two; do not invent strength meters or complexity rules.
+1. **Primary surface has no password step.** INCR-33's password step is *new design*, not a port — but it is fully constrained by (a) the wireframe precedent (fields, order, confirm rationale, `*` markers) and (b) the live `AcceptForm` (styling, labels, and the shared `passwordProblem` validation). The rule is **min-8 + at least one letter + at least one number (max-128)**, single-sourced in `lib/password.ts` (`passwordSchema`/`passwordProblem`, PR #244) — reuse that helper; do not add a strength meter or re-hardcode the strings.
 2. **"Step" is ambiguous.** Live flow is 2 steps; unified surface is 6→8. Recommended: password **inline** in the identity step (no counter change). A literal 3rd step is allowed but unshown in any surface — if chosen, update all counter/pill strings.
 3. **CSSPS is optional in schema** (`csspsCode … .optional()`). Removing the UI field is safe; whether to drop the schema/type key is a data-model decision (out of scope — Kofi/Claude Code).
 4. **Phone-first login vs password.** The current admin signs in by phone/OTP ("Sign in with your phone number", `DonePanel`). Adding a password at signup is additive; confirm with product whether phone/OTP remains a parallel path (the AcceptForm footnote "You can also sign in with your phone via OTP" suggests both coexist) — affects the identity-step lede copy ("you sign in with your phone number").
 5. **Proprietor role has a wireframe precedent but no live-wizard slot.** Item (3) is invisible in signup UI as briefed; the only authored `Proprietor` appears in a non-live surface's role select. Nothing to render.
 6. **`full-wizard.tsx` is not the target.** It mirrors the unified surface's long flow and is used for super-admin tenant setup. Build the password step in `wizard.tsx` only.
 7. **No-alpha discipline.** New password fields use `border-border-2` / `bg-gold-bg` (filled tint) / `focus:border-gold` — all solid tokens. Verify in the live preview, not the build (memory *no-alpha-token-opacity*).
+8. **OTP-first is flag-gated.** The done-phase OTP-finish step (§3.3) renders only when `otpLoginRequired()` (`authIsLive() && AUTH_OTP_LIVE`) is true; default OFF, so the default done panel keeps the `Sign in →` / `Go to sign in` links to `/login?accepted=1`. The password rule (min-8 + letter + number) is single-sourced in `lib/password.ts` (PR #244). Verify both against the flag/helper, not a build snapshot — see `docs/senior/incr-auth-otp-first-login-ruling.md`.
 
 ---
 

--- a/omnischools/docs/senior/l2-login-password-surface-map.md
+++ b/omnischools/docs/senior/l2-login-password-surface-map.md
@@ -83,15 +83,19 @@ For a **change** (vs first-set), add a current-password field on top:
 3. **Confirm password** — `type="password"`. Label **"Confirm password"** (verbatim from accept-form).
 - Submit-on-Enter (`onKeyDown … Enter`) like accept-form.
 
-### 3.2 Validation copy (reuse the exact strings)
-- `newPassword.length < 8` → **`"Password must be at least 8 characters."`** (verbatim, accept-form line 19).
-- `newPassword !== confirm` → **`"Passwords don't match."`** (verbatim, accept-form line 23).
-- Error render: single line under the form, `<p className="text-sm text-terra">…</p>` (matches accept-form + security-form's `msg` pattern). No per-field red outline (design has none).
+### 3.2 Validation copy (single-sourced via `passwordProblem` — do NOT re-hardcode)
+`change-password-form.tsx` validates `newPassword` through **`passwordProblem` (`lib/password.ts`, PR #244)** — the same helper accept-form / set-new-password use. The rule is **min 8 + at least one letter + at least one number (max 128)**; the messages, in check order, are:
+- **`"Password must be at least 8 characters"`** (< 8)
+- **`"Password must include at least one letter"`** (no letter)
+- **`"Password must include at least one number"`** (no digit)
+- **`"Password must be at most 128 characters"`** (> 128)
+- then `newPassword !== confirm` → **`"Passwords don't match."`**
+- **Render:** the live inline hint (`text-[12px] text-terra`) shows the current failing rule `.`-suffixed (`{pwProblem}.`) plus the mismatch line; the submit-time error (`text-sm text-terra`) shows the raw `passwordProblem` message. No per-field red outline (design has none).
 - `current` empty / wrong → server-side; surface as the same `text-terra` line (e.g. *"Current password is incorrect."* — new string, honest and minimal).
 
 ### 3.3 What NOT to add
-- **No strength meter, no complexity rules** beyond min-8. The archive surface has a strength meter (for its **12-char** archive key) — **do not copy it here**; the account pattern (accept-form) is min-8, meterless. Adding one would drift from the live set-password screen. (Flagged in §8.)
-- Min-length is **8** for the account (accept-form), **not** 12 (that's archive-only).
+- **No strength meter.** The archive surface has a strength meter (for its **12-char** archive key) — **do not copy it here**; the account pattern is meterless. The account rule is the shared `passwordSchema` — **min-8 + at least one letter + at least one number (max-128)** (`lib/password.ts`, PR #244), validated through `passwordProblem` — not just min-8, and not re-hardcoded per form. Adding a meter would drift from the live screens. (Flagged in §8.)
+- Min-length is **8** for the account, **not** 12 (that's archive-only).
 
 ### 3.4 Field styling & container (reuse `security-form.tsx` + `accept-form.tsx`)
 Put the three inputs in a card matching the surrounding SecurityForm blocks:
@@ -103,6 +107,13 @@ Put the three inputs in a card matching the surrounding SecurityForm blocks:
 | Save button | `rounded-md bg-navy px-5 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-navy-deep disabled:opacity-50` (security-form Save) |
 | Save label | **"Change password"** / busy **"Saving…"**; success `text-green` **"Saved."**, error `text-terra` (mirror security-form's `msg` render) |
 | Disabled-until | `disabled={busy || !dirty}` idiom from security-form (dirty = all three fields non-empty) |
+
+### 3.5 Login-card first-login hint (INCR-AUTH-OTP / PR #243) — always shown, NOT flag-gated
+
+Distinct surface, captured here per the sync brief: the **`/login` card** (`components/auth/login-form.tsx`, mapped in `l3-forgot-password-surface-map.md` §1) now renders a **static first-login hint on the Password tab** — always present, never varying with whether the number exists / is confirmed (enumeration-safe; **not** gated by `AUTH_OTP_LIVE`, unlike the onboarding OTP-finish step in `l1-signup-surface-map.md` §3.3). A brand-new account must verify by OTP once (which confirms the phone) before password sign-in works.
+- Copy (verbatim): **"First time signing in? Verify your number on the Phone OTP tab first — your password works after that."**
+- Container: `rounded-md bg-bg px-3 py-2 text-[12px] leading-relaxed text-navy-3`; the phrases **"First time signing in?"** and **"Phone OTP"** are `<b className="text-navy-2">`.
+- Placement: top of the Password-tab branch, above the phone / password inputs.
 
 ---
 
@@ -159,14 +170,15 @@ Design mapping only; the schema calls below are the implementer's, but the surfa
 
 ## 8. Drift / notes log
 
-1. **Zero authored surfaces** for either the change-password form or the user table — both are net-new UI, but fully constrained by `accept-form.tsx` (password fields, min-8, exact validation strings), `security-form.tsx` (card/field/button styling), `staff-table.tsx`/`staff-row.tsx`/`role-editor.tsx` (the list + roles + per-row actions), and `confirm-dialog.tsx` (destructive pattern). Assemble; do not invent.
+1. **Zero authored surfaces** for either the change-password form or the user table — both are net-new UI, but fully constrained by `accept-form.tsx` (password fields + the shared `passwordProblem` validation), `security-form.tsx` (card/field/button styling), `staff-table.tsx`/`staff-row.tsx`/`role-editor.tsx` (the list + roles + per-row actions), and `confirm-dialog.tsx` (destructive pattern). Assemble; do not invent.
 2. **Both homes already exist and are named** in `lib/settings-nav.ts`: `Login & password → /settings/security` (self) and `Roles & access → /staff` (admin). Don't create new routes.
 3. **Reset password = re-issue invite link.** The row's existing Invite/"Copy invite link" is the reset mechanism; relabel for active users. No separate reset flow.
 4. **Block is school-scoped**, not a global `ref_user` disable — multi-school login integrity (§7.2). Strong recommendation, but the column/mechanism is the data owner's call.
 5. **Status pills are prescribed, not authored** — 3 (+1) states on the green/warn/terra/(neutral) tri-state the codebase already uses; solid `-bg` tints only, no slash-opacity. Verify contrast in the live preview.
-6. **No strength meter, min-8 not min-12.** The archive surface's meter + 12-char rule are for the data-export ZIP key, a different concern; the account pattern is meterless min-8. Keep it that way.
+6. **No strength meter; the account rule is min-8 + a letter + a number, not min-12.** The archive surface's meter + 12-char rule are for the data-export ZIP key, a different concern; the account pattern is meterless and single-sourced in `lib/password.ts` (`passwordSchema`/`passwordProblem`, PR #244). Keep it that way.
 7. **`last-active` column skipped** — no `lastLogin` field, no surface authors it. The "login activity log" is the separate `/settings/audit` (`schoolup-audit-log-viewer.html`), adjacent to but out of L2 scope.
 8. **2FA stays where it is.** The existing `require2fa` toggle in `security-form.tsx` is the "2FA for admins" of the Login & password card; the change-password card sits above it on the same page. `schoolup-2fa-enrolment.html` is the (Tier-4) enrolment walkthrough, a future addition, not part of INCR-34.
+9. **Login-card first-login hint (INCR-AUTH-OTP / PR #243).** The `/login` Password tab now always shows a static, enumeration-safe first-login-OTP hint (§3.5) — **not** gated by `AUTH_OTP_LIVE`. It lives on `login-form.tsx` (mapped in the L3 map §1), a different surface from L2's change-password / user-management; captured here per the sync brief. Password validation across all these forms is single-sourced in `lib/password.ts` (PR #244).
 
 ---
 

--- a/omnischools/docs/senior/l3-forgot-password-surface-map.md
+++ b/omnischools/docs/senior/l3-forgot-password-surface-map.md
@@ -101,7 +101,7 @@ The two paths diverge in shape but share **enumeration-safe copy** — the confi
 *(There is no green success banner at Step 2 — nothing has changed yet; a calm neutral card, per the landing modal's register and archive-recovery's non-alarmist tone.)*
 
 ### Step 3 — Set the new password (NO current-password field)
-Reuse **`change-password-form.tsx`'s New / Confirm** block **minus the "Current password" field** — identity is already proven (OTP verified, or the email token). This is the closest sibling; it already has the min-8 + confirm-match live-validation UX.
+Reuse **`change-password-form.tsx`'s New / Confirm** block **minus the "Current password" field** — identity is already proven (OTP verified, or the email token). This is the closest sibling; it already has the shared `passwordProblem` (min-8 + a letter + a number) + confirm-match live-validation UX. (The shipped build lifts this into a dedicated `components/auth/set-new-password.tsx`.)
 
 | Field / element | Copy | Class / token (verbatim from `change-password-form.tsx`) |
 |---|---|---|
@@ -111,9 +111,9 @@ Reuse **`change-password-form.tsx`'s New / Confirm** block **minus the "Current 
 | Input 1 | placeholder **"At least 8 characters"** | `fieldClass`; `type="password"`; `autoComplete="new-password"` |
 | Label | **"Confirm new password"** | `labelClass` |
 | Input 2 | placeholder **"••••••••"** | `fieldClass`; `type="password"`; `autoComplete="new-password"`; submit-on-Enter |
-| Live validation | too-short: **"Password must be at least 8 characters."**; mismatch: **"Passwords don't match."** | `text-[12px] text-terra` (verbatim strings + tokens from `change-password-form.tsx` L82–83; identical to `accept-form.tsx`) |
-| Button | **"Set new password"** / busy **"Saving…"** | primary button; `disabled` until `next.length >= 8 && next === confirm` |
-| Success | → redirect **`/login?reset=1`** | login card shows a green banner **"Password updated — sign in below."** (mirror the `?accepted=1` banner; add a `reset` branch to `login-form.tsx`'s banner) |
+| Live validation | failing rule via `passwordProblem` (`.`-suffixed): **"Password must be at least 8 characters"** / **"Password must include at least one letter"** / **"Password must include at least one number"** / **"Password must be at most 128 characters"**; mismatch: **"Passwords don't match."** | `text-[12px] text-terra` (from `set-new-password.tsx`; rule single-sourced in `lib/password.ts` — `passwordSchema`/`passwordProblem`, PR #244 — shared with `accept-form.tsx` / `change-password-form.tsx`) |
+| Button | **"Set new password"** / busy **"Saving…"** | primary button; `disabled` until `!passwordProblem(next) && next === confirm` (min-8 + a letter + a number, max-128, and matching) |
+| Success | → redirect **`/login?reset=1`** | login card shows a green banner **"Password updated — sign in with your new password."** (the `reset` branch of `login-form.tsx`'s banner) |
 | Error | server message | `text-sm text-terra` |
 
 **Why no "Current password":** the reset-completion user is anonymous-but-proven (OTP/token), not a signed-in session. So it is `accept-form` shaped (set-from-nothing), **not** `change-password-form` shaped (re-auth the old one). We borrow `change-password-form`'s *New/Confirm* markup because it is the newest and cleanest, but drop `current` and its `signInWithPassword` re-auth.
@@ -137,7 +137,7 @@ Identical palette to the login card & accept-form; every class above is Tailwind
 | **2 Phone (OTP)** | empty 6-digit input | button **"Verifying…"**, `disabled` | wrong/expired code → `text-terra` (**"Invalid code."** verbatim from `verifyLogin`) | session established → Step 3 |
 | **2 Email** | terminal card, nothing to submit | — | — | user leaves for inbox; returns via tokened link → `reset/[token]` renders Step 3 |
 | **2 Email (bad token)** | — | — | invalid/expired token → `accept/[token]`-style guard card: **"This reset link isn't valid or has expired — request a new one."** + **"Go to reset →"** (`text-gold`) | — |
-| **3 Set password** | both fields empty, button `disabled` | button **"Saving…"** | too-short / mismatch inline (`text-[12px] text-terra`); server error `text-sm text-terra` | success → redirect `/login?reset=1` (green banner) |
+| **3 Set password** | both fields empty, button `disabled` | button **"Saving…"** | failing-rule via `passwordProblem` (min-8 + letter + number) / mismatch inline (`text-[12px] text-terra`); server error `text-sm text-terra` | success → redirect `/login?reset=1` (green banner) |
 
 **Enumeration-safety rule (states 1→2):** Step 1 must advance to Step 2 with the **same** confirmation copy **regardless** of whether the handle matches an account. Do not branch the UI on account existence. (Mechanism caveat for the implementer in §7.3.)
 
@@ -170,7 +170,7 @@ Design mapping only; the calls below are the implementer's, but the surfaces + l
 2. **Forgot link placement is authored** — below the password input, above the submit, right-aligned, 12px gold, hover underline (`.forgot`). Port to the **Password tab only** of the live card as a `Link href="/reset"`.
 3. **Both paths requested; phone is primary, email is net-new infra.** Phone reuses live OTP seams end-to-end; email needs `resetPasswordForEmail` + a recovery-token route and only serves accounts with an email on file.
 4. **No "Current password" on the reset-completion step** — identity is OTP/token-proven, so it's `accept-form`-shaped (set from nothing), not `change-password-form`-shaped (re-auth old). Borrow the latter's New/Confirm markup, drop `current` + the re-auth.
-5. **No strength meter, min-8 not min-12.** The archive surface's meter + 12-char rule are the data-export ZIP key — a different concern. The account pattern is meterless min-8; keep it.
+5. **No strength meter; the account rule is min-8 + a letter + a number, not min-12.** The archive surface's meter + 12-char rule are the data-export ZIP key — a different concern. The account pattern is meterless and single-sourced in `lib/password.ts` (`passwordSchema`/`passwordProblem`, PR #244); keep it.
 6. **Enumeration-safe copy** — Step-1→2 confirmation is identical for real and unknown handles; never "no account found." The *mechanism* (Supabase auto-create / rate leak) is a security flag for Sarah (§7.3), not a UI branch.
 7. **Home:** `app/(marketing)/reset/page.tsx` (+ `reset/[token]/page.tsx` for the email landing), unauthenticated, same chrome as `login/` and `accept/`. Success → `/login?reset=1` with a green banner mirroring `?accepted=1`.
 8. **Phone reset overlaps the OTP login tab** — a forgetful user can already sign in via OTP and change the password in Settings (L2a). The phone reset path is a convenience over that existing capability, not new capability; owner's call whether both paths ship at once or email lands later.


### PR DESCRIPTION
Design-source sync (Dex LOW-2 from #244). The L1 signup, L2 login-password, and L3 forgot-password surface maps drifted after two merged auth increments changed the shipped copy; Lucy re-mapped them against the current components.

- **Password complexity (#244):** the single-sourced `passwordProblem` rule (min-8 + a letter + a number, max-128) + the wizard help text `"At least 8 characters, with a letter and a number."` + the live inline hint now showing the actual failing rule — reflected across L1 §3, L2 §3 (change-password), L3 §3 (set-new-password).
- **OTP-first login (#243):** L1 gains the done-phase `OnboardingOtpFinish` step (gated by `AUTH_OTP_LIVE`); L2 gains the Password-tab static first-login hint (always shown, not gated).
- Also fixed a stale reset-success banner line in L3 (`"sign in below"` → the shipped `"sign in with your new password."`).

Docs-only — no code, no schema, no prod-paste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
