### PR TITLE
INCR-AUTH-CAPTCHA · Cloudflare Turnstile bot protection (audit #4)

### DIFF
--- a/omnischools/.env.example
+++ b/omnischools/.env.example
@@ -37,3 +37,6 @@ AUTH_DEV_BYPASS=true
 # OTP-mandatory FIRST login (INCR-AUTH-OTP). Keep "false" until the prod Supabase SMS provider + "Confirm
 # phone" are on (DEPLOY.md §1 P1–P3), then set "true" (P4). Read ONLY when auth is live; inert in dev.
 AUTH_OTP_LIVE=false
+# Cloudflare Turnstile site key (INCR-AUTH-CAPTCHA, audit #4). Unset = captcha inert (no widget, no token).
+# Set together with enabling Supabase Auth → Protection captcha + its secret (DEPLOY.md §1 C1–C3).
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=

--- a/omnischools/DEPLOY.md
+++ b/omnischools/DEPLOY.md
@@ -39,6 +39,12 @@ SMS/email behind `lib/{sms,email}`, jobs as HTTP POST + shared secret. Hosting t
 
    See `docs/senior/incr-auth-otp-first-login-ruling.md` §5. `AUTH_OTP_LIVE` stays `false` until P1–P3 are done.
 
+   **CAPTCHA rollout (INCR-AUTH-CAPTCHA, audit #4) — optional bot protection; coordinate in order:**
+   - **C1.** Create a Cloudflare **Turnstile** widget → get the **site key** (public) + **secret key**; add your prod domain + `localhost` to its allowed hostnames.
+   - **C2.** Supabase **Auth → Protection → enable CAPTCHA → Turnstile → paste the secret key**. (This makes GoTrue REQUIRE a token on every auth call.)
+   - **C3.** Set **`NEXT_PUBLIC_TURNSTILE_SITE_KEY`** (env table) to the site key.
+   Do **C2 + C3 together** — enabling Supabase captcha without the site key set makes auth require a token the client isn't sending. With both unset it is fully inert (no widget, no token). See `docs/senior/incr-auth-captcha-plan.md`. (To use hCaptcha instead: pick it in C2, and the site key in C3 is the hCaptcha site key — the widget lib/CSP origin would need swapping.)
+
 ## 2 · Apply schema + RLS to prod (run locally, once)
 Run from `omnischools/` with the **direct** connection string. These are safe on an empty DB.
 Run as the project's `postgres` user so the RLS bypass role is granted to it.
@@ -66,6 +72,7 @@ Tip: `pnpm db:rls-test` against prod should pass (cross-tenant reads blocked).
    | `SUPABASE_SERVICE_ROLE_KEY` | service_role key |
    | `AUTH_DEV_BYPASS` | `false`  ← flips on real phone-OTP auth |
    | `AUTH_OTP_LIVE` | `false` until P1–P3 done, then `true`  ← OTP-mandatory first login (INCR-AUTH-OTP) |
+   | `NEXT_PUBLIC_TURNSTILE_SITE_KEY` | optional — Cloudflare Turnstile site key; unset = captcha inert (INCR-AUTH-CAPTCHA) |
    | `NEXT_PUBLIC_SITE_URL` | your Vercel URL (e.g. `https://omnischools.vercel.app`) |
    | `CRON_SECRET` | a long random string |
    | `HUBTEL_CLIENT_ID` / `_SECRET` / `_SENDER_ID` | optional (SMS goes live when set) |

--- a/omnischools/components/auth/accept-form.tsx
+++ b/omnischools/components/auth/accept-form.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { acceptInvite } from "@/lib/actions/invites";
 import { passwordProblem } from "@/lib/password";
+import { CaptchaWidget, useCaptcha } from "@/components/auth/captcha-widget";
 
 const fieldClass =
   "w-full rounded-md border border-border-2 bg-bg px-3.5 py-2.5 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
@@ -14,6 +15,7 @@ export function AcceptForm({ token, contact }: { token: string; contact: string 
   const [confirm, setConfirm] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const captcha = useCaptcha();
 
   async function submit() {
     const problem = passwordProblem(password);
@@ -25,12 +27,19 @@ export function AcceptForm({ token, contact }: { token: string; contact: string 
       setError("Passwords don't match.");
       return;
     }
+    if (captcha.missing()) {
+      setError("Please complete the verification below.");
+      return;
+    }
     setSaving(true);
     setError(null);
-    const res = await acceptInvite({ token, password });
+    const res = await acceptInvite({ token, password, captchaToken: captcha.token || undefined });
     setSaving(false);
     if (res.ok) router.push("/login?accepted=1");
-    else setError(res.error ?? "Could not complete sign-up.");
+    else {
+      captcha.reset();
+      setError(res.error ?? "Could not complete sign-up.");
+    }
   }
 
   return (
@@ -62,6 +71,7 @@ export function AcceptForm({ token, contact }: { token: string; contact: string 
         />
       </div>
       {error && <p className="text-sm text-terra">{error}</p>}
+      <CaptchaWidget onToken={captcha.setToken} resetKey={captcha.resetKey} />
       <button
         onClick={submit}
         disabled={saving}

--- a/omnischools/components/auth/captcha-widget.tsx
+++ b/omnischools/components/auth/captcha-widget.tsx
@@ -1,0 +1,56 @@
+"use client";
+import { useState } from "react";
+import { Turnstile } from "@marsidev/react-turnstile";
+import { captchaSiteKey, captchaEnabled } from "@/lib/captcha";
+
+/**
+ * Per-form captcha state (INCR-AUTH-CAPTCHA). Pair with <CaptchaWidget>: feed `setToken`/`resetKey` to the
+ * widget, call `missing()` at the top of submit to block until solved, pass `token` to the action, and call
+ * `reset()` on a failed attempt (the token is single-use). All no-ops when the site key is unset.
+ */
+export function useCaptcha() {
+  const [token, setToken] = useState("");
+  const [resetKey, setResetKey] = useState(0);
+  return {
+    token,
+    setToken,
+    resetKey,
+    /** True when a token is required (captcha enabled) but not yet solved — block submit. */
+    missing: () => captchaEnabled() && !token,
+    /** After a failed attempt: clear the spent token and remount the widget for a fresh one. */
+    reset: () => {
+      setToken("");
+      setResetKey((k) => k + 1);
+    },
+  };
+}
+
+/**
+ * INCR-AUTH-CAPTCHA — the shared Cloudflare Turnstile widget. Renders ONLY when
+ * `NEXT_PUBLIC_TURNSTILE_SITE_KEY` is set; otherwise returns null (no widget, no token, fully inert).
+ * `onToken(token)` fires on solve; on error/expiry it fires `onToken("")` so the caller can require a
+ * FRESH token before submit. The token is single-use — after a failed attempt, bump `resetKey` (used as
+ * the React `key`) to remount the widget and clear the spent token.
+ */
+export function CaptchaWidget({
+  onToken,
+  resetKey,
+}: {
+  onToken: (token: string) => void;
+  resetKey?: number;
+}) {
+  const siteKey = captchaSiteKey();
+  if (!siteKey) return null;
+  return (
+    <div className="mt-1">
+      <Turnstile
+        key={resetKey}
+        siteKey={siteKey}
+        onSuccess={onToken}
+        onError={() => onToken("")}
+        onExpire={() => onToken("")}
+        options={{ theme: "auto" }}
+      />
+    </div>
+  );
+}

--- a/omnischools/components/auth/change-password-form.tsx
+++ b/omnischools/components/auth/change-password-form.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { changeOwnPassword } from "@/lib/actions/auth";
 import { passwordProblem } from "@/lib/password";
 import { rekeySnapshots } from "@/lib/score-ledger/pwa-store";
+import { CaptchaWidget, useCaptcha } from "@/components/auth/captcha-widget";
 
 /**
  * INCR-34 (L2a) — self-service change password. Shared by the staff Settings › Login & security page
@@ -21,10 +22,12 @@ export function ChangePasswordForm({ sessionId }: { sessionId?: string }) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [done, setDone] = useState(false);
+  const captcha = useCaptcha();
 
   const pwProblem = next.length > 0 ? passwordProblem(next) : null;
   const mismatch = confirm.length > 0 && next !== confirm;
-  const canSubmit = !!current && !passwordProblem(next) && next === confirm && !busy;
+  const canSubmit =
+    !!current && !passwordProblem(next) && next === confirm && !captcha.missing() && !busy;
 
   async function submit() {
     setError(null);
@@ -32,8 +35,13 @@ export function ChangePasswordForm({ sessionId }: { sessionId?: string }) {
     const problem = passwordProblem(next);
     if (problem) return setError(problem);
     if (next !== confirm) return setError("Passwords don't match.");
+    if (captcha.missing()) return setError("Please complete the verification below.");
     setBusy(true);
-    const res = await changeOwnPassword({ currentPassword: current, newPassword: next });
+    const res = await changeOwnPassword({
+      currentPassword: current,
+      newPassword: next,
+      captchaToken: captcha.token || undefined,
+    });
     if (res.ok) {
       // INCR-39: the R264 re-auth rotated the session id — our offline-buffer partition prefix. Re-key
       // THIS user's own pending scores old→new BEFORE the success state / any nav, so the next
@@ -53,6 +61,7 @@ export function ChangePasswordForm({ sessionId }: { sessionId?: string }) {
       setConfirm("");
     } else {
       setBusy(false);
+      captcha.reset(); // the re-auth consumed the single-use token
       setError(res.error ?? "Could not update your password.");
     }
   }
@@ -103,6 +112,7 @@ export function ChangePasswordForm({ sessionId }: { sessionId?: string }) {
         </p>
       )}
 
+      <CaptchaWidget onToken={captcha.setToken} resetKey={captcha.resetKey} />
       <button
         onClick={submit}
         disabled={!canSubmit}

--- a/omnischools/components/auth/login-form.tsx
+++ b/omnischools/components/auth/login-form.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { requestOtp, verifyLogin, passwordLogin } from "@/lib/actions/auth";
+import { CaptchaWidget, useCaptcha } from "@/components/auth/captcha-widget";
 
 const fieldClass =
   "w-full rounded-md border border-border-2 bg-bg px-3.5 py-2.5 text-sm text-navy outline-none transition-colors focus:border-gold focus:bg-surface";
@@ -20,30 +21,39 @@ export function LoginForm({
   const [password, setPassword] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const captcha = useCaptcha();
 
   async function sendCode() {
+    if (captcha.missing()) return setError("Please complete the verification below.");
     setBusy(true);
     setError(null);
-    const res = await requestOtp(phone);
+    const res = await requestOtp(phone, captcha.token || undefined);
     setBusy(false);
     if (res.ok) setStep("otp");
-    else setError(res.error ?? "Could not send code.");
+    else {
+      captcha.reset();
+      setError(res.error ?? "Could not send code.");
+    }
   }
 
   async function verify() {
     setBusy(true);
     setError(null);
-    const res = await verifyLogin(phone, otp);
+    const res = await verifyLogin(phone, otp); // verify (2nd step) is not captcha-gated
     setBusy(false);
     if (res && !res.ok) setError(res.error);
   }
 
   async function signInPassword() {
+    if (captcha.missing()) return setError("Please complete the verification below.");
     setBusy(true);
     setError(null);
-    const res = await passwordLogin(phone, password);
+    const res = await passwordLogin(phone, password, captcha.token || undefined);
     setBusy(false);
-    if (res && !res.ok) setError(res.error);
+    if (res && !res.ok) {
+      captcha.reset();
+      setError(res.error);
+    }
   }
 
   const tab = (m: "otp" | "password", label: string) => (
@@ -93,6 +103,7 @@ export function LoginForm({
               onChange={(e) => setPhone(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && sendCode()}
             />
+            <CaptchaWidget onToken={captcha.setToken} resetKey={captcha.resetKey} />
             <button
               onClick={sendCode}
               disabled={busy}
@@ -162,6 +173,7 @@ export function LoginForm({
           >
             Forgot password?
           </Link>
+          <CaptchaWidget onToken={captcha.setToken} resetKey={captcha.resetKey} />
           <button
             onClick={signInPassword}
             disabled={busy}

--- a/omnischools/components/auth/reset-form.tsx
+++ b/omnischools/components/auth/reset-form.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { requestOtp, requestPasswordReset, verifyResetOtp } from "@/lib/actions/auth";
 import { SetNewPassword } from "@/components/auth/set-new-password";
+import { CaptchaWidget, useCaptcha } from "@/components/auth/captcha-widget";
 
 /**
  * INCR-36 (L3) — the reset flow (INCR-36 · Module L / L3). Two prove-identity paths (owner: BOTH), NOT
@@ -29,30 +30,36 @@ export function ResetForm() {
   const [email, setEmail] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const captcha = useCaptcha();
 
   async function sendCode() {
+    if (captcha.missing()) return setError("Please complete the verification below.");
     setBusy(true);
     setError(null);
-    const res = await requestOtp(phone);
+    const res = await requestOtp(phone, captcha.token || undefined);
     setBusy(false);
     if (res.ok) setStep("otp");
-    else setError(res.error ?? "Could not send code.");
+    else {
+      captcha.reset();
+      setError(res.error ?? "Could not send code.");
+    }
   }
 
   async function verify() {
     setBusy(true);
     setError(null);
-    const res = await verifyResetOtp(phone, otp);
+    const res = await verifyResetOtp(phone, otp); // verify is not captcha-gated
     setBusy(false);
     if (res.ok) setStep("setpw");
     else setError(res.error ?? "Invalid code.");
   }
 
   async function sendLink() {
+    if (captcha.missing()) return setError("Please complete the verification below.");
     setBusy(true);
     setError(null);
     // NEUTRAL-ALWAYS — the action never surfaces existence; we always advance to the same card.
-    await requestPasswordReset({ email });
+    await requestPasswordReset({ email, captchaToken: captcha.token || undefined });
     setBusy(false);
     setStep("sent");
   }
@@ -105,6 +112,7 @@ export function ResetForm() {
                 onChange={(e) => setPhone(e.target.value)}
                 onKeyDown={(e) => e.key === "Enter" && sendCode()}
               />
+              <CaptchaWidget onToken={captcha.setToken} resetKey={captcha.resetKey} />
               <button onClick={sendCode} disabled={busy} className={primaryBtn}>
                 {busy ? "Sending…" : "Send code"}
               </button>
@@ -119,6 +127,7 @@ export function ResetForm() {
                 onChange={(e) => setEmail(e.target.value)}
                 onKeyDown={(e) => e.key === "Enter" && sendLink()}
               />
+              <CaptchaWidget onToken={captcha.setToken} resetKey={captcha.resetKey} />
               <button onClick={sendLink} disabled={busy} className={primaryBtn}>
                 {busy ? "Sending…" : "Send reset link"}
               </button>

--- a/omnischools/components/onboarding/wizard.tsx
+++ b/omnischools/components/onboarding/wizard.tsx
@@ -23,6 +23,7 @@ import {
 import { onboardSchool } from "@/lib/actions/onboarding";
 import { requestOtp, verifyLogin } from "@/lib/actions/auth";
 import { passwordProblem } from "@/lib/password";
+import { CaptchaWidget, useCaptcha } from "@/components/auth/captcha-widget";
 
 type Form = Partial<OnboardInput> & { subtype?: SchoolSubtype; confirmPassword?: string };
 
@@ -55,6 +56,7 @@ export function OnboardingWizard({ initialType }: { initialType?: CardId }) {
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [result, setResult] = useState<Extract<OnboardResult, { ok: true }> | null>(null);
+  const captcha = useCaptcha();
 
   const set = (k: keyof Form, v: string) => setForm((prev) => ({ ...prev, [k]: v }));
   const f = (k: keyof Form) => (form[k] as string) ?? "";
@@ -121,14 +123,18 @@ export function OnboardingWizard({ initialType }: { initialType?: CardId }) {
     // Defensive re-check of both steps; onboardSchool re-validates everything server-side too.
     const err = identityError() ?? passwordError();
     if (err) return setError(err);
+    if (captcha.missing()) return setError("Please complete the verification below.");
     setSubmitting(true);
     setError(null);
-    const res = await onboardSchool(form);
+    const res = await onboardSchool({ ...form, captchaToken: captcha.token || undefined });
     setSubmitting(false);
     if (res.ok) {
       setResult(res);
       setPhase("done");
-    } else setError(res.error);
+    } else {
+      captcha.reset();
+      setError(res.error);
+    }
   }
 
   const schoolInitial = (form.schoolName?.trim()?.[0] ?? "S").toUpperCase();
@@ -200,7 +206,12 @@ export function OnboardingWizard({ initialType }: { initialType?: CardId }) {
               onChangeType={backToType}
             />
           ) : (
-            <PasswordStep form={form} f={f} set={set} />
+            <>
+              <PasswordStep form={form} f={f} set={set} />
+              <div className="mt-4 max-w-[460px]">
+                <CaptchaWidget onToken={captcha.setToken} resetKey={captcha.resetKey} />
+              </div>
+            </>
           )}
 
           {error && <p className="mt-4 text-sm text-terra">{error}</p>}

--- a/omnischools/components/onboarding/wizard.tsx
+++ b/omnischools/components/onboarding/wizard.tsx
@@ -24,6 +24,7 @@ import { onboardSchool } from "@/lib/actions/onboarding";
 import { requestOtp, verifyLogin } from "@/lib/actions/auth";
 import { passwordProblem } from "@/lib/password";
 import { CaptchaWidget, useCaptcha } from "@/components/auth/captcha-widget";
+import { captchaEnabled } from "@/lib/captcha";
 
 type Form = Partial<OnboardInput> & { subtype?: SchoolSubtype; confirmPassword?: string };
 
@@ -703,8 +704,9 @@ export function DonePanel({
               we&apos;ll guide you through the rest from a checklist.
             </p>
           </div>
-          {/* When OTP-first is live, the OTP card below is the sign-in action; else link to /login. */}
-          {!result.otpLive && (
+          {/* When OTP-first is live AND captcha is off, the OTP card below is the sign-in action; else
+              link to /login (whose OTP send IS captcha-wired — the onboarding auto-send is not). */}
+          {(!result.otpLive || captchaEnabled()) && (
             <Link
               href="/login?accepted=1"
               className="rounded-lg bg-gold px-6 py-3.5 text-sm font-bold text-navy transition-colors hover:brightness-95"
@@ -716,7 +718,9 @@ export function DonePanel({
       </div>
 
       {/* INCR-AUTH-OTP · auto-sign-in (Option A): verify the phone via OTP → confirms it + lands in /dashboard. */}
-      {result.otpLive && <OnboardingOtpFinish phone={result.adminPhone} />}
+      {/* The onboarding auto-send is NOT captcha-wired (no user interaction before the send), so when
+          captcha is on we skip it and route to /login above, whose OTP send solves a captcha. */}
+      {result.otpLive && !captchaEnabled() && <OnboardingOtpFinish phone={result.adminPhone} />}
 
       <div className="mt-6">
         <div className="mb-3 font-display text-base font-medium text-navy">

--- a/omnischools/docs/senior/incr-auth-captcha-plan.md
+++ b/omnischools/docs/senior/incr-auth-captcha-plan.md
@@ -1,0 +1,22 @@
+# INCR-AUTH-CAPTCHA — plan: bot protection on the auth entry points
+
+**Status:** built (Claude Code) · follow-up (e) of the auth audit (item #4 — brute-force / bot-spam of the login + OTP-send + reset endpoints). **Provider:** Cloudflare Turnstile (owner may switch to hCaptcha; both are Supabase-native).
+
+## Why / what
+Supabase Auth has native CAPTCHA support (Auth → Protection). When enabled, GoTrue **requires** a `captchaToken` on every friction endpoint — `signInWithOtp`, `signInWithPassword`, `signUp`, `resetPasswordForEmail` — or the call is rejected. So this is **all-or-nothing at the project level**: the client must send a token on *every* auth entry point, not just login. `verifyOtp` (submitting the code) is NOT captcha-gated — only the initiating calls are.
+
+## Design
+- **Inert until configured** (mirrors `AUTH_OTP_LIVE`): a new **`NEXT_PUBLIC_TURNSTILE_SITE_KEY`**. No key ⇒ `captchaEnabled()` false ⇒ no widget renders and no token is sent (`lib/captcha.ts`). The seam passes `options.captchaToken` only when a token is present, so with the key unset and Supabase captcha OFF, nothing changes.
+- **Seam-only Supabase touch** (portability): `captchaToken?` threads through `lib/auth` (`signInWithPhone`, `signInWithPassword`, `createPasswordUser`, `sendPasswordResetEmail`) into `options: { captchaToken }`. Feature code never touches `supabase.auth.*`.
+- **One shared widget** `components/auth/captcha-widget.tsx` (wraps `@marsidev/react-turnstile`): renders only when `captchaSiteKey()` is set; `onToken(token)` on solve; a `resetKey` prop remounts it to clear the **single-use** token after a failed attempt.
+- **Entry points** (each gets the widget + threads the token): login OTP-send + password (`login-form`), onboarding signup (`wizard`), invite-accept (`accept-form`), password reset — phone OTP-send + email (`reset-form`).
+- **CSP:** `next.config.mjs` report-only CSP gains Turnstile's origins (`https://challenges.cloudflare.com`) in `script-src` + `frame-src`.
+
+## Owner rollout (coordinate, or auth breaks) — like the OTP P-steps
+1. Create a Cloudflare **Turnstile** widget → get the **site key** (public) + **secret** (server).
+2. Add the secret in Supabase **Auth → Protection → enable CAPTCHA → Turnstile → secret key**.
+3. Set **`NEXT_PUBLIC_TURNSTILE_SITE_KEY`** (env) to the site key + add your domain (and `localhost` for testing) to the Turnstile widget's allowed hostnames.
+Do 1→2→3 together: enabling Supabase captcha (step 2) makes GoTrue require a token, and the client only sends one once the site key is set (step 3). With both unset it's fully inert. To switch to hCaptcha instead: pick hCaptcha in step 2, and swap the widget lib + the CSP origin (the seam/token flow is identical).
+
+## Gate note
+No live demo possible here (dev-bypass makes auth inert + no site key + the running dev server is a different worktree). Verified by source + `tsc`/build/suite; the widget lifecycle is delegated to the maintained `@marsidev/react-turnstile`.

--- a/omnischools/docs/senior/incr-auth-captcha-plan.md
+++ b/omnischools/docs/senior/incr-auth-captcha-plan.md
@@ -18,5 +18,11 @@ Supabase Auth has native CAPTCHA support (Auth → Protection). When enabled, Go
 3. Set **`NEXT_PUBLIC_TURNSTILE_SITE_KEY`** (env) to the site key + add your domain (and `localhost` for testing) to the Turnstile widget's allowed hostnames.
 Do 1→2→3 together: enabling Supabase captcha (step 2) makes GoTrue require a token, and the client only sends one once the site key is set (step 3). With both unset it's fully inert. To switch to hCaptcha instead: pick hCaptcha in step 2, and swap the widget lib + the CSP origin (the seam/token flow is identical).
 
+## The non-form captcha-gated call sites (Dex M1 — completeness)
+Three OTHER callers hit the same captcha-gated GoTrue endpoints and would break once captcha is enabled. Handled so nothing silently no-sends:
+- **`changeOwnPassword`** (self-service, `lib/actions/auth.ts`) — its R264 re-auth `signInWithPassword` is interactive, so the change-password form now renders `<CaptchaWidget>` and threads `captchaToken`. Fully supported with captcha on.
+- **`initiatePasswordReset`** (admin resets a user, `lib/actions/users.ts`) — server-triggered, no target user present to solve a challenge. **Decision: refuse honestly when `captchaEnabled()`** — return an error directing the admin to have the user self-reset at `/reset` (which IS captcha-wired), instead of SMSing a code GoTrue rejected. Admin-triggered phone reset is unavailable while captcha is on; self-reset covers it.
+- **`OnboardingOtpFinish`** (the OTP-first done-panel auto-sign-in) — auto-sends on mount, incompatible with a mandatory pre-send challenge. **Decision: when `captchaEnabled()`, skip the panel and route to `/login`** (whose OTP send is captcha-wired). Only relevant when BOTH `AUTH_OTP_LIVE` and captcha are on.
+
 ## Gate note
 No live demo possible here (dev-bypass makes auth inert + no site key + the running dev server is a different worktree). Verified by source + `tsc`/build/suite; the widget lifecycle is delegated to the maintained `@marsidev/react-turnstile`.

--- a/omnischools/lib/actions/auth.ts
+++ b/omnischools/lib/actions/auth.ts
@@ -59,6 +59,7 @@ export async function signOutAction(): Promise<void> {
 export async function changeOwnPassword(input: {
   currentPassword: string;
   newPassword: string;
+  captchaToken?: string;
 }): Promise<{ ok: boolean; error?: string; newSessionId?: string }> {
   const currentPassword = input?.currentPassword ?? "";
   const newPassword = input?.newPassword ?? "";
@@ -68,7 +69,8 @@ export async function changeOwnPassword(input: {
   }
   const user = await requireUser();
   // Prove the current password before changing it (blocks a walk-up attacker on an unlocked session).
-  const reauth = await signInWithPassword(user.phone, currentPassword);
+  // The re-auth hits GoTrue's captcha-gated signInWithPassword, so forward the token (INCR-AUTH-CAPTCHA).
+  const reauth = await signInWithPassword(user.phone, currentPassword, input?.captchaToken);
   if (!reauth.ok) return { ok: false, error: "Current password is incorrect." };
   const res = await updatePassword(newPassword);
   if (!res.ok) return { ok: false, error: res.error ?? "Could not update your password." };

--- a/omnischools/lib/actions/auth.ts
+++ b/omnischools/lib/actions/auth.ts
@@ -17,10 +17,11 @@ import { recordAudit } from "@/lib/db/audit";
 
 export async function requestOtp(
   phone: string,
+  captchaToken?: string,
 ): Promise<{ ok: boolean; error?: string }> {
   if (!phone || phone.length < 7)
     return { ok: false, error: "Enter a valid phone number." };
-  return signInWithPhone(phone);
+  return signInWithPhone(phone, captchaToken);
 }
 
 export async function verifyLogin(
@@ -35,9 +36,10 @@ export async function verifyLogin(
 export async function passwordLogin(
   phone: string,
   password: string,
+  captchaToken?: string,
 ): Promise<{ ok: false; error: string }> {
   if (!phone || !password) return { ok: false, error: "Enter your phone and password." };
-  const res = await signInWithPassword(phone, password);
+  const res = await signInWithPassword(phone, password, captchaToken);
   if (!res.ok) return { ok: false, error: res.error ?? "Invalid phone or password." };
   redirect("/dashboard");
 }
@@ -108,14 +110,17 @@ export async function changeOwnPassword(input: {
  * Supabase — so the UI can never tell a registered address from an unknown one. `redirectTo` is built
  * from NEXT_PUBLIC_SITE_URL, mirroring `createInvite`'s link (invites.ts).
  */
-export async function requestPasswordReset(input: { email: string }): Promise<{ ok: true }> {
+export async function requestPasswordReset(input: {
+  email: string;
+  captchaToken?: string;
+}): Promise<{ ok: true }> {
   const email = input?.email?.trim() ?? "";
   try {
     // The recovery link lands on a ROUTE HANDLER (not the /reset-password Server Component): only a
     // route handler / server action can PERSIST the exchanged session cookie (a Server Component's
     // cookie write is a silent no-op — lib/supabase/server.ts setAll catch, no refresh middleware).
     const redirectTo = `${process.env.NEXT_PUBLIC_SITE_URL ?? ""}/auth/reset-callback`;
-    const res = await sendPasswordResetEmail(email, redirectTo);
+    const res = await sendPasswordResetEmail(email, redirectTo, input?.captchaToken);
     if (res.error) console.error("[auth] reset email send error (swallowed for R273):", res.error);
   } catch (err) {
     console.error("[auth] requestPasswordReset threw (swallowed for R273):", err);

--- a/omnischools/lib/actions/invites.ts
+++ b/omnischools/lib/actions/invites.ts
@@ -190,6 +190,7 @@ export async function revokeInvite(input: unknown): Promise<Result> {
 const AcceptSchema = z.object({
   token: z.string().min(6),
   password: passwordSchema, // shared app-side policy (audit #5): min-8 + a letter + a number
+  captchaToken: z.string().optional(), // INCR-AUTH-CAPTCHA — forwarded to Supabase signUp when enabled
 });
 
 export async function acceptInvite(input: unknown): Promise<Result> {
@@ -197,7 +198,7 @@ export async function acceptInvite(input: unknown): Promise<Result> {
   if (!parsed.success) {
     return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };
   }
-  const { token, password } = parsed.data;
+  const { token, password, captchaToken } = parsed.data;
 
   // 1) Look up the invite (no session yet → bypass RLS).
   const found = await withoutTenantScope(async (tx) => {
@@ -237,7 +238,7 @@ export async function acceptInvite(input: unknown): Promise<Result> {
   if (!inv.phone) return { ok: false, error: "This invite has no phone on file." };
 
   // 2) Create the password account (Supabase) — outside the DB transaction.
-  const auth = await createPasswordUser(inv.phone, password);
+  const auth = await createPasswordUser(inv.phone, password, captchaToken);
   if (!auth.ok) return { ok: false, error: auth.error };
 
   // 3) Link the ref_user + role assignment, mark accepted (bypass RLS).

--- a/omnischools/lib/actions/onboarding.ts
+++ b/omnischools/lib/actions/onboarding.ts
@@ -76,7 +76,7 @@ export async function onboardSchool(input: unknown): Promise<OnboardResult> {
   // "already registered"); a no-op returning ok in dev-bypass. The ref_user row is linked by phone in
   // the tx below (adminPhone reused). The owner can still also sign in via OTP.
   const adminPhone = normalizeGhanaPhone(d.adminPhone);
-  const auth = await createPasswordUser(adminPhone, d.password);
+  const auth = await createPasswordUser(adminPhone, d.password, d.captchaToken);
   if (!auth.ok) return { ok: false, error: auth.error ?? "Could not set your password." };
   const nz = (v?: string) => (v && v.trim() ? v.trim() : null);
   const academicYear = nz(d.academicYear) ?? currentAcademicYear();

--- a/omnischools/lib/actions/users.ts
+++ b/omnischools/lib/actions/users.ts
@@ -2,6 +2,7 @@
 import { and, eq, gte, isNull, lte, or } from "drizzle-orm";
 import { requireSchool, resolveActor, assertAnyRole } from "@/lib/auth/server";
 import { signInWithPhone } from "@/lib/auth";
+import { captchaEnabled } from "@/lib/captcha";
 import { sendSms } from "@/lib/sms";
 import { USER_ADMIN_ROLES, canManageTarget } from "@/lib/access";
 import { withSchool } from "@/lib/db/rls";
@@ -143,6 +144,17 @@ export async function initiatePasswordReset(input: { targetUserId: string }): Pr
   });
   if (!gated.ok) return gated;
   if (!gated.phone) return { ok: false, error: "That user has no phone on file to send a code to." };
+
+  // INCR-AUTH-CAPTCHA — this admin-initiated OTP send hits GoTrue's captcha-gated signInWithOtp, but the
+  // TARGET user isn't here to solve a challenge (the admin is the one clicking). When captcha is on, refuse
+  // HONESTLY and point to the user's own captcha-solvable reset — rather than SMS a code GoTrue rejected.
+  if (captchaEnabled()) {
+    return {
+      ok: false,
+      error:
+        "Bot-protection is on, so a reset code can't be sent from here. Ask this user to reset their own password from the sign-in screen (“Forgot password?”).",
+    };
+  }
 
   // Dispatch a one-time code to the target's OWN stored phone; they sign in and set a new password
   // themselves (L2a). The admin never sets or sees a password. Console-degrades with no SMS creds.

--- a/omnischools/lib/actions/users.ts
+++ b/omnischools/lib/actions/users.ts
@@ -124,6 +124,18 @@ export async function activateUser(input: { targetUserId: string }): Promise<Res
 export async function initiatePasswordReset(input: { targetUserId: string }): Promise<Result> {
   const { user, school } = await requireSchool();
   await assertAnyRole(USER_ADMIN_ROLES);
+  // INCR-AUTH-CAPTCHA (up-front, before any audit/DB work): this admin-initiated OTP send hits GoTrue's
+  // captcha-gated signInWithOtp, but the TARGET user isn't here to solve a challenge. When captcha is on,
+  // refuse HONESTLY — no `reset_initiated` audit for a reset that won't happen, no SMS for a code GoTrue
+  // rejected — and point to the user's own captcha-solvable reset. (System-wide condition, target-agnostic
+  // message, so refusing before the target-gate leaks nothing.)
+  if (captchaEnabled()) {
+    return {
+      ok: false,
+      error:
+        "Bot-protection is on, so a reset code can't be sent from here. Ask this user to reset their own password from the sign-in screen (“Forgot password?”).",
+    };
+  }
   const targetUserId = input?.targetUserId ?? "";
   const actor = await resolveActor(school.id);
 
@@ -144,17 +156,6 @@ export async function initiatePasswordReset(input: { targetUserId: string }): Pr
   });
   if (!gated.ok) return gated;
   if (!gated.phone) return { ok: false, error: "That user has no phone on file to send a code to." };
-
-  // INCR-AUTH-CAPTCHA — this admin-initiated OTP send hits GoTrue's captcha-gated signInWithOtp, but the
-  // TARGET user isn't here to solve a challenge (the admin is the one clicking). When captcha is on, refuse
-  // HONESTLY and point to the user's own captcha-solvable reset — rather than SMS a code GoTrue rejected.
-  if (captchaEnabled()) {
-    return {
-      ok: false,
-      error:
-        "Bot-protection is on, so a reset code can't be sent from here. Ask this user to reset their own password from the sign-in screen (“Forgot password?”).",
-    };
-  }
 
   // Dispatch a one-time code to the target's OWN stored phone; they sign in and set a new password
   // themselves (L2a). The admin never sets or sees a password. Console-degrades with no SMS creds.

--- a/omnischools/lib/auth-l2a.test.ts
+++ b/omnischools/lib/auth-l2a.test.ts
@@ -14,9 +14,9 @@ const FORM = readCode("components/auth/change-password-form.tsx");
 
 describe("L2a · self change-password action", () => {
   it("L2-1 · re-auths with the current password, THEN updates; current-session only (no target id)", () => {
-    expect(ACTION).toContain("signInWithPassword(user.phone, currentPassword)");
+    expect(ACTION).toContain("signInWithPassword(user.phone, currentPassword");
     expect(ACTION).toContain("updatePassword(newPassword)");
-    expect(ACTION.indexOf("signInWithPassword(user.phone, currentPassword)")).toBeLessThan(
+    expect(ACTION.indexOf("signInWithPassword(user.phone, currentPassword")).toBeLessThan(
       ACTION.indexOf("updatePassword(newPassword)"),
     );
     // the action input is {currentPassword, newPassword} only — no admin/other-account target.
@@ -34,7 +34,7 @@ describe("L2a · self change-password action", () => {
     expect(ACTION).toContain("passwordProblem(newPassword)");
     // scope to changeOwnPassword's own re-auth call (signInWithPassword( also appears in passwordLogin)
     expect(ACTION.indexOf("passwordProblem(newPassword)")).toBeLessThan(
-      ACTION.indexOf("signInWithPassword(user.phone, currentPassword)"),
+      ACTION.indexOf("signInWithPassword(user.phone, currentPassword"),
     );
   });
 
@@ -71,7 +71,9 @@ describe("L2a · self change-password action", () => {
     expect(FORM).toContain("Current password");
     expect(FORM).toContain("New password");
     expect(FORM).toContain("Confirm new password");
-    expect(FORM).toContain("changeOwnPassword({ currentPassword: current, newPassword: next })");
+    expect(FORM).toContain("changeOwnPassword({");
+    expect(FORM).toContain("currentPassword: current");
+    expect(FORM).toContain("newPassword: next");
     expect(FORM).toContain("Passwords don't match.");
     expect((FORM.match(/type="password"/g) ?? []).length).toBe(3);
   });

--- a/omnischools/lib/auth-l3.test.ts
+++ b/omnischools/lib/auth-l3.test.ts
@@ -113,8 +113,8 @@ describe("L3 · forgot-password", () => {
 
   it("L3 · the reset flow reuses the login-card idioms + set-new-password has no current-password field", () => {
     // both prove-identity paths are offered (owner: BOTH), not auto-routed
-    expect(RESET_FORM).toContain('requestOtp(phone)');
-    expect(RESET_FORM).toContain("requestPasswordReset({ email })");
+    expect(RESET_FORM).toContain("requestOtp(phone,"); // + optional captchaToken (INCR-AUTH-CAPTCHA)
+    expect(RESET_FORM).toContain("requestPasswordReset({ email,");
     expect(RESET_FORM).toContain("verifyResetOtp(phone, otp)");
     // the OTP input reuses the login-card mono treatment
     expect(RESET_FORM).toContain("text-center font-mono text-lg tracking-[0.3em]");

--- a/omnischools/lib/auth-l3.test.ts
+++ b/omnischools/lib/auth-l3.test.ts
@@ -72,7 +72,7 @@ describe("L3 · forgot-password", () => {
     expect(reset).not.toContain("signInWithPassword");
     // contrast: the Settings self-serve change KEEPS its current-password re-auth
     expect(change).toContain("currentPassword");
-    expect(change).toContain("signInWithPassword(user.phone, currentPassword)");
+    expect(change).toContain("signInWithPassword(user.phone, currentPassword");
   });
 
   it("R276 · completePasswordReset reads amr and refuses a password-only session", () => {

--- a/omnischools/lib/auth/create-password-user-anon.test.ts
+++ b/omnischools/lib/auth/create-password-user-anon.test.ts
@@ -55,7 +55,7 @@ describe("AUTH-OTP-05 · createPasswordUser uses anon signUp, never admin-confir
 
 describe("AUTH-OTP-05 · both onboarding AND invite-accept route through createPasswordUser", () => {
   it("onboardSchool creates the credential via createPasswordUser", () => {
-    expect(ONBOARD_ACTION).toContain("createPasswordUser(adminPhone, d.password)");
+    expect(ONBOARD_ACTION).toContain("createPasswordUser(adminPhone, d.password"); // + optional captchaToken
   });
 
   it("acceptInvite creates the credential via createPasswordUser (no admin-confirm either)", () => {

--- a/omnischools/lib/auth/index.ts
+++ b/omnischools/lib/auth/index.ts
@@ -144,8 +144,10 @@ export function normalizeGhanaPhone(input: string): string {
  * @supabase/* type copies can drop methods from `SupabaseAuthClient` in some install
  * layouts (passes locally, failed on Vercel). Runtime is unchanged — the methods exist.
  */
+// INCR-AUTH-CAPTCHA — the friction endpoints accept `options.captchaToken` (Supabase native captcha).
+type Captcha = { captchaToken?: string };
 type SupabaseAuthApi = {
-  signInWithOtp(creds: { phone: string }): Promise<{ error: { message: string } | null }>;
+  signInWithOtp(creds: { phone: string; options?: Captcha }): Promise<{ error: { message: string } | null }>;
   verifyOtp(creds: {
     phone: string;
     token: string;
@@ -154,10 +156,12 @@ type SupabaseAuthApi = {
   signUp(creds: {
     phone: string;
     password: string;
+    options?: Captcha;
   }): Promise<{ error: { message: string } | null }>;
   signInWithPassword(creds: {
     phone: string;
     password: string;
+    options?: Captcha;
   }): Promise<{ error: { message: string } | null }>;
   // INCR-34 (L2a) — change the CURRENT session's own password (self-service; no target id).
   updateUser(attrs: { password: string }): Promise<{ error: { message: string } | null }>;
@@ -166,7 +170,7 @@ type SupabaseAuthApi = {
   // No token row on our side (seam-only).
   resetPasswordForEmail(
     email: string,
-    options: { redirectTo: string },
+    options: { redirectTo: string } & Captcha,
   ): Promise<{ error: { message: string } | null }>;
   // INCR-36 (L3) — exchange the PKCE `?code=…` on the reset-password landing for a recovery session.
   exchangeCodeForSession(
@@ -186,9 +190,11 @@ async function authApi(): Promise<SupabaseAuthApi> {
   return (await createClient()).auth as unknown as SupabaseAuthApi;
 }
 
-/** Begin phone-OTP sign-in (sends an SMS code in live mode). */
+/** Begin phone-OTP sign-in (sends an SMS code in live mode). `captchaToken` is forwarded when the
+ *  Supabase native captcha is enabled (INCR-AUTH-CAPTCHA); undefined otherwise (inert). */
 export async function signInWithPhone(
   phone: string,
+  captchaToken?: string,
 ): Promise<{ ok: boolean; error?: string }> {
   const normalized = normalizeGhanaPhone(phone);
   if (!authIsLive()) {
@@ -202,7 +208,10 @@ export async function signInWithPhone(
   // no known-vs-unknown oracle. A legitimate `ref_user` with no Supabase account yet IS "known" here, so
   // their first OTP still creates + links their account normally.
   if (!(await phoneIsRegistered(normalized))) return { ok: true };
-  const { error } = await (await authApi()).signInWithOtp({ phone: normalized });
+  const { error } = await (await authApi()).signInWithOtp({
+    phone: normalized,
+    options: captchaToken ? { captchaToken } : undefined,
+  });
   // Enumeration-safety (Sarah, INCR-38): an unknown phone never reaches GoTrue (can't rate-limit), so a
   // REGISTERED phone must NOT be the only one able to return {ok:false} — that asymmetry is an existence
   // oracle (a target that ever rate-limits is registered). Swallow + log server-side; return the SAME
@@ -247,6 +256,7 @@ export async function verifyPhoneOtp(
 export async function createPasswordUser(
   phone: string,
   password: string,
+  captchaToken?: string,
 ): Promise<{ ok: boolean; error?: string }> {
   if (!authIsLive()) return { ok: true };
   const { error } = await (
@@ -254,6 +264,7 @@ export async function createPasswordUser(
   ).signUp({
     phone: normalizeGhanaPhone(phone),
     password,
+    options: captchaToken ? { captchaToken } : undefined,
   });
   if (error && !/already (registered|exists)/i.test(error.message)) {
     return { ok: false, error: error.message };
@@ -265,6 +276,7 @@ export async function createPasswordUser(
 export async function signInWithPassword(
   phone: string,
   password: string,
+  captchaToken?: string,
 ): Promise<{ ok: boolean; error?: string }> {
   if (!authIsLive()) return { ok: true };
   const { error } = await (
@@ -272,6 +284,7 @@ export async function signInWithPassword(
   ).signInWithPassword({
     phone: normalizeGhanaPhone(phone),
     password,
+    options: captchaToken ? { captchaToken } : undefined,
   });
   return error ? { ok: false, error: error.message } : { ok: true };
 }
@@ -299,9 +312,13 @@ export async function updatePassword(
 export async function sendPasswordResetEmail(
   email: string,
   redirectTo: string,
+  captchaToken?: string,
 ): Promise<{ ok: boolean; error?: string }> {
   if (!authIsLive()) return { ok: true };
-  const { error } = await (await authApi()).resetPasswordForEmail(email, { redirectTo });
+  const { error } = await (await authApi()).resetPasswordForEmail(email, {
+    redirectTo,
+    ...(captchaToken ? { captchaToken } : {}),
+  });
   return error ? { ok: false, error: error.message } : { ok: true };
 }
 

--- a/omnischools/lib/captcha-wiring.test.ts
+++ b/omnischools/lib/captcha-wiring.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { readCode } from "@/lib/test-utils/source-shape";
+
+/**
+ * INCR-AUTH-CAPTCHA (audit #4) — the token threads through the `lib/auth` seam into `options.captchaToken`
+ * on every friction endpoint, and each entry-point action + form forwards it. This is an UN-DEMOABLE
+ * feature (widget inert without a site key, auth inert under dev-bypass, Turnstile is an external
+ * Cloudflare service, the dev server runs a different worktree), so it is proven by source-shape (the
+ * house instrument, same as auth-l3) PLUS one runtime proof that the token actually reaches Supabase.
+ * `readCode` strips comments so the INCR-AUTH-CAPTCHA docblocks don't self-trip the greps.
+ */
+const SEAM = readCode("lib/auth/index.ts");
+const AUTH_ACTION = readCode("lib/actions/auth.ts");
+const INVITE_ACTION = readCode("lib/actions/invites.ts");
+const ONBOARD_ACTION = readCode("lib/actions/onboarding.ts");
+const ONBOARD_SCHEMA = readCode("lib/onboarding.ts");
+
+/** The body of an `export async function NAME`, up to the next top-level `export` (matches auth-l3). */
+function body(src: string, name: string): string {
+  const start = src.indexOf(`export async function ${name}`);
+  if (start === -1) return "";
+  const after = src.indexOf("\nexport ", start + 1);
+  return src.slice(start, after === -1 ? undefined : after);
+}
+
+/* -------------------------------------------------- item 2 · the lib/auth seam */
+
+describe("seam · the 4 friction fns forward options.captchaToken (source)", () => {
+  const OPTS = "options: captchaToken ? { captchaToken } : undefined";
+
+  it("signInWithPhone(phone, captchaToken?) → signInWithOtp with options", () => {
+    const b = body(SEAM, "signInWithPhone");
+    expect(b).toContain("captchaToken?: string");
+    expect(b).toContain(".signInWithOtp({");
+    expect(b).toContain(OPTS);
+  });
+
+  it("createPasswordUser(phone, password, captchaToken?) → signUp with options", () => {
+    const b = body(SEAM, "createPasswordUser");
+    expect(b).toContain("captchaToken?: string");
+    expect(b).toContain(".signUp({");
+    expect(b).toContain(OPTS);
+  });
+
+  it("signInWithPassword(phone, password, captchaToken?) → signInWithPassword with options", () => {
+    const b = body(SEAM, "signInWithPassword");
+    expect(b).toContain("captchaToken?: string");
+    expect(b).toContain(".signInWithPassword({");
+    expect(b).toContain(OPTS);
+  });
+
+  it("sendPasswordResetEmail(email, redirectTo, captchaToken?) → resetPasswordForEmail spreads the token", () => {
+    const b = body(SEAM, "sendPasswordResetEmail");
+    expect(b).toContain("captchaToken?: string");
+    expect(b).toContain(".resetPasswordForEmail(email, {");
+    // different shape — a second positional-options arg, so the token is spread in, not nested under options
+    expect(b).toContain("...(captchaToken ? { captchaToken } : {})");
+  });
+
+  it("verifyPhoneOtp is NOT captcha-gated — the verify step takes no token", () => {
+    const b = body(SEAM, "verifyPhoneOtp");
+    expect(b).toContain(".verifyOtp({");
+    expect(b).not.toContain("captchaToken"); // no param, no options, no forwarding
+  });
+});
+
+/* ---------------------------------------------- item 3a · the entry-point actions */
+
+describe("actions · each entry-point accepts + forwards the token (source)", () => {
+  it("requestOtp forwards the token to signInWithPhone", () => {
+    const b = body(AUTH_ACTION, "requestOtp");
+    expect(b).toContain("captchaToken?: string");
+    expect(b).toContain("signInWithPhone(phone, captchaToken)");
+  });
+
+  it("passwordLogin forwards the token to signInWithPassword", () => {
+    const b = body(AUTH_ACTION, "passwordLogin");
+    expect(b).toContain("captchaToken?: string");
+    expect(b).toContain("signInWithPassword(phone, password, captchaToken)");
+  });
+
+  it("requestPasswordReset forwards the token to sendPasswordResetEmail", () => {
+    const b = body(AUTH_ACTION, "requestPasswordReset");
+    expect(b).toContain("captchaToken?: string");
+    expect(b).toContain("sendPasswordResetEmail(email, redirectTo, input?.captchaToken)");
+  });
+
+  it("acceptInvite validates captchaToken on AcceptSchema and forwards it to createPasswordUser", () => {
+    expect(INVITE_ACTION).toContain("captchaToken: z.string().optional()");
+    const b = body(INVITE_ACTION, "acceptInvite");
+    expect(b).toContain("captchaToken");
+    expect(b).toContain("createPasswordUser(inv.phone, password, captchaToken)");
+  });
+
+  it("onboardSchool validates captchaToken on OnboardSchema and forwards d.captchaToken to createPasswordUser", () => {
+    expect(ONBOARD_SCHEMA).toContain("captchaToken: z.string().optional()");
+    expect(ONBOARD_ACTION).toContain("createPasswordUser(adminPhone, d.password, d.captchaToken)");
+  });
+});
+
+/* -------------------------------------------------------- item 3b · the 4 forms */
+
+const FORMS: { name: string; src: string; action: string }[] = [
+  {
+    name: "login-form",
+    src: readCode("components/auth/login-form.tsx"),
+    action: "requestOtp(phone, captcha.token || undefined)",
+  },
+  {
+    name: "accept-form",
+    src: readCode("components/auth/accept-form.tsx"),
+    action: "acceptInvite({ token, password, captchaToken: captcha.token || undefined })",
+  },
+  {
+    name: "reset-form",
+    src: readCode("components/auth/reset-form.tsx"),
+    action: "requestOtp(phone, captcha.token || undefined)",
+  },
+  {
+    name: "wizard",
+    src: readCode("components/onboarding/wizard.tsx"),
+    action: "onboardSchool({ ...form, captchaToken: captcha.token || undefined })",
+  },
+];
+
+describe("forms · every entry point renders the widget, guards, forwards + resets (source)", () => {
+  for (const { name, src, action } of FORMS) {
+    it(`${name} wires the shared captcha widget + hook`, () => {
+      expect(src).toContain("const captcha = useCaptcha()");
+      expect(src).toContain(
+        "<CaptchaWidget onToken={captcha.setToken} resetKey={captcha.resetKey} />",
+      );
+      expect(src).toContain("captcha.missing()");
+      expect(src).toContain("captcha.token || undefined"); // passes the token, undefined when unsolved
+      expect(src).toContain("captcha.reset()"); // single-use token cleared after a failed attempt
+    });
+
+    it(`${name} blocks submit on captcha.missing() BEFORE calling the action`, () => {
+      expect(src).toContain(action);
+      expect(src.indexOf("captcha.missing()")).toBeLessThan(src.indexOf(action));
+    });
+  }
+});
+
+/* -------------------- item 2 (runtime) · the token actually reaches Supabase */
+
+// Mock the Supabase server client so the seam's `authApi()` resolves to a capturing spy. `vi.hoisted`
+// so the object exists when `vi.mock` is hoisted above the imports.
+const supa = vi.hoisted(() => {
+  const auth = {
+    signUp: vi.fn(async () => ({ error: null })),
+    signInWithPassword: vi.fn(async () => ({ error: null })),
+    resetPasswordForEmail: vi.fn(async () => ({ error: null })),
+  };
+  return { auth, createClient: vi.fn(async () => ({ auth })) };
+});
+vi.mock("@/lib/supabase/server", () => ({ createClient: supa.createClient }));
+
+describe("seam (runtime) · the token lands in the Supabase call, absent when unsolved", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    // Make authIsLive() true so the seam reaches authApi() (dev-bypass would no-op it).
+    vi.stubEnv("AUTH_DEV_BYPASS", "false");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://x.supabase.co");
+    supa.auth.signUp.mockClear();
+    supa.auth.signInWithPassword.mockClear();
+    supa.auth.resetPasswordForEmail.mockClear();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("createPasswordUser: token → options.captchaToken; no token → options undefined", async () => {
+    const auth = await import("@/lib/auth");
+    await auth.createPasswordUser("+233200000000", "password1", "TOK123");
+    expect(supa.auth.signUp).toHaveBeenLastCalledWith(
+      expect.objectContaining({ options: { captchaToken: "TOK123" } }),
+    );
+    // MUTATION GUARD: hardcode `options: undefined` in the seam and the token line above goes RED.
+    await auth.createPasswordUser("+233200000000", "password1");
+    expect(supa.auth.signUp).toHaveBeenLastCalledWith(
+      expect.objectContaining({ options: undefined }),
+    );
+  });
+
+  it("signInWithPassword: token → options.captchaToken; no token → options undefined", async () => {
+    const auth = await import("@/lib/auth");
+    await auth.signInWithPassword("+233200000000", "password1", "TOK123");
+    expect(supa.auth.signInWithPassword).toHaveBeenLastCalledWith(
+      expect.objectContaining({ options: { captchaToken: "TOK123" } }),
+    );
+    await auth.signInWithPassword("+233200000000", "password1");
+    expect(supa.auth.signInWithPassword).toHaveBeenLastCalledWith(
+      expect.objectContaining({ options: undefined }),
+    );
+  });
+
+  it("sendPasswordResetEmail: token spread into the options arg; no token → redirectTo only", async () => {
+    const auth = await import("@/lib/auth");
+    await auth.sendPasswordResetEmail("head@school.gh", "https://site/auth/reset-callback", "TOK123");
+    expect(supa.auth.resetPasswordForEmail).toHaveBeenLastCalledWith(
+      "head@school.gh",
+      { redirectTo: "https://site/auth/reset-callback", captchaToken: "TOK123" },
+    );
+    await auth.sendPasswordResetEmail("head@school.gh", "https://site/auth/reset-callback");
+    expect(supa.auth.resetPasswordForEmail).toHaveBeenLastCalledWith(
+      "head@school.gh",
+      { redirectTo: "https://site/auth/reset-callback" }, // no captchaToken key
+    );
+  });
+});

--- a/omnischools/lib/captcha-wiring.test.ts
+++ b/omnischools/lib/captcha-wiring.test.ts
@@ -210,3 +210,33 @@ describe("seam (runtime) · the token lands in the Supabase call, absent when un
     );
   });
 });
+
+/* -------------------------------------------------- M1 (Dex) · the 3 other captcha-gated call sites */
+describe("M1 · the non-form captcha-gated callers are handled (completeness)", () => {
+  const CHANGE_FORM = readCode("components/auth/change-password-form.tsx");
+  const USERS_ACTION = readCode("lib/actions/users.ts");
+  const WIZARD = readCode("components/onboarding/wizard.tsx");
+
+  it("changeOwnPassword forwards captchaToken to the re-auth signInWithPassword", () => {
+    const b = body(AUTH_ACTION, "changeOwnPassword");
+    expect(b).toContain("captchaToken?: string");
+    expect(b).toContain("signInWithPassword(user.phone, currentPassword, input?.captchaToken)");
+  });
+
+  it("the change-password form renders the widget, gates missing(), threads the token", () => {
+    expect(CHANGE_FORM).toContain("<CaptchaWidget");
+    expect(CHANGE_FORM).toContain("useCaptcha()");
+    expect(CHANGE_FORM).toContain("captcha.missing()");
+    expect(CHANGE_FORM).toContain("captchaToken: captcha.token");
+  });
+
+  it("initiatePasswordReset refuses honestly when captchaEnabled(), BEFORE the OTP send (no lie-SMS)", () => {
+    const b = body(USERS_ACTION, "initiatePasswordReset");
+    expect(b).toContain("captchaEnabled()");
+    expect(b.indexOf("captchaEnabled()")).toBeLessThan(b.indexOf("signInWithPhone(gated.phone)"));
+  });
+
+  it("the onboarding OTP-finish panel is skipped when captchaEnabled() (routes to the /login card)", () => {
+    expect(WIZARD).toContain("result.otpLive && !captchaEnabled() && <OnboardingOtpFinish");
+  });
+});

--- a/omnischools/lib/captcha.test.ts
+++ b/omnischools/lib/captcha.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 
 // INCR-AUTH-CAPTCHA — the captcha config helper is the on-switch: inert when NEXT_PUBLIC_TURNSTILE_SITE_KEY
 // is unset/empty, active when set. `env` is parsed once at module load, so each case stubs then re-imports.
@@ -8,6 +10,14 @@ async function load(siteKey?: string) {
   vi.resetModules();
   vi.stubEnv("NEXT_PUBLIC_TURNSTILE_SITE_KEY", siteKey);
   return import("@/lib/captcha");
+}
+
+// Same stub-then-reimport dance for the widget/hook module (it reads the site key transitively via
+// lib/captcha → lib/env, both parsed at load). renderToStaticMarkup runs in node (no jsdom needed).
+async function loadWidget(siteKey?: string) {
+  vi.resetModules();
+  vi.stubEnv("NEXT_PUBLIC_TURNSTILE_SITE_KEY", siteKey);
+  return import("@/components/auth/captcha-widget");
 }
 
 afterEach(() => {
@@ -32,5 +42,47 @@ describe("captcha config (INCR-AUTH-CAPTCHA)", () => {
     const { captchaEnabled, captchaSiteKey } = await load("0x_test_sitekey");
     expect(captchaEnabled()).toBe(true);
     expect(captchaSiteKey()).toBe("0x_test_sitekey");
+  });
+});
+
+/**
+ * The shared widget + `useCaptcha` hook — the un-demoable half (inert in dev, external Cloudflare
+ * script, wrong worktree runs the dev server). Proven here via renderToStaticMarkup instead. The
+ * freshly-imported hook is parked on `hookRef` and exercised through a real React render by `MissingProbe`
+ * (a named, capitalised component so eslint's react/display-name + rules-of-hooks stay satisfied; the ref
+ * name is off `use*` so the call site isn't misread — the hook's own useState lives in the widget module).
+ */
+let hookRef: (() => { missing: () => boolean }) | null = null;
+function MissingProbe() {
+  return createElement("output", null, String(hookRef!().missing()));
+}
+
+describe("CaptchaWidget + useCaptcha (INCR-AUTH-CAPTCHA)", () => {
+  it("INERT (KEY) — <CaptchaWidget> renders NOTHING with no site key (no widget, no token)", async () => {
+    const { CaptchaWidget } = await loadWidget(undefined);
+    const html = renderToStaticMarkup(createElement(CaptchaWidget, { onToken: () => {} }));
+    // MUTATION GUARD: delete `if (!siteKey) return null` and this renders the Turnstile mount → RED.
+    expect(html).toBe("");
+  });
+
+  it("renders the Turnstile mount when the site key IS set (proves the null-guard is non-vacuous)", async () => {
+    const { CaptchaWidget } = await loadWidget("0x_test_sitekey");
+    const html = renderToStaticMarkup(
+      createElement(CaptchaWidget, { onToken: () => {}, resetKey: 0 }),
+    );
+    expect(html).not.toBe("");
+    expect(html).toContain("cf-turnstile"); // @marsidev/react-turnstile's mount node
+  });
+
+  it("INERT (KEY) — useCaptcha().missing() is FALSE when disabled, so submit is NOT blocked", async () => {
+    hookRef = (await loadWidget(undefined)).useCaptcha;
+    // missing() === captchaEnabled() && !token; disabled ⇒ false regardless of token ⇒ every form submits.
+    expect(renderToStaticMarkup(createElement(MissingProbe))).toBe("<output>false</output>");
+  });
+
+  it("useCaptcha().missing() is TRUE when enabled with no token yet — submit blocked until solved", async () => {
+    hookRef = (await loadWidget("0x_test_sitekey")).useCaptcha;
+    // token starts "" (useState); enabled + empty ⇒ blocked. This is the property the 4 forms gate on.
+    expect(renderToStaticMarkup(createElement(MissingProbe))).toBe("<output>true</output>");
   });
 });

--- a/omnischools/lib/captcha.test.ts
+++ b/omnischools/lib/captcha.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+// INCR-AUTH-CAPTCHA — the captcha config helper is the on-switch: inert when NEXT_PUBLIC_TURNSTILE_SITE_KEY
+// is unset/empty, active when set. `env` is parsed once at module load, so each case stubs then re-imports.
+vi.setConfig({ testTimeout: 20_000 });
+
+async function load(siteKey?: string) {
+  vi.resetModules();
+  vi.stubEnv("NEXT_PUBLIC_TURNSTILE_SITE_KEY", siteKey);
+  return import("@/lib/captcha");
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe("captcha config (INCR-AUTH-CAPTCHA)", () => {
+  it("inert when the site key is unset — no widget, no token", async () => {
+    const { captchaEnabled, captchaSiteKey } = await load(undefined);
+    expect(captchaEnabled()).toBe(false);
+    expect(captchaSiteKey()).toBeUndefined();
+  });
+
+  it("inert when the site key is an empty string", async () => {
+    const { captchaEnabled, captchaSiteKey } = await load("");
+    expect(captchaEnabled()).toBe(false);
+    expect(captchaSiteKey()).toBeUndefined();
+  });
+
+  it("active when a site key is set", async () => {
+    const { captchaEnabled, captchaSiteKey } = await load("0x_test_sitekey");
+    expect(captchaEnabled()).toBe(true);
+    expect(captchaSiteKey()).toBe("0x_test_sitekey");
+  });
+});

--- a/omnischools/lib/captcha.ts
+++ b/omnischools/lib/captcha.ts
@@ -1,0 +1,15 @@
+import { env } from "@/lib/env";
+
+/**
+ * INCR-AUTH-CAPTCHA (audit #4) — client-safe captcha config. The site key is PUBLIC (NEXT_PUBLIC), so this
+ * is importable from client components. Its PRESENCE is the on-switch: unset ⇒ no widget renders and no
+ * token is sent, so the auth flow is byte-identical to today (and Supabase captcha must be OFF to match).
+ * See docs/senior/incr-auth-captcha-plan.md. Provider = Cloudflare Turnstile.
+ */
+export function captchaSiteKey(): string | undefined {
+  return env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || undefined;
+}
+
+export function captchaEnabled(): boolean {
+  return !!captchaSiteKey();
+}

--- a/omnischools/lib/env.ts
+++ b/omnischools/lib/env.ts
@@ -19,6 +19,11 @@ const schema = z.object({
   NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().optional(),
   SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
 
+  // Cloudflare Turnstile site key (INCR-AUTH-CAPTCHA, audit #4). PUBLIC (client). Its PRESENCE enables
+  // the captcha widget + token flow; unset ⇒ inert (no widget, no token). Coordinate with the Supabase
+  // Auth → Protection captcha toggle + secret (see docs/senior/incr-auth-captcha-plan.md).
+  NEXT_PUBLIC_TURNSTILE_SITE_KEY: z.string().optional(),
+
   // Claude Vision — score-ledger scan extraction (Path B / Item 4). Server-only (NOT
   // NEXT_PUBLIC): the base64 photo is sent to Claude from our own API route, never the
   // client. Absent in dev/CI → the extractor falls back to the deterministic stub.

--- a/omnischools/lib/onboarding-done-panel-render.test.ts
+++ b/omnischools/lib/onboarding-done-panel-render.test.ts
@@ -92,7 +92,7 @@ describe("AUTH-OTP-06 · OTP card auto-sends once on mount and verifies via veri
   const WIZARD = readCode("components/onboarding/wizard.tsx");
 
   it("the done phase renders OnboardingOtpFinish exactly when result.otpLive", () => {
-    expect(WIZARD).toContain("result.otpLive && <OnboardingOtpFinish");
+    expect(WIZARD).toContain("result.otpLive && !captchaEnabled() && <OnboardingOtpFinish");
     // and the plain Sign-in button is the else case (gated on NOT otpLive)
     expect(WIZARD).toContain("!result.otpLive");
   });

--- a/omnischools/lib/onboarding-l1.test.ts
+++ b/omnischools/lib/onboarding-l1.test.ts
@@ -76,7 +76,7 @@ describe("L1 · the signup password step", () => {
   });
 
   it("L1-8 · live-mode signup creates the Supabase password credential (before the tx)", () => {
-    expect(ACTION).toContain("createPasswordUser(adminPhone, d.password)");
+    expect(ACTION).toContain("createPasswordUser(adminPhone, d.password"); // + optional captchaToken
     // ordered BEFORE the DB transaction (mirrors acceptInvite — no orphaned school on auth failure)
     expect(ACTION.indexOf("createPasswordUser(adminPhone")).toBeLessThan(
       ACTION.indexOf("await withoutTenantScope"),

--- a/omnischools/lib/onboarding.ts
+++ b/omnischools/lib/onboarding.ts
@@ -402,6 +402,8 @@ export const OnboardSchema = z.object({
   accountantName: z.string().max(160).optional().or(z.literal("")),
   accountantPhone: z.string().max(40).optional().or(z.literal("")),
   accountantEmail: z.string().email().optional().or(z.literal("")),
+  // INCR-AUTH-CAPTCHA — forwarded to Supabase signUp when the native captcha is enabled; UI-only otherwise.
+  captchaToken: z.string().optional(),
 });
 
 export type OnboardInput = z.infer<typeof OnboardSchema>;

--- a/omnischools/next.config.mjs
+++ b/omnischools/next.config.mjs
@@ -36,14 +36,17 @@ const nextConfig = {
 const csp = [
   "default-src 'self'",
   // Next injects inline hydration/bootstrap scripts; no nonce middleware yet, so 'unsafe-inline'.
-  "script-src 'self' 'unsafe-inline'",
+  // Cloudflare Turnstile (INCR-AUTH-CAPTCHA) loads its script from challenges.cloudflare.com.
+  "script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com",
   // Tailwind + styled-jsx emit inline styles.
   "style-src 'self' 'unsafe-inline'",
   // School logo/stamp are Supabase-storage <img>; data:/blob: for embedded assets.
   "img-src 'self' data: blob: https://*.supabase.co",
   "font-src 'self' data:",
-  // Supabase Auth/REST/Realtime (wss for realtime).
-  "connect-src 'self' https://*.supabase.co wss://*.supabase.co",
+  // Supabase Auth/REST/Realtime (wss for realtime) + Turnstile's siteverify/telemetry.
+  "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://challenges.cloudflare.com",
+  // Turnstile renders its challenge inside an iframe from challenges.cloudflare.com.
+  "frame-src 'self' https://challenges.cloudflare.com",
   "frame-ancestors 'none'",
   "base-uri 'self'",
   "form-action 'self'",

--- a/omnischools/package.json
+++ b/omnischools/package.json
@@ -66,6 +66,7 @@
     "db:verify-census": "tsx --tsconfig scripts/tsconfig.json scripts/verify-census-handfill.ts"
   },
   "dependencies": {
+    "@marsidev/react-turnstile": "^1.6.0",
     "@react-pdf/renderer": "^4.5.1",
     "@supabase/ssr": "^0.10.3",
     "@supabase/supabase-js": "^2.107.0",

--- a/omnischools/pnpm-lock.yaml
+++ b/omnischools/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
 
   .:
     dependencies:
+      '@marsidev/react-turnstile':
+        specifier: ^1.6.0
+        version: 1.6.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-pdf/renderer':
         specifier: ^4.5.1
         version: 4.5.1(react@19.2.8)
@@ -664,6 +667,12 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@marsidev/react-turnstile@1.6.0':
+    resolution: {integrity: sha512-T2Um71ZdBgQBiyS01xgRMvDWk+mEsrLtXLFVhOC917OVEO584wbPOWj1sw35RaM17+q9QoADgLVcH60xr9NRqQ==}
+    peerDependencies:
+      react: ^17.0.2 || ^18.0.0 || ^19.0
+      react-dom: ^17.0.2 || ^18.0.0 || ^19.0
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -3392,6 +3401,11 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@marsidev/react-turnstile@1.6.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:


### PR DESCRIPTION
## INCR-AUTH-CAPTCHA · Cloudflare Turnstile bot protection (audit #4, follow-up (e))

The last audit follow-up — bot/brute-force protection on the auth endpoints. Spec: `docs/senior/incr-auth-captcha-plan.md`.

### ⚠️ Inert until configured
A new `NEXT_PUBLIC_TURNSTILE_SITE_KEY` is the on-switch: unset ⇒ no widget renders, no token is sent, auth is byte-identical to today. **Merging changes nothing** until you configure it. Rollout (DEPLOY.md §1 C1–C3), coordinate together:
1. Create a Cloudflare **Turnstile** widget → site key (public) + secret.
2. Supabase **Auth → Protection → enable CAPTCHA → Turnstile → secret**.
3. Set `NEXT_PUBLIC_TURNSTILE_SITE_KEY` to the site key.
(Enabling Supabase captcha without the site key set would make auth demand a token the client isn't sending — do 2+3 together.)

### What it does
Supabase's native captcha is **all-or-nothing** — once enabled it requires a `captchaToken` on every friction endpoint (`signInWithOtp`/`signInWithPassword`/`signUp`/`resetPasswordForEmail`). So:
- **Seam-only:** a `captchaToken?` threads through `lib/auth` into `options: { captchaToken }`; feature code never touches `supabase.auth.*` (portable — hCaptcha is one widget + one CSP line away).
- **One shared widget + `useCaptcha()` hook** render on every entry point: login (OTP-send + password), onboarding signup, invite-accept, and both reset paths.
- **The three non-form callers** of those endpoints are handled too (Dex completeness): `changeOwnPassword` (widget on the change-password form + token), admin-initiated reset (honest refusal → self-reset when captcha is on, no misleading SMS), and the onboarding OTP-finish auto-send (routes to the captcha-wired `/login` when captcha is on).
- **CSP:** Turnstile's origins added to the report-only `script-src`/`connect-src` + a new `frame-src`; clickjacking still enforced via `X-Frame-Options: DENY`.
- Dependency: `@marsidev/react-turnstile@1.6.0` (pinned, lockfile committed).

### Security shape
The site key is public; the **secret lives only in the Supabase dashboard** — the app forwards the token, Supabase verifies it. Enumeration-safety is preserved (the neutral-always OTP-send + reset paths are unchanged). No schema, no prod-paste.

### Gates
- **Quinn (QA) 🟢** — full suite **2039 green**, tsc/build green; widget/hook render + seam/action/form wiring proven (inert-by-default, token→`options.captchaToken` via a runtime supabase mock), 3 mutations RED'd. Un-demoable half (external Turnstile + inert-by-default) covered by source + `renderToStaticMarkup`.
- **Dex (architecture) ✅** — seam threading, widget/hook DRY, dep + lock-in bounds, CSP, inert-flag all sound; found + confirmed the fold of **MAJOR-1** (3 missed captcha-gated call sites) + an audit-fidelity nit.
- **Sarah (security + final) 🟢 CLEAR** — no secret leak (site key public, secret dashboard-only, app forwards but never verifies the token — GoTrue does); supply-chain clean (pinned, lockfile sha512, zero install scripts, single Cloudflare origin = the CSP allowlist); enumeration-safety preserved (neutral-always paths unchanged, token rides inside the known branch only); inert when unconfigured; M1 fixes safe (the un-tokened `signInWithPhone` is unreachable when captcha is on, no service-role bypass); clickjacking intact (`X-Frame-Options: DENY` + `frame-ancestors 'none'`).

### Follow-up
This completes the 5-item security audit's code work. Optional next: promote the CSP from report-only to enforcing once a deploy proves the allowlist (tracked, not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
