### PR TITLE
feat(students): capture + show guardian email on the student profile

### DIFF
--- a/omnischools/app/(app)/students/[id]/edit/page.tsx
+++ b/omnischools/app/(app)/students/[id]/edit/page.tsx
@@ -67,6 +67,7 @@ export default async function EditStudentPage(props: { params: Promise<{ id: str
                 name: guardian.name,
                 phone: guardian.phone,
                 relationship: guardian.relationship,
+                email: guardian.email,
               }
             : null
         }

--- a/omnischools/app/(app)/students/[id]/page.tsx
+++ b/omnischools/app/(app)/students/[id]/page.tsx
@@ -578,6 +578,7 @@ export default async function StudentDetailPage(props: { params: Promise<{ id: s
                     {g.name} <span className="text-navy-3">· {cap(g.relationship)}</span>
                   </div>
                   <div className="font-mono text-xs text-navy-3">{g.phone}</div>
+                  {g.email && <div className="text-xs text-navy-3">{g.email}</div>}
                 </div>
                 <div className="flex items-center gap-3">
                   {g.isPrimary && (

--- a/omnischools/components/students/edit-student-form.tsx
+++ b/omnischools/components/students/edit-student-form.tsx
@@ -20,7 +20,7 @@ type Student = {
   classId: string | null;
   status: string;
 };
-type Guardian = { name: string; phone: string; relationship: string } | null;
+type Guardian = { name: string; phone: string; relationship: string; email: string | null } | null;
 type Health = {
   bloodGroup: string | null;
   allergies: string | null;
@@ -62,6 +62,7 @@ export function EditStudentForm({
       guardianName: formData.get("guardianName"),
       guardianPhone: formData.get("guardianPhone"),
       guardianRelation: formData.get("guardianRelation"),
+      guardianEmail: formData.get("guardianEmail"),
       bloodGroup: formData.get("bloodGroup"),
       allergies: formData.get("allergies"),
       conditions: formData.get("conditions"),
@@ -190,6 +191,18 @@ export function EditStudentForm({
               <option value="OTHER">Other</option>
             </select>
           </div>
+        </div>
+        <div className="mt-4">
+          <label className={labelClass}>
+            Email <span className="font-normal text-navy-3">(optional)</span>
+          </label>
+          <input
+            name="guardianEmail"
+            type="email"
+            defaultValue={guardian?.email ?? ""}
+            placeholder="guardian@example.com"
+            className={fieldClass}
+          />
         </div>
       </div>
 

--- a/omnischools/components/students/new-student-form.tsx
+++ b/omnischools/components/students/new-student-form.tsx
@@ -25,6 +25,7 @@ export function NewStudentForm({ classes }: { classes: { id: string; name: strin
       guardianName: formData.get("guardianName"),
       guardianPhone: formData.get("guardianPhone"),
       guardianRelation: formData.get("guardianRelation"),
+      guardianEmail: formData.get("guardianEmail"),
     });
     setSaving(false);
     if (res.ok) router.push(`/students/${res.studentId}`);
@@ -115,6 +116,17 @@ export function NewStudentForm({ classes }: { classes: { id: string; name: strin
               <option value="OTHER">Other</option>
             </select>
           </div>
+        </div>
+        <div className="mt-4">
+          <label className={labelClass}>
+            Email <span className="font-normal text-navy-3">(optional)</span>
+          </label>
+          <input
+            name="guardianEmail"
+            type="email"
+            placeholder="guardian@example.com"
+            className={fieldClass}
+          />
         </div>
       </div>
 

--- a/omnischools/lib/actions/students.ts
+++ b/omnischools/lib/actions/students.ts
@@ -31,6 +31,7 @@ const CreateStudentSchema = z.object({
   guardianName: z.string().max(160).optional().or(z.literal("")),
   guardianPhone: z.string().max(40).optional().or(z.literal("")),
   guardianRelation: z.enum(["MOTHER", "FATHER", "GUARDIAN", "OTHER"]).default("GUARDIAN"),
+  guardianEmail: z.string().max(160).email("Enter a valid guardian email address.").optional().or(z.literal("")),
 });
 
 export type CreateStudentResult =
@@ -81,6 +82,7 @@ export async function createStudent(input: unknown): Promise<CreateStudentResult
           name: d.guardianName,
           relationship: d.guardianRelation,
           phone: normalizeGhanaPhone(d.guardianPhone),
+          email: d.guardianEmail || null,
           isPrimary: true,
         });
       }
@@ -119,6 +121,7 @@ const UpdateStudentSchema = z.object({
   guardianName: z.string().max(160).optional().or(z.literal("")),
   guardianPhone: z.string().max(40).optional().or(z.literal("")),
   guardianRelation: z.enum(["MOTHER", "FATHER", "GUARDIAN", "OTHER"]).default("GUARDIAN"),
+  guardianEmail: z.string().max(160).email("Enter a valid guardian email address.").optional().or(z.literal("")),
   // Health & emergency record (all optional)
   bloodGroup: z.string().max(8).optional().or(z.literal("")),
   allergies: z.string().max(1000).optional().or(z.literal("")),
@@ -186,7 +189,7 @@ export async function updateStudent(input: unknown): Promise<CreateStudentResult
         if (primary) {
           await tx
             .update(studentGuardians)
-            .set({ name: d.guardianName, phone, relationship: d.guardianRelation })
+            .set({ name: d.guardianName, phone, relationship: d.guardianRelation, email: d.guardianEmail || null })
             .where(eq(studentGuardians.id, primary.id));
         } else {
           await tx.insert(studentGuardians).values({
@@ -195,6 +198,7 @@ export async function updateStudent(input: unknown): Promise<CreateStudentResult
             name: d.guardianName,
             relationship: d.guardianRelation,
             phone,
+            email: d.guardianEmail || null,
             isPrimary: true,
           });
         }
@@ -262,6 +266,7 @@ const ImportRowSchema = z.object({
   guardianName: z.string().max(160).optional().or(z.literal("")),
   guardianPhone: z.string().max(40).optional().or(z.literal("")),
   guardianRelation: z.enum(["MOTHER", "FATHER", "GUARDIAN", "OTHER"]).default("GUARDIAN"),
+  guardianEmail: z.string().max(160).email("Enter a valid guardian email address.").optional().or(z.literal("")),
 });
 const ImportStudentsSchema = z.object({
   rows: z.array(ImportRowSchema).min(1, "No rows to import").max(1000),
@@ -314,6 +319,7 @@ export async function importStudents(input: unknown): Promise<ImportStudentsResu
             name: r.guardianName,
             relationship: r.guardianRelation,
             phone: normalizeGhanaPhone(r.guardianPhone),
+            email: r.guardianEmail || null,
             isPrimary: true,
           });
         }


### PR DESCRIPTION
Adds an email field for a student''s guardian on the profile page.

**Key finding:** the `student_guardian.email` column has existed since migration **0002** — the data schema already had it. The gap was purely UI: the student create/edit forms never collected it and the profile never displayed it (it was always left NULL). So this is a wiring change — **no schema, no migration, no prod-paste**.

Wired end-to-end:
- `guardianEmail` added to the create / edit / import action schemas (`lib/actions/students.ts`) — Zod-validated email, optional; stored on the primary-guardian insert/update.
- **Email** input on the new-student and edit-student forms (with the existing value as the edit default).
- Guardian email shown in the profile **Guardians & contact** section (under the phone).

The admissions applicant flow already captured guardian email; the CSV bulk-import UI is a separate surface (the action schema now accepts the field, but the CSV template/validator doesn''t collect it yet — a small follow-up if wanted).

**Verified:** `tsc` clean · full suite **2039 green** · `next build` green. No new attack surface — guardian email is contact data handled exactly like the existing guardian phone (staff-only, tenant-scoped display; Zod-validated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)