### PR TITLE
feat(students): guardian email in the CSV bulk import (follow-up to #247)

### DIFF
--- a/omnischools/components/students/student-import.tsx
+++ b/omnischools/components/students/student-import.tsx
@@ -72,6 +72,7 @@ export function StudentImport({
         guardianName: r.guardianName,
         guardianPhone: r.guardianPhone,
         guardianRelation: r.relationship,
+        guardianEmail: r.guardianEmail,
       })),
     });
     setBusy(false);
@@ -210,7 +211,12 @@ export function StudentImport({
                     <td className="px-3 py-2.5 text-navy-2">{r.sex ?? "—"}</td>
                     <td className="px-3 py-2.5 text-navy-2">{r.dateOfBirth ?? "—"}</td>
                     <td className="px-3 py-2.5 text-navy-2">{r.className || "—"}</td>
-                    <td className="px-3 py-2.5 text-navy-2">{r.guardianName || "—"}</td>
+                    <td className="px-3 py-2.5 text-navy-2">
+                      {r.guardianName || "—"}
+                      {r.guardianEmail && (
+                        <div className="text-xs text-navy-3">{r.guardianEmail}</div>
+                      )}
+                    </td>
                     <td className="px-3 py-2.5">
                       {r.errors.length > 0 ? (
                         <span className="text-xs text-terra">{r.errors.join("; ")}</span>

--- a/omnischools/lib/import/student-import.test.ts
+++ b/omnischools/lib/import/student-import.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { validateStudentRows, STUDENT_IMPORT_HEADERS } from "@/lib/import/student-import";
+
+/**
+ * Guardian-email column on the student CSV bulk-import (follow-up to the profile-page guardian email).
+ * Appended as the LAST column so an older 9-column CSV stays valid (relationship keeps its index).
+ */
+describe("student CSV import · guardian email column", () => {
+  const noClasses: Record<string, string> = {};
+  // A clean, error-free base row (First,Last,Other,Gender,DOB,Class,GuardianName,GuardianPhone,Relationship).
+  const base = ["Ama", "Boateng", "", "F", "", "", "Ama Boateng", "0241112222", "Mother"];
+
+  it("appends 'Guardian email' as the last template column", () => {
+    expect(STUDENT_IMPORT_HEADERS).toContain("Guardian email");
+    expect(STUDENT_IMPORT_HEADERS[STUDENT_IMPORT_HEADERS.length - 1]).toBe("Guardian email");
+  });
+
+  it("accepts a valid guardian email and carries it onto the row", () => {
+    const { rows } = validateStudentRows([[...base, "ama@example.com"]], noClasses);
+    expect(rows[0].guardianEmail).toBe("ama@example.com");
+    expect(rows[0].errors).toHaveLength(0);
+  });
+
+  it("flags an invalid guardian email as an error", () => {
+    const { rows } = validateStudentRows([[...base, "not-an-email"]], noClasses);
+    expect(rows[0].errors).toContain("Guardian email is invalid");
+  });
+
+  it("treats an absent (old 9-column CSV) or blank email as fine — optional, backward-compatible", () => {
+    const legacy = validateStudentRows([base], noClasses); // no 10th column at all
+    expect(legacy.rows[0].guardianEmail).toBe("");
+    expect(legacy.rows[0].errors).toHaveLength(0);
+    const blank = validateStudentRows([[...base, ""]], noClasses);
+    expect(blank.rows[0].errors).toHaveLength(0);
+  });
+});

--- a/omnischools/lib/import/student-import.ts
+++ b/omnischools/lib/import/student-import.ts
@@ -14,6 +14,7 @@ export const STUDENT_IMPORT_HEADERS = [
   "Guardian name",
   "Guardian phone",
   "Relationship (Mother/Father/Guardian)",
+  "Guardian email",
 ];
 
 export const STUDENT_IMPORT_SAMPLE: string[][] = [
@@ -27,8 +28,9 @@ export const STUDENT_IMPORT_SAMPLE: string[][] = [
     "Ama Boateng",
     "0241112222",
     "Mother",
+    "ama.boateng@example.com",
   ],
-  ["Kwame", "Mensah", "Kofi", "M", "2013-09-01", "", "", "", ""],
+  ["Kwame", "Mensah", "Kofi", "M", "2013-09-01", "", "", "", "", ""],
 ];
 
 export type RelationCode = "MOTHER" | "FATHER" | "GUARDIAN" | "OTHER";
@@ -45,6 +47,7 @@ export type StudentRow = {
   guardianName: string;
   guardianPhone: string; // normalised E.164 when valid
   relationship: RelationCode;
+  guardianEmail: string;
   errors: string[];
   warnings: string[];
 };
@@ -127,6 +130,10 @@ export function validateStudentRows(
     if (!guardianName && !guardianPhoneRaw)
       warnings.push("No guardian — parent won't be invited");
 
+    const guardianEmail = get(9);
+    if (guardianEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(guardianEmail))
+      errors.push("Guardian email is invalid");
+
     return {
       index: i + 1,
       firstName,
@@ -139,6 +146,7 @@ export function validateStudentRows(
       guardianName,
       guardianPhone,
       relationship: normRelation(get(8)),
+      guardianEmail,
       errors,
       warnings,
     };


### PR DESCRIPTION
Follow-up to #247 — carries guardian email through the **CSV bulk import** (the profile create/edit forms + display shipped in #247; the import was the one remaining entry point).

- **Guardian email** added to the downloadable CSV template + sample — **appended as the last column**, so an existing 9-column CSV still imports correctly (relationship keeps its index; a missing 10th column reads as empty).
- Validated in `validateStudentRows` (optional; format-checked, flags a bad address as a row error).
- Threaded through `runImport` into the `importStudents` action (which already accepted `guardianEmail` from #247), and shown under the guardian name in the review table.
- Unit test on the pure validator (valid / invalid / absent-legacy / blank).

**Verified:** tsc clean · `next build` green · new import test green. (The full-suite run flagged the census-PDF size test, which is an unrelated load-flake — it passes standalone; this PR doesn't touch the census PDF.) No schema, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
