### PR TITLE
feat(insights): Directors' Insights dashboard (/insights)

### DIFF
--- a/omnischools/app/(app)/insights/page.tsx
+++ b/omnischools/app/(app)/insights/page.tsx
@@ -13,6 +13,7 @@ import type {
   TerminalResultSummary,
 } from "@/lib/rollup/school-rollup";
 import type { ClassPerfRow, LevelPerfRow } from "@/lib/reports/class-performance-data";
+import { compareLevelLabel } from "@/lib/reports/class-performance-data";
 import type { SubjectPerfRow } from "@/lib/reports/subject-performance-data";
 import type {
   CensusEnrolment,
@@ -743,7 +744,7 @@ function EnrolmentTile({
   arm: RollupArm<EnrolmentArm>;
   census: CensusEnrolment;
 }) {
-  const byLevel = [...census.byLevel].sort((a, b) => a.level.localeCompare(b.level));
+  const byLevel = [...census.byLevel].sort((a, b) => compareLevelLabel(a.level, b.level));
 
   const dims: DrillDimension[] = [
     { key: "class", label: "By class", content: <EnrolClassBars rows={census.byClass} /> },

--- a/omnischools/app/(app)/insights/page.tsx
+++ b/omnischools/app/(app)/insights/page.tsx
@@ -1,0 +1,1208 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { requireSchoolRole } from "@/lib/auth/server";
+import { INSIGHTS_READ_ROLES } from "@/lib/access";
+import { getDirectorsInsights, type DirectorsInsights } from "@/lib/insights/insights-data";
+import type {
+  AttendanceArm,
+  EnrolmentArm,
+  InfrastructureSummary,
+  NetPositionFinanceArm,
+  PerformanceArm,
+  RollupArm,
+  TerminalResultSummary,
+} from "@/lib/rollup/school-rollup";
+import type { ClassPerfRow, LevelPerfRow } from "@/lib/reports/class-performance-data";
+import type { SubjectPerfRow } from "@/lib/reports/subject-performance-data";
+import type {
+  CensusEnrolment,
+  CensusClassRow,
+  CensusLevelRow,
+} from "@/lib/reports/census-enrolment-data";
+import type { InsightsAttendanceLevelRow } from "@/lib/insights/insights-data";
+import { attendanceTone } from "@/lib/reports/grade-band";
+import { boardGhs } from "@/lib/board/tiles";
+import { ReportFilters } from "@/components/reports/report-filters";
+import { PerfBar, ColumnHeads } from "@/components/reports/report-kit";
+import {
+  TrendPill,
+  AbsencePanel,
+  Tile,
+  SummaryCell,
+  StatusSplit,
+  Line,
+  StreamCard,
+  FEMALE_HEX,
+  MALE_HEX,
+} from "@/components/board/board-tiles";
+import { DrillIn, type DrillDimension } from "@/components/insights/drill-in";
+import { cn } from "@/lib/utils";
+
+/**
+ * INS · Directors' Insights (`/insights`) — the acting director/admin's consolidated analytics
+ * dashboard. It EXTENDS the read-only board (`app/(board)/board/page.tsx`, shared primitives lifted to
+ * `components/board/board-tiles.tsx`) with a "Needs your attention" action panel and real AGGREGATE
+ * drill-ins (Performance/Attendance/Enrolment by class · by year-group · by subject, + gender & age).
+ *
+ * HARD INVARIANT (owner-stated, INS-21..24): everything on this page is AGGREGATE — class / year-group
+ * (level) / subject / age-band — NEVER an individual student. The data comes from `getDirectorsInsights`,
+ * whose type carries no student-identifying field, and `getAttendanceSummary` (which carries per-student
+ * `needsAttention[]`) is never in the path — attendance is the PII-stripped `rollup.attendance`.
+ * Reads the SESSION school id via `requireSchoolRole`, never a URL/query id.
+ */
+export const dynamic = "force-dynamic";
+
+export default async function InsightsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ periodId?: string }>;
+}) {
+  const { school } = await requireSchoolRole(INSIGHTS_READ_ROLES);
+  const { periodId } = await searchParams;
+  const data = await getDirectorsInsights(school.id, { periodId });
+  const { rollup, census } = data;
+
+  const termLabel = rollup.period
+    ? `${rollup.period.label} · ${rollup.period.academicYear}`
+    : "No academic period configured";
+  const academic = academicSummary(rollup.performance);
+  const attention = buildAttention(data, termLabel);
+
+  return (
+    <div className="mx-auto max-w-page space-y-6">
+      {/* ── Header ── */}
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="font-display text-xl font-medium text-navy">
+            Directors&apos; <em className="not-italic text-gold">insights</em>.
+          </h1>
+          <p className="mt-1 text-[13px] text-navy-2">{termLabel} · consolidated director dashboard</p>
+        </div>
+      </div>
+
+      {/* ── Period selector (verbatim board) ── */}
+      <ReportFilters
+        terms={rollup.terms}
+        activePeriodId={rollup.period?.periodId ?? null}
+        showClass={false}
+      />
+
+      {/* ── Summary strip — the scan layer (verbatim board) ── */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+        <SummaryCell
+          lead
+          label="Students on roll"
+          value={
+            rollup.enrolment.status === "CAPTURED"
+              ? rollup.enrolment.data.roll.toLocaleString("en-GH")
+              : "—"
+          }
+          sub={
+            rollup.enrolment.status === "CAPTURED" ? (
+              <>
+                {rollup.enrolment.data.gender.male} boys · {rollup.enrolment.data.gender.female} girls{" "}
+                <TrendPill
+                  delta={rollup.enrolment.data.netChange}
+                  context="this term"
+                  flatLabel="no change"
+                />
+              </>
+            ) : (
+              rollup.enrolment.reason
+            )
+          }
+        />
+        <SummaryCell
+          label="Attendance rate"
+          value={
+            rollup.attendance.status === "CAPTURED"
+              ? rollup.attendance.data.schoolRate == null
+                ? "—"
+                : `${rollup.attendance.data.schoolRate}%`
+              : "—"
+          }
+          sub={
+            rollup.attendance.status === "CAPTURED" ? (
+              rollup.attendance.data.schoolDelta == null ? (
+                "(present + late) ÷ all marks"
+              ) : (
+                <TrendPill delta={rollup.attendance.data.schoolDelta} unit="pts" context="vs last term" />
+              )
+            ) : (
+              rollup.attendance.reason
+            )
+          }
+        />
+        <SummaryCell label="Academic standing" value={academic.value} sub={academic.sub} />
+        <SummaryCell
+          label="Fee collection"
+          value={
+            rollup.feeCollections.status === "CAPTURED"
+              ? `${rollup.feeCollections.data.collectionRate}%`
+              : "—"
+          }
+          sub={
+            rollup.feeCollections.status === "CAPTURED"
+              ? `${boardGhs(rollup.feeCollections.data.collected)} of ${boardGhs(rollup.feeCollections.data.billed)} billed`
+              : rollup.feeCollections.reason
+          }
+        />
+        <SummaryCell
+          label="Facilities"
+          value={
+            rollup.infrastructure.status === "CAPTURED"
+              ? rollup.infrastructure.data.classrooms.pctGood == null
+                ? "—"
+                : `${rollup.infrastructure.data.classrooms.pctGood}%`
+              : "—"
+          }
+          sub={
+            rollup.infrastructure.status === "CAPTURED"
+              ? `${rollup.infrastructure.data.classrooms.good}/${rollup.infrastructure.data.classrooms.total} classrooms sound`
+              : rollup.infrastructure.reason
+          }
+        />
+      </div>
+
+      {/* ── Needs your attention — the act-on-it panel [NEW] ── */}
+      <AttentionPanel items={attention} />
+
+      {/* ── Financial position (verbatim board) ── */}
+      <FinanceTile arm={rollup.netPositionFinance} />
+
+      {/* ── Attendance | Enrolment ── */}
+      <div className="grid gap-4 lg:grid-cols-2">
+        <AttendanceTile arm={rollup.attendance} byLevel={data.attendanceByLevel} />
+        <EnrolmentTile arm={rollup.enrolment} census={census} />
+      </div>
+
+      {/* ── Performance | Infrastructure ── */}
+      <div className="grid gap-4 lg:grid-cols-2">
+        <PerformanceTile data={data} termLabel={termLabel} />
+        <InfrastructureTile arm={rollup.infrastructure} />
+      </div>
+    </div>
+  );
+}
+
+/* ───────────────────────────── Summary academic cell (verbatim board) ───────────────────────────── */
+
+/** Cell 3 headline: prefer the captured Basic average; else Senior readiness; else the applicable
+ *  tier's honest reason. NO blend across tiers (R357). Copied from the board (page-local, can't import). */
+function academicSummary(p: PerformanceArm): { value: string; sub: ReactNode } {
+  if (p.basic.status === "CAPTURED" && p.basic.data.overallAverage != null) {
+    const d = p.basic.data;
+    return {
+      value: `${d.overallAverage}%`,
+      sub: (
+        <>
+          {d.passRate != null && <>{d.passRate}% pass · </>}
+          {d.gradedClasses} {d.gradedClasses === 1 ? "class" : "classes"} graded{" "}
+          <TrendPill delta={d.overallDelta} unit="pts" context="vs last term" />
+        </>
+      ),
+    };
+  }
+  if (p.senior.status === "CAPTURED") {
+    const d = p.senior.data;
+    return { value: `${d.subjectsReady}/${d.subjectsTotal}`, sub: "subjects STPSHS-ready" };
+  }
+  const applicable = p.basic.status !== "NOT_APPLICABLE" ? p.basic : p.senior;
+  return { value: "—", sub: applicable.status === "CAPTURED" ? null : applicable.reason };
+}
+
+/* ───────────────────────────── Needs your attention [NEW] ───────────────────────────── */
+
+type ActionSeverity = "terra" | "warn" | "navy-2";
+type ActionItem = { key: string; href: string; dot: ActionSeverity; label: string; value: string };
+const DOT: Record<ActionSeverity, string> = {
+  terra: "bg-terra",
+  warn: "bg-warn",
+  "navy-2": "bg-navy-2",
+};
+
+/**
+ * The conditional action rows — each rendered ONLY when its condition is genuinely true (omit-not-fake:
+ * an absent problem is absent, never a green "all good" row). Every row is a school-wide count/amount or
+ * a subject count — NEVER a per-student list. Deferred for v1 (no cheap signal / needs its own gated
+ * route): the "Census not filed" row (§17-D) and the "Export board pack" button (§17-F).
+ */
+function buildAttention(d: DirectorsInsights, termLabel: string): ActionItem[] {
+  const items: ActionItem[] = [];
+  const { rollup, classPerf } = d;
+
+  const fees = rollup.feeCollections;
+  if (fees.status === "CAPTURED" && fees.data.outstanding > 0) {
+    items.push({
+      key: "fees",
+      href: "/billing",
+      dot: fees.data.collectionRate < 60 ? "terra" : "warn",
+      label: "Outstanding fees",
+      value: `${boardGhs(fees.data.outstanding)} outstanding · ${fees.data.collectionRate}% collected`,
+    });
+  }
+
+  // Ungraded classes — Basic tier only; count from getClassPerformance (§17-E), not the rollup arm.
+  if (rollup.performance.basic.status !== "NOT_APPLICABLE") {
+    const ungraded = classPerf.totalClasses - classPerf.classesGraded;
+    if (ungraded > 0) {
+      items.push({
+        key: "ungraded",
+        href: "/gradebook",
+        dot: "warn",
+        label: "Ungraded classes",
+        value: `${ungraded} of ${classPerf.totalClasses} ${
+          classPerf.totalClasses === 1 ? "class has" : "classes have"
+        } no gradebook scores for ${termLabel}`,
+      });
+    }
+  }
+
+  if (rollup.attendance.status !== "CAPTURED") {
+    items.push({
+      key: "attendance",
+      href: "/attendance",
+      dot: "warn",
+      label: "Attendance not captured",
+      value: rollup.attendance.reason,
+    });
+  }
+
+  if (rollup.infrastructure.status !== "CAPTURED") {
+    items.push({
+      key: "facilities",
+      href: "/reports/facilities",
+      dot: "navy-2",
+      label: "Facilities snapshot missing",
+      value: rollup.infrastructure.reason,
+    });
+  }
+
+  const sen = rollup.performance.senior;
+  if (sen.status === "CAPTURED" && sen.data.subjectsAtRisk > 0) {
+    items.push({
+      key: "senior",
+      href: "/senior/headmaster-summary",
+      dot: "terra",
+      label: "Senior readiness at risk",
+      value: `${sen.data.subjectsAtRisk} subject${sen.data.subjectsAtRisk === 1 ? "" : "s"} at risk for STPSHS · ${sen.data.subjectsPartial} partial`,
+    });
+  }
+
+  const order: Record<ActionSeverity, number> = { terra: 0, warn: 1, "navy-2": 2 };
+  return items.sort((a, b) => order[a.dot] - order[b.dot]);
+}
+
+function AttentionPanel({ items }: { items: ActionItem[] }) {
+  return (
+    <Tile
+      title="Needs your"
+      accent="attention"
+      meta={items.length > 0 ? `${items.length} item${items.length === 1 ? "" : "s"}` : undefined}
+    >
+      {items.length === 0 ? (
+        <p className="mt-3 text-[13px] text-navy-3">
+          Everything&apos;s current — nothing needs your attention this term.
+        </p>
+      ) : (
+        <div className="mt-3 space-y-2">
+          {items.map((it) => (
+            <Link
+              key={it.key}
+              href={it.href}
+              className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg border border-border bg-surface px-4 py-3 hover:bg-gold-bg"
+            >
+              <span className={cn("h-2 w-2 shrink-0 rounded-full", DOT[it.dot])} aria-hidden />
+              <span className="text-[13px] font-semibold text-navy">{it.label}</span>
+              <span className="text-xs text-navy-3">{it.value}</span>
+              <span className="ml-auto text-navy-3" aria-hidden>
+                ›
+              </span>
+            </Link>
+          ))}
+        </div>
+      )}
+    </Tile>
+  );
+}
+
+/* ───────────────────────────── Drill-in bar-list primitives ───────────────────────────── */
+
+const PERF_COLS = "lg:grid-cols-[minmax(7rem,1fr)_1.7fr_minmax(9rem,auto)]";
+const SUBJ_COLS = "lg:grid-cols-[minmax(7rem,1fr)_1.5fr_minmax(11rem,auto)]";
+const ATT_COLS = "lg:grid-cols-[minmax(7rem,1fr)_1.7fr_minmax(5rem,auto)]";
+const ENROL_COLS = "lg:grid-cols-[minmax(7rem,1fr)_1.7fr_minmax(9rem,auto)]";
+
+function DrillList({
+  cols,
+  heads,
+  children,
+}: {
+  cols: string;
+  heads: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div className="mt-1 overflow-hidden rounded-lg border border-border">
+      <ColumnHeads cols={cols}>{heads}</ColumnHeads>
+      <div className="divide-y divide-border">{children}</div>
+    </div>
+  );
+}
+
+/** A single aggregate bar row: label (+sub) · bar · trailing readout. Stacks on mobile, grid on lg. */
+function BarRow({
+  cols,
+  label,
+  sub,
+  bar,
+  trailing,
+}: {
+  cols: string;
+  label: ReactNode;
+  sub?: ReactNode;
+  bar: ReactNode;
+  trailing?: ReactNode;
+}) {
+  return (
+    <div className={cn("space-y-1.5 px-6 py-2.5 lg:grid lg:items-center lg:gap-4 lg:space-y-0", cols)}>
+      <div className="min-w-0">
+        <div className="truncate text-[13px] text-navy">{label}</div>
+        {sub && <div className="mt-0.5 font-mono text-[10px] text-navy-3">{sub}</div>}
+      </div>
+      <div>{bar}</div>
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 lg:justify-end">{trailing}</div>
+    </div>
+  );
+}
+
+function GenderBar({
+  female,
+  male,
+  heightClass = "h-2.5",
+}: {
+  female: number;
+  male: number;
+  heightClass?: string;
+}) {
+  return (
+    <div className={cn("flex w-full overflow-hidden rounded-pill border border-border bg-bg", heightClass)}>
+      {female > 0 && <div style={{ flexGrow: female, backgroundColor: FEMALE_HEX }} aria-hidden />}
+      {male > 0 && <div style={{ flexGrow: male, backgroundColor: MALE_HEX }} aria-hidden />}
+    </div>
+  );
+}
+
+/* ───────────────────────────── Performance tile + drill-in ───────────────────────────── */
+
+function PerformanceTile({ data, termLabel }: { data: DirectorsInsights; termLabel: string }) {
+  const { rollup, classPerf, subjectPerf, levelPerf } = data;
+  const { basic, senior } = rollup.performance;
+  const terminal = rollup.terminalResults;
+
+  const dims: DrillDimension[] = [
+    {
+      key: "class",
+      label: "By class",
+      content: classPerf.hasAnyScores ? (
+        <ClassPerfBars rows={classPerf.rows} />
+      ) : (
+        <div className="mt-1">
+          <AbsencePanel>{perfReason(basic, termLabel)}</AbsencePanel>
+        </div>
+      ),
+    },
+    {
+      key: "year",
+      label: "By year group",
+      content: levelPerf.hasAnyScores ? (
+        <LevelPerfBars rows={levelPerf.rows} />
+      ) : (
+        <div className="mt-1">
+          <AbsencePanel>{perfReason(basic, termLabel)}</AbsencePanel>
+        </div>
+      ),
+    },
+    {
+      key: "subject",
+      label: "By subject",
+      content: subjectPerf.hasAnyScores ? (
+        <SubjectPerfBars rows={subjectPerf.rows} />
+      ) : (
+        <div className="mt-1">
+          <AbsencePanel>{perfReason(basic, termLabel)}</AbsencePanel>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <Tile title="Academic" accent="performance" meta="cross-tier · this term">
+      <div className="mt-3 space-y-3">
+        {basic.status !== "NOT_APPLICABLE" && (
+          <div>
+            <div className="text-[10px] font-bold uppercase tracking-[0.12em] text-navy-3">
+              Basic · gradebook
+            </div>
+            {basic.status === "CAPTURED" ? (
+              <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1">
+                <div className="font-display text-3xl font-medium leading-none text-navy">
+                  {basic.data.overallAverage == null ? "—" : `${basic.data.overallAverage}%`}
+                </div>
+                {basic.data.passRate != null && (
+                  <span className="text-[11px] font-semibold text-navy-2">
+                    {basic.data.passRate}% pass rate
+                  </span>
+                )}
+                <span className="text-[11px] text-navy-3">
+                  {basic.data.gradedClasses} {basic.data.gradedClasses === 1 ? "class" : "classes"} graded
+                </span>
+                <TrendPill delta={basic.data.overallDelta} unit="pts" context="vs last term" />
+              </div>
+            ) : (
+              <p className="mt-1 text-[13px] leading-relaxed text-navy-3">{basic.reason}</p>
+            )}
+          </div>
+        )}
+
+        {senior.status !== "NOT_APPLICABLE" && (
+          <div>
+            <div className="text-[10px] font-bold uppercase tracking-[0.12em] text-navy-3">
+              Senior · STPSHS readiness
+            </div>
+            {senior.status === "CAPTURED" ? (
+              <div className="mt-1 text-[13px] text-navy-2">
+                <span className="font-display text-xl font-medium text-navy">
+                  {senior.data.subjectsReady}
+                </span>{" "}
+                of {senior.data.subjectsTotal} subjects ready ·{" "}
+                <span className="font-semibold text-gold">{senior.data.subjectsPartial} partial</span> ·{" "}
+                <span className="font-semibold text-terra">{senior.data.subjectsAtRisk} at risk</span>
+              </div>
+            ) : (
+              <p className="mt-1 text-[13px] leading-relaxed text-navy-3">{senior.reason}</p>
+            )}
+          </div>
+        )}
+
+        {(terminal.bece.status !== "NOT_APPLICABLE" ||
+          terminal.wassce.status !== "NOT_APPLICABLE") && (
+          <div>
+            <div className="text-[10px] font-bold uppercase tracking-[0.12em] text-navy-3">
+              Terminal exams
+            </div>
+            <div className="mt-1 space-y-2">
+              <TerminalLine label="BECE" arm={terminal.bece} />
+              <TerminalLine label="WASSCE" arm={terminal.wassce} />
+            </div>
+          </div>
+        )}
+      </div>
+
+      <DrillIn dimensions={dims} defaultDim="class" />
+    </Tile>
+  );
+}
+
+function perfReason(basic: PerformanceArm["basic"], termLabel: string): string {
+  if (basic.status !== "CAPTURED") return basic.reason;
+  return `No gradebook scores recorded for ${termLabel}.`;
+}
+
+function ClassPerfBars({ rows }: { rows: ClassPerfRow[] }) {
+  return (
+    <DrillList
+      cols={PERF_COLS}
+      heads={
+        <>
+          <span>Class</span>
+          <span>Average</span>
+          <span className="lg:text-right">Grade · vs last term</span>
+        </>
+      }
+    >
+      {rows.map((r) => (
+        <BarRow
+          key={r.classId}
+          cols={PERF_COLS}
+          label={r.name}
+          sub={`${r.studentsGraded} graded`}
+          bar={<PerfBar value={r.average} tone={r.tone} suffix="%" />}
+          trailing={
+            <>
+              <span className="font-mono text-xs text-navy-2">{r.grade ?? "—"}</span>
+              <TrendPill delta={r.delta} unit="pts" context="vs last term" />
+            </>
+          }
+        />
+      ))}
+    </DrillList>
+  );
+}
+
+function LevelPerfBars({ rows }: { rows: LevelPerfRow[] }) {
+  return (
+    <DrillList
+      cols={PERF_COLS}
+      heads={
+        <>
+          <span>Year group</span>
+          <span>Average</span>
+          <span className="lg:text-right">Pass · vs last term</span>
+        </>
+      }
+    >
+      {rows.map((r) => (
+        <BarRow
+          key={r.level}
+          cols={PERF_COLS}
+          label={<span className="font-mono">{r.level}</span>}
+          sub={`${r.classesGraded} of ${r.classes} ${r.classes === 1 ? "class" : "classes"} graded`}
+          bar={<PerfBar value={r.average} tone={r.tone} suffix="%" />}
+          trailing={
+            <>
+              <span className="font-mono text-xs text-navy-2">
+                {r.passRate == null ? "—" : `${r.passRate}% pass`}
+              </span>
+              <TrendPill delta={r.delta} unit="pts" context="vs last term" />
+            </>
+          }
+        />
+      ))}
+    </DrillList>
+  );
+}
+
+function SubjectPerfBars({ rows }: { rows: SubjectPerfRow[] }) {
+  return (
+    <DrillList
+      cols={SUBJ_COLS}
+      heads={
+        <>
+          <span>Subject</span>
+          <span>Average</span>
+          <span className="lg:text-right">Grade · Pass · vs last term</span>
+        </>
+      }
+    >
+      {rows.map((r) => (
+        <BarRow
+          key={r.subjectId}
+          cols={SUBJ_COLS}
+          label={r.name}
+          sub={r.code ?? undefined}
+          bar={<PerfBar value={r.average} tone={r.tone} suffix="%" />}
+          trailing={
+            <>
+              <span className="font-mono text-xs text-navy-2">{r.grade ?? "—"}</span>
+              <span className="font-mono text-xs text-navy-3">
+                {r.passRate == null ? "—" : `${r.passRate}% pass`}
+              </span>
+              <TrendPill delta={r.delta} unit="pts" context="vs last term" />
+            </>
+          }
+        />
+      ))}
+    </DrillList>
+  );
+}
+
+/* ───────────────────────────── Attendance tile + drill-in ───────────────────────────── */
+
+function AttendanceTile({
+  arm,
+  byLevel,
+}: {
+  arm: RollupArm<AttendanceArm>;
+  byLevel: InsightsAttendanceLevelRow[];
+}) {
+  if (arm.status !== "CAPTURED") {
+    return (
+      <Tile title="Attendance" accent="this term">
+        <div className="mt-4">
+          <AbsencePanel>{arm.reason}</AbsencePanel>
+        </div>
+      </Tile>
+    );
+  }
+
+  // Worst-first (Lucy §9.1 flag #5 — the director's watch-list read): ascending by rate, null last.
+  const byClass = [...arm.data.byClass].sort(
+    (a, b) => (a.rate ?? 101) - (b.rate ?? 101) || a.name.localeCompare(b.name),
+  );
+
+  const dims: DrillDimension[] = [
+    {
+      key: "class",
+      label: "By class",
+      content: (
+        <AttendanceBars
+          cols={ATT_COLS}
+          headLabel="Class"
+          rows={byClass.map((c) => ({
+            key: c.classId,
+            label: c.name,
+            rate: c.rate,
+            marked: c.marked,
+            counts: c.counts,
+          }))}
+        />
+      ),
+    },
+    {
+      key: "year",
+      label: "By year group",
+      content: (
+        <AttendanceBars
+          cols={ATT_COLS}
+          headLabel="Year group"
+          rows={byLevel.map((l) => ({
+            key: l.level,
+            label: <span className="font-mono">{l.level}</span>,
+            rate: l.rate,
+            marked: l.marked,
+            counts: l.counts,
+          }))}
+        />
+      ),
+    },
+  ];
+
+  return (
+    <Tile
+      title="Attendance"
+      accent="this term"
+      meta={`${arm.data.totalMarked.toLocaleString("en-GH")} marks recorded`}
+    >
+      <div className="mt-3 flex items-center gap-3">
+        <div className="font-display text-3xl font-medium leading-none text-navy">
+          {arm.data.schoolRate == null ? "—" : `${arm.data.schoolRate}%`}
+        </div>
+        {arm.data.schoolDelta == null ? (
+          <span className="text-[11px] text-navy-3">(present + late) ÷ all marks</span>
+        ) : (
+          <TrendPill delta={arm.data.schoolDelta} unit="pts" context="vs last term" />
+        )}
+      </div>
+      <StatusSplit totals={arm.data.statusTotals} />
+      <DrillIn dimensions={dims} defaultDim="class" />
+    </Tile>
+  );
+}
+
+type AttendanceBarRow = {
+  key: string;
+  label: ReactNode;
+  rate: number | null;
+  marked: number;
+  counts: { present: number; late: number; excused: number; medical: number; absent: number };
+};
+
+function AttendanceBars({
+  cols,
+  headLabel,
+  rows,
+}: {
+  cols: string;
+  headLabel: string;
+  rows: AttendanceBarRow[];
+}) {
+  return (
+    <DrillList
+      cols={cols}
+      heads={
+        <>
+          <span>{headLabel}</span>
+          <span>Rate · P L E M A</span>
+          <span className="lg:text-right">Marks</span>
+        </>
+      }
+    >
+      {rows.map((r) => (
+        <div key={r.key} className="px-6 py-3">
+          <div className={cn("space-y-1.5 lg:grid lg:items-center lg:gap-4 lg:space-y-0", cols)}>
+            <div className="truncate text-[13px] text-navy">{r.label}</div>
+            <PerfBar value={r.rate} tone={attendanceTone(r.rate)} suffix="%" />
+            <div className="font-mono text-[10px] text-navy-3 lg:text-right">
+              {r.marked.toLocaleString("en-GH")} marks
+            </div>
+          </div>
+          <StatusSplit totals={r.counts} className="mt-2" />
+        </div>
+      ))}
+    </DrillList>
+  );
+}
+
+/* ───────────────────────────── Enrolment tile + drill-in ───────────────────────────── */
+
+function EnrolmentTile({
+  arm,
+  census,
+}: {
+  arm: RollupArm<EnrolmentArm>;
+  census: CensusEnrolment;
+}) {
+  const byLevel = [...census.byLevel].sort((a, b) => a.level.localeCompare(b.level));
+
+  const dims: DrillDimension[] = [
+    { key: "class", label: "By class", content: <EnrolClassBars rows={census.byClass} /> },
+    { key: "year", label: "By year group", content: <EnrolLevelBars rows={byLevel} /> },
+    { key: "gender", label: "Gender", content: <GenderViz census={census} /> },
+    { key: "age", label: "Age", content: <AgeViz census={census} /> },
+  ];
+
+  return (
+    <Tile
+      title="Enrolment"
+      accent="at a glance"
+      meta={arm.status === "CAPTURED" ? arm.data.levelSummary : undefined}
+    >
+      {arm.status !== "CAPTURED" ? (
+        <div className="mt-4">
+          <AbsencePanel>{arm.reason}</AbsencePanel>
+        </div>
+      ) : (
+        <>
+          <EnrolmentBody d={arm.data} />
+          {census.roll > 0 && <DrillIn dimensions={dims} defaultDim="class" />}
+        </>
+      )}
+    </Tile>
+  );
+}
+
+function EnrolmentBody({ d }: { d: EnrolmentArm }) {
+  const dash = (n: number | null) => (n == null ? "—" : n.toLocaleString("en-GH"));
+  return (
+    <div className="mt-3 space-y-4">
+      <div className="flex items-center gap-3">
+        <div className="font-display text-3xl font-medium leading-none text-navy">
+          {d.roll.toLocaleString("en-GH")}
+        </div>
+        <TrendPill delta={d.netChange} context="this term" flatLabel="no change" />
+      </div>
+
+      <div>
+        <GenderBar female={d.gender.female} male={d.gender.male} />
+        <div className="mt-1.5 font-mono text-[10px] text-navy-3">
+          {d.gender.female}F · {d.gender.male}M
+        </div>
+      </div>
+
+      <dl className="space-y-1 text-[13px]">
+        <Line label="Active classes" value={d.activeClasses.toLocaleString("en-GH")} />
+        <Line label="Avg class size" value={d.avgClassSize.toLocaleString("en-GH")} />
+        <Line label="Teaching staff" value={d.teachingStaff.toLocaleString("en-GH")} />
+        <Line
+          label="Student : teacher"
+          value={d.studentTeacherRatio == null ? "—" : `${d.studentTeacherRatio}:1`}
+        />
+      </dl>
+
+      <div className="border-t border-border pt-3">
+        <div className="text-[10px] font-bold uppercase tracking-[0.12em] text-navy-3">
+          Intake this term
+        </div>
+        <div className="mt-1 text-[13px] text-navy-2">
+          {dash(d.admissionsThisTerm)} new{" "}
+          <span className="text-navy-3">
+            ({dash(d.intakeFemale)}F · {dash(d.intakeMale)}M)
+          </span>
+        </div>
+        <div className="mt-2 text-[13px] text-navy-2">
+          <span className="text-navy-3">Lifetime exits:</span> {d.withdrew.toLocaleString("en-GH")}{" "}
+          withdrew · {d.transferred.toLocaleString("en-GH")} transferred ·{" "}
+          {d.graduated.toLocaleString("en-GH")} graduated ({d.lifetimeExits.toLocaleString("en-GH")}{" "}
+          total)
+        </div>
+        <p className="mt-1 text-[11px] leading-relaxed text-navy-3">
+          Withdrawals, transfers and graduations are current lifetime totals — per-term exit dating
+          arrives when status history is tracked.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function EnrolClassBars({ rows }: { rows: CensusClassRow[] }) {
+  if (rows.length === 0) {
+    return (
+      <div className="mt-1">
+        <AbsencePanel>No students currently enrolled.</AbsencePanel>
+      </div>
+    );
+  }
+  return (
+    <DrillList
+      cols={ENROL_COLS}
+      heads={
+        <>
+          <span>Class</span>
+          <span>Girls / boys</span>
+          <span className="lg:text-right">Enrolled</span>
+        </>
+      }
+    >
+      {rows.map((r) => (
+        <BarRow
+          key={r.classId}
+          cols={ENROL_COLS}
+          label={r.name}
+          bar={<GenderBar female={r.female} male={r.male} />}
+          trailing={
+            <span className="font-mono text-xs text-navy-2">
+              {r.total} · {r.female}F · {r.male}M
+            </span>
+          }
+        />
+      ))}
+    </DrillList>
+  );
+}
+
+function EnrolLevelBars({ rows }: { rows: CensusLevelRow[] }) {
+  return (
+    <DrillList
+      cols={ENROL_COLS}
+      heads={
+        <>
+          <span>Year group</span>
+          <span>Girls / boys</span>
+          <span className="lg:text-right">Enrolled</span>
+        </>
+      }
+    >
+      {rows.map((r) => (
+        <BarRow
+          key={r.level}
+          cols={ENROL_COLS}
+          label={<span className="font-mono">{r.level}</span>}
+          bar={<GenderBar female={r.female} male={r.male} />}
+          trailing={
+            <span className="font-mono text-xs text-navy-2">
+              {r.total} · {r.female}F · {r.male}M
+            </span>
+          }
+        />
+      ))}
+    </DrillList>
+  );
+}
+
+/** Gender dimension = the school headline bar (the per-class/level splits are the two lists above). */
+function GenderViz({ census }: { census: CensusEnrolment }) {
+  const g = census.gender;
+  const femalePct = g.total > 0 ? Math.round((g.female / g.total) * 100) : 0;
+  const malePct = g.total > 0 ? Math.round((g.male / g.total) * 100) : 0;
+  return (
+    <div className="mt-1 rounded-lg border border-border p-4">
+      <GenderBar female={g.female} male={g.male} heightClass="h-3" />
+      <div className="mt-2 font-mono text-[11px] text-navy-2">
+        {femalePct}% girls · {malePct}% boys · {g.total} on roll
+      </div>
+      <p className="mt-2 text-[11px] leading-relaxed text-navy-3">
+        Girls and boys per class and per year-group are in the “By class” and “By year group”
+        breakdowns.
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Age dimension — the school-scope age histogram (gender-split stacked bars, normalised to the modal
+ * age) + the GES "enrolment by approved age" bands + the honest DOB-unknown footnote. A student with no
+ * DOB is NEVER assigned an age (GOV8-05): they surface in the `dobUnknown` footnote and the approved-age
+ * `unknown` band, shown, never dropped. (A by-level age sub-toggle is a v1 follow-up.)
+ */
+function AgeViz({ census }: { census: CensusEnrolment }) {
+  const byAge = new Map<number, { female: number; male: number }>();
+  for (const lvl of census.ageByLevel) {
+    for (const b of lvl.byAge) {
+      const e = byAge.get(b.age) ?? { female: 0, male: 0 };
+      e.female += b.female;
+      e.male += b.male;
+      byAge.set(b.age, e);
+    }
+  }
+  const ages = [...byAge.entries()]
+    .map(([age, s]) => ({ age, female: s.female, male: s.male, total: s.female + s.male }))
+    .sort((a, b) => a.age - b.age);
+  const maxTotal = ages.reduce((m, a) => Math.max(m, a.total), 0);
+
+  const appr = census.approvedAge.reduce(
+    (acc, a) => ({
+      under: acc.under + a.under,
+      on: acc.on + a.on,
+      over: acc.over + a.over,
+      unknown: acc.unknown + a.unknown,
+    }),
+    { under: 0, on: 0, over: 0, unknown: 0 },
+  );
+  const apprTotal = appr.under + appr.on + appr.over + appr.unknown;
+
+  const dobFootnote =
+    census.dobUnknown > 0 ? (
+      <p className="mt-3 text-[11px] leading-relaxed text-navy-3">
+        {census.dobUnknown} student{census.dobUnknown === 1 ? "" : "s"} have no date of birth recorded
+        — counted in the roll but never assigned an age.
+      </p>
+    ) : null;
+
+  const asOf = (
+    <p className="mt-3 text-[11px] text-navy-3">
+      Enrolment, gender &amp; age are a point-in-time census snapshot, as of {census.censusDate}.
+    </p>
+  );
+
+  if (ages.length === 0) {
+    return (
+      <div className="mt-1">
+        <AbsencePanel>No date-of-birth data recorded yet — no age distribution to show.</AbsencePanel>
+        {dobFootnote}
+        {asOf}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-1 rounded-lg border border-border p-4">
+      <div className="text-[10px] font-bold uppercase tracking-[0.12em] text-navy-3">
+        Age distribution · girls / boys
+      </div>
+      <div className="mt-2 space-y-1.5">
+        {ages.map((a) => (
+          <div key={a.age} className="grid items-center gap-2 lg:grid-cols-[3rem_1fr_auto] lg:gap-3">
+            <div className="font-mono text-[11px] text-navy-2">{a.age} yrs</div>
+            <div className="flex h-2.5 w-full overflow-hidden rounded-pill border border-border bg-bg">
+              <div
+                className="flex h-full overflow-hidden"
+                style={{ width: `${maxTotal > 0 ? (a.total / maxTotal) * 100 : 0}%` }}
+              >
+                {a.female > 0 && (
+                  <div style={{ flexGrow: a.female, backgroundColor: FEMALE_HEX }} aria-hidden />
+                )}
+                {a.male > 0 && (
+                  <div style={{ flexGrow: a.male, backgroundColor: MALE_HEX }} aria-hidden />
+                )}
+              </div>
+            </div>
+            <div className="font-mono text-[10px] text-navy-3 lg:text-right">
+              {a.female}F · {a.male}M · {a.total}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {apprTotal > 0 && (
+        <div className="mt-4 border-t border-border pt-3">
+          <div className="text-[10px] font-bold uppercase tracking-[0.12em] text-navy-3">
+            Enrolment by approved age
+          </div>
+          <div className="mt-2 flex h-2.5 w-full overflow-hidden rounded-pill border border-border bg-bg">
+            {appr.on > 0 && <div className="bg-green" style={{ flexGrow: appr.on }} aria-hidden />}
+            {appr.under > 0 && <div className="bg-gold" style={{ flexGrow: appr.under }} aria-hidden />}
+            {appr.over > 0 && <div className="bg-terra" style={{ flexGrow: appr.over }} aria-hidden />}
+            {appr.unknown > 0 && (
+              <div className="bg-navy-3" style={{ flexGrow: appr.unknown }} aria-hidden />
+            )}
+          </div>
+          <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 font-mono text-[10px]">
+            <span className="text-green">{appr.on} on age</span>
+            <span className="text-gold">{appr.under} under</span>
+            <span className="text-terra">{appr.over} over</span>
+            {appr.unknown > 0 && <span className="text-navy-3">{appr.unknown} unknown DOB</span>}
+          </div>
+        </div>
+      )}
+
+      {dobFootnote}
+      {asOf}
+    </div>
+  );
+}
+
+/* ───────────────────────────── Finance tile (verbatim board) ───────────────────────────── */
+
+function FinanceTile({ arm }: { arm: RollupArm<NetPositionFinanceArm> }) {
+  return (
+    <Tile title="Financial" accent="position" className="col-span-full">
+      <p className="mt-1 max-w-2xl text-[13px] leading-relaxed text-navy-3">
+        Three separate records shown side by side. Fee collections and the school&apos;s books are kept
+        as separate ledgers and are not combined into a single profit; payroll is a current monthly
+        figure.
+      </p>
+
+      {arm.status !== "CAPTURED" ? (
+        <div className="mt-4">
+          <AbsencePanel>{arm.reason}</AbsencePanel>
+        </div>
+      ) : (
+        <div className="mt-4 grid gap-4 sm:grid-cols-3">
+          <StreamCard title="Fee collections">
+            {arm.data.fees.status === "CAPTURED" ? (
+              <>
+                <Headline>{boardGhs(arm.data.fees.data.collected)}</Headline>
+                <Caption>collected · this term</Caption>
+                <div className="mt-3">
+                  <PerfBar value={arm.data.fees.data.collectionRate} tone="gold" suffix="%" />
+                </div>
+                <div className="mt-1.5 text-[11px] text-navy-3">
+                  {boardGhs(arm.data.fees.data.outstanding)} outstanding
+                </div>
+              </>
+            ) : (
+              <Reason>{arm.data.fees.reason}</Reason>
+            )}
+          </StreamCard>
+
+          <StreamCard title="Books (this term)">
+            {arm.data.books.status === "CAPTURED" ? (
+              <dl className="mt-2 space-y-1 text-[13px]">
+                <Line label="Income" value={boardGhs(arm.data.books.data.income)} />
+                <Line label="Expense" value={boardGhs(arm.data.books.data.expense)} />
+                <Line label="Net" value={boardGhs(arm.data.books.data.net)} strong />
+              </dl>
+            ) : (
+              <Reason>{arm.data.books.reason}</Reason>
+            )}
+          </StreamCard>
+
+          <StreamCard title="Payroll">
+            {arm.data.payroll.status === "CAPTURED" ? (
+              <>
+                <Headline>{boardGhs(arm.data.payroll.data.schoolPaidMonthlyTotal)}</Headline>
+                <Caption>school-paid · gross · monthly</Caption>
+                <div className="mt-2 text-[11px] leading-relaxed text-navy-3">
+                  GES-paid (memo, not added): {boardGhs(arm.data.payroll.data.gesPaidMonthlyMemo)}
+                  {arm.data.payroll.data.allowanceMonthlyMemo > 0 && (
+                    <>
+                      <br />
+                      Allowance (memo, not added):{" "}
+                      {boardGhs(arm.data.payroll.data.allowanceMonthlyMemo)}
+                    </>
+                  )}
+                </div>
+              </>
+            ) : (
+              <Reason>{arm.data.payroll.reason}</Reason>
+            )}
+          </StreamCard>
+        </div>
+      )}
+    </Tile>
+  );
+}
+
+const Headline = ({ children }: { children: ReactNode }) => (
+  <div className="mt-2 font-display text-2xl font-medium text-navy">{children}</div>
+);
+const Caption = ({ children }: { children: ReactNode }) => (
+  <div className="mt-0.5 text-[11px] text-navy-3">{children}</div>
+);
+const Reason = ({ children }: { children: ReactNode }) => (
+  <div className="mt-2 text-[13px] leading-relaxed text-navy-3">{children}</div>
+);
+
+/* ───────────────────────────── Terminal line (verbatim board) ───────────────────────────── */
+
+function TerminalLine({ label, arm }: { label: string; arm: RollupArm<TerminalResultSummary> }) {
+  if (arm.status === "NOT_APPLICABLE") return null;
+  return (
+    <div>
+      <div className="text-[11px] font-semibold text-navy-2">{label}</div>
+      {arm.status === "CAPTURED" ? (
+        <div className="mt-0.5 flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+          <span className="font-display text-xl font-medium text-navy">{arm.data.passRate}%</span>
+          <span className="text-[12px] text-navy-3">pass · {arm.data.year}</span>
+          <span className="text-[12px] text-navy-3">
+            {arm.data.passedCount.toLocaleString("en-GH")}/
+            {arm.data.totalCandidates.toLocaleString("en-GH")} passed
+          </span>
+          <span className="font-mono text-[10px] text-navy-3">
+            {arm.data.female.passed}/{arm.data.female.candidates}F ·{" "}
+            {arm.data.male.passed}/{arm.data.male.candidates}M
+          </span>
+        </div>
+      ) : (
+        <p className="mt-0.5 text-[13px] leading-relaxed text-navy-3">{arm.reason}</p>
+      )}
+    </div>
+  );
+}
+
+/* ───────────────────────────── Infrastructure tile (verbatim board) ───────────────────────────── */
+
+const yesNo = (b: boolean) => (b ? "Yes" : "No");
+const dashNum = (n: number | null) => (n == null ? "—" : n.toLocaleString("en-GH"));
+
+function InfrastructureTile({ arm }: { arm: RollupArm<InfrastructureSummary> }) {
+  return (
+    <Tile
+      title="Infrastructure"
+      accent="& facilities"
+      meta={
+        arm.status === "CAPTURED"
+          ? `${arm.data.capturedFor.periodLabel} · ${arm.data.capturedFor.academicYear}`
+          : undefined
+      }
+    >
+      {arm.status !== "CAPTURED" ? (
+        <div className="mt-4">
+          <AbsencePanel>{arm.reason}</AbsencePanel>
+        </div>
+      ) : (
+        <InfrastructureBody d={arm.data} />
+      )}
+    </Tile>
+  );
+}
+
+function InfrastructureBody({ d }: { d: InfrastructureSummary }) {
+  return (
+    <div className="mt-3 space-y-4">
+      <div className="flex items-center gap-3">
+        <div className="font-display text-3xl font-medium leading-none text-navy">
+          {d.classrooms.pctGood == null ? "—" : `${d.classrooms.pctGood}%`}
+        </div>
+        <div className="text-[11px] leading-tight text-navy-3">
+          classrooms sound
+          <br />
+          {d.classrooms.good}/{d.classrooms.total} good · {d.classrooms.needingRepair} need repair
+        </div>
+      </div>
+
+      <dl className="space-y-1 text-[13px]">
+        <Line label="Water" value={d.utilities.waterSource} />
+        <Line label="Electricity" value={d.utilities.electricitySource} />
+        <Line
+          label="Sanitation"
+          value={`${d.utilities.latrineType} · ${d.utilities.latrinesTotal.toLocaleString("en-GH")} latrines`}
+        />
+        <Line label="Handwashing" value={yesNo(d.utilities.handwashing)} />
+        <Line
+          label="ICT lab"
+          value={
+            d.ict.hasLab ? `Yes · ${dashNum(d.ict.working)}/${dashNum(d.ict.computers)} working` : "No"
+          }
+        />
+        <Line label="Internet" value={yesNo(d.ict.internet)} />
+        <Line
+          label="Library"
+          value={d.library.has ? `Yes · ${dashNum(d.library.bookCount)} books` : "No"}
+        />
+        <Line
+          label="Feeding"
+          value={
+            d.feeding.gsfpParticipating
+              ? `GSFP · ${dashNum(d.feeding.pupilsFedDaily)} fed daily`
+              : d.feeding.hasKitchen
+                ? "Own kitchen"
+                : "None"
+          }
+        />
+        {d.textbooks.availability && <Line label="Textbooks" value={d.textbooks.availability} />}
+      </dl>
+    </div>
+  );
+}

--- a/omnischools/app/(board)/board/page.tsx
+++ b/omnischools/app/(board)/board/page.tsx
@@ -3,7 +3,6 @@ import { requireBoard } from "@/lib/auth/server";
 import {
   getSchoolRollup,
   type AttendanceArm,
-  type AttendanceStatusTotals,
   type EnrolmentArm,
   type InfrastructureSummary,
   type NetPositionFinanceArm,
@@ -15,9 +14,17 @@ import {
 import { boardGhs } from "@/lib/board/tiles";
 import { ReportFilters } from "@/components/reports/report-filters";
 import { PerfBar } from "@/components/reports/report-kit";
-import { ATTENDANCE_STATUS_ORDER, ATTENDANCE_STATUS_META } from "@/lib/attendance-status";
-import { TrendPill, AbsencePanel } from "@/components/board/board-tiles";
-import { cn } from "@/lib/utils";
+import {
+  TrendPill,
+  AbsencePanel,
+  SummaryCell,
+  Tile,
+  Line,
+  StreamCard,
+  StatusSplit,
+  FEMALE_HEX,
+  MALE_HEX,
+} from "@/components/board/board-tiles";
 
 /**
  * GOV-4 · the read-only board/director dashboard (`/board`, `requireBoard()` — BOARD_MEMBER only).
@@ -178,31 +185,6 @@ export default async function BoardPage({
 
 /* ───────────────────────────── Summary strip ───────────────────────────── */
 
-function SummaryCell({
-  label,
-  value,
-  sub,
-  lead,
-}: {
-  label: string;
-  value: string;
-  sub?: ReactNode;
-  lead?: boolean;
-}) {
-  return (
-    <div
-      className={cn(
-        "rounded-xl border px-4 py-3.5",
-        lead ? "border-gold-soft bg-gold-bg" : "border-border bg-surface",
-      )}
-    >
-      <div className="text-[10px] font-bold uppercase tracking-[0.14em] text-navy-3">{label}</div>
-      <div className="mt-1 font-display text-3xl font-medium leading-none text-navy">{value}</div>
-      {sub && <div className="mt-1.5 text-xs leading-relaxed text-navy-3">{sub}</div>}
-    </div>
-  );
-}
-
 /** Cell 3 headline: prefer the captured Basic average; else Senior readiness; else the applicable
  *  tier's honest reason. NO blend across tiers (R357) — one tier's figure, never a mixed number. */
 function academicSummary(p: PerformanceArm): { value: string; sub: ReactNode } {
@@ -227,34 +209,6 @@ function academicSummary(p: PerformanceArm): { value: string; sub: ReactNode } {
   // Neither captured — surface the reason of the tier that APPLIES (skip a NOT_APPLICABLE tier).
   const applicable = p.basic.status !== "NOT_APPLICABLE" ? p.basic : p.senior;
   return { value: "—", sub: applicable.status === "CAPTURED" ? null : applicable.reason };
-}
-
-/* ───────────────────────────── Tile shell ───────────────────────────── */
-
-function Tile({
-  title,
-  accent,
-  meta,
-  className,
-  children,
-}: {
-  title: string;
-  accent: string;
-  meta?: ReactNode;
-  className?: string;
-  children: ReactNode;
-}) {
-  return (
-    <section className={cn("rounded-xl border border-border bg-surface px-[22px] py-5", className)}>
-      <div className="flex items-baseline justify-between gap-3">
-        <h2 className="font-display text-lg font-medium text-navy">
-          {title} <em className="not-italic text-gold">{accent}</em>.
-        </h2>
-        {meta && <div className="text-[11px] text-navy-3">{meta}</div>}
-      </div>
-      {children}
-    </section>
-  );
 }
 
 /* ───────────────────────────── Finance tile ───────────────────────────── */
@@ -364,47 +318,7 @@ function AttendanceTile({ arm }: { arm: RollupArm<AttendanceArm> }) {
   );
 }
 
-/** The five-status segmented bar + a P·L·E·M·A readout — aggregate, no PII. Medical (M) is its own
- *  status (navy-2), the sickbay→attendance readout, never folded into Absent. */
-function StatusSplit({ totals }: { totals: AttendanceStatusTotals }) {
-  const total =
-    totals.present + totals.late + totals.excused + totals.medical + totals.absent;
-  return (
-    <div className="mt-4">
-      <div className="flex h-2.5 w-full overflow-hidden rounded-pill border border-border bg-bg">
-        {total > 0 &&
-          ATTENDANCE_STATUS_ORDER.map((s) => {
-            const count = totals[s.toLowerCase() as keyof AttendanceStatusTotals];
-            if (count === 0) return null;
-            return (
-              <div
-                key={s}
-                className={ATTENDANCE_STATUS_META[s].seg}
-                style={{ flexGrow: count }}
-                aria-hidden
-              />
-            );
-          })}
-      </div>
-      <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 font-mono text-[10px]">
-        {ATTENDANCE_STATUS_ORDER.map((s) => {
-          const meta = ATTENDANCE_STATUS_META[s];
-          const count = totals[s.toLowerCase() as keyof AttendanceStatusTotals];
-          return (
-            <span key={s} className={meta.num}>
-              {meta.letter} {count.toLocaleString("en-GH")}
-            </span>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
 /* ───────────────────────────── Enrolment tile ───────────────────────────── */
-
-const FEMALE_HEX = "#C77B9E";
-const MALE_HEX = "#6B86B0";
 
 function EnrolmentTile({ arm }: { arm: RollupArm<EnrolmentArm> }) {
   return (
@@ -686,15 +600,6 @@ function InfrastructureBody({ d }: { d: InfrastructureSummary }) {
 
 /* ───────────────────────────── Shared stream/line bits ───────────────────────────── */
 
-function StreamCard({ title, children }: { title: string; children: ReactNode }) {
-  return (
-    <section className="rounded-xl border border-border bg-surface px-[22px] py-[18px]">
-      <div className="text-[11px] font-semibold uppercase tracking-wide text-navy-3">{title}</div>
-      {children}
-    </section>
-  );
-}
-
 const Headline = ({ children }: { children: ReactNode }) => (
   <div className="mt-2 font-display text-2xl font-medium text-navy">{children}</div>
 );
@@ -704,14 +609,3 @@ const Caption = ({ children }: { children: ReactNode }) => (
 const Reason = ({ children }: { children: ReactNode }) => (
   <div className="mt-2 text-[13px] leading-relaxed text-navy-3">{children}</div>
 );
-
-function Line({ label, value, strong }: { label: string; value: string; strong?: boolean }) {
-  return (
-    <div className="flex items-center justify-between">
-      <dt className="text-navy-3">{label}</dt>
-      <dd className={strong ? "font-display font-medium text-navy" : "font-mono text-navy-2"}>
-        {value}
-      </dd>
-    </div>
-  );
-}

--- a/omnischools/components/board/board-tiles.tsx
+++ b/omnischools/components/board/board-tiles.tsx
@@ -1,10 +1,19 @@
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
+import { ATTENDANCE_STATUS_ORDER, ATTENDANCE_STATUS_META } from "@/lib/attendance-status";
+// Type-only import — fully erased at compile time, so this pure module never pulls in the
+// `server-only` rollup at runtime (the render test can still import it in node).
+import type { AttendanceStatusTotals } from "@/lib/rollup/school-rollup";
 
 /**
  * GOV-4 · shared, PURE presentational primitives for the board/director dashboard. No `server-only`,
  * no DB — so the honest-absence look (treatment C) is render-testable off the server-only page
  * (`lib/board/board-tiles-render.test.ts`). The page owns the data; these own the pixels.
+ *
+ * INS (Directors' Insights) — the summary/tile atoms (`SummaryCell`, `Tile`, `StatusSplit`, `Line`,
+ * `StreamCard`, `FEMALE_HEX`/`MALE_HEX`) were LIFTED here verbatim from `app/(board)/board/page.tsx`
+ * so both the board and `/insights` import them 1:1 (no duplication, board renders identically). Pure
+ * move, no behaviour change.
  */
 
 /**
@@ -97,5 +106,133 @@ export function AbsencePanel({ children }: { children: ReactNode }) {
     <p className="rounded-xl border border-border bg-surface px-[22px] py-[18px] text-[13px] leading-relaxed text-navy-3">
       {children}
     </p>
+  );
+}
+
+/* ───────── Lifted board primitives (shared by board + /insights) ───────── */
+
+/** School-stats pink/blue — the ONE sanctioned non-token inline hex (gender mini-bar). Never take
+ *  slash-opacity on these (memory `no-alpha-token-opacity`); use solid hex + `flexGrow`. */
+export const FEMALE_HEX = "#C77B9E";
+export const MALE_HEX = "#6B86B0";
+
+/** The scan-strip cell: a label + a big display value + an optional sub. `lead` → gold-bg accent. */
+export function SummaryCell({
+  label,
+  value,
+  sub,
+  lead,
+}: {
+  label: string;
+  value: string;
+  sub?: ReactNode;
+  lead?: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl border px-4 py-3.5",
+        lead ? "border-gold-soft bg-gold-bg" : "border-border bg-surface",
+      )}
+    >
+      <div className="text-[10px] font-bold uppercase tracking-[0.14em] text-navy-3">{label}</div>
+      <div className="mt-1 font-display text-3xl font-medium leading-none text-navy">{value}</div>
+      {sub && <div className="mt-1.5 text-xs leading-relaxed text-navy-3">{sub}</div>}
+    </div>
+  );
+}
+
+/** The tile shell: a titled `<section>` with a gold accent word and an optional right-aligned meta. */
+export function Tile({
+  title,
+  accent,
+  meta,
+  className,
+  children,
+}: {
+  title: string;
+  accent: string;
+  meta?: ReactNode;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className={cn("rounded-xl border border-border bg-surface px-[22px] py-5", className)}>
+      <div className="flex items-baseline justify-between gap-3">
+        <h2 className="font-display text-lg font-medium text-navy">
+          {title} <em className="not-italic text-gold">{accent}</em>.
+        </h2>
+        {meta && <div className="text-[11px] text-navy-3">{meta}</div>}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+/** A label : value definition line (mono value, or a display-strong one). */
+export function Line({ label, value, strong }: { label: string; value: string; strong?: boolean }) {
+  return (
+    <div className="flex items-center justify-between">
+      <dt className="text-navy-3">{label}</dt>
+      <dd className={strong ? "font-display font-medium text-navy" : "font-mono text-navy-2"}>
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+/** A titled sub-card inside a tile (finance streams). */
+export function StreamCard({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="rounded-xl border border-border bg-surface px-[22px] py-[18px]">
+      <div className="text-[11px] font-semibold uppercase tracking-wide text-navy-3">{title}</div>
+      {children}
+    </section>
+  );
+}
+
+/**
+ * The five-status segmented bar + a P·L·E·M·A readout — aggregate, no PII. Medical (M) is its own
+ * status (navy-2), the sickbay→attendance readout, never folded into Absent
+ * ([[attendance-five-statuses]]). `className` lets a caller tighten the top margin inside a drill-in row.
+ */
+export function StatusSplit({
+  totals,
+  className,
+}: {
+  totals: AttendanceStatusTotals;
+  className?: string;
+}) {
+  const total =
+    totals.present + totals.late + totals.excused + totals.medical + totals.absent;
+  return (
+    <div className={cn("mt-4", className)}>
+      <div className="flex h-2.5 w-full overflow-hidden rounded-pill border border-border bg-bg">
+        {total > 0 &&
+          ATTENDANCE_STATUS_ORDER.map((s) => {
+            const count = totals[s.toLowerCase() as keyof AttendanceStatusTotals];
+            if (count === 0) return null;
+            return (
+              <div
+                key={s}
+                className={ATTENDANCE_STATUS_META[s].seg}
+                style={{ flexGrow: count }}
+                aria-hidden
+              />
+            );
+          })}
+      </div>
+      <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 font-mono text-[10px]">
+        {ATTENDANCE_STATUS_ORDER.map((s) => {
+          const meta = ATTENDANCE_STATUS_META[s];
+          const count = totals[s.toLowerCase() as keyof AttendanceStatusTotals];
+          return (
+            <span key={s} className={meta.num}>
+              {meta.letter} {count.toLocaleString("en-GH")}
+            </span>
+          );
+        })}
+      </div>
+    </div>
   );
 }

--- a/omnischools/components/insights/drill-in.tsx
+++ b/omnischools/components/insights/drill-in.tsx
@@ -1,0 +1,76 @@
+"use client";
+import { useId, useState, type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * INS · the ONLY client component on `/insights`. It holds two pieces of local UI state — `open` (the
+ * disclosure) and `activeDim` (which dimension shows) — and renders the SERVER-PRE-RENDERED aggregate
+ * `content` node for the active dimension. It NEVER refetches and NEVER holds student data: every
+ * dimension's node is already-rendered aggregate JSX in the RSC payload (memory
+ * `reports-data-is-server-only` — the server owns data + formatting). Switching dimension is instant.
+ *
+ * A single-dimension drill still gets the disclosure; the segmented control is suppressed (mirrors the
+ * ledger class-switcher's "suppressed when only one" rule).
+ */
+export type DrillDimension = { key: string; label: string; content: ReactNode };
+
+export function DrillIn({
+  toggleLabel = "Break down",
+  dimensions,
+  defaultDim,
+}: {
+  toggleLabel?: string;
+  dimensions: DrillDimension[];
+  defaultDim?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [activeDim, setActiveDim] = useState(defaultDim ?? dimensions[0]?.key);
+  const panelId = useId();
+
+  if (dimensions.length === 0) return null;
+  const active = dimensions.find((d) => d.key === activeDim) ?? dimensions[0];
+
+  return (
+    <div className="mt-4 border-t border-border pt-3">
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-controls={panelId}
+        onClick={() => setOpen((v) => !v)}
+        className="inline-flex items-center gap-1 text-xs font-semibold text-gold hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gold"
+      >
+        {open ? `Hide breakdown ▴` : `${toggleLabel} ▾`}
+      </button>
+
+      {open && (
+        <div id={panelId} className="mt-3">
+          {dimensions.length > 1 && (
+            <div className="mb-3 flex flex-wrap gap-2" role="tablist" aria-label="Break down by">
+              {dimensions.map((d) => {
+                const on = d.key === active.key;
+                return (
+                  <button
+                    key={d.key}
+                    type="button"
+                    role="tab"
+                    aria-selected={on}
+                    onClick={() => setActiveDim(d.key)}
+                    className={cn(
+                      "rounded-pill border px-3 py-1 text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gold",
+                      on
+                        ? "border-navy bg-navy text-bg"
+                        : "border-border-2 bg-surface text-navy-3 hover:border-gold hover:text-navy-2",
+                    )}
+                  >
+                    {d.label}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+          <div role="tabpanel">{active.content}</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/omnischools/docs/senior/incr-directors-insights-spec.md
+++ b/omnischools/docs/senior/incr-directors-insights-spec.md
@@ -1,0 +1,154 @@
+# Directors' Insights — spec + acceptance criteria
+
+**Steward:** Kofi (Domain / Spec) · **Status:** ready for build · **Series:** `INS-01..INS-31`
+**Persona:** Director / management (Proprietor · Headmaster · Admin) — **not** the read-only `BOARD_MEMBER`
+**Tier:** cross-tier (Basic + Senior + Combined), tier-gated per arm like `/board`.
+
+This is the real build of the consolidated director dashboard mock (KPI scan strip · "Needs your attention" panel · finance/academic/operational panels · drill-in links). It is **composition, not net-new data**: it re-serves the *aggregate* projections that already ship behind `/board` and `/reports`, adds three drill-in dimensions (by class · by year-group/level · by subject), and a gender + age distribution. The hard rule that shapes every decision below: **everything is aggregate — class / year-group / subject — never an individual-student row.**
+
+Grounding (verified in `senior-live` on 2026-08-19):
+- `lib/rollup/school-rollup.ts` — `getSchoolRollup(schoolId, {periodId})`, the aggregate spine of `/board`. Arms are honesty-gated (`RollupArm`: `CAPTURED` / `NOT_CAPTURED` / `NOT_APPLICABLE`) and already **PII-stripped** (attendance arm's own note: "Aggregate-only re-exposure — no needsAttention/criticalCount/thresholds (PII/ops)").
+- `lib/reports/census-enrolment-data.ts` — `getCensusEnrolment(schoolId)`: `roll`, `gender` (SexSplit), `byClass` (+`level`), `byLevel`, `ageByLevel`, `approvedAge`, `dobUnknown`. **The single source for the by-level + gender + age drill-ins.** Fully aggregate, no PII.
+- `lib/reports/class-performance-data.ts` — `getClassPerformance(schoolId,{periodId})`: per-class aggregate `rows[]` (no student rows).
+- `lib/reports/subject-performance-data.ts` — `getSubjectPerformance(schoolId,{periodId})`: per-subject aggregate `rows[]` (no student rows).
+- `classes.level` (`db/schema/students.ts:37`, `text`, nullable, e.g. `"JHS 1"`, `"Form 2"`) — the year-group key. **No schema change is needed** (see §6).
+- Access model: `lib/access.ts` + `lib/auth/server.ts` (`requireSchool` → staff gate + finance-only path confinement; `requireSchoolRole(allowed)` → adds the role redirect).
+
+---
+
+## 1 · Route + access
+
+**Ruling — route.** Live at top-level **`/insights`** inside the staff `app/(app)` group. **Do NOT nest it under `/reports`.** `/reports` is a finance-only-reachable prefix (`FINANCE_SECTIONS` includes `/reports`), so `/reports/insights` would satisfy `pathAllowedForFinance()` and rely *solely* on the role redirect to keep an Accountant out — a fragile, single-lock leak. A sibling top-level segment is stopped by **both** the finance path-confinement layer **and** the role gate. Exact name is `OC-INS-ROUTE` — recommend `/insights`.
+
+**Ruling — gate.** Guard with `requireSchoolRole(INSIGHTS_READ_ROLES)` where `INSIGHTS_READ_ROLES = ["ADMIN", "HEADMASTER", "PROPRIETOR"]`. Introduce it as a **new, purpose-named** group in `lib/access.ts`, membership initially identical to `STAFF_ADMIN_ROLES` / `USER_ADMIN_ROLES` but semantically distinct: this is the *director analytics read* gate, not the authorization root (`STAFF_ADMIN_ROLES` = "who may mint administrators") nor the login-lifecycle set (`USER_ADMIN_ROLES`). This follows the codebase's own discipline — purpose-named gates so widening one never silently widens another — and directly answers the standing hazard [[builds-widen-ratified-authz-and-self-bless]]: do **not** reuse a wider or auth-root sibling.
+
+**Ruling — relationship to existing surfaces.** It **complements, never replaces**: `/dashboard` stays the staff landing; `/reports` stays the report hub (and owns the *deep*, per-student detail, e.g. attendance needs-attention); `/board` stays `BOARD_MEMBER`-only. `/insights` is the director's consolidated overview that **drills INTO** the existing reports (its drill-ins link out to the full `/reports/*` pages for anything below aggregate grain).
+
+**Ruling — exclusions.** `VICE_HEADMASTER_ACADEMIC` is **excluded by default**: this surface carries the finance/net-position streams (fees, books, payroll), which are governance, not academics. Whether VHA should be admitted (and, if so, whether the finance panel is hidden from them) is `OC-INS-VHA`. Finance-only staff (Accountant / Bursar), Teacher, Form Master, Student, Parent, and `BOARD_MEMBER` never reach it.
+
+---
+
+## 2 · Reuse-vs-build (composition map)
+
+**Reuse — no new SQL (8 of 9 data needs):**
+
+| Need | Source (existing) |
+|---|---|
+| KPI scan strip (roll, attendance, academic standing, fee %, facilities) | `getSchoolRollup` arms |
+| Finance panel (fees · books · payroll, three un-summed streams) | `rollup.netPositionFinance` |
+| Terminal results (BECE/WASSCE) · Infrastructure | `rollup.terminalResults`, `rollup.infrastructure` |
+| Performance headline + Senior readiness | `rollup.performance` |
+| Performance drill-in **by class** | `getClassPerformance().rows` |
+| Performance drill-in **by subject** | `getSubjectPerformance().rows` |
+| Attendance drill-in **by class** | `rollup.attendance.data.byClass` (PII-stripped) |
+| Attendance drill-in **by year-group** | fold `rollup.attendance.data.byClass` counts by a `classId→level` map from `getCensusEnrolment().byClass` — **exact** (integer P/L/E/M/A counts sum losslessly; rate = (ΣP+ΣL)/Σmarked) |
+| Enrolment **by class / by level**, **gender split**, **age distribution** | `getCensusEnrolment()` (`byClass`, `byLevel`, `gender`, `ageByLevel`, `approvedAge`) |
+
+**Build — exactly ONE new reader:** **performance by year-group (level).** It cannot be composed honestly: `ClassPerfRow.average` is rounded to 1 dp and the reader exposes `studentsGraded` (a distinct-student count) but not the score-row count, so a mean-of-class-means weighted by `studentsGraded` would be a fabricated figure (wrong denominator, compounding rounding). Build a level-grouped aggregate — `getLevelPerformance(schoolId,{periodId})`, or a `byLevel[]` addition to `getClassPerformance` — that groups `gradebook_score.total` by `classes.level` with the **same** per-score basis already in `scopedSchoolAggregate`: `AVG(total)` over non-null totals; pass rate via `passRateOf(count(*) filter total>=PASS_MARK, count(*) filter total not null)`; `studentsGraded = count(distinct studentId)`. Classes with `level IS NULL` bucket under an `"Unspecified"` level (honest, mirrors census `UNSPECIFIED`).
+
+**Optional thin composition seam (recommended):** a single server entry `getDirectorsInsights(schoolId,{periodId})` that awaits the readers above and returns **only aggregate types** — the structural place the aggregate-only invariant (§4) is guaranteed and where Quinn/Sarah test. It stays zero-SQL beyond the one new level reader, mirroring how `getSchoolRollup` composes.
+
+**Do NOT call `getAttendanceSummary` from this surface.** It returns `needsAttention: NeedsAttentionRow[]` carrying `studentId` / student `name` / `studentCode` — per-student PII. Use `rollup.attendance` (already stripped) instead. This is the one reuse trap that would breach §5.
+
+---
+
+## 3 · Drill-in data contracts
+
+Presentation model (in-page expandable sections vs tabs vs linked detail) is **Lucy's call**; this section rules only the **data each drill-in must carry**. Recommended default: in-page expandable sections per metric family (data is already loaded server-side; the full `/reports/*` pages remain the linked "deep" detail). Term selection (`?periodId`, reusing `ReportFilters` as `/board` does) governs **performance · attendance · finance · senior-readiness · terminal (year)**. **Enrolment, gender, and age are point-in-time snapshots** (census reader is as-of-now, ACTIVE-only, not period-scoped) — label them as such; they do not change with the period selector.
+
+**Performance** (three dimensions):
+- *by class* — one row per active class: class name, average, grade (on the school `grade_scale`), delta vs prior term, `studentsGraded` count. Source `getClassPerformance().rows`.
+- *by year-group (level)* — one row per distinct `classes.level`: level label, level average, pass rate, `studentsGraded`, optional delta. Source the new `getLevelPerformance`.
+- *by subject* — one row per active subject: subject name/code, average, grade, pass rate, delta, highest/lowest **scores** (not names). Source `getSubjectPerformance().rows`.
+
+**Attendance** (two dimensions):
+- *by class* — class name, rate = (P+L)/marked, marked count, P/L/E/M/A `counts`. Source `rollup.attendance.data.byClass`.
+- *by year-group (level)* — level label, folded P/L/E/M/A counts, marked, recomputed rate. Source the fold in §2.
+- All **five** attendance statuses (Present/Late/Excused/**Medical**/Absent) preserved and shown distinctly; Medical ("M") is never folded into Absent ([[attendance-five-statuses]]).
+
+**Enrolment** (two dimensions + gender + age):
+- *by class* — class name, `level`, enrolled, female/male counts. Source `getCensusEnrolment().byClass` (or `rollup.enrolment.data.byClass`).
+- *by year-group (level)* — level label, female/male/total. Source `getCensusEnrolment().byLevel`.
+
+---
+
+## 4 · Gender + age distribution
+
+**Gender** — aggregate counts at school, per class, and per level, from `getCensusEnrolment().gender` / `.byClass` / `.byLevel` (each a `SexSplit {female, male, total}`). No per-student rows.
+
+**Age distribution** — reuse `getCensusEnrolment().ageByLevel` (age × sex histogram per level, plus a `dobUnknown` bucket) and/or `.approvedAge` (under / on / over the GES official age per level, plus an `unknown` bucket). Both are **gender-disaggregated and aggregate**. A student with a NULL date-of-birth is **never coerced to an age** — they surface in `dobUnknown` / the level `unknown` bucket (census honesty), and that bucket must be **shown**, never dropped or backfilled.
+
+---
+
+## 5 · Aggregate-only invariant (KEY — owner-stated hard rule)
+
+**INV.** No individual-student row appears anywhere on `/insights` or any of its drill-ins. Granularity is **class / year-group / subject** only. A reader that projects a student **name, id, student-code, or date-of-birth** into this surface is a **violation**. This mirrors the rollup/census no-PII discipline and is testable structurally:
+- Every reader feeding `/insights` returns only class/level/subject-keyed aggregate rows and counts.
+- `getAttendanceSummary` (student `needsAttention[]`) is **not** in the composition (§2).
+- The `getDirectorsInsights` seam's return type contains no student-identifying field; a projection that adds one is a compile-time/type violation Sarah can pin.
+- Staff/class metadata at the aggregate grain (a class's teacher name, a class/subject name) is **not** student PII and is permitted as row labelling.
+
+Per-student drill-in is an **explicit future call** ("for now") — `OC-INS-PERSTUDENT`. When built it lives behind a **tighter** gate + PII handling (like the existing `/reports/*` detail pages), never by widening this surface.
+
+---
+
+## 6 · Schema
+
+**None.** Every figure derives from existing tables (`students`, `classes`, `gradebook_score`, `attendance_record`, plus the finance/facilities/terminal sources the rollup already reads). `classes.level` (`text`, nullable) already exists and is the year-group key; the new by-level performance reader is a pure `GROUP BY classes.level` over existing columns. **No migration, no new column, no RLS change — this does not pull in Wells.**
+
+---
+
+## 7 · Honesty
+
+Inherit omit-not-fake wholesale: every rollup arm renders its `CAPTURED` figure, or its `NOT_CAPTURED` / `NOT_APPLICABLE` **reason string** — never a fabricated zero (a *real* captured zero renders as a true zero). The finance panel keeps the three streams **separate and un-summed** (no "net position"/"profit" scalar). The "Needs your attention" panel is **aggregate-signal-only** (e.g. "3 classes below 75% attendance", "fee collection 62% — GHS X outstanding", "2 subjects at risk for STPSHS", "Form 2 average down 6 pts vs last term") with drill-in / report links; it must **not** reproduce the per-student needs-attention list (that stays on `/reports/operational/attendance-summary` behind its own gate).
+
+---
+
+## Acceptance criteria (`INS-01..INS-31`)
+
+### Route + access
+- **INS-01 (Sarah).** ADMIN/HEADMASTER/PROPRIETOR at the active school → `/insights` renders.
+- **INS-02 (Sarah).** A finance-only session (ACCOUNTANT/BURSAR only) → redirected to `FINANCE_HOME` `/billing`, no insights data — enforced by BOTH finance path-confinement (route not in `FINANCE_SECTIONS`) AND the role gate.
+- **INS-03 (Sarah).** TEACHER-only / FORM_MASTER-only / STUDENT / PARENT → redirected to `/dashboard`, no data.
+- **INS-04 (Sarah).** `BOARD_MEMBER`-only → redirected to `BOARD_HOME` `/board`.
+- **INS-05 (Sarah).** `INSIGHTS_READ_ROLES` is a distinct named group — NOT an alias/import of `STAFF_ADMIN_ROLES`/`USER_ADMIN_ROLES`/any wider set. Mutating the guard to a wider group reds a test.
+- **INS-06 (Sarah).** Reads the SESSION school id, never a URL/query id (`withSchool` FORCE-RLS boundary).
+
+### Composition + drill-in presence (functional)
+- **INS-07 (Quinn).** KPI scan strip from `getSchoolRollup` arms (roll, attendance %, academic standing, fee %, facilities), each honesty-gated.
+- **INS-08 (Quinn).** Finance panel = fees + books + payroll as three separate streams, no summed "net position".
+- **INS-09 (Quinn).** Performance exposes THREE drill-in dimensions — by class, by year-group (level), by subject — each present, each an aggregate average (+ pass rate where the source provides it).
+- **INS-10 (Quinn).** Performance *by class* rows match `getClassPerformance().rows` for the term.
+- **INS-11 (Quinn).** Performance *by subject* rows match `getSubjectPerformance().rows`.
+- **INS-12 (Quinn).** Performance *by year-group* groups classes sharing a `classes.level` (e.g. "Form 2 Science" + "Form 2 General Arts A" → one **Form 2** row); its average is a level-grouped per-score aggregate, NOT a mean of rounded class averages. `level IS NULL` → an "Unspecified" row.
+- **INS-13 (Quinn).** Attendance drill-ins by class + year-group; by-class rows match `rollup.attendance.data.byClass`.
+- **INS-14 (Quinn).** Attendance *by year-group* counts = sum of constituent classes' P/L/E/M/A; rate = (ΣP+ΣL)/Σmarked (lossless integer fold).
+- **INS-15 (Quinn).** All FIVE attendance statuses shown distinctly; Medical never merged into Absent.
+- **INS-16 (Quinn).** Enrolment drill-ins by class + year-group; by-level totals match `getCensusEnrolment().byLevel`.
+- **INS-17 (Quinn).** Gender split at school + per class/level (female/male/total), matching census `gender`/`byClass`/`byLevel`.
+- **INS-18 (Quinn).** Age distribution shown, gender-disaggregated, matching `ageByLevel` and/or `approvedAge`.
+- **INS-19 (Quinn).** Unknown-DOB students appear in a visible `dobUnknown`/`unknown` bucket, never assigned a coerced age.
+- **INS-20 (Quinn).** "Needs your attention" = aggregate signals only (class/level/subject-grain) + links; NO per-student list.
+
+### Aggregate-only invariant (security)
+- **INS-21 (Sarah).** No response/markup on `/insights` or any drill-in carries a student name/id/code/DOB. (Age is a bucket count, never a per-pupil value.)
+- **INS-22 (Sarah).** `getAttendanceSummary` is NOT in the `/insights` data path; attendance comes from PII-stripped `rollup.attendance`. Wiring its `needsAttention[]` reds a test.
+- **INS-23 (Sarah).** Every reader/type feeding `/insights` (incl. the new by-level reader + the `getDirectorsInsights` seam) exposes only class/level/subject-keyed aggregates; adding a student-identifying field is a type/structural violation.
+- **INS-24 (Sarah).** Drill-in granularity stops at class/year-group/subject; no path expands to an individual-student row (`OC-INS-PERSTUDENT`, deferred).
+
+### Honesty + term filter (functional)
+- **INS-25 (Quinn).** Each metric renders its real value OR its `NOT_CAPTURED`/`NOT_APPLICABLE` reason — never a fabricated zero; a genuine captured zero renders as a real zero.
+- **INS-26 (Quinn).** A tier-inapplicable arm is omitted/marked NOT_APPLICABLE (BASIC → no Senior-readiness/WASSCE; SENIOR → no Basic-gradebook/BECE).
+- **INS-27 (Quinn).** `?periodId` re-scopes performance/attendance/finance/senior-readiness; enrolment/gender/age are labelled point-in-time and don't change with the selector.
+- **INS-28 (Quinn).** An empty/new school renders honest empties, does not error or invent data.
+- **INS-29 (Quinn).** Only source-exposed deltas shown; no computed verdict/health score.
+- **INS-30 (Sarah).** The new by-level reader is `withSchool`-scoped (tenant-isolated) and omits/`null`s a level with no graded scores (never `0`).
+- **INS-31 (Sarah).** No new migration/RLS ships; `/insights` reads only existing tables. A schema diff fails review.
+
+---
+
+## Open calls (owner)
+- **OC-INS-ROUTE** — exact route name. Recommend `/insights` (top-level, NOT under `/reports`).
+- **OC-INS-VHA** — admit `VICE_HEADMASTER_ACADEMIC`? Default **no** (finance/governance exposure); if yes, decide whether the finance panel is hidden from them.
+- **OC-INS-PERSTUDENT** — per-student drill-in deferred ("for now"); when built, behind a tighter PII-aware gate, never by widening `/insights`.
+- **OC-INS-AGE-FREEZE** — age/gender as-of-now (live census snapshot). Recommend live-as-of-now, matching `/board`.

--- a/omnischools/docs/senior/incr-directors-insights-surface-map.md
+++ b/omnischools/docs/senior/incr-directors-insights-surface-map.md
@@ -1,0 +1,661 @@
+# INCR — Directors' Insights — Surface Map
+
+**Author:** Lucy (design cartographer) · **Status:** design spec, ready for the implementation engineer.
+**Scope:** the acting **director/admin** analytics dashboard — the board overview's richer, act-on-it
+sibling. It **extends** the shipped `app/(board)/board/page.tsx` (the closest existing surface and the
+visual source of truth) with (a) a **"Needs your attention"** action panel and (b) real **aggregate
+drill-ins** on Performance / Attendance / Enrolment (by class · by year-group · by subject), plus a
+**gender-split** and an **age-distribution** viz on Enrolment. This is **not a redesign** — it reuses the
+board's `Tile` / `SummaryCell` / `TrendPill` / `AbsencePanel` / `StatusSplit` / gender mini-bar / `PerfBar`
+idioms verbatim. Where the mockup and the shipped board disagree, **the shipped board wins on visual
+presentation**; Kofi's data/AC spec wins on logic. Every drift is flagged inline and collected in the drift
+log. Kofi is speccing data/AC in parallel — the **Data-shape assumptions (§17)** section marks every place
+this map assumes a reader/field so the two specs reconcile.
+
+> **HARD CONSTRAINT (repeated because it governs every section): aggregate-only.** No student name, no
+> student row, no per-student anything appears anywhere on this surface or in any drill-in. Every drill-in
+> row is a **class / year-group / subject / age-band** aggregate. This is structurally enforced by sourcing
+> only from aggregate readers (§17) that expose counts and averages, never `rows[]` of students.
+
+## Source surfaces & code (verified first-hand)
+
+| Source | Role in this map |
+|---|---|
+| `app/(board)/board/page.tsx` | **PRIMARY visual + interaction source.** The 5-cell summary strip (lead cell gold-bg), the Financial-position full-width tile, Attendance \| Enrolment and Performance \| Infrastructure pairs, `Tile` / `SummaryCell` anatomy, `academicSummary()`, `StatusSplit` (P/L/E/M/A), the gender mini-bar (`FEMALE_HEX`/`MALE_HEX`), `Line`/`StreamCard`/`Headline`/`Caption`/`Reason`, the omit-not-fake `AbsencePanel` for NOT_CAPTURED. Reused **verbatim**; the drill-ins slot **inside** the existing tiles. |
+| `components/board/board-tiles.tsx` | The **pure presentational** primitives (`TrendPill`, `ComingSoon`, `AbsencePanel`) — no `server-only`, no DB. The right home to also lift the shared `SummaryCell` / `Tile` / `StatusSplit` / `Line` so both board and insights import them (§15). |
+| `components/reports/report-kit.tsx` | `PerfBar` (track + tone fill + mono value, capped 100), `ColumnHeads`, `SectionCard`, `Kpi`/`FeaturedKpi`, `SnapshotPill`. `PerfBar` is the drill-in bar; it is pure/presentational (usable client-side). |
+| `components/reports/report-filters.tsx` | `ReportFilters` — the term-pill + class `<select>` URL-param filter bar. The **period selector** (verbatim, `showClass={false}`) **and** the term-pill visual is the exact idiom the drill-in segmented control reuses. |
+| `lib/rollup/school-rollup.ts` | `getSchoolRollup()` → the whole summary strip + all six tiles. Also the source of the drill-in seeds already loaded: `attendance.data.byClass` (`AttendanceClassRow`, P/L/E/M/A counts) and `enrolment.data.byClass` (`EnrolmentClassRow`, female/male). |
+| `lib/reports/class-performance-data.ts` | `getClassPerformance()` → `rows: ClassPerfRow[]` (classId·name·average·grade·tone·delta·studentsGraded) — the **Performance › by class** drill-in. |
+| `lib/reports/subject-performance-data.ts` | `getSubjectPerformance()` → `rows: SubjectPerfRow[]` (subjectId·name·average·grade·tone·delta·passRate·highest·lowest) — the **Performance › by subject** drill-in. |
+| `lib/reports/census-enrolment-data.ts` | `getCensusEnrolment()` → `byClass` / `byLevel` (each `{name/level, female, male, total}`), `ageByLevel` (per-year `{age, female, male, total}` + `dobUnknown`), `approvedAge` (under/on/over/unknown vs GES official age), `dobUnknown`, `censusDate`. The **single reader** behind Enrolment by-class, by-year-group, gender-split and age-distribution. Aggregate, sex-split, `officialAgeForLevel` + `ageAsOf` honesty already built in. |
+| `lib/reports/school-stats-data.ts` | `getSchoolStats().byClass` carries `classes.level` — the year-group key. Confirms `level` is the form-level source for grouping. |
+| `lib/attendance-status.ts` | `ATTENDANCE_STATUS_ORDER` + `ATTENDANCE_STATUS_META` (P green / L gold / E warn / **M navy-2** / A terra). The 5-status colours the attendance drill-in reuses; Medical stays first-class (sickbay→attendance hook). |
+| `lib/access.ts` | Role groups. `STAFF_ADMIN_ROLES` = ADMIN·HEADMASTER·PROPRIETOR (the acting director persona); `SENIOR_MANAGEMENT_ROLES` = ADMIN·HEADMASTER·VICE_HEADMASTER_ACADEMIC. §0.4. |
+| `app/(app)/senior/headmaster-summary/page.tsx` | Reference for the **senior-tier acting page** pattern — `requireSchoolRole()`, `dynamic="force-dynamic"`, `mx-auto max-w-page`, period tabs, the shared hero voice, honest dashed empty states. The insights page follows this frame. |
+| `md files/design-tokens.json` + `styles/tokens.css` | Canonical tokens. Use the Tailwind token class (`text-gold`, `bg-navy`, `border-border`), never inline `var(--x)`. |
+
+---
+
+## 0. Decisions the brief asked me to make explicit
+
+### 0.1 New route, or a mode of `/board`? → **A new route under the app frame. Not part of `/board`.**
+
+`/board` is gated `requireBoard()` = **BOARD_MEMBER only, read-only governance** (its docblock and the
+board-pack route's `x-pathname` confinement are explicit). Directors' Insights is the **acting** persona —
+the same figures, but the director can click through to *fix* them. Different audience, different auth,
+different capability. Build it as a **new server route in the operational app frame**, e.g.
+`app/(app)/directors/page.tsx` (or `app/(app)/senior/insights/page.tsx` if it ships senior-first — see
+§0.4 / drift #1), `export const dynamic = "force-dynamic"`, `mx-auto max-w-page`. It **reuses the board's
+components** but is its own page — the board stays the read-only mirror; insights is the cockpit.
+
+> Why not extend `/board` with a `?mode=` flag: the board is auth-confined to BOARD_MEMBER and its
+> board-pack export is path-confined to `/board`. A director is usually **not** a board member. Folding the
+> two would either widen `requireBoard()` (an authz regression — see memory `builds-widen-ratified-authz`)
+> or leave directors locked out. Separate route, shared pixels.
+
+### 0.2 Drill-in interaction pattern → **In-page disclosure + segmented dimension control. One surface, one data load.**
+
+The brief asks me to pick and justify. **Chosen: in-page.** Each drillable tile keeps its board summary
+always visible, and gains a **disclosure** ("Break down ▾") that reveals an aggregate **bar list**; a
+**segmented control** (the ReportFilters term-pill idiom) switches the dimension (**By class · By year-group
+· By subject**). Rejected: a linked detail route (heavier — a second page, a second load, a second place for
+the same aggregate to drift; and the mockup's "links" were exactly the thing the owner asked to replace with
+*real* drill-ins **on this surface**).
+
+**Mechanics (lazy + typed + SSR-friendly):** the page is a server component. It **loads and pre-shapes every
+dimension's aggregate rows** (all pre-formatted primitives — memory `reports-data-is-server-only`), and
+**server-renders each dimension's bar list**. A thin client component `<DrillIn>` receives those pre-rendered
+nodes as slots and owns only two pieces of local UI state — `open` (the disclosure) and `activeDim` (which
+slot shows). Switching dimension is **instant, no refetch, no URL churn**; no student data can leak because
+the client only ever holds already-rendered aggregate JSX. This is the whole client-JS surface of the page.
+
+> Alternative considered and rejected: URL-param dimension switch (`?perfDim=class`) via `<Link>` chips (the
+> ReportFilters pattern, zero client JS). It works, but three tiles × their own param + re-nav on every
+> switch (and native `<details>` losing its open state across the nav) is more moving parts than one small
+> `<DrillIn>`. Take the higher rung: one client component, instant switches. (If the team prefers zero client
+> JS, the `<Link>`-chip form is a drop-in — flag #6.)
+
+### 0.3 What is aggregated, and is any of it per-student? → **Counts and averages only. Never a student row.**
+
+Restating the hard constraint as a build rule: every drill-in row's unit is **class / year-group (form
+level) / subject / age-band**. The readers behind them (§17) expose `average` / `passRate` / `female` /
+`male` / `total` / P·L·E·M·A `counts` — **there is no student-name field to render**. The one place the
+board already shows sex counts is aggregate (gender mini-bar `NF · NM`); the age viz is age-band × sex
+counts. No "top student", no "at-risk pupil list", no per-student trajectory. If a future owner wants a
+student-level drill, that is a **different, permission-gated surface** — not this one.
+
+### 0.4 Role gate → **`STAFF_ADMIN_ROLES` (ADMIN · HEADMASTER · PROPRIETOR), the director persona.**
+
+The acting director/admin persona maps to `STAFF_ADMIN_ROLES` (PROPRIETOR = the school director/owner). Gate
+with `requireSchoolRole(STAFF_ADMIN_ROLES)` (the headmaster-summary precedent). If the surface ships
+senior-first, `SENIOR_MANAGEMENT_ROLES` is the alternative (adds VICE_HEADMASTER_ACADEMIC, drops PROPRIETOR).
+**Recommend a dedicated per-surface group `DIRECTOR_INSIGHTS_ROLES`** (named like `WASSCE_SETUP_ROLES` so it
+can diverge later without touching another gate), seeded = `STAFF_ADMIN_ROLES`. Confirm the exact set with
+Kofi/PO — this is the one authz decision, and per memory `builds-widen-ratified-authz`, **gate to the
+spec, do not copy a wider sibling**. Drift #1.
+
+---
+
+## 1. Token & type reference
+
+All base tokens/type families map exactly as in `ledger-surface-map.md §0` and `incr57 §1` — **use the
+Tailwind token class, never inline `var(--x)`**; `font-display`=Fraunces, `font-body`=Manrope,
+`font-mono`=JetBrains Mono; empty/missing value = em-dash `—` in `text-navy-3`, never `0`/`N/A`. Palette
+(from the brief, all shipped tokens): navy `#1A2B47` / navy-2 `#2D3F5C` / navy-3 `#5C6675`; gold `#C8975B` /
+gold-soft `#E8D4B8` (`border-gold-soft`) / gold-bg `#F5EBDC`; page `#FAF7F2` (`bg-bg`); surface `#FFFFFF`;
+border `#E5DFD3` (`border-border`) / border-2 `#D4CCBA`; green `#2F6B47` / green-bg `#E5EFE8`; terra
+`#B84A39` / terra-bg `#F5E1DC`; warn `#C58A2E` / warn-bg `#F5E9D0`; navy-deep `#13203A` (`bg-navy-deep`).
+
+**Reused idioms (already shipped — do NOT reinvent):**
+
+| Element | Where it lives | Exact classes / values |
+|---|---|---|
+| Summary cell (lead) | board `SummaryCell` | `rounded-xl border px-4 py-3.5`; lead → `border-gold-soft bg-gold-bg`; label `text-[10px] font-bold uppercase tracking-[0.14em] text-navy-3`; value `font-display text-3xl font-medium leading-none text-navy`; sub `mt-1.5 text-xs leading-relaxed text-navy-3` |
+| Tile shell | board `Tile` | `rounded-xl border border-border bg-surface px-[22px] py-5`; title `font-display text-lg font-medium text-navy` with `<em className="not-italic text-gold">` accent; meta `text-[11px] text-navy-3` |
+| Trend pill | `TrendPill` | glyph ▲/▼/— + sign, up `bg-green-bg text-green`, down `bg-terra-bg text-terra`, flat `bg-bg text-navy-3`; `rounded-pill px-2 py-0.5 font-mono text-[10px] font-bold`. **Only sanctioned state colour** — encodes sign of an EXPOSED delta, never a health verdict. |
+| Honest-absence panel | `AbsencePanel` | `rounded-xl border border-border bg-surface px-[22px] py-[18px] text-[13px] leading-relaxed text-navy-3` — solid border, no number (treatment A). Reused for every NOT_CAPTURED drill-in. |
+| Perf/rate bar | `PerfBar` | track `h-2.5 rounded-pill border border-border bg-bg`; fill tone `bg-green`/`bg-gold`/`bg-terra`/`bg-navy-3` capped 100; value `min-w-[42px] text-right font-mono text-xs font-semibold`, `—` when null |
+| Column heads | `ColumnHeads` | `hidden … lg:grid border-b border-border bg-bg px-6 py-3 text-[9px] font-bold uppercase tracking-[0.1em] text-navy-3` |
+| P/L/E/M/A status split | board `StatusSplit` + `ATTENDANCE_STATUS_META` | segmented bar `h-2.5 rounded-pill border border-border bg-bg`, per-status `.seg` fill (`bg-green`/`bg-gold`/`bg-warn`/`bg-navy-2`/`bg-terra`), `flexGrow: count`; readout `font-mono text-[10px]` `P n · L n · E n · M n · A n` in each status's `.num` colour |
+| Gender mini-bar | board `EnrolmentBody` | `h-2.5 rounded-pill border border-border bg-bg`; female seg `style={{flexGrow, backgroundColor: "#C77B9E"}}`, male `"#6B86B0"`; readout `font-mono text-[10px] text-navy-3` `NF · NM`. **Sanctioned non-token inline hex** (school-stats pink/blue); per `no-alpha-token-opacity` never slash-opacity these. |
+| Term-pill / segmented chip | `ReportFilters` | `rounded-pill border px-3 py-1 text-xs font-semibold`; active `border-navy bg-navy text-bg`; inactive `border-border-2 bg-surface text-navy-3 hover:border-gold hover:text-navy-2` |
+
+**New surface classes introduced (three small ones — token-only):**
+
+| New element | Build | Tokens |
+|---|---|---|
+| Action row (`ActionRow`, §5) | a link row: marker dot + label + value + chevron `›` | `flex items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3 hover:bg-gold-bg`; label `text-[13px] font-semibold text-navy`; value `text-xs text-navy-3`; chevron `text-navy-3`; severity dot `h-2 w-2 rounded-full` in `bg-terra`/`bg-warn`/`bg-navy-2` |
+| Disclosure toggle (`<DrillIn>` summary, §7) | `Break down ▾` / `Hide breakdown ▴` | `inline-flex items-center gap-1 text-xs font-semibold text-gold hover:underline` |
+| Age-band stacked bar (§10.3) | one per age year — reuses the **gender mini-bar** verbatim | female `#C77B9E` / male `#6B86B0` inline segs; age label `font-mono text-[11px] text-navy-2` |
+
+> **Token-opacity trap (memory `no-alpha-token-opacity`):** the action-panel hover (`hover:bg-gold-bg`), the
+> disclosure, and every drill-in use **solid tint tokens** (`bg-gold-bg`, `bg-green-bg`, `bg-terra-bg`,
+> `bg-warn-bg`, `bg-bg`). Do **not** reach for `bg-navy/80` / `text-bg/70` slash-opacity on raw-hex tokens.
+> The gender/age pink & blue are the one sanctioned inline-hex exception (user-ish school-stats colours), and
+> even those must not take slash-opacity — use solid hex + `flexGrow`. **Verify tints in the live preview,
+> not the build.**
+
+---
+
+## 2. Page frame & section order (extends the board 1:1)
+
+Server component, `dynamic="force-dynamic"`, `<div className="mx-auto max-w-page space-y-6">`. Order, with
+[NEW]/[verbatim] marked:
+
+1. **Header** — title + period selector row + "Export board pack" action. §3.
+2. **Period selector** — `ReportFilters showClass={false}`, verbatim board. §3.
+3. **Summary strip** — 5 `SummaryCell` (lead = roll). **[verbatim board]** §4.
+4. **Needs your attention** — act-on-it action panel. **[NEW — the director-can-act differentiator]** §5.
+5. **Financial position** — full-width `FinanceTile`. **[verbatim board]** §6.
+6. **Attendance** \| **Enrolment** — `lg:grid-cols-2`. Each summary tile is board-verbatim; each gains an
+   in-tile **drill-in** (Attendance: class/year; Enrolment: class/year + gender + age). §9, §10.
+7. **Performance** \| **Infrastructure** — `lg:grid-cols-2`. Performance gains the class/year/subject
+   drill-in; Infrastructure is board-verbatim (no drill-in requested). §8, §11.
+
+The board's exact grid pairing is preserved; the drill-ins live **inside** their tiles (the tile grows
+taller when opened). This is the "extend, don't redesign" answer — the scan layer is unchanged.
+
+---
+
+## 3. Header + period selector + export
+
+**Header** (`flex flex-wrap items-start justify-between gap-3`):
+
+- **Title** (`font-display text-xl font-medium text-navy`): **`Directors' `** `<em className="not-italic
+  text-gold">`**`insights`**`</em>``.`  → renders "Directors' *insights*." (mirrors board's "Board
+  *overview*.").
+- **Sub** (`mt-1 text-[13px] text-navy-2`): `[dynamic]` `{termLabel} · consolidated director dashboard`
+  where `termLabel` = `` `${period.label} · ${period.academicYear}` `` or `No academic period configured`
+  (board's exact `termLabel`). The board's word is "read-only governance snapshot"; here it is
+  **"consolidated director dashboard"** (this one acts).
+- **Export action** (right): **`Export board pack`** — `rounded-md border border-border-2 bg-surface px-3
+  py-1.5 text-xs font-semibold text-navy hover:bg-bg print:hidden`, `target="_blank" rel="noopener"`. Href
+  carries the on-screen `?periodId`. **See drift #2 / §16:** the shipped board-pack route lives under
+  `/board` and is `requireBoard()`-confined, so a director route can't reuse it as-is — it needs its own
+  export endpoint (mirror `board-pack/route.ts` under the insights path, gated by the same role group) **or**
+  the button is stubbed for v1. The button renders regardless; the target is the build dependency.
+
+**Period selector** — `ReportFilters terms={rollup.terms} activePeriodId={rollup.period?.periodId ?? null}
+showClass={false}` — **verbatim**. Writes `?periodId=<uuid>`; the page re-loads server-side (force-dynamic).
+The whole page (summary + tiles + drill-ins) is scoped to the selected term, exactly as the board is.
+
+---
+
+## 4. Summary strip — the scan layer [verbatim board]
+
+Five `SummaryCell` in `grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5`, **copied from the board with no
+change** (same fields, same honest `—` + reason for non-CAPTURED, same `TrendPill` deltas):
+
+| # | Cell | value | sub | lead? |
+|---|---|---|---|---|
+| 1 | **Students on roll** | `enrolment.data.roll` (en-GH) else `—` | `{male} boys · {female} girls` + `TrendPill(netChange, "this term", flat "no change")` else `reason` | **lead** (`bg-gold-bg`) |
+| 2 | **Attendance rate** | `attendance.data.schoolRate + "%"` else `—` | `TrendPill(schoolDelta,"pts","vs last term")` or `(present + late) ÷ all marks` else `reason` | — |
+| 3 | **Academic standing** | `academicSummary().value` (Basic avg %, else `{ready}/{total}` senior, else `—`) | `academicSummary().sub` (`{pass}% pass · N classes graded` + delta) | — |
+| 4 | **Fee collection** | `feeCollections.data.collectionRate + "%"` else `—` | `{boardGhs(collected)} of {boardGhs(billed)} billed` else `reason` | — |
+| 5 | **Facilities** | `infrastructure.data.classrooms.pctGood + "%"` else `—` | `{good}/{total} classrooms sound` else `reason` | — |
+
+Keep `academicSummary()` verbatim (R357 — one tier's figure, never a blended number). Keep the omit-not-fake
+discipline: a non-CAPTURED cell shows `—` + its reason string, never a fabricated `0`.
+
+---
+
+## 5. "Needs your attention" — the act-on-it panel [NEW]
+
+The single feature that makes this the *director's* dashboard, not the board's mirror: a compact list of
+**act-on-it rows**, each an aggregate signal + a chevron to the surface that fixes it. Placed directly under
+the summary strip (highest scan priority after the KPIs).
+
+**Section shell:** a `Tile` titled **`Needs your `**`<em>`**`attention`**`</em>``.` , meta `[dynamic]`
+`{n} items` (omit meta when 0). Body = a `space-y-2` list of `ActionRow`s.
+
+**`ActionRow`** (new, §1): `<Link href>` · severity dot · label + value · chevron `›`. Severity dot colour:
+terra (urgent) / warn (watch) / navy-2 (informational). Rows are **only rendered when their condition is
+genuinely true** (omit-not-fake — an absent problem is absent, never a green "all good" row inside the list).
+
+**The rows (each conditional; sorted terra → warn → navy-2):**
+
+| Row | Condition (from loaded data) | Value copy `[dynamic]` | Chevron → | Severity |
+|---|---|---|---|---|
+| **Outstanding fees** | `feeCollections.status==="CAPTURED" && outstanding > 0` | `{boardGhs(outstanding)} outstanding · {collectionRate}% collected` | Billing / fees surface | terra if `collectionRate < 60`, else warn |
+| **Ungraded classes** | `classPerf.totalClasses - classPerf.classesGraded > 0` (Basic tier) | `{ungraded} of {totalClasses} classes have no gradebook scores for {termLabel}` | Gradebook / `/senior/academic-progress` | warn |
+| **Attendance not captured** | `attendance.status !== "CAPTURED"` | the arm `reason` (e.g. `No attendance marked for Term 2 · 2025/26.`) | Attendance register | warn |
+| **Census not filed** | `[assumed]` census return for the year is not submitted (§17) | `The GES annual census for {academicYear} is not yet submitted.` | Census surface | navy-2 (informational) unless a window deadline is near |
+| **Facilities snapshot missing** | `infrastructure.status !== "CAPTURED"` | `No facilities snapshot captured yet.` | Facilities capture | navy-2 |
+| **Senior readiness at risk** | `performance.senior.status==="CAPTURED" && subjectsAtRisk > 0` | `{subjectsAtRisk} subject(s) at risk for STPSHS · {subjectsPartial} partial` | `/senior/headmaster-summary` (the roll-up) | terra |
+
+**Honest empty state** (all conditions false): a single positive line, **not** a blank tile —
+`Everything's current — nothing needs your attention this term.` (`text-[13px] text-navy-3`, matching the
+incr57 "Every subject on track" positive-empty convention). Distinct from a data-absent state.
+
+> **Aggregate-only note:** every row is a school-wide count/amount or a subject count. None names a student or
+> a parent. "Outstanding fees" is the school total, not a debtor list; "ungraded classes" is a class count,
+> not a teacher list. The drill *into* each is the linked operational surface's own (permissioned)
+> responsibility — the panel only surfaces the aggregate signal.
+
+---
+
+## 6. Financial position [verbatim board]
+
+Full-width `FinanceTile` (`col-span-full`), **copied unchanged**. Title `Financial `*`position`*`.`; the lede
+about three separate un-reconciled ledgers; then either `AbsencePanel(reason)` or the three `StreamCard`s —
+**Fee collections** (`boardGhs(collected)` + `PerfBar(collectionRate, "gold", "%")` + outstanding),
+**Books (this term)** (`Income`/`Expense`/`Net` via `Line`), **Payroll** (`schoolPaidMonthlyTotal` + GES /
+allowance memos). **No drill-in** — a finance drill-in was not requested; keep the honesty invariant (never a
+single summed "net position"; each stream keeps its own reason). If a director wants finance detail they
+click through to the finance reports (a linked surface, out of scope here).
+
+---
+
+## 7. The drill-in interaction pattern (the crux)
+
+One reusable client component drives all three drillable tiles.
+
+### 7.1 `<DrillIn>` — the component
+
+```
+<DrillIn
+  toggleLabel="Break down"                    // shows "Break down ▾" / "Hide breakdown ▴"
+  dimensions={[
+    { key: "class",   label: "By class",      content: <ClassBars … /> },      // server-rendered node
+    { key: "year",    label: "By year group", content: <YearBars … /> },
+    { key: "subject", label: "By subject",    content: <SubjectBars … /> },     // Performance only
+  ]}
+  defaultDim="class"
+/>
+```
+
+- **`"use client"`**, ~30 lines. Holds `open` (bool) and `activeDim` (string). Renders: the disclosure
+  toggle; when open, the **segmented control** (one chip per `dimensions[]`, ReportFilters pill idiom) + the
+  active dimension's pre-rendered `content` node. That is the entire client footprint of the page.
+- **`content` is a server-rendered ReactNode** (the bar list, already formatted with `PerfBar` /
+  `StatusSplit` / gender bars and string labels). The server owns data + formatting (memory
+  `reports-data-is-server-only`); the client only toggles which node is visible. **No student data can reach
+  the client** — only aggregate JSX does.
+- **No refetch on switch** — every dimension's node is in the RSC payload already (a handful of aggregate
+  rows each). Instant. `defaultDim` = `"class"` for all three.
+- **`dimensions[]` with one entry** → render the bar list with **no segmented control** (a single-dimension
+  drill still gets the disclosure; the chip row is suppressed — mirrors the ledger class-switcher's
+  "suppressed when only one" rule).
+
+### 7.2 The bar-list anatomy (shared by all dimensions)
+
+Each dimension's `content` is a list. Header row = `ColumnHeads` (`lg:grid`, hidden on mobile). Each data row
+= a `grid` row: **label** (left, `text-[13px] text-navy` — a class/level/subject name, `font-mono` for level
+codes) · **`PerfBar`** (the metric) · a small **mono readout** · optional **`TrendPill`**. Rows are sorted by
+the readers (descending average / rate). A row with no captured value renders `—` (PerfBar null → `—`), never
+`0`. If the whole dimension is empty → `AbsencePanel(arm.reason)` in place of the list.
+
+> **Why segmented control, not tabs-as-routes or accordions:** the segmented control (a) is the shipped
+> ReportFilters pill — zero new visual grammar; (b) keeps all dimensions one thumb-reach apart for scanning;
+> (c) never navigates, so the tile's summary and the rest of the page don't reload. Accordions-per-dimension
+> would stack three lists; a route-per-dimension is §0.2's rejected heavier path.
+
+---
+
+## 8. Performance tile + drill-in (by class · by year-group · by subject)
+
+**Summary portion** = board `PerformanceTile` **verbatim**: title `Academic `*`performance`*`.`, meta
+`cross-tier · this term`; Basic gradebook line (overall average % + pass rate + graded-classes + delta) and/or
+Senior STPSHS-readiness line (`ready / partial / at risk`) and/or Terminal exams (BECE / WASSCE), each
+honest-absence-gated on its own tier (omit-not-fake; `NOT_APPLICABLE` omitted).
+
+**Drill-in** (`<DrillIn>`, three dimensions):
+
+### 8.1 By class — source `getClassPerformance().rows` (`ClassPerfRow[]`)
+Row grid (`ColumnHeads`: `Class · Avg · Grade · vs last term`):
+- **Label:** `row.name` (`text-[13px] text-navy`).
+- **Bar:** `PerfBar value={row.average} tone={row.tone} suffix="%"` (tone from `performanceTone`: ≥70 green /
+  ≥50 gold / else terra; null → `—`).
+- **Grade:** `row.grade` (`font-mono text-xs text-navy-2`) — from the school's own grade scale; `—` when null.
+- **Trend:** `TrendPill(row.delta, "pts", "vs last term")` (null → no pill).
+- **Mono caption** (secondary line / on mobile): `{studentsGraded} graded`.
+- **Sorted** descending by average (reader already sorts). Ungraded class → `average=null` → `—` row.
+- **Whole-dimension empty:** `performance.basic` NOT_CAPTURED → `AbsencePanel(basic.reason)`
+  (e.g. "No gradebook scores recorded for Term 2 · 2025/26.").
+
+### 8.2 By subject — source `getSubjectPerformance().rows` (`SubjectPerfRow[]`)
+Same grid + one extra column (`ColumnHeads`: `Subject · Avg · Grade · Pass · vs last term`):
+- **Label:** `row.name` (+ `row.code` in `font-mono text-[10px] text-navy-3` when present).
+- **Bar:** `PerfBar value={row.average} tone={row.tone} suffix="%"`.
+- **Grade:** `row.grade`.
+- **Pass:** `row.passRate != null ? row.passRate + "% pass" : —` (`font-mono text-xs`) — the share ≥ PASS_MARK
+  (50), aggregate per-score basis; null when nothing graded (never `0%`).
+- **Trend:** `TrendPill(row.delta, "pts", "vs last term")`.
+- **Sorted** descending by average. Empty → `AbsencePanel` (subject reader's honest empty).
+
+### 8.3 By year-group (form level) — **derived; see §17 data note**
+Rows = one per **`classes.level`** (e.g. `JHS 1` / `JHS 2` / `JHS 3`, or `Form 1` / `Form 2` / `Form 3`).
+Row = level label · `PerfBar(levelAverage, performanceTone, "%")` · `{gradedClasses} of {classes} classes` ·
+`TrendPill(levelDelta,"pts")`. **`levelAverage` must be a `studentsGraded`-weighted mean of the member class
+averages, NOT a mean of means** (a mean of means over-weights small classes). Sorted by level order (numeric
+within the tier), not by average, so the ladder JHS1→JHS3 reads top-to-bottom. Empty → the same
+`basic.reason` panel.
+
+> **Data note (§17-A):** `ClassPerfRow` carries no `level`. Either (a) project `classes.level` onto
+> `ClassPerfRow` in `getClassPerformance` and reduce by level in-memory here (weighted by `studentsGraded`),
+> or (b) Kofi adds a `byLevel` aggregate to a director-insights reader. `getSchoolStats().byClass` proves
+> `level` is available on `classes`. **Recommend (a)** — one column added to an existing select, in-memory
+> reduce, no new query. Flag for reconciliation.
+
+---
+
+## 9. Attendance tile + drill-in (by class · by year-group)
+
+**Summary portion** = board `AttendanceTile` **verbatim**: title `Attendance `*`this term`*`.`, meta
+`{totalMarked} marks recorded`; either `AbsencePanel(reason)` or the big `schoolRate%` + `TrendPill(schoolDelta,
+"pts","vs last term")` (or the `(present + late) ÷ all marks` caption when delta null) + `StatusSplit(statusTotals)`
+(the P/L/E/M/A segmented bar + mono readout). **Keep Medical (M) first-class navy-2** — it is the
+sickbay→attendance readout, never folded into Absent (memory `attendance-five-statuses`).
+
+**Drill-in** (`<DrillIn>`, two dimensions — no subject dimension for attendance):
+
+### 9.1 By class — source `attendance.data.byClass` (`AttendanceClassRow[]`, already loaded in the rollup)
+Row grid (`ColumnHeads`: `Class · Rate · P L E M A`):
+- **Label:** `row.name`.
+- **Bar:** `PerfBar value={row.rate} tone={attendanceTone(row.rate)} suffix="%"` (attendance scale: ≥90 green /
+  ≥75 gold / else terra; null → `—`).
+- **Status readout:** a **compact `StatusSplit(row.counts)`** — reuse the exact board component (the 5-status
+  segmented bar + `P n · L n · E n · M n · A n` mono readout). This is the per-class P/L/E/M/A breakdown,
+  aggregate counts only.
+- **Mono caption:** `{marked} marks`.
+- **Sorted** descending by rate (lowest-attendance classes are the ones a director watches — optionally sort
+  ascending so the at-risk classes surface first; **recommend ascending by rate** so "who needs help" is at
+  the top. Flag #5 — pick one.)
+- A class with `rate=null` (marks exist but rate not derivable) or `marked=0` → `—` bar; whole-dimension
+  NOT_CAPTURED → `AbsencePanel(attendance.reason)`.
+
+### 9.2 By year-group (form level) — **derived; see §17 data note**
+Rows = one per level; row = level label · `PerfBar(levelRate, attendanceTone, "%")` · a `StatusSplit` over the
+**summed** P/L/E/M/A counts for the level · `{marked} marks`. **`levelRate` = (present + late) ÷ all marks over
+the level's summed counts** (the board's own rate definition — recompute from summed counts, do not average
+class rates). Sorted by level order.
+
+> **Data note (§17-B):** `AttendanceClassRow` carries no `level`. Same fix as §8.3: project `classes.level`
+> onto the attendance byClass row (in `getAttendanceSummary` / the rollup) and reduce by level in-memory. The
+> level's rate/counts are honest sums, so no fabrication risk.
+
+---
+
+## 10. Enrolment tile + drill-in (by class · by year-group · gender split · age distribution)
+
+**Summary portion** = board `EnrolmentTile` / `EnrolmentBody` **verbatim**: title `Enrolment `*`at a glance`*`.`,
+meta `levelSummary`; roll headline + `TrendPill(netChange)`; the **gender mini-bar** (`NF · NM`); the structure
+`Line`s (active classes / avg class size / teaching staff / student:teacher); the intake-this-term + lifetime
+exits block with the honest per-term caveat. **No fabricated term-windowed zeros** (`—` for nulls).
+
+**Drill-in** (`<DrillIn>`, dimensions: **By class · By year-group** + the two dedicated vizzes **Gender** and
+**Age**). All four powered by **one reader**, `getCensusEnrolment(school.id)` (§17-C) — it returns `byClass`
+(with `level`), `byLevel`, `ageByLevel`, `approvedAge`, `dobUnknown`, `censusDate`, all aggregate sex-split.
+
+### 10.1 By class — source `census.byClass` (`CensusClassRow[]`: name, level, female, male, total)
+Row grid (`ColumnHeads`: `Class · Enrolled · Girls / Boys`):
+- **Label:** `row.name`.
+- **Enrolled:** `row.total` (`font-mono text-navy`).
+- **Gender bar:** the **gender mini-bar verbatim** — female `#C77B9E` seg (`flexGrow: row.female`) + male
+  `#6B86B0` seg (`flexGrow: row.male`) in an `h-2.5 rounded-pill` track; readout `{female}F · {male}M`
+  (`font-mono text-[10px] text-navy-3`).
+- **Sorted** by class name (reader order). An `Unassigned` synthetic row appears **only** when unassigned
+  active students exist (the reader adds it so tallies sum to roll — honest gap, not dropped). A zero-student
+  class still lists (GES-style). Empty roll → `AbsencePanel("No students currently enrolled.")`.
+
+### 10.2 By year-group (form level) — source `census.byLevel` (`CensusLevelRow[]`: level, female, male, total)
+Same row shape, keyed on level; the gender mini-bar per level; sorted by level. **This is available directly
+from the census reader — no derivation needed** (unlike performance/attendance year-group, §8.3/§9.2). An
+`Unspecified` level row appears for classes with a null `level` (honest).
+
+### 10.3 Gender split viz — school + per class/level
+The gender split is the mini-bar seen twice:
+- **School total bar** — a wide gender mini-bar over `census.gender` (`{female}F · {male}M · {total} total`),
+  shown at the top of the Gender dimension (bigger than the per-row bars: `h-3`).
+- **Per class/level bars** — reuse the §10.1/§10.2 rows' gender bars (the same bars, so "By class"/"By
+  year-group" already *are* the gender split at that grain). The **Gender** dimension is therefore a
+  thin wrapper: school total bar + a segmented sub-toggle (class ↔ level) reusing the §10.1/§10.2 lists. To
+  avoid duplicating the segmented control, **recommend folding gender into the class/level rows** (they carry
+  the bar already) and making **Gender** a school-level summary strip only:
+  `{femalePct}% girls · {malePct}% boys · {total} on roll` with the wide bar. Lazy: the per-grain split is
+  the class/level list; Gender = the school headline bar. (Flag #4 — confirm whether a standalone per-level
+  gender table is wanted beyond the class/level lists already showing it.)
+
+### 10.4 Age distribution viz — age bands × gender (the census hook)
+The richest new viz. Source: `census.ageByLevel` (per-year buckets) + `census.approvedAge` (GES bands) +
+`census.dobUnknown`. **A sub-toggle** (segmented, reusing the pill idiom) picks scope: **School** (sum
+`ageByLevel` across levels per age) or **By level** (one level's `byAge`). Default = **School**.
+
+**(a) Age histogram — gender-split stacked bars (primary form):**
+One row per **age year** present, ascending (e.g. 12, 13, 14, 15…). Each row:
+- **Age label:** `{age} yrs` (`font-mono text-[11px] text-navy-2`).
+- **Stacked gender bar:** the **gender mini-bar verbatim** — female `#C77B9E` (`flexGrow: bucket.female`) +
+  male `#6B86B0` (`flexGrow: bucket.male`), in an `h-2.5 rounded-pill` track. **Bar widths normalise across
+  rows to the largest age bucket's total** so tall bars read as the modal age (compute `maxTotal =
+  max(bucket.total)`; each row's track holds the female+male segs plus an empty spacer to `maxTotal` — or
+  simply set the row's flex-basis proportional to `bucket.total / maxTotal`). This gives the histogram shape
+  (a real distribution, not equal-width rows).
+- **Readout:** `{bucket.female}F · {bucket.male}M · {bucket.total}` (`font-mono text-[10px] text-navy-3`).
+
+> **Optional richer variant — population pyramid (flag #4):** female bars grow **left**, male bars grow
+> **right**, from a centred axis, one row per age — the classic census pyramid. It's more custom CSS (two
+> half-tracks + a centre rule) but reads beautifully for a school-age distribution. **Base spec = stacked
+> bars (reuses the shipped mini-bar verbatim, zero new mechanics);** offer the pyramid only if the owner asks.
+
+**(b) Approved-age bands (the GES "enrolment by approved age" — 3 tone-coded bands):**
+Below the histogram, for the selected scope, `census.approvedAge` per level (or summed for School over levels
+that *have* an official age). Three tone-coded readouts + a thin 3-segment bar:
+- **On age** — `green` / `bg-green` seg — `count` at exactly `officialAge`.
+- **Under age** — `gold` / `bg-gold` seg — younger than `officialAge`.
+- **Over age** — `terra` / `bg-terra` seg — older than `officialAge`.
+- **Unknown DOB** — `navy-3` / `bg-navy-3` seg — students with no DOB (never coerced to an age).
+Label each: `{on} on age · {under} under · {over} over` (`font-mono text-[10px]`, each in its tone). Levels
+with no GES official age (nursery/creche, unparseable label) are **omitted** from this band (the reader
+already excludes them — you cannot assess "approved age" without an official reference). This is the direct
+census cross-module hook (§16).
+
+**(c) Honest DOB-unknown treatment (omit-not-fake, GOV8-05):**
+`census.dobUnknown > 0` → a footnote under the age viz: `{dobUnknown} student(s) have no date of birth
+recorded — they are counted in the roll but never assigned an age.` (`text-[11px] text-navy-3`). **Never
+bucket unknowns into an age band.** If **every** student lacks a DOB (histogram empty), show only this
+footnote + `AbsencePanel`-style note, not an empty chart.
+
+**As-of note:** the census reader freezes ages to `censusDate` (default now). Show a small meta
+`as of {censusDate}` (`text-[11px] text-navy-3`) so the director knows the age snapshot's reference point.
+The census roll (ACTIVE now) reconciles with the summary tile's roll (also ACTIVE now) — they must match
+(§17-C reconciliation note).
+
+---
+
+## 11. Infrastructure [verbatim board]
+
+Board `InfrastructureTile` / `InfrastructureBody` **copied unchanged**: title `Infrastructure `*`& facilities`*`.`,
+meta `{periodLabel} · {academicYear}`; `%` classrooms sound + count; the utilities / ICT / library / feeding /
+textbooks `Line`s; honest `AbsencePanel(reason)` when no snapshot. **No drill-in requested** — facilities is
+a latest-snapshot read, not a class/subject aggregate. Keep the captured-zero honesty (0 working computers,
+handwashing false render as real values, never absence).
+
+---
+
+## 12. Interaction-state inventory (every state, per region)
+
+| Region | State | Visual / copy |
+|---|---|---|
+| Period pill | active / inactive | `border-navy bg-navy text-bg` / `border-border-2 bg-surface text-navy-3 hover:border-gold` |
+| Summary cell | captured / not-captured | value + sub / `—` + reason string (omit-not-fake); lead cell always `bg-gold-bg` |
+| Trend pill | up / down / flat / none | `bg-green-bg text-green ▲` / `bg-terra-bg text-terra ▼` / `bg-bg text-navy-3 —` / no pill (`delta==null`) |
+| Action row | present / hover | `border-border bg-surface` / `hover:bg-gold-bg`; severity dot terra/warn/navy-2 |
+| Action panel | populated / **empty (GOOD)** | rows / `Everything's current — nothing needs your attention this term.` (positive empty, not blank) |
+| Disclosure | closed / open | `Break down ▾` (`text-gold`) / `Hide breakdown ▴`; content region below |
+| Dimension segment | active / inactive | period-pill classes (active `bg-navy text-bg`); **suppressed entirely when one dimension** |
+| Drill-in bar row | captured / null | `PerfBar` fill + value / `PerfBar` `—` (null → empty track, `—` value), never `0` |
+| Drill-in dimension | populated / empty | bar list / `AbsencePanel(arm.reason)` (the tier's honest reason) |
+| Status split (P/L/E/M/A) | with marks / zero | segmented bar + mono readout / no segments when `total===0` (readout still shows `n 0` in each tone) |
+| Gender bar | mixed / single-sex / empty | both segs / one seg (other `flexGrow:0`) / no segs when total 0 |
+| Age histogram | populated / all-DOB-unknown | per-age stacked bars + approved-age bands / DOB-unknown footnote only + honest note |
+| Approved-age band | has official age / no official age | 3-seg tone bar / level omitted (nursery/unparseable) |
+| Facilities / attendance / senior arm | CAPTURED / NOT_CAPTURED / NOT_APPLICABLE | figure / `AbsencePanel(reason)` / omitted (tier doesn't apply) |
+| Whole page | loading | `dynamic="force-dynamic"` SSR — first paint is populated; no client skeleton, no spinner (same as board) |
+| Whole page | error | server component — a load failure throws to the route error boundary (existing behaviour); no inline error card |
+| No period configured | — | summary cells `—`; each tile's arm renders its `No academic period configured.` reason; action panel may still show census/facilities rows |
+
+---
+
+## 13. Responsive / PWA
+
+- **No dedicated PWA variant.** This is a **management desktop surface** (director/admin), like the
+  headmaster-summary and board — the PWA form-factor belongs to the teacher's ledger. Responsive is pure
+  Tailwind breakpoints, no separate component.
+- **Summary strip:** `grid-cols-2 sm:grid-cols-3 lg:grid-cols-5` (board verbatim — stacks 2→3→5).
+- **Tile pairs:** `grid gap-4 lg:grid-cols-2` (board verbatim — single column below `lg`).
+- **Action panel:** rows are full-width `flex`; the value wraps under the label on narrow widths
+  (`flex-wrap`), chevron stays right.
+- **Drill-in:** `ColumnHeads` is `hidden lg:grid` (board/report-kit convention) — below `lg`, each row shows a
+  stacked label + inline mono readout (the bar stays full-width). The segmented control `flex flex-wrap`.
+- **Age histogram / gender bars:** already full-width bars; they reflow naturally. When the **Enrolment**
+  drill-in (the tallest, with age + gender) is open on a half-width tile at `lg`, the age viz may feel tight
+  — **optional:** let the Enrolment tile go `col-span-full` while its drill-in is open (a client class toggle
+  the `<DrillIn>` already knows about). Default keeps the board grid; **verify in the live preview** (flag #7).
+
+---
+
+## 14. Accessibility
+
+- **Disclosure** = a real `<button aria-expanded aria-controls>` toggling a region (or a native
+  `<details>/<summary>` if the team drops the client component — the native element is keyboard/AT-complete
+  for free). Focus-visible ring on the toggle and every segment chip.
+- **Segmented control** = a `role="tablist"` of `role="tab"`/`aria-selected` buttons controlling one
+  `role="tabpanel"`, **or** simple buttons with `aria-pressed` (lighter, fine for a 2–3 option switch). Arrow-key
+  movement between segments is a nice-to-have, not required for 2–3 options.
+- **Bars are decorative; numbers are authoritative.** Every `PerfBar` / gender bar / status seg is `aria-hidden`
+  (the board already marks the segmented bars `aria-hidden`); the adjacent mono readout carries the real value
+  for screen readers. Direction/severity never rely on colour alone — `TrendPill` carries a glyph + sign +
+  text; status readout carries the letter (P/L/E/M/A); approved-age carries the word (on/under/over).
+- **Contrast:** all text on `bg-surface`/`bg-bg` is navy/navy-2/navy-3 (AA). The pink/blue gender segs are
+  decorative (`aria-hidden`), so their contrast is not a text concern; the `F`/`M` labels are navy-3 text.
+- **Landmarks/headings:** each `Tile` is a `<section>` with an `<h2>`; the action panel and drill-in sub-lists
+  use nested headings/labels so the page has a coherent outline. The action rows are links with descriptive
+  text ("Outstanding fees — GHS … outstanding"), not "click here".
+- **Chevron `›` / disclosure glyphs** are text with an accessible label on the link (the row's label text
+  already describes the destination).
+
+---
+
+## 15. Component / build map (what actually gets written)
+
+New route, board components reused. **No redesign of the board; a small lift of its shared primitives.**
+
+| Surface region | Reuse (shipped) | New work |
+|---|---|---|
+| Page frame | headmaster-summary frame (`requireSchoolRole`, `dynamic`, `max-w-page`) | `app/(app)/directors/page.tsx` (or `/senior/insights` — §0.1) |
+| Header + period | board header block + `ReportFilters` | copy structure; swap copy; wire `Export board pack` href (needs own export route — drift #2) |
+| Summary strip | board `SummaryCell` + `academicSummary()` | verbatim; **lift `SummaryCell` into `components/board/board-tiles.tsx`** so both pages import it |
+| Financial / Infrastructure tiles | board `FinanceTile` / `InfrastructureTile` + `StreamCard`/`Line` | verbatim; lift `Tile`/`Line`/`StreamCard` to the shared pure module |
+| **Needs your attention** | `Tile` shell + `<Link>` | new `ActionRow` + the conditional-row logic (all fields from already-loaded arms + class-perf totals; census flag = §17-D) |
+| **`<DrillIn>`** | ReportFilters pill idiom | new ~30-line client component (`open` + `activeDim`, renders server-node slots) |
+| Performance drill-in | `getClassPerformance` (loaded), `getSubjectPerformance` (new call), `PerfBar`, `ColumnHeads`, `TrendPill` | `ClassBars`/`SubjectBars`/`YearBars` server nodes; year-group needs `level` on `ClassPerfRow` (§17-A) |
+| Attendance drill-in | `attendance.data.byClass` (loaded), board `StatusSplit`, `attendanceTone`, `PerfBar` | `ClassBars`/`YearBars`; **lift `StatusSplit` to the shared pure module**; year-group needs `level` (§17-B) |
+| Enrolment drill-in | gender mini-bar (board), `PerfBar` | `getCensusEnrolment` call; `ClassBars`/`YearBars`/`GenderViz`/`AgeViz` server nodes (§17-C) |
+| Absence / empty states | `AbsencePanel`, headmaster-summary dashed-card copy | reuse verbatim |
+| Role gate | `requireSchoolRole` | `STAFF_ADMIN_ROLES` or a new `DIRECTOR_INSIGHTS_ROLES` (§0.4, drift #1) |
+
+**Shared-primitive lift (small, low-risk refactor):** `Tile`, `SummaryCell`, `StatusSplit`, `Line`,
+`StreamCard`, and the gender-bar constants (`FEMALE_HEX`/`MALE_HEX`) are currently **local functions in
+`app/(board)/board/page.tsx`**. To reuse them 1:1 without duplication, lift them into
+`components/board/board-tiles.tsx` (already the pure, `server-only`-free "these own the pixels" module) and
+import them into **both** the board page and the insights page. Pure move, no behaviour change, keeps the
+board render tests green. **This is the only edit to a shipped file; verify the board still renders
+identically in the live preview.** (If the team prefers zero changes to `board/page.tsx`, duplicate the five
+tiny helpers into `components/insights/` instead — flag #3.)
+
+**Data loads (server, in `Promise.all`):** `getSchoolRollup(school.id, {periodId})` (summary + all tiles +
+attendance/enrolment byClass) · `getClassPerformance(school.id, {periodId})` (class + year-group performance)
+· `getSubjectPerformance(school.id, {periodId})` (subject performance) · `getCensusEnrolment(school.id)`
+(enrolment by-class/level + gender + age). Each is an existing aggregate reader.
+
+---
+
+## 16. Cross-module hooks (design commitments to preserve)
+
+| Hook | Where on this surface | Preserve as |
+|---|---|---|
+| **fee collection → billing** | "Outstanding fees" action row (§5) + Financial tile | The aggregate outstanding amount is the signal; the chevron routes to the billing surface where a director acts. Never a debtor/student list here. |
+| **score ledger → STPSHS export** | "Senior readiness at risk" action row + Performance drill-in senior line | The `ready / partial / at risk` counts are the STPSHS-readiness answer; the chevron routes to `/senior/headmaster-summary` (the subject roll-up), the drill toward the STPSHS export. |
+| **sickbay → attendance ("M")** | Attendance `StatusSplit` (summary + per-class/level drill-in) | Medical (M) stays a first-class navy-2 status, never folded into Absent — the sickbay→register readout is visible at school, class, and year-group grain. |
+| **census → enrolment (age × sex × approved-age)** | Enrolment age-distribution viz + approved-age bands (§10.4) + "Census not filed" action row | The GES census disaggregation (`getCensusEnrolment`) is surfaced here as a live director viz; the action row nudges filing. The age/approved-age figures ARE the census input — keep the honesty (DOB-unknown never aged, no-official-age levels omitted). |
+| **ledger trajectory → WASSCE predictor** | Performance drill-in (senior) — **future drill-through** | Out of this build's scope, but the by-subject/by-class senior figures are the predictor's input; leave the Performance drill-in as the natural future entry point (a subject → WASSCE-predictor link). Do not build now; note the seam. |
+| **board pack export** | Header "Export board pack" (§3) | The insights figures ARE the board-pack input; the export must render the same term's aggregate. Needs its own role-gated export route (drift #2). |
+
+---
+
+## 17. Data-shape assumptions to reconcile with Kofi
+
+Everything the surface **assumes** about readers/fields, so the two specs meet cleanly. **A–C are the crux;
+D–E are the action panel.**
+
+- **§17-A — Performance by year-group needs `level` on `ClassPerfRow`.** `getClassPerformance` returns no
+  `level`. Assumption: project `classes.level` onto `ClassPerfRow` (one column on the existing select) and
+  reduce by level in-memory, `studentsGraded`-weighted mean. No new query. (`getSchoolStats.byClass` confirms
+  `level` exists.) If Kofi prefers a first-class `byLevel` aggregate in the reader, the surface consumes that
+  instead — same shape (`{level, average, gradedClasses, classes, delta}`).
+- **§17-B — Attendance by year-group needs `level` on `AttendanceClassRow`.** Same as A: project `classes.level`
+  onto the attendance byClass row, reduce by level, recompute `rate = (present+late) ÷ all marks` from summed
+  counts (not an average of class rates). No new query.
+- **§17-C — Enrolment drill-in + gender + age all source `getCensusEnrolment(school.id)`.** It already returns
+  `byClass` (with level), `byLevel`, `ageByLevel` (per-year sex split + `dobUnknown`), `approvedAge`
+  (under/on/over/unknown vs `officialAgeForLevel`), `dobUnknown`, `censusDate`. **Reconciliation:** the census
+  roll is ACTIVE as-of `censusDate` (default now); the summary Enrolment tile's roll is ACTIVE now
+  (`getSchoolStats`). They must match — confirm both are ACTIVE-only and un-windowed, or pass the same
+  reference date. If Kofi's insights reader already computes age/gender, the surface consumes that instead;
+  the shapes above are the contract.
+- **§17-D — "Census not filed" action row needs a filed/unfiled signal.** The census track (GOV-9) has a
+  `census_return` concept. Assumption: a cheap boolean "is there a submitted census return for
+  `(school, academicYear)`?" — a small reader or a field on the return. If none exists yet, **omit this row**
+  (omit-not-fake) until Kofi exposes the signal. Do not fabricate a "due" state.
+- **§17-E — "Ungraded classes" needs `totalClasses` + `classesGraded`.** Both are on
+  `ClassPerformance` (`totalClasses`, `classesGraded`) — already loaded for the drill-in. The rollup's
+  `BasicPerformanceSummary` exposes only `gradedClasses`, so **compute the ungraded count from
+  `getClassPerformance`, not the rollup arm.** No new data.
+- **§17-F — Export route.** The insights "board pack" needs a role-gated export endpoint (mirror
+  `app/(board)/board/board-pack/route.ts`) under the insights path, since the shipped one is `requireBoard()`
+  + `/board`-confined. Kofi/PO to confirm scope; the button renders either way.
+
+---
+
+## Open questions / drift log (consolidated)
+
+1. **Route + role gate (§0.1, §0.4).** New route `app/(app)/directors/` vs `app/(app)/senior/insights/`; gate
+   `STAFF_ADMIN_ROLES` vs `SENIOR_MANAGEMENT_ROLES` vs a new `DIRECTOR_INSIGHTS_ROLES`. Recommend a dedicated
+   per-surface group seeded = `STAFF_ADMIN_ROLES`. **Gate to the spec, never copy a wider sibling** (memory
+   `builds-widen-ratified-authz`). Confirm with PO.
+2. **"Export board pack" target (§3, §17-F).** The shipped board-pack route is `requireBoard()`/`/board`-confined
+   — a director route can't reuse it. Needs its own role-gated export endpoint, or the button stubs for v1.
+   Confirm scope.
+3. **Shared-primitive lift (§15).** Lifting `Tile`/`SummaryCell`/`StatusSplit`/`Line`/`StreamCard` from
+   `board/page.tsx` into the pure `board-tiles.tsx` is the clean reuse (one shipped-file edit, verify board
+   unchanged in preview). Alternative: duplicate the five tiny helpers into `components/insights/`. Recommend
+   the lift. Confirm.
+4. **Gender/age viz depth (§10.3, §10.4).** (a) Is a standalone per-level gender table wanted, or is the
+   gender split adequately shown by the per-class/level rows' mini-bars (recommend the latter; Gender = school
+   headline bar only)? (b) Age viz: stacked gender bars (base, reuses shipped mini-bar) or the population
+   pyramid variant (richer, custom CSS)? Recommend stacked for v1. Confirm.
+5. **Attendance drill-in sort (§9.1).** Sort classes/levels **ascending by rate** (worst-first, "who needs
+   help" at top) or descending? Recommend ascending for the director's watch-list read. Confirm.
+6. **Drill-in mechanic (§0.2).** In-page `<DrillIn>` client component (recommended, instant switch) vs
+   zero-JS `<Link>`-chip URL-param dimension switch (heavier nav, native-`<details>` state loss). Recommend the
+   client component. Confirm if the team wants zero client JS.
+7. **Enrolment tile width when open (§13).** Optionally let the Enrolment tile go `col-span-full` while its
+   (tall) age+gender drill-in is open, else keep the board 2-col grid. Verify in the live preview
+   (memory `no-alpha-token-opacity` — tints + this layout are preview checks, not build checks).
+8. **Year-group label vocabulary.** Use the school's own `classes.level` text verbatim ("JHS 3" / "Form 2" /
+   "Primary 5") — do not normalise or invent labels. The census reader already sorts levels lexically; if a
+   numeric tier order is wanted (JHS1→JHS3), sort on the parsed level number. Confirm the ordering rule.
+
+---
+
+*Map produced against: `app/(board)/board/page.tsx`, `components/board/board-tiles.tsx`,
+`components/reports/report-kit.tsx`, `components/reports/report-filters.tsx`, `lib/rollup/school-rollup.ts`,
+`lib/reports/class-performance-data.ts`, `lib/reports/subject-performance-data.ts`,
+`lib/reports/census-enrolment-data.ts`, `lib/reports/school-stats-data.ts`, `lib/attendance-status.ts`,
+`lib/access.ts`, `app/(app)/senior/headmaster-summary/page.tsx`; tokens from `md files/design-tokens.json` +
+`styles/tokens.css`. Follows the shape of `docs/senior/ledger-surface-map.md` and
+`docs/senior/incr57-headmaster-rollup-surface-map.md`. Aggregate-only is a hard constraint — every drill-in
+row is a class / year-group / subject / age-band, never a student.*
+</content>
+</invoke>

--- a/omnischools/lib/access.test.ts
+++ b/omnischools/lib/access.test.ts
@@ -9,6 +9,9 @@ import {
   SENIOR_LEDGER_ROLES,
   SENIOR_MANAGEMENT_ROLES,
   WASSCE_SETUP_ROLES,
+  INSIGHTS_READ_ROLES,
+  STAFF_ADMIN_ROLES,
+  USER_ADMIN_ROLES,
 } from "./access";
 
 describe("hasAnyRole", () => {
@@ -81,6 +84,45 @@ describe("PARENT is denied every INCR-15→18 gate group (AC D6/D7)", () => {
       expect(hasAnyRole(["PARENT"], group)).toBe(false);
     });
   }
+});
+
+describe("INSIGHTS_READ_ROLES — the Directors' Insights read gate (INS-05)", () => {
+  // The regression LOCK the AC mandates: "mutating the guard to a wider group reds a test". The gate is
+  // director analytics READ — ADMIN · HEADMASTER · PROPRIETOR — and nothing else. Widening it (appending a
+  // role, or reassigning it to a wider sibling like SENIOR_MANAGEMENT_ROLES) breaks the exact-set assertion.
+  // Directly fences [[builds-widen-ratified-authz-and-self-bless]] (a green suite must not hide a widened gate).
+  it("admits exactly ADMIN · HEADMASTER · PROPRIETOR, in that shape", () => {
+    expect([...INSIGHTS_READ_ROLES].sort()).toEqual(["ADMIN", "HEADMASTER", "PROPRIETOR"]);
+  });
+
+  it("admits the three director roles", () => {
+    for (const r of ["ADMIN", "HEADMASTER", "PROPRIETOR"]) {
+      expect(hasAnyRole([r], INSIGHTS_READ_ROLES)).toBe(true);
+    }
+  });
+
+  it("DENIES VHA (OC-INS-VHA), finance-only, teacher, form master, student, parent, board member", () => {
+    for (const r of [
+      "VICE_HEADMASTER_ACADEMIC",
+      "ACCOUNTANT",
+      "BURSAR",
+      "TEACHER",
+      "FORM_MASTER",
+      "STUDENT",
+      "PARENT",
+      "BOARD_MEMBER",
+    ]) {
+      expect(hasAnyRole([r], INSIGHTS_READ_ROLES)).toBe(false);
+    }
+  });
+
+  it("is a DISTINCT named group — not an alias/reference of a sibling gate (INS-05)", () => {
+    // A separate binding, so widening STAFF_ADMIN_ROLES / USER_ADMIN_ROLES never silently widens this.
+    expect(INSIGHTS_READ_ROLES).not.toBe(STAFF_ADMIN_ROLES);
+    expect(INSIGHTS_READ_ROLES).not.toBe(USER_ADMIN_ROLES);
+    // …and it must NOT carry SENIOR_MANAGEMENT_ROLES' membership (that set includes the excluded VHA).
+    expect([...INSIGHTS_READ_ROLES].sort()).not.toEqual([...SENIOR_MANAGEMENT_ROLES].sort());
+  });
 });
 
 describe("isStaff — the invite/manage gate (AC C1 staff-gating / A1)", () => {

--- a/omnischools/lib/access.ts
+++ b/omnischools/lib/access.ts
@@ -71,6 +71,29 @@ export const USER_ADMIN_ROLES = [
 ] as const satisfies readonly KnownAppRole[];
 
 /**
+ * 🔴 INS (Directors' Insights / `/insights`) — who may READ the consolidated director analytics
+ * dashboard (KPI scan strip · finance/academic/operational panels · aggregate drill-ins). ADMIN +
+ * HEADMASTER + PROPRIETOR — the acting director persona.
+ *
+ * A DISTINCT, purpose-named READ gate, membership initially identical to STAFF_ADMIN_ROLES /
+ * USER_ADMIN_ROLES but SEMANTICALLY SEPARATE: this is "who may read the director analytics", NOT the
+ * authorization root (STAFF_ADMIN_ROLES = "who may mint administrators") nor the login-lifecycle set
+ * (USER_ADMIN_ROLES = block/reset/activate). Naming it apart is the codebase discipline that keeps
+ * widening one gate from silently widening another, and directly answers the standing hazard
+ * [[builds-widen-ratified-authz-and-self-bless]] — gate to the spec, never reuse a wider sibling.
+ *
+ * VICE_HEADMASTER_ACADEMIC is DELIBERATELY EXCLUDED by default (OC-INS-VHA): the surface carries the
+ * finance/net-position streams (fees · books · payroll), which are governance, not academics. Finance-only
+ * staff (Accountant / Bursar), Teacher, Form Master, Student, Parent and BOARD_MEMBER never reach it.
+ * `as const satisfies` makes a typo'd code a compile error.
+ */
+export const INSIGHTS_READ_ROLES = [
+  "ADMIN",
+  "HEADMASTER",
+  "PROPRIETOR",
+] as const satisfies readonly KnownAppRole[];
+
+/**
  * Senior (SHS) tier role groups. The score ledger is a teaching surface (teachers + form
  * masters + academic leadership); the Vice Headmaster progress view is management-only
  * (Admin, Headmaster, Vice Headmaster Academic). STUDENT / PARENT never reach either.

--- a/omnischools/lib/insights/insights-data.test.ts
+++ b/omnischools/lib/insights/insights-data.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { cwd } from "node:process";
+import type { AttendanceClassRow } from "@/lib/rollup/school-rollup";
+
+/**
+ * INS-14 / INS-22 / INS-23 · the Directors' Insights composition seam.
+ *
+ *  • the by-year-group attendance fold is a LOSSLESS integer sum (P/L/E/M/A + marked) with the rate
+ *    RECOMPUTED as (ΣP+ΣL)/Σmarked — never a mean of class rates; Medical stays first-class;
+ *  • the folded rows carry ONLY aggregate keys — no student name / id / code / DOB (the aggregate-only
+ *    invariant, structurally);
+ *  • the seam SOURCE never reaches `getAttendanceSummary` / its `needsAttention[]` PII, and never
+ *    projects a student-identifying field — the one hard reuse trap (INS-22/23).
+ *
+ * Mocks `@/lib/db/rls` (mirrors census-enrolment-data.test.ts) so the server-only seam loads with no DB.
+ */
+vi.mock("@/lib/db/rls", () => ({ withSchool: vi.fn() }));
+
+const { foldAttendanceByLevel } = await import("./insights-data");
+
+const z = () => ({ present: 0, late: 0, excused: 0, medical: 0, absent: 0 });
+const clsRow = (
+  classId: string,
+  name: string,
+  counts: Partial<ReturnType<typeof z>>,
+): AttendanceClassRow => {
+  const c = { ...z(), ...counts };
+  const marked = c.present + c.late + c.excused + c.medical + c.absent;
+  return { classId, name, rate: null, marked, counts: c };
+};
+
+describe("foldAttendanceByLevel · lossless integer fold to year-group (INS-14)", () => {
+  const byClass: AttendanceClassRow[] = [
+    clsRow("c1", "JHS 1 A", { present: 80, late: 5, excused: 2, medical: 1, absent: 12 }),
+    clsRow("c2", "JHS 1 B", { present: 40, late: 5, excused: 0, medical: 3, absent: 12 }),
+    clsRow("c3", "JHS 2 A", { present: 90, late: 0, excused: 0, medical: 0, absent: 10 }),
+    clsRow("c4", "No-level room", { present: 10, late: 0, excused: 0, medical: 0, absent: 10 }),
+  ];
+  const levelByClassId = new Map([
+    ["c1", "JHS 1"],
+    ["c2", "JHS 1"],
+    ["c3", "JHS 2"],
+    // c4 intentionally absent → folds under "Unspecified"
+  ]);
+  const rows = foldAttendanceByLevel(byClass, levelByClassId);
+  const byLevel = Object.fromEntries(rows.map((r) => [r.level, r]));
+
+  it("sums the five P/L/E/M/A counts per level (Medical never merged into Absent)", () => {
+    const j1 = byLevel["JHS 1"];
+    expect(j1.counts).toEqual({ present: 120, late: 10, excused: 2, medical: 4, absent: 24 });
+    expect(j1.marked).toBe(160); // 100 + 60
+  });
+
+  it("recomputes rate = round((ΣP+ΣL)/Σmarked·100), NOT a mean of class rates", () => {
+    // JHS 1 fold: (120 + 10) / 160 = 81.25 → 81. A mean of the two class rates (85, 75) would give
+    // 80 — the fold's 81 proves it re-derives from summed counts, not by averaging rates.
+    expect(byLevel["JHS 1"].rate).toBe(81);
+    expect(byLevel["JHS 2"].rate).toBe(90); // 90/100
+    expect(byLevel["Unspecified"].rate).toBe(50); // 10/20 → an unmapped class folds honestly
+  });
+
+  it("a class with no matching level folds under 'Unspecified'", () => {
+    expect(byLevel["Unspecified"]).toBeTruthy();
+    expect(byLevel["Unspecified"].marked).toBe(20);
+  });
+
+  it("empty marks → rate null (never 0)", () => {
+    const [only] = foldAttendanceByLevel([clsRow("c9", "Empty", {})], new Map([["c9", "JHS 3"]]));
+    expect(only.rate).toBeNull();
+    expect(only.marked).toBe(0);
+  });
+
+  it("folded rows expose ONLY aggregate keys — no student name/id/code/DOB", () => {
+    for (const r of rows) {
+      expect(Object.keys(r).sort()).toEqual(["counts", "level", "marked", "rate"]);
+    }
+  });
+});
+
+/* ── INS-22/23: the seam source never touches student PII or getAttendanceSummary ── */
+
+const stripComments = (s: string): string =>
+  s.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+const seam = stripComments(readFileSync(resolve(cwd(), "lib/insights/insights-data.ts"), "utf8"));
+const page = stripComments(readFileSync(resolve(cwd(), "app/(app)/insights/page.tsx"), "utf8"));
+
+describe("Directors' Insights source · aggregate-only, no PII trap (INS-22/23)", () => {
+  it("the seam never imports/calls getAttendanceSummary or its needsAttention[] PII", () => {
+    expect(seam).not.toMatch(/getAttendanceSummary/);
+    expect(seam).not.toMatch(/needsAttention/);
+  });
+
+  it("neither the seam nor the page projects a student-identifying field", () => {
+    for (const [name, src] of [
+      ["seam", seam],
+      ["page", page],
+    ] as const) {
+      expect(src, name).not.toMatch(/getAttendanceSummary/);
+      expect(src, name).not.toMatch(/dateOfBirth/);
+      expect(src, name).not.toMatch(/studentCode/);
+      expect(src, name).not.toMatch(/\bstudentId\b/);
+    }
+  });
+});

--- a/omnischools/lib/insights/insights-data.ts
+++ b/omnischools/lib/insights/insights-data.ts
@@ -1,0 +1,110 @@
+import "server-only";
+import { getSchoolRollup, type AttendanceClassRow, type SchoolRollup } from "@/lib/rollup/school-rollup";
+import {
+  getClassPerformance,
+  getLevelPerformance,
+  compareLevelLabel,
+  UNSPECIFIED_LEVEL,
+  type ClassPerformance,
+  type LevelPerformance,
+} from "@/lib/reports/class-performance-data";
+import {
+  getSubjectPerformance,
+  type SubjectPerformance,
+} from "@/lib/reports/subject-performance-data";
+import { getCensusEnrolment, type CensusEnrolment } from "@/lib/reports/census-enrolment-data";
+
+/**
+ * INS · the Directors' Insights composition seam. Server-only, ZERO SQL beyond the readers it awaits
+ * (the one net-new query is `getLevelPerformance`); it re-serves the AGGREGATE projections that already
+ * ship behind `/board` and `/reports` plus the by-level attendance fold, and returns an
+ * AGGREGATE-ONLY bundle. This is the structural enforcement point for the owner-stated hard invariant
+ * (INS-23): the `DirectorsInsights` type contains NO student-identifying field (name / id / code /
+ * DOB) — every member is class / year-group (level) / subject / age-band keyed.
+ *
+ * TRAP (INS-22, the one hard reuse trap): this seam MUST NEVER call `getAttendanceSummary` — it returns
+ * `needsAttention[]` carrying `studentId` / student `name` / `studentCode` (PII). Attendance here comes
+ * from `rollup.attendance` (already PII-stripped by the rollup) and is folded by level below.
+ */
+
+/** One folded year-group attendance row — the lossless integer sum of its member classes (INS-14). */
+export type InsightsAttendanceLevelRow = {
+  level: string;
+  rate: number | null; // (ΣP+ΣL)/Σmarked, recomputed — NOT an average of class rates
+  marked: number;
+  counts: { present: number; late: number; excused: number; medical: number; absent: number };
+};
+
+export type DirectorsInsights = {
+  rollup: SchoolRollup;
+  classPerf: ClassPerformance;
+  subjectPerf: SubjectPerformance;
+  levelPerf: LevelPerformance;
+  census: CensusEnrolment;
+  /** Attendance folded by year-group; empty when the attendance arm is not CAPTURED. */
+  attendanceByLevel: InsightsAttendanceLevelRow[];
+};
+
+/**
+ * PURE lossless fold of the PII-stripped `AttendanceClassRow[]` to year-group grain (INS-14). Sums the
+ * five P/L/E/M/A counts + `marked` per level and RECOMPUTES `rate = round((ΣP+ΣL)/Σmarked·100)` — the
+ * board's own rate definition over the summed counts, never a mean of class rates. A class whose id is
+ * not in `levelByClassId` folds under `"Unspecified"` (honest). No DB → unit-tested directly.
+ */
+export function foldAttendanceByLevel(
+  byClass: readonly AttendanceClassRow[],
+  levelByClassId: ReadonlyMap<string, string>,
+): InsightsAttendanceLevelRow[] {
+  const acc = new Map<
+    string,
+    { marked: number; counts: InsightsAttendanceLevelRow["counts"] }
+  >();
+  for (const c of byClass) {
+    const level = levelByClassId.get(c.classId) ?? UNSPECIFIED_LEVEL;
+    const a =
+      acc.get(level) ??
+      { marked: 0, counts: { present: 0, late: 0, excused: 0, medical: 0, absent: 0 } };
+    a.marked += c.marked;
+    a.counts.present += c.counts.present;
+    a.counts.late += c.counts.late;
+    a.counts.excused += c.counts.excused;
+    a.counts.medical += c.counts.medical;
+    a.counts.absent += c.counts.absent;
+    acc.set(level, a);
+  }
+  return [...acc.entries()]
+    .map(([level, a]) => ({
+      level,
+      marked: a.marked,
+      counts: a.counts,
+      rate:
+        a.marked > 0 ? Math.round(((a.counts.present + a.counts.late) / a.marked) * 100) : null,
+    }))
+    .sort((x, y) => compareLevelLabel(x.level, y.level));
+}
+
+export async function getDirectorsInsights(
+  schoolId: string,
+  opts: { periodId?: string } = {},
+): Promise<DirectorsInsights> {
+  const [rollup, classPerf, subjectPerf, levelPerf, census] = await Promise.all([
+    getSchoolRollup(schoolId, { periodId: opts.periodId }),
+    getClassPerformance(schoolId, { periodId: opts.periodId }),
+    getSubjectPerformance(schoolId, { periodId: opts.periodId }),
+    getLevelPerformance(schoolId, { periodId: opts.periodId }),
+    // Enrolment / gender / age are a point-in-time census snapshot (ACTIVE-only, un-windowed) — they
+    // do NOT move with the term selector; the surface labels them as-of `census.censusDate`.
+    getCensusEnrolment(schoolId),
+  ]);
+
+  // classId → year-group level, from the census by-class rows (which carry `level`).
+  const levelByClassId = new Map<string, string>();
+  for (const c of census.byClass) levelByClassId.set(c.classId, c.level ?? UNSPECIFIED_LEVEL);
+
+  const attendanceByLevel =
+    rollup.attendance.status === "CAPTURED"
+      ? foldAttendanceByLevel(rollup.attendance.data.byClass, levelByClassId)
+      : [];
+
+  return { rollup, classPerf, subjectPerf, levelPerf, census, attendanceByLevel };
+}

--- a/omnischools/lib/reports/class-performance-data.ts
+++ b/omnischools/lib/reports/class-performance-data.ts
@@ -243,3 +243,185 @@ export async function getClassPerformance(
     };
   });
 }
+
+/* ─────────────────────── Performance BY YEAR-GROUP (level) — INS ─────────────────────── */
+
+/**
+ * The ONE net-new reader Directors' Insights needs (Kofi §2). Performance grouped by
+ * `classes.level` — the year-group ladder (JHS 1 / Form 2 / Primary 5). It CANNOT be composed from
+ * `getClassPerformance` honestly: `ClassPerfRow.average` is rounded to 1 dp and carries no score-row
+ * count, so a mean-of-class-means would fabricate a figure (wrong denominator + compounded rounding).
+ * So this is a REAL per-score `GROUP BY classes.level` — the SAME per-score basis as
+ * `scopedSchoolAggregate`: AVG(total) over non-null totals, pass rate via `passRateOf`, distinct
+ * students graded — never a mean of rounded class averages (INS-12). Classes with `level IS NULL`
+ * bucket under `"Unspecified"` (mirrors census UNSPECIFIED). A level with active classes but no graded
+ * scores renders `null` (never 0) — INS-30.
+ */
+export const UNSPECIFIED_LEVEL = "Unspecified";
+
+export type LevelPerfRow = {
+  level: string;
+  average: number | null; // 1 dp; null when nothing graded in the level (never 0)
+  grade: string | null;
+  tone: PerfTone;
+  passRate: number | null; // per-score % ≥ PASS_MARK; null when nothing graded
+  studentsGraded: number;
+  classesGraded: number;
+  classes: number; // active classes in the level (denominator)
+  priorAverage: number | null;
+  delta: number | null;
+};
+
+export type LevelPerformance = {
+  terms: AcademicTerm[];
+  term: AcademicTerm | null;
+  priorTerm: AcademicTerm | null;
+  rows: LevelPerfRow[];
+  hasAnyScores: boolean;
+};
+
+/** SQL-shaped per-level aggregate (one row per distinct `classes.level`, incl. a `level: null` row). */
+export type LevelAgg = {
+  level: string | null;
+  avg: number | null;
+  passed: number;
+  graded: number;
+  students: number;
+  classesGraded: number;
+};
+/** SQL-shaped active-class count per level (the "N classes" denominator; incl. a `level: null` row). */
+export type LevelClassCount = { level: string | null; classes: number };
+
+const levelKey = (l: string | null): string => l ?? UNSPECIFIED_LEVEL;
+
+/** Ladder rank: JHS1<JHS2<JHS3 by the first integer in the label; `Unspecified` last. */
+export function compareLevelLabel(a: string, b: string): number {
+  const rank = (lvl: string) => {
+    if (lvl === UNSPECIFIED_LEVEL) return Number.POSITIVE_INFINITY;
+    const n = lvl.match(/\d+/);
+    return n ? parseInt(n[0], 10) : Number.MAX_SAFE_INTEGER - 1;
+  };
+  return rank(a) - rank(b) || a.localeCompare(b);
+}
+
+/**
+ * The PURE assembly of the per-level rows from the SQL aggregates — no DB, so it is unit-tested
+ * directly (the per-score AVG honesty lives in the `GROUP BY` SQL below; this proves the null→
+ * "Unspecified" bucketing, the null-not-zero average, pass-rate/grade/tone/delta and the ladder sort).
+ * Rows come from the set of levels that have ANY active class (a level with classes but no scores still
+ * shows, as `—`); a graded level with no active-class-count row (shouldn't happen) is unioned in defensively.
+ */
+export function assembleLevelPerformance(
+  cur: readonly LevelAgg[],
+  prior: readonly LevelAgg[],
+  classCounts: readonly LevelClassCount[],
+  bands: GradeBand[],
+): LevelPerfRow[] {
+  const curMap = new Map(cur.map((a) => [levelKey(a.level), a]));
+  const priorMap = new Map(prior.map((a) => [levelKey(a.level), a]));
+  const countMap = new Map(classCounts.map((c) => [levelKey(c.level), c.classes]));
+
+  const levels = new Set<string>([...countMap.keys(), ...curMap.keys()]);
+  const rows: LevelPerfRow[] = [...levels].map((level) => {
+    const a = curMap.get(level);
+    const p = priorMap.get(level);
+    const average = a && a.avg != null && a.graded > 0 ? round1(a.avg) : null;
+    const priorAverage = p && p.avg != null && p.graded > 0 ? round1(p.avg) : null;
+    return {
+      level,
+      average,
+      grade: average != null ? gradeForScore(bands, average) : null,
+      tone: performanceTone(average),
+      passRate: a ? passRateOf(a.passed, a.graded) : null,
+      studentsGraded: a?.students ?? 0,
+      classesGraded: a?.classesGraded ?? 0,
+      classes: countMap.get(level) ?? 0,
+      priorAverage,
+      delta: average != null && priorAverage != null ? round1(average - priorAverage) : null,
+    };
+  });
+  rows.sort((x, y) => compareLevelLabel(x.level, y.level));
+  return rows;
+}
+
+/** Per-level per-score aggregate for one period, over ACTIVE classes only (matches getClassPerformance scope). */
+async function levelAggregates(
+  tx: Tx,
+  schoolId: string,
+  periodId: string,
+): Promise<LevelAgg[]> {
+  const rows = await tx
+    .select({
+      level: classes.level,
+      avg: sql<string | null>`avg(${gradebookScores.total})`,
+      passed: sql<number>`count(*) filter (where ${gradebookScores.total} >= ${PASS_MARK})::int`,
+      graded: sql<number>`count(*) filter (where ${gradebookScores.total} is not null)::int`,
+      students: sql<number>`count(distinct ${gradebookScores.studentId}) filter (where ${gradebookScores.total} is not null)::int`,
+      classesGraded: sql<number>`count(distinct ${students.classId}) filter (where ${gradebookScores.total} is not null)::int`,
+    })
+    .from(gradebookScores)
+    .innerJoin(
+      students,
+      and(
+        eq(gradebookScores.studentId, students.id),
+        eq(gradebookScores.schoolId, students.schoolId),
+      ),
+    )
+    .innerJoin(
+      classes,
+      and(eq(students.classId, classes.id), eq(students.schoolId, classes.schoolId)),
+    )
+    .where(
+      and(
+        eq(gradebookScores.schoolId, schoolId),
+        eq(gradebookScores.periodId, periodId),
+        eq(classes.active, true),
+      ),
+    )
+    .groupBy(classes.level);
+  return rows.map((r) => ({
+    level: r.level,
+    avg: r.avg != null ? Number(r.avg) : null,
+    passed: r.passed,
+    graded: r.graded,
+    students: r.students,
+    classesGraded: r.classesGraded,
+  }));
+}
+
+export async function getLevelPerformance(
+  schoolId: string,
+  opts: { periodId?: string } = {},
+): Promise<LevelPerformance> {
+  const terms = await listAcademicTerms(schoolId);
+  const term = resolveSelectedTerm(terms, opts.periodId);
+  const prior = term ? previousTerm(terms, term) : null;
+
+  const empty: LevelPerformance = { terms, term, priorTerm: prior, rows: [], hasAnyScores: false };
+  if (!term) return empty;
+
+  return withSchool(schoolId, async (tx) => {
+    const bands: GradeBand[] = (
+      await tx
+        .select({ grade: gradeScale.grade, label: gradeScale.label, minScore: gradeScale.minScore })
+        .from(gradeScale)
+        .where(eq(gradeScale.schoolId, schoolId))
+    ).map((b) => ({ grade: b.grade, label: b.label, minScore: Number(b.minScore) }));
+
+    const classCounts: LevelClassCount[] = (
+      await tx
+        .select({ level: classes.level, classes: sql<number>`count(*)::int` })
+        .from(classes)
+        .where(and(eq(classes.schoolId, schoolId), eq(classes.active, true)))
+        .groupBy(classes.level)
+    ).map((r) => ({ level: r.level, classes: r.classes }));
+
+    const [cur, priorAgg] = await Promise.all([
+      levelAggregates(tx, schoolId, term.periodId),
+      prior ? levelAggregates(tx, schoolId, prior.periodId) : Promise.resolve([] as LevelAgg[]),
+    ]);
+
+    const rows = assembleLevelPerformance(cur, priorAgg, classCounts, bands);
+    return { terms, term, priorTerm: prior, rows, hasAnyScores: rows.some((r) => r.average != null) };
+  });
+}

--- a/omnischools/lib/reports/level-performance.test.ts
+++ b/omnischools/lib/reports/level-performance.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import type { GradeBand } from "@/lib/gradebook/grade-scale";
+
+/**
+ * INS-12 / INS-30 · the performance-BY-YEAR-GROUP assembler. The per-score `AVG(total)` honesty lives
+ * in the `GROUP BY classes.level` SQL of `getLevelPerformance`; this proves the PURE assembly over that
+ * SQL aggregate: `classes.level IS NULL` → an `"Unspecified"` bucket, a level with active classes but no
+ * graded scores renders a NULL average (never 0), pass-rate/grade/tone/delta, and the year-group ladder
+ * sort. Mocks `@/lib/db/rls` (mirrors census-enrolment-data.test.ts) so the reader module loads with no DB.
+ */
+vi.mock("@/lib/db/rls", () => ({ withSchool: vi.fn() }));
+
+const { assembleLevelPerformance, compareLevelLabel, UNSPECIFIED_LEVEL } = await import(
+  "./class-performance-data"
+);
+
+const bands: GradeBand[] = [
+  { grade: "A", label: null, minScore: 80 },
+  { grade: "B", label: null, minScore: 70 },
+  { grade: "C", label: null, minScore: 50 },
+  { grade: "F", label: null, minScore: 0 },
+];
+
+describe("assembleLevelPerformance · GROUP BY level → aggregate rows", () => {
+  // JHS 3 has active classes but NO graded scores (absent from `cur`) → null average, never 0.
+  const classCounts = [
+    { level: "JHS 1", classes: 2 },
+    { level: "JHS 2", classes: 1 },
+    { level: "JHS 3", classes: 1 },
+    { level: null, classes: 1 }, // a null-level active class → the "Unspecified" bucket
+  ];
+  const cur = [
+    { level: "JHS 1", avg: 55.04, passed: 6, graded: 12, students: 6, classesGraded: 2 },
+    { level: "JHS 2", avg: 72.4, passed: 8, graded: 10, students: 5, classesGraded: 1 },
+    { level: null, avg: 40.0, passed: 1, graded: 4, students: 2, classesGraded: 1 },
+  ];
+  const prior = [{ level: "JHS 1", avg: 50.0, passed: 4, graded: 12, students: 6, classesGraded: 2 }];
+
+  const rows = assembleLevelPerformance(cur, prior, classCounts, bands);
+  const byLevel = Object.fromEntries(rows.map((r) => [r.level, r]));
+
+  it("emits one row per level in the ladder, Unspecified last", () => {
+    expect(rows.map((r) => r.level)).toEqual(["JHS 1", "JHS 2", "JHS 3", UNSPECIFIED_LEVEL]);
+  });
+
+  it("null classes.level buckets under 'Unspecified' with its own aggregate", () => {
+    const u = byLevel[UNSPECIFIED_LEVEL];
+    expect(u.average).toBe(40);
+    expect(u.passRate).toBe(25); // 1/4
+    expect(u.grade).toBe("F");
+    expect(u.classes).toBe(1);
+  });
+
+  it("a level with active classes but no graded scores is NULL, never 0 (INS-30)", () => {
+    const j3 = byLevel["JHS 3"];
+    expect(j3.average).toBeNull();
+    expect(j3.passRate).toBeNull();
+    expect(j3.grade).toBeNull();
+    expect(j3.tone).toBe("none");
+    expect(j3.studentsGraded).toBe(0);
+    expect(j3.classesGraded).toBe(0);
+    expect(j3.classes).toBe(1);
+  });
+
+  it("per-score average is rounded to 1dp; pass rate + grade + delta come from the aggregate", () => {
+    const j1 = byLevel["JHS 1"];
+    expect(j1.average).toBe(55); // round1(55.04)
+    expect(j1.passRate).toBe(50); // 6/12
+    expect(j1.grade).toBe("C");
+    expect(j1.tone).toBe("gold");
+    expect(j1.classesGraded).toBe(2);
+    expect(j1.classes).toBe(2);
+    expect(j1.delta).toBe(5); // 55 − 50 (prior)
+
+    const j2 = byLevel["JHS 2"];
+    expect(j2.average).toBe(72.4);
+    expect(j2.grade).toBe("B");
+    expect(j2.passRate).toBe(80); // 8/10
+    expect(j2.delta).toBeNull(); // no prior term for JHS 2
+  });
+});
+
+describe("compareLevelLabel · year-group ladder", () => {
+  it("orders by the numeric year within the tier, Unspecified last", () => {
+    const sorted = ["JHS 3", UNSPECIFIED_LEVEL, "JHS 1", "JHS 2"].sort(compareLevelLabel);
+    expect(sorted).toEqual(["JHS 1", "JHS 2", "JHS 3", UNSPECIFIED_LEVEL]);
+    expect(compareLevelLabel("Form 1", "Form 2")).toBeLessThan(0);
+    expect(compareLevelLabel("Form 2", UNSPECIFIED_LEVEL)).toBeLessThan(0);
+  });
+});


### PR DESCRIPTION
## Directors' Insights (`/insights`)

A new director/management analytics surface — the aggregate, PII-stripped read on the whole school for ADMIN / HEADMASTER / PROPRIETOR. Composes the readers the board dashboard already uses plus **one** new honest by-level aggregate. **No schema, no RLS, no prod-paste** — reads existing tenant tables only.

### What it does
- **KPI strip + "Needs your attention"** — aggregate signals only (outstanding fees, ungraded classes, attendance-not-captured, facilities gaps, senior-readiness), never a per-student list.
- **In-page drill-ins** (no page reload; server pre-renders each dimension, client only toggles):
  - **Performance** — by **class · year-group · subject**.
  - **Attendance** — by class · year-group, all 5 statuses kept distinct (Medical never folded away).
  - **Enrolment** — by class · year-group + **gender split** + **age distribution** (with an honest "no DOB recorded" bucket, never coerced to an age).
- **Finance** — three separate un-summed streams (no fabricated "net position").
- Every metric shows its real value or its `NOT_CAPTURED` / `NOT_APPLICABLE` reason. Term-filterable; enrolment/gender/age are point-in-time.

### Aggregate-only (owner requirement)
No student name / id / code / DOB anywhere on the page or any drill-in — enforced structurally: the `getDirectorsInsights` return type carries no student-identifying field, and the PII-bearing `getAttendanceSummary` is banned from the path (attendance uses the stripped `rollup.attendance`, folded to year-group by lossless integer sum).

### The one new reader
`getLevelPerformance` — a real per-score `GROUP BY classes.level` aggregate (not a dishonest mean-of-class-means; right denominator, no compounded rounding). Scoreless level → `—`, never a fake 0. `withSchool`-scoped like its siblings.

### Gate verdicts (all green)
- **Quinn (QA):** GREEN — 2059 tests pass, tsc + build clean. Proved the honest by-level aggregate + the lossless attendance fold by mutation. Added a mutation-verified regression-lock on the role gate (a silent widening now reds a test — `ed62d57`).
- **Dex (architecture):** APPROVE — clean composition seam, behaviour-preserving shared-primitive lift (board renders identically), no new platform lock-in.
- **Sarah (security):** CLEAN — gate is a distinct group (not a widened sibling) and blocks every non-director principal; reader is tenant-scoped + injection-safe; no PII reaches the browser.

### Deferred to a follow-up (documented in the specs)
- "Export board pack" button (needs its own role-gated PDF route).
- "Census not filed" nudge (no cheap filed/unfiled signal yet).
- By-level age sub-toggle (kept the client footprint to the single `<DrillIn>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
