### PR TITLE
feat(insights): board-pack PDF export + GES census-not-filed nudge (grace)

### DIFF
--- a/omnischools/app/(app)/insights/page.tsx
+++ b/omnischools/app/(app)/insights/page.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import Link from "next/link";
 import { requireSchoolRole } from "@/lib/auth/server";
 import { INSIGHTS_READ_ROLES } from "@/lib/access";
-import { getDirectorsInsights, type DirectorsInsights } from "@/lib/insights/insights-data";
+import { getDirectorsInsights, censusNudge, type DirectorsInsights } from "@/lib/insights/insights-data";
 import type {
   AttendanceArm,
   EnrolmentArm,
@@ -79,6 +79,16 @@ export default async function InsightsPage({
           </h1>
           <p className="mt-1 text-[13px] text-navy-2">{termLabel} · consolidated director dashboard</p>
         </div>
+        {/* Board-pack PDF (§17-F) — the SAME aggregate governance pack the board gets (GOV-5), re-gated for
+            directors. Streams the on-screen term; lives at /api so the download convention holds. */}
+        <a
+          href={`/api/insights/board-pack${rollup.period?.periodId ? `?periodId=${rollup.period.periodId}` : ""}`}
+          target="_blank"
+          rel="noopener"
+          className="rounded-md border border-border-2 bg-surface px-3 py-1.5 text-xs font-semibold text-navy hover:bg-bg print:hidden"
+        >
+          Board pack (PDF)
+        </a>
       </div>
 
       {/* ── Period selector (verbatim board) ── */}
@@ -225,8 +235,7 @@ const DOT: Record<ActionSeverity, string> = {
 /**
  * The conditional action rows — each rendered ONLY when its condition is genuinely true (omit-not-fake:
  * an absent problem is absent, never a green "all good" row). Every row is a school-wide count/amount or
- * a subject count — NEVER a per-student list. Deferred for v1 (no cheap signal / needs its own gated
- * route): the "Census not filed" row (§17-D) and the "Export board pack" button (§17-F).
+ * a subject count — NEVER a per-student list.
  */
 function buildAttention(d: DirectorsInsights, termLabel: string): ActionItem[] {
   const items: ActionItem[] = [];
@@ -287,6 +296,19 @@ function buildAttention(d: DirectorsInsights, termLabel: string): ActionItem[] {
       dot: "terra",
       label: "Senior readiness at risk",
       value: `${sen.data.subjectsAtRisk} subject${sen.data.subjectsAtRisk === 1 ? "" : "s"} at risk for STPSHS · ${sen.data.subjectsPartial} partial`,
+    });
+  }
+
+  // GES annual census — DRAFT (warn) or not-started (navy-2), only once the resolved year is underway
+  // and not yet filed (§17-D, Kofi's ruling). Suppressed when no academic year is configured.
+  const nudge = censusNudge(d.censusFiling, rollup.terms, new Date().toISOString().slice(0, 10));
+  if (nudge) {
+    items.push({
+      key: "census",
+      href: "/reports/statutory/generate-annual-census",
+      dot: nudge.dot,
+      label: "GES annual census",
+      value: nudge.value,
     });
   }
 

--- a/omnischools/app/(app)/insights/page.tsx
+++ b/omnischools/app/(app)/insights/page.tsx
@@ -299,8 +299,8 @@ function buildAttention(d: DirectorsInsights, termLabel: string): ActionItem[] {
     });
   }
 
-  // GES annual census — DRAFT (warn) or not-started (navy-2), only once the resolved year is underway
-  // and not yet filed (§17-D, Kofi's ruling). Suppressed when no academic year is configured.
+  // GES annual census — DRAFT (warn) or not-started (navy-2), not yet filed (§17-D, Kofi's ruling).
+  // NONE holds through an early-year grace window; DRAFT is exempt. Suppressed when no year is configured.
   const nudge = censusNudge(d.censusFiling, rollup.terms, new Date().toISOString().slice(0, 10));
   if (nudge) {
     items.push({

--- a/omnischools/app/api/insights/board-pack/route.ts
+++ b/omnischools/app/api/insights/board-pack/route.ts
@@ -1,0 +1,73 @@
+import { requireSchoolRole } from "@/lib/auth/server";
+import { INSIGHTS_READ_ROLES } from "@/lib/access";
+import { getSchoolRollup } from "@/lib/rollup/school-rollup";
+import { renderBoardPackPdf } from "@/lib/pdf/render-board-pack";
+import type { BoardPackData } from "@/lib/pdf/board-pack-document";
+
+// @react-pdf/renderer is Node-only (fontkit); never run this on the edge.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/insights/board-pack — the DIRECTORS' downloadable governance-overview PDF (INS §17-F follow-up).
+ *
+ * The SAME aggregate board pack the board sees (GOV-5), re-gated for the director tier: `INSIGHTS_READ_ROLES`
+ * (ADMIN/HEADMASTER/PROPRIETOR), the same gate as the `/insights` page. It lives under `app/api/*` — the
+ * repo's authenticated-download convention (receipts / report-cards / sen census-export) — NOT under the
+ * page tree (which `no-html-link-for-pages` would flag); and unlike `requireBoard()`, `requireSchoolRole`
+ * carries no `/board*` x-pathname confinement, so `/api` is the correct home (a director hitting `/board/*`
+ * would be bounced). School id is SESSION-derived (never a URL id — R339); `?periodId` only picks the term.
+ * Content is the PII-stripped rollup arms directors already see on `/insights` — no new exposure. Clone of
+ * the `/board/board-pack` route (same data, same document), differing only in the gate + location.
+ */
+export async function GET(req: Request) {
+  const { school } = await requireSchoolRole(INSIGHTS_READ_ROLES);
+  const periodId = new URL(req.url).searchParams.get("periodId") ?? undefined;
+
+  const rollup = await getSchoolRollup(school.id, { periodId });
+
+  const termLabel = rollup.period
+    ? `${rollup.period.label} · ${rollup.period.academicYear}`
+    : "No academic period configured";
+
+  const data: BoardPackData = {
+    rollup,
+    meta: {
+      schoolName: school.name,
+      schoolInitials: initialsOf(school.name),
+      termLabel,
+      generatedAtLabel: fmtDateTime(rollup.generatedAt),
+    },
+  };
+
+  const pdf = await renderBoardPackPdf(data);
+  const term = termLabel.replace(/[^A-Za-z0-9]+/g, "-").replace(/^-|-$/g, "");
+  return new Response(new Uint8Array(pdf), {
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": `inline; filename="Board-pack-${term}.pdf"`,
+      "Cache-Control": "private, no-store",
+    },
+  });
+}
+
+// 2-letter school-crest initials (matches the shipped PDF loaders' one-liner: "Aggrey Memorial" → "AM").
+const initialsOf = (name: string) =>
+  name
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? "")
+    .join("") || "S";
+
+// Documents take pre-formatted dates (house style) — format in the route, in the school tz/locale.
+const fmtDateTime = (d: Date) =>
+  d
+    .toLocaleString("en-GB", {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    })
+    .replace(",", " ·");

--- a/omnischools/lib/insights/insights-data.test.ts
+++ b/omnischools/lib/insights/insights-data.test.ts
@@ -18,7 +18,7 @@ import type { AttendanceClassRow } from "@/lib/rollup/school-rollup";
  */
 vi.mock("@/lib/db/rls", () => ({ withSchool: vi.fn() }));
 
-const { foldAttendanceByLevel } = await import("./insights-data");
+const { foldAttendanceByLevel, censusNudge } = await import("./insights-data");
 
 const z = () => ({ present: 0, late: 0, excused: 0, medical: 0, absent: 0 });
 const clsRow = (
@@ -76,6 +76,54 @@ describe("foldAttendanceByLevel · lossless integer fold to year-group (INS-14)"
     for (const r of rows) {
       expect(Object.keys(r).sort()).toEqual(["counts", "level", "marked", "rate"]);
     }
+  });
+});
+
+/* ── §17-D: the "GES annual census" attention row (Kofi's ruling) ── */
+
+describe("censusNudge · GES annual census attention row (§17-D)", () => {
+  const TODAY = "2026-01-15";
+  // A year that is underway: Term 1 of 2025/26 started before TODAY.
+  const started = [
+    { academicYear: "2025/26", startsOn: "2025-09-01" },
+    { academicYear: "2025/26", startsOn: "2026-01-06" },
+  ];
+
+  it("COMPLETED → no row (omit-not-fake; never a 'filed' row) [AC-1]", () => {
+    expect(censusNudge({ academicYear: "2025/26", status: "COMPLETED" }, started, TODAY)).toBeNull();
+  });
+
+  it("NONE + year underway → navy-2 'not started' row [AC-2]", () => {
+    const n = censusNudge({ academicYear: "2025/26", status: "NONE" }, started, TODAY);
+    expect(n).toEqual({
+      dot: "navy-2",
+      value: "Not started for 2025/26 — this year's return is not yet filed.",
+    });
+  });
+
+  it("DRAFT + year underway → warn 'complete it' row [AC-3]", () => {
+    const n = censusNudge({ academicYear: "2025/26", status: "DRAFT" }, started, TODAY);
+    expect(n).toEqual({
+      dot: "warn",
+      value: "Draft saved for 2025/26 — review and complete it to file the return.",
+    });
+  });
+
+  it("not-started year (all its terms start after today) → no premature row [AC-5]", () => {
+    const future = [{ academicYear: "2026/27", startsOn: "2026-09-01" }];
+    expect(censusNudge({ academicYear: "2026/27", status: "NONE" }, future, TODAY)).toBeNull();
+    // …even a DRAFT waits until the year is underway.
+    expect(censusNudge({ academicYear: "2026/27", status: "DRAFT" }, future, TODAY)).toBeNull();
+  });
+
+  it("no filing state (no academic year configured) → no row [AC-6]", () => {
+    expect(censusNudge(null, started, TODAY)).toBeNull();
+  });
+
+  it("keys only on ANNUAL status + year — the value carries no PII, only the year string [AC-8]", () => {
+    const n = censusNudge({ academicYear: "2025/26", status: "NONE" }, started, TODAY);
+    expect(n?.value).toContain("2025/26");
+    expect(n?.value).not.toMatch(/\d{4}-\d{2}-\d{2}/); // no raw dates/DOB leaked
   });
 });
 

--- a/omnischools/lib/insights/insights-data.test.ts
+++ b/omnischools/lib/insights/insights-data.test.ts
@@ -82,27 +82,27 @@ describe("foldAttendanceByLevel · lossless integer fold to year-group (INS-14)"
 /* ── §17-D: the "GES annual census" attention row (Kofi's ruling) ── */
 
 describe("censusNudge · GES annual census attention row (§17-D)", () => {
-  const TODAY = "2026-01-15";
-  // A year that is underway: Term 1 of 2025/26 started before TODAY.
+  // 2025/26 opens 2025-09-01; with a 42-day grace the NONE nudge starts on 2025-10-13.
   const started = [
     { academicYear: "2025/26", startsOn: "2025-09-01" },
     { academicYear: "2025/26", startsOn: "2026-01-06" },
   ];
+  const WELL_AFTER = "2026-01-15"; // long past the grace window
 
   it("COMPLETED → no row (omit-not-fake; never a 'filed' row) [AC-1]", () => {
-    expect(censusNudge({ academicYear: "2025/26", status: "COMPLETED" }, started, TODAY)).toBeNull();
+    expect(censusNudge({ academicYear: "2025/26", status: "COMPLETED" }, started, WELL_AFTER)).toBeNull();
   });
 
-  it("NONE + year underway → navy-2 'not started' row [AC-2]", () => {
-    const n = censusNudge({ academicYear: "2025/26", status: "NONE" }, started, TODAY);
+  it("NONE past the grace window → navy-2 'not started' row [AC-2]", () => {
+    const n = censusNudge({ academicYear: "2025/26", status: "NONE" }, started, WELL_AFTER);
     expect(n).toEqual({
       dot: "navy-2",
       value: "Not started for 2025/26 — this year's return is not yet filed.",
     });
   });
 
-  it("DRAFT + year underway → warn 'complete it' row [AC-3]", () => {
-    const n = censusNudge({ academicYear: "2025/26", status: "DRAFT" }, started, TODAY);
+  it("DRAFT once the year is underway → warn 'complete it' row [AC-3]", () => {
+    const n = censusNudge({ academicYear: "2025/26", status: "DRAFT" }, started, WELL_AFTER);
     expect(n).toEqual({
       dot: "warn",
       value: "Draft saved for 2025/26 — review and complete it to file the return.",
@@ -111,19 +111,34 @@ describe("censusNudge · GES annual census attention row (§17-D)", () => {
 
   it("not-started year (all its terms start after today) → no premature row [AC-5]", () => {
     const future = [{ academicYear: "2026/27", startsOn: "2026-09-01" }];
-    expect(censusNudge({ academicYear: "2026/27", status: "NONE" }, future, TODAY)).toBeNull();
+    expect(censusNudge({ academicYear: "2026/27", status: "NONE" }, future, WELL_AFTER)).toBeNull();
     // …even a DRAFT waits until the year is underway.
-    expect(censusNudge({ academicYear: "2026/27", status: "DRAFT" }, future, TODAY)).toBeNull();
+    expect(censusNudge({ academicYear: "2026/27", status: "DRAFT" }, future, WELL_AFTER)).toBeNull();
   });
 
   it("no filing state (no academic year configured) → no row [AC-6]", () => {
-    expect(censusNudge(null, started, TODAY)).toBeNull();
+    expect(censusNudge(null, started, WELL_AFTER)).toBeNull();
   });
 
   it("keys only on ANNUAL status + year — the value carries no PII, only the year string [AC-8]", () => {
-    const n = censusNudge({ academicYear: "2025/26", status: "NONE" }, started, TODAY);
+    const n = censusNudge({ academicYear: "2025/26", status: "NONE" }, started, WELL_AFTER);
     expect(n?.value).toContain("2025/26");
     expect(n?.value).not.toMatch(/\d{4}-\d{2}-\d{2}/); // no raw dates/DOB leaked
+  });
+
+  // ── the early-year grace window (OC-CENSUS-NUDGE-WINDOW: 6 weeks / 42 days from opening) ──
+  it("NONE inside the grace window (day 41) → silent — a new year isn't yet late [grace]", () => {
+    expect(censusNudge({ academicYear: "2025/26", status: "NONE" }, started, "2025-10-12")).toBeNull();
+  });
+
+  it("NONE on the day the grace elapses (day 42, 2025-10-13) → navy-2 fires [grace boundary]", () => {
+    const n = censusNudge({ academicYear: "2025/26", status: "NONE" }, started, "2025-10-13");
+    expect(n?.dot).toBe("navy-2");
+  });
+
+  it("DRAFT is grace-EXEMPT — fires from the moment the year is underway, inside the window [grace]", () => {
+    const n = censusNudge({ academicYear: "2025/26", status: "DRAFT" }, started, "2025-09-15");
+    expect(n?.dot).toBe("warn");
   });
 });
 

--- a/omnischools/lib/insights/insights-data.ts
+++ b/omnischools/lib/insights/insights-data.ts
@@ -93,14 +93,29 @@ export function foldAttendanceByLevel(
 export type CensusNudge = { dot: "warn" | "navy-2"; value: string };
 
 /**
+ * Days after a school year opens before the "not started" (NONE) census nudge appears. Ghana's annual
+ * GES/EMIS return is typically due a few weeks after schools reopen, so a school in the first weeks of a
+ * new year is not yet late — we hold the nudge through this grace window rather than nag from day one
+ * (OC-CENSUS-NUDGE-WINDOW, owner-chosen: grace, ~6 weeks). We do NOT model a hardcoded GES date; the
+ * window is a tunable offset from the year's own opening (the first term's `startsOn`), so it survives
+ * calendar changes. A started-but-unsubmitted DRAFT is EXEMPT — "finish what you started" is fair the
+ * moment the year is underway.
+ */
+export const CENSUS_NUDGE_GRACE_DAYS = 42;
+
+/** Add whole days to an ISO "YYYY-MM-DD" date, returning ISO (UTC math; Ghana is GMT so this is the local day). */
+const addDaysIso = (iso: string, days: number): string =>
+  new Date(new Date(`${iso}T00:00:00Z`).getTime() + days * 86_400_000).toISOString().slice(0, 10);
+
+/**
  * PURE decision for the "GES annual census" attention row (§17-D, Kofi's ruling). Returns the row's
  * severity + copy, or `null` when no nudge is due:
  *   • COMPLETED (filed) or no filing state (no academic year) → null (omit-not-fake; never a "filed" row).
- *   • the resolved academic year hasn't started yet (no term with `startsOn <= today`) → null — a
+ *   • the resolved academic year hasn't opened yet (its earliest term's `startsOn > today`) → null — a
  *     pre-configured future year is not yet outstanding (AC-5), so we don't nag prematurely.
- * Otherwise: DRAFT → warn ("finish it", window-immune); NONE → navy-2 (gentlest, the only early-year case).
- * No modelled GES deadline — severity, not suppression, carries the early-year nuance. `today` is
- * "YYYY-MM-DD" (compared lexically against the ISO `startsOn`, matching resolveSelectedTerm).
+ *   • NONE still within the early-year grace window (`< opening + CENSUS_NUDGE_GRACE_DAYS`) → null.
+ * Otherwise: DRAFT → warn ("finish it", grace-EXEMPT); NONE past the window → navy-2 (gentlest).
+ * `today` is "YYYY-MM-DD" (compared lexically against the ISO `startsOn`, matching resolveSelectedTerm).
  */
 export function censusNudge(
   filing: { academicYear: string; status: CensusFilingStatus } | null,
@@ -108,17 +123,25 @@ export function censusNudge(
   today: string,
 ): CensusNudge | null {
   if (!filing || filing.status === "COMPLETED") return null;
-  const underway = terms.some((t) => t.academicYear === filing.academicYear && t.startsOn <= today);
-  if (!underway) return null;
-  return filing.status === "DRAFT"
-    ? {
-        dot: "warn",
-        value: `Draft saved for ${filing.academicYear} — review and complete it to file the return.`,
-      }
-    : {
-        dot: "navy-2",
-        value: `Not started for ${filing.academicYear} — this year's return is not yet filed.`,
-      };
+  // The year's opening = the earliest term start of that academic year (ISO date strings sort by date).
+  const opening = terms
+    .filter((t) => t.academicYear === filing.academicYear)
+    .map((t) => t.startsOn)
+    .sort()[0];
+  if (!opening || opening > today) return null; // year hasn't opened → not yet outstanding (AC-5)
+  if (filing.status === "DRAFT") {
+    // Grace-exempt: a saved draft should be finished regardless of the early-year window.
+    return {
+      dot: "warn",
+      value: `Draft saved for ${filing.academicYear} — review and complete it to file the return.`,
+    };
+  }
+  // NONE: hold through the honest early-year filing window, then surface it gently.
+  if (today < addDaysIso(opening, CENSUS_NUDGE_GRACE_DAYS)) return null;
+  return {
+    dot: "navy-2",
+    value: `Not started for ${filing.academicYear} — this year's return is not yet filed.`,
+  };
 }
 
 export async function getDirectorsInsights(

--- a/omnischools/lib/insights/insights-data.ts
+++ b/omnischools/lib/insights/insights-data.ts
@@ -13,6 +13,7 @@ import {
   type SubjectPerformance,
 } from "@/lib/reports/subject-performance-data";
 import { getCensusEnrolment, type CensusEnrolment } from "@/lib/reports/census-enrolment-data";
+import { getAnnualCensusStatus, type CensusFilingStatus } from "@/lib/reports/census/filing-status";
 
 /**
  * INS · the Directors' Insights composition seam. Server-only, ZERO SQL beyond the readers it awaits
@@ -43,6 +44,11 @@ export type DirectorsInsights = {
   census: CensusEnrolment;
   /** Attendance folded by year-group; empty when the attendance arm is not CAPTURED. */
   attendanceByLevel: InsightsAttendanceLevelRow[];
+  /**
+   * This year's ANNUAL GES census filing state (INS §17-D nudge). `null` when no academic year is
+   * configured (the nudge can't name a year, so it's suppressed rather than fabricated).
+   */
+  censusFiling: { academicYear: string; status: CensusFilingStatus } | null;
 };
 
 /**
@@ -83,6 +89,38 @@ export function foldAttendanceByLevel(
     .sort((x, y) => compareLevelLabel(x.level, y.level));
 }
 
+/** The §17-D census attention row's severity + copy (Kofi's ruling); `dot` is a subset of the panel's. */
+export type CensusNudge = { dot: "warn" | "navy-2"; value: string };
+
+/**
+ * PURE decision for the "GES annual census" attention row (§17-D, Kofi's ruling). Returns the row's
+ * severity + copy, or `null` when no nudge is due:
+ *   • COMPLETED (filed) or no filing state (no academic year) → null (omit-not-fake; never a "filed" row).
+ *   • the resolved academic year hasn't started yet (no term with `startsOn <= today`) → null — a
+ *     pre-configured future year is not yet outstanding (AC-5), so we don't nag prematurely.
+ * Otherwise: DRAFT → warn ("finish it", window-immune); NONE → navy-2 (gentlest, the only early-year case).
+ * No modelled GES deadline — severity, not suppression, carries the early-year nuance. `today` is
+ * "YYYY-MM-DD" (compared lexically against the ISO `startsOn`, matching resolveSelectedTerm).
+ */
+export function censusNudge(
+  filing: { academicYear: string; status: CensusFilingStatus } | null,
+  terms: readonly { academicYear: string; startsOn: string }[],
+  today: string,
+): CensusNudge | null {
+  if (!filing || filing.status === "COMPLETED") return null;
+  const underway = terms.some((t) => t.academicYear === filing.academicYear && t.startsOn <= today);
+  if (!underway) return null;
+  return filing.status === "DRAFT"
+    ? {
+        dot: "warn",
+        value: `Draft saved for ${filing.academicYear} — review and complete it to file the return.`,
+      }
+    : {
+        dot: "navy-2",
+        value: `Not started for ${filing.academicYear} — this year's return is not yet filed.`,
+      };
+}
+
 export async function getDirectorsInsights(
   schoolId: string,
   opts: { periodId?: string } = {},
@@ -106,5 +144,13 @@ export async function getDirectorsInsights(
       ? foldAttendanceByLevel(rollup.attendance.data.byClass, levelByClassId)
       : [];
 
-  return { rollup, classPerf, subjectPerf, levelPerf, census, attendanceByLevel };
+  // One cheap indexed lookup on the existing census_return table (depends on the resolved period, so it
+  // can't join the Promise.all above). Suppressed when no academic year is configured — the nudge would
+  // have no year to name.
+  const academicYear = rollup.period?.academicYear ?? null;
+  const censusFiling = academicYear
+    ? { academicYear, status: await getAnnualCensusStatus(schoolId, academicYear) }
+    : null;
+
+  return { rollup, classPerf, subjectPerf, levelPerf, census, attendanceByLevel, censusFiling };
 }

--- a/omnischools/lib/reports/census/filing-status.ts
+++ b/omnischools/lib/reports/census/filing-status.ts
@@ -1,0 +1,36 @@
+import "server-only";
+import { and, eq } from "drizzle-orm";
+import { withSchool } from "@/lib/db/rls";
+import { censusReturn } from "@/db/schema";
+
+export type CensusFilingStatus = "COMPLETED" | "DRAFT" | "NONE";
+
+/**
+ * Cheap one-row lookup: is THIS year's ANNUAL GES census filed? (INS §17-D nudge signal.)
+ *   COMPLETED → filed + locked (the print-and-sign PDF is the official return)
+ *   DRAFT     → generated, not yet completed
+ *   NONE      → no return row for this (school × ANNUAL × academic_year)
+ *
+ * ANNUAL only — the annual GES return is the statutory filing directors answer for (the MID_YEAR return is
+ * out of scope for the nudge). `withSchool`-scoped (RLS applies); reads the EXISTING `census_return` table
+ * that GOV-8/GOV-9 write — no new schema. The `academicYear` comes from the caller's resolved rollup period.
+ */
+export async function getAnnualCensusStatus(
+  schoolId: string,
+  academicYear: string,
+): Promise<CensusFilingStatus> {
+  const rows = await withSchool(schoolId, (tx) =>
+    tx
+      .select({ status: censusReturn.status })
+      .from(censusReturn)
+      .where(
+        and(
+          eq(censusReturn.schoolId, schoolId),
+          eq(censusReturn.cadence, "ANNUAL"),
+          eq(censusReturn.academicYear, academicYear),
+        ),
+      )
+      .limit(1),
+  );
+  return (rows[0]?.status as CensusFilingStatus | undefined) ?? "NONE";
+}


### PR DESCRIPTION
## Directors' Insights — two deferred follow-ups

Ships the two items scoped out of #249. **No schema, no RLS, no prod-paste** — reads existing tables only.

### 1. Export board pack (§17-F)
A new director-gated route `GET /api/insights/board-pack` (`INSIGHTS_READ_ROLES`) plus a **"Board pack (PDF)"** button on the insights header (threads the on-screen term). It reuses `getSchoolRollup → renderBoardPackPdf` **verbatim** — the exact aggregate governance pack the board already downloads (GOV-5), so directors get **no new data exposure**. It lives under `/api` (the repo's authenticated-download convention) because `requireSchoolRole` — unlike `requireBoard` — carries no `/board*` path confinement.

### 2. "GES annual census" nudge (§17-D)
A new *Needs your attention* row driven by the existing `census_return` table (`getAnnualCensusStatus` → `COMPLETED` / `DRAFT` / `NONE`, ANNUAL-only). Per Kofi's ruling + your grace-period decision:

| State | Behaviour |
|---|---|
| **Filed** (COMPLETED) | silent — never a green "all filed" row |
| **Not started** (NONE) | **silent for the first ~6 weeks** of the school year (grace window measured from the year's own first-term start), then a gentle `navy-2` "not yet filed" nudge |
| **Draft, unsubmitted** | `warn` "review and complete it" as soon as the year is underway — **grace-exempt** (you've already engaged) |
| No academic year / year not yet begun | silent |

The grace window is a tunable offset (`CENSUS_NUDGE_GRACE_DAYS = 42`) from the school year's opening — **not a hardcoded GES date** — so it survives calendar changes. The logic is a pure, unit-tested `censusNudge()`; the value carries only the year string (aggregate-only, no PII).

`OC-CENSUS-NUDGE-WINDOW` is now resolved as **grace (6 weeks)** per your call.

### Gate verdicts (all green)
- **Quinn (QA):** GREEN — 2068 tests, tsc + build clean; grace logic mutation-proven (grace check, DRAFT-exemption, and the not-opened guard each red a test).
- **Dex (architecture):** APPROVE — correct runtime/reuse, honest tunable grace, timezone-sound date math, clean pure/IO seam split, no new lock-in.
- **Sarah (security):** CLEAN — the download route's gate blocks every non-director (redirect throws before any byte streams), session-scoped (no IDOR), PII-free pack; `getAnnualCensusStatus` is tenant-scoped + injection-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
