### PR TITLE
chore(ci): PR-to-project-board tracking workflow

### DIFF
--- a/.github/workflows/pr-project-tracking.yml
+++ b/.github/workflows/pr-project-tracking.yml
@@ -1,0 +1,45 @@
+name: Track PRs on the project board
+
+# Adds every new PR to the Omnischools project board (org project #1) and posts a
+# tracking comment, so the owner, partners, and the AI build-loop agents coordinate
+# from one place. Pairs with the project's BUILT-IN workflows (auto-add + auto-status
+# on merge), which are toggled in the project UI — see docs/ops/project-tracking.md.
+#
+# Requires an org/repo secret PROJECT_PAT: a fine-grained PAT with Projects (read+write)
+# on the Omnischools org. The add-to-project step is `continue-on-error`, so if the
+# secret is absent the workflow still posts the comment instead of failing every PR.
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  track:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add the PR to the Omnischools project board
+        continue-on-error: true
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/Omnischools/projects/1
+          github-token: ${{ secrets.PROJECT_PAT }}
+
+      - name: Post a tracking comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          cat > "$RUNNER_TEMP/pr-comment.md" <<'EOF'
+          🤖 **Tracked on the [Omnischools project board](https://github.com/orgs/Omnischools/projects/1)** — the single source of truth for the team.
+
+          Owner / reviewers, set these on the board so partners and the AI agents stay in sync:
+          - **Status** → `In progress` while under review; `Done` on merge (the built-in workflow also flips this on merge).
+          - **Owner** → who this is on: `Kofi` · `Wells` · `Lucy` · `Claude Code` · `Quinn` · `Dex` · `Sarah` · `Pence` · `Wunpini` · `Frederick`.
+          - **Assignee** → the person if a human action is needed (provisioning, business, integration).
+          EOF
+          gh pr comment "$PR" --repo "$REPO" --body-file "$RUNNER_TEMP/pr-comment.md"

--- a/omnischools/docs/ops/project-tracking.md
+++ b/omnischools/docs/ops/project-tracking.md
@@ -1,0 +1,35 @@
+# Project board = single source of truth
+
+The **Omnischools** GitHub project (org project **#1**,
+`https://github.com/orgs/Omnischools/projects/1`) is where the owner, partners, and the
+AI build-loop agents coordinate. Every PR and planned item lives there.
+
+## Fields
+- **Status** — `Todo` / `In progress` / `Done`.
+- **Owner** (custom single-select) — the build-loop agent or person responsible:
+  `Kofi` (spec) · `Wells` (DB/RLS) · `Lucy` (design) · `Claude Code` (impl) ·
+  `Quinn` (QA) · `Dex` (arch) · `Sarah` (security) · `Pence` (PM) · `Wunpini` (owner) ·
+  `Frederick` (payments/integration). GitHub **Assignees** stay real people only
+  (`WunpiniFuseini`, `FrederickOB`) — used when a *human* action is needed
+  (provisioning keys, business registration, Hubtel/Paystack).
+
+## PR tracking = two layers (both on)
+1. **Action** — `.github/workflows/pr-project-tracking.yml` adds each new PR to the board
+   and posts a tracking comment. It needs a secret **`PROJECT_PAT`** (a fine-grained PAT,
+   org `Omnischools`, **Projects: read+write**), added under
+   *repo (or org) → Settings → Secrets and variables → Actions*. Without it the add step
+   is skipped (the comment still posts).
+2. **Built-in project workflows** (toggle once in the project UI →
+   *⋯ menu → Workflows*):
+   - **Auto-add to project** — filter `is:pr`, repo `Omnischools/omnischools`.
+   - **Item added → Status: Todo** (or `In progress` for PRs).
+   - **Pull request merged → Status: Done.**
+   - **Item closed → Status: Done.**
+
+These can't be enabled via the API — flip them once in the UI and they run server-side
+forever after.
+
+## Rule for all work
+When a PR opens: it lands on the board (Action + auto-add). The reviewer/owner sets
+**Owner** and, if a human must act, an **Assignee**. On merge, Status flips to `Done`.
+Add a board item for any planned work that isn't already tracked.


### PR DESCRIPTION
Adds a GitHub Action that, on each new PR, **adds the PR to the [Omnischools project board](https://github.com/orgs/Omnischools/projects/1)** and **posts a tracking comment** prompting Status / Owner / Assignee — so you, Frederick, and the AI build-loop agents coordinate from one place.

- `.github/workflows/pr-project-tracking.yml` — add-to-project (org project #1) + comment. Degrades gracefully if the `PROJECT_PAT` secret is absent (comment still posts).
- `docs/ops/project-tracking.md` — how to add the `PROJECT_PAT` secret + toggle the project's built-in auto-add / auto-status workflows (the API can't set those; one-time UI toggle).

**Action needed after merge:** add a fine-grained PAT secret `PROJECT_PAT` (org Omnischools, Projects read+write), and flip the built-in workflows in the project UI (documented). This is the first GitHub Action in the repo (relates to #252).

🤖 Generated with [Claude Code](https://claude.com/claude-code)