### PR TITLE
feat(nav): Insights nav entry for directors + board shell nav (#301)

### DIFF
--- a/omnischools/app/(board)/layout.tsx
+++ b/omnischools/app/(board)/layout.tsx
@@ -1,5 +1,6 @@
 import { requireBoard } from "@/lib/auth/server";
 import { SignOutButton } from "@/components/app/sign-out-button";
+import { BoardNav } from "@/components/board/board-nav";
 
 /**
  * The read-only BOARD/DIRECTOR shell (GOV-2 / R333) — its OWN route group, deliberately NOT the staff
@@ -20,6 +21,7 @@ export default async function BoardLayout({ children }: { children: React.ReactN
           <div className="font-display text-[15px] font-medium text-navy">{school.name}</div>
           <div className="text-[11px] text-navy-3">Board overview · read-only</div>
         </div>
+        <BoardNav />
         <SignOutButton />
       </header>
       <main className="mx-auto max-w-[980px] px-7 pb-9 pt-6">{children}</main>

--- a/omnischools/components/app/sidebar.tsx
+++ b/omnischools/components/app/sidebar.tsx
@@ -26,12 +26,14 @@ import {
   HeartHandshake,
   Presentation,
   Landmark,
+  LineChart,
   type LucideIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   isFinanceOnly,
   hasAnyRole,
+  INSIGHTS_READ_ROLES,
   SENIOR_LEDGER_ROLES,
   SENIOR_MANAGEMENT_ROLES,
   BOARDING_ROLES,
@@ -57,6 +59,14 @@ const NAV: { href: string; label: string; Icon: LucideIcon }[] = [
   { href: "/inbox", label: "Inbox", Icon: MessageSquare },
   { href: "/settings", label: "Settings", Icon: Settings },
 ];
+
+/**
+ * Directors' Insights — the consolidated director/management analytics dashboard (#301). A role-gated
+ * TOP-LEVEL item (ALL tiers, not senior-only), shown only to INSIGHTS_READ_ROLES (Admin / Headmaster /
+ * Proprietor) — mirrors the page's own `requireSchoolRole(INSIGHTS_READ_ROLES)` so the link never
+ * dangles for a role that can't open it. Inserted right after Reports (analytics cluster).
+ */
+const INSIGHTS_ITEM = { href: "/insights", label: "Insights", Icon: LineChart };
 
 const TIER: Record<string, string> = {
   BASIC: "Basic",
@@ -212,12 +222,16 @@ export function AppSidebar({
           : [n],
       )
     : NAV;
+  // Directors (Admin/Headmaster/Proprietor) also get the Insights analytics dashboard, after Reports.
+  const withInsights = hasAnyRole(user.roles, INSIGHTS_READ_ROLES)
+    ? fullNav.flatMap((n) => (n.href === "/reports" ? [n, INSIGHTS_ITEM] : [n]))
+    : fullNav;
   // Finance-only staff see a billing-focused nav; everyone else sees the full set.
   const nav = isFinanceOnly(user.roles)
     ? FINANCE_NAV_ORDER.map((href) => NAV.find((n) => n.href === href)).filter(
         (n): n is (typeof NAV)[number] => !!n,
       )
-    : fullNav;
+    : withInsights;
   const roleLabel = user.roles[0] ? titleCase(user.roles[0]) : "";
 
   return (

--- a/omnischools/components/board/board-nav.tsx
+++ b/omnischools/components/board/board-nav.tsx
@@ -1,0 +1,40 @@
+"use client";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+
+/**
+ * The read-only board shell's nav. The board group has exactly two surfaces — the Overview dashboard
+ * and Account — and no sidebar, so without this there is no link back to the overview from Account.
+ * Both hrefs stay inside `/board*` (requireBoard's path confinement); never a link out to staff surfaces.
+ */
+const ITEMS = [
+  { href: "/board", label: "Overview" },
+  { href: "/board/account", label: "Account" },
+];
+
+export function BoardNav() {
+  const pathname = usePathname();
+  return (
+    <nav className="flex items-center gap-1 print:hidden">
+      {ITEMS.map(({ href, label }) => {
+        const active = pathname === href;
+        return (
+          <Link
+            key={href}
+            href={href}
+            aria-current={active ? "page" : undefined}
+            className={cn(
+              "rounded-md px-3 py-1.5 text-[13px] font-medium transition-colors",
+              active
+                ? "bg-gold/15 text-navy"
+                : "text-navy-3 hover:bg-bg hover:text-navy",
+            )}
+          >
+            {label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/omnischools/lib/board/board-gov2.test.ts
+++ b/omnischools/lib/board/board-gov2.test.ts
@@ -282,6 +282,26 @@ describe("requireSchool · non-staff branch routes a board-only session to /boar
   });
 });
 
+// ── BoardNav · the shell nav stays inside the /board* confinement (#301) ────────────────────────
+describe("BoardNav · every nav href is confined to /board* (#301)", () => {
+  // Source-assertion (the nav is a client component with usePathname — no render harness here). The
+  // read-only board shell is path-confined by requireBoard/pathAllowedForBoard; its nav must NEVER
+  // link OUT to a staff surface. If someone adds `{ href: "/dashboard", … }`, this reds.
+  const src = readFileSync(resolve(cwd(), "components/board/board-nav.tsx"), "utf8");
+  const hrefs = [...src.matchAll(/href:\s*"([^"]+)"/g)].map((m) => m[1]);
+
+  it("declares exactly the two board surfaces (Overview /board, Account /board/account)", () => {
+    expect(hrefs).toEqual(["/board", "/board/account"]);
+  });
+
+  it("no href escapes /board — and each is admitted by pathAllowedForBoard", () => {
+    for (const href of hrefs) {
+      expect(href === "/board" || href.startsWith("/board/"), href).toBe(true);
+      expect(pathAllowedForBoard(href), href).toBe(true);
+    }
+  });
+});
+
 // ── GOV2-14/15 · landing honesty (pure boardTile helper) ────────────────────────────────────────
 describe("GOV2-14/15 · boardTile honours the omit-not-fake convention", () => {
   it("GOV2-14 · a NOT_CAPTURED arm renders its reason and NEVER a number (value fn is not called)", () => {


### PR DESCRIPTION
## Insights nav entry — directors + board (#301)

Closes #301 (Directors' Insights was reachable only by typing the URL).

- **Director:** a role-gated **"Insights"** item in the staff sidebar (after Reports), shown only to `INSIGHTS_READ_ROLES` (Admin/Headmaster/Proprietor) — the **same constant** `/insights` and its API twin gate on, so the link never dangles or over-shows. Finance-only and other staff never see it.
- **Board:** the read-only board shell had **no nav at all**, so moving between the Overview dashboard and Account had no link back. Added a minimal **BoardNav** (Overview → `/board`, Account → `/board/account`), active-aware, both hrefs confined to `/board*`.

**No schema, no RLS, no prod-paste** — presentational only; the page/route guards (the real boundaries) are untouched.

### Gates
- **Quinn (QA):** GREEN — 2074 tests, tsc + build clean; gating traced per-persona (director sees it; teacher/student/parent/finance-only don't). Added a mutation-proven test locking the BoardNav hrefs to `/board*`.
- **Sarah (security):** CLEAN — real gates unchanged, gates on `INSIGHTS_READ_ROLES` directly (no widened sibling), board confinement intact.
- **Dex:** intentionally skipped — a nav change has no architecture surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
