### PR TITLE
fix(import): unify the CSV guardian-email validator (client preview == server) (#308)

### DIFF
--- a/omnischools/lib/actions/students.ts
+++ b/omnischools/lib/actions/students.ts
@@ -7,6 +7,7 @@ import { requireSchool, resolveActor, assertWriteAccess } from "@/lib/auth/serve
 import { normalizeGhanaPhone } from "@/lib/auth";
 import { and, count, eq, inArray } from "drizzle-orm";
 import { nextStudentCode } from "@/lib/students-helpers";
+import { guardianEmailSchema } from "@/lib/import/student-import";
 import type { Tx } from "@/lib/db";
 import {
   students,
@@ -31,7 +32,7 @@ const CreateStudentSchema = z.object({
   guardianName: z.string().max(160).optional().or(z.literal("")),
   guardianPhone: z.string().max(40).optional().or(z.literal("")),
   guardianRelation: z.enum(["MOTHER", "FATHER", "GUARDIAN", "OTHER"]).default("GUARDIAN"),
-  guardianEmail: z.string().max(160).email("Enter a valid guardian email address.").optional().or(z.literal("")),
+  guardianEmail: guardianEmailSchema,
 });
 
 export type CreateStudentResult =
@@ -121,7 +122,7 @@ const UpdateStudentSchema = z.object({
   guardianName: z.string().max(160).optional().or(z.literal("")),
   guardianPhone: z.string().max(40).optional().or(z.literal("")),
   guardianRelation: z.enum(["MOTHER", "FATHER", "GUARDIAN", "OTHER"]).default("GUARDIAN"),
-  guardianEmail: z.string().max(160).email("Enter a valid guardian email address.").optional().or(z.literal("")),
+  guardianEmail: guardianEmailSchema,
   // Health & emergency record (all optional)
   bloodGroup: z.string().max(8).optional().or(z.literal("")),
   allergies: z.string().max(1000).optional().or(z.literal("")),
@@ -266,7 +267,7 @@ const ImportRowSchema = z.object({
   guardianName: z.string().max(160).optional().or(z.literal("")),
   guardianPhone: z.string().max(40).optional().or(z.literal("")),
   guardianRelation: z.enum(["MOTHER", "FATHER", "GUARDIAN", "OTHER"]).default("GUARDIAN"),
-  guardianEmail: z.string().max(160).email("Enter a valid guardian email address.").optional().or(z.literal("")),
+  guardianEmail: guardianEmailSchema,
 });
 const ImportStudentsSchema = z.object({
   rows: z.array(ImportRowSchema).min(1, "No rows to import").max(1000),

--- a/omnischools/lib/import/guardian-email-validator.test.ts
+++ b/omnischools/lib/import/guardian-email-validator.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { validateStudentRows, guardianEmailSchema } from "@/lib/import/student-import";
+
+/**
+ * #308 — the CSV preview validator (client) once used a looser regex than the server's Zod
+ * `.email()`, so the review table could mark a row "Ready" that the server then rejected.
+ * Both sides now route through `guardianEmailSchema`. This test proves it: for every case it
+ * runs the REAL preview path (`validateStudentRows`) and the REAL server schema object (the
+ * one `lib/actions/students.ts` imports) and asserts they accept/reject identically.
+ */
+describe("guardian email · preview validator agrees with server schema (#308)", () => {
+  // First,Last,Other,Gender,DOB,Class,GuardianName,GuardianPhone,Relationship — clean base.
+  const base = ["Ama", "Boateng", "", "F", "", "", "Ama Boateng", "0241112222", "Mother"];
+
+  // The preview accepts an email when the row has no email-related error.
+  const previewAccepts = (email: string) => {
+    const { rows } = validateStudentRows([[...base, email]], {});
+    return !rows[0].errors.includes("Guardian email is invalid");
+  };
+  const serverAccepts = (email: string) => guardianEmailSchema.safeParse(email).success;
+
+  const cases: { email: string; valid: boolean }[] = [
+    // valid
+    { email: "a@b.co", valid: true },
+    { email: "x.y+z@sub.example.com", valid: true },
+    { email: "ama@example.com", valid: true },
+    { email: "", valid: true }, // optional — blank stays valid on both
+    // invalid
+    { email: "no-at", valid: false },
+    { email: "a@b", valid: false }, // no TLD
+    { email: "a@ b.c", valid: false }, // space
+    { email: "a@b.c", valid: false }, // 1-char TLD — the old regex accepted this, server didn't
+    { email: "a@b.123", valid: false }, // numeric TLD
+    { email: ".a@b.co", valid: false }, // leading dot
+    { email: "a@b..com", valid: false }, // consecutive dots
+  ];
+
+  it.each(cases)("preview and server agree on $email", ({ email, valid }) => {
+    const p = previewAccepts(email);
+    const s = serverAccepts(email);
+    expect(p).toBe(s); // no divergence
+    expect(p).toBe(valid); // and both match the expected verdict
+  });
+
+  it("blank guardian email is valid on both (optional field)", () => {
+    expect(previewAccepts("")).toBe(true);
+    expect(serverAccepts("")).toBe(true);
+  });
+});

--- a/omnischools/lib/import/student-import.ts
+++ b/omnischools/lib/import/student-import.ts
@@ -1,4 +1,23 @@
+import { z } from "zod";
 import { isValidGhanaPhone, normalizePhone } from "./csv";
+
+/**
+ * Guardian email — the SINGLE source of truth shared by the CSV preview validator (below)
+ * and the server create/edit/import actions (`lib/actions/students.ts`). Optional; blank
+ * stays valid. #308: the preview used to run a looser regex than the server's Zod `.email()`,
+ * so the review table could mark a row "Ready" that the server then rejected. Both sides now
+ * import this one schema, so no divergence is possible. Client-safe (zod runs on the client).
+ */
+export const guardianEmailSchema = z
+  .string()
+  .max(160)
+  .email("Enter a valid guardian email address.")
+  .optional()
+  .or(z.literal(""));
+
+/** True when a guardian email is acceptable. Blank = acceptable (the field is optional). */
+export const isValidGuardianEmail = (email: string): boolean =>
+  guardianEmailSchema.safeParse(email).success;
 
 /**
  * Student bulk-import spec + validator. Pure + client-safe so the review table can
@@ -131,7 +150,7 @@ export function validateStudentRows(
       warnings.push("No guardian — parent won't be invited");
 
     const guardianEmail = get(9);
-    if (guardianEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(guardianEmail))
+    if (guardianEmail && !isValidGuardianEmail(guardianEmail))
       errors.push("Guardian email is invalid");
 
     return {


### PR DESCRIPTION
Closes #308.

The CSV bulk-import review table validated guardian email on the client with a loose regex while the server used Zod `.email()` — so a row shown "Ready" could be rejected by the server, failing the whole batch. Fix: one shared `guardianEmailSchema` + `isValidGuardianEmail()` in the client-safe `lib/import/student-import.ts`, consumed by the client preview AND all three server schemas (create / edit / import). No divergence possible now.

**Gates:** Quinn GREEN (2086 tests; mutation-proven the shared schema pins the verdicts). Dex APPROVE (client/server boundary clean, no server-only leak). Sarah N/A — the server boundary is unchanged; only the client preview was tightened to match. No schema / prod-paste.