### PR TITLE
fix(sort): canonical year-group ladder order across all sort sites (#305)

### DIFF
--- a/omnischools/app/(app)/billing/page.tsx
+++ b/omnischools/app/(app)/billing/page.tsx
@@ -16,6 +16,7 @@ import {
   students,
 } from "@/db/schema";
 import { num, daysOverdue } from "@/lib/fees-helpers";
+import { compareLevelLabel } from "@/lib/reports/level-order";
 import { InvoicesTable, type InvoiceRow } from "@/components/billing/invoices-table";
 import { CreateFeeStructureForm } from "@/components/billing/create-fee-structure-form";
 import { FeeStructureCard } from "@/components/billing/fee-structure-card";
@@ -98,8 +99,8 @@ export default async function BillingPage() {
       tx
         .selectDistinct({ level: classes.level })
         .from(classes)
-        .where(and(eq(classes.schoolId, school.id), isNotNull(classes.level)))
-        .orderBy(asc(classes.level)),
+        .where(and(eq(classes.schoolId, school.id), isNotNull(classes.level))),
+      // ↑ ladder-ordered in JS at the dropdown (#305); SQL asc() would sort "JHS 1" before "Primary 2".
     ),
     withSchool(school.id, (tx) =>
       tx
@@ -515,7 +516,10 @@ export default async function BillingPage() {
           <CreateFeeStructureForm
             defaultYear={year}
             feeItemOptions={feeCatRows.map((c) => c.name)}
-            levelOptions={levelRows.map((l) => l.level).filter((l): l is string => !!l)}
+            levelOptions={levelRows
+              .map((l) => l.level)
+              .filter((l): l is string => !!l)
+              .sort(compareLevelLabel)}
             yearOptions={yearRows.map((y) => y.year)}
           />
         </div>

--- a/omnischools/app/(app)/students/page.tsx
+++ b/omnischools/app/(app)/students/page.tsx
@@ -4,6 +4,7 @@ import { requireSchool } from "@/lib/auth/server";
 import { isFinanceOnly } from "@/lib/access";
 import { withSchool } from "@/lib/db/rls";
 import { students } from "@/db/schema";
+import { compareLevelLabel } from "@/lib/reports/level-order";
 import { StudentsBrowser } from "@/components/students/students-browser";
 import { StudentsEmpty } from "@/components/students/students-empty";
 
@@ -42,7 +43,7 @@ export default async function StudentsPage() {
 
   const classOptions = Array.from(
     new Set(rows.map((r) => r.currentClassLabel).filter((c): c is string => !!c)),
-  ).sort();
+  ).sort(compareLevelLabel); // #305 · ladder order so "Primary 2" precedes "JHS 1"
 
   return (
     <div className="mx-auto max-w-page">

--- a/omnischools/components/dashboard/insight-tiles.tsx
+++ b/omnischools/components/dashboard/insight-tiles.tsx
@@ -11,7 +11,7 @@ import type {
   TerminalResultSummary,
 } from "@/lib/rollup/school-rollup";
 import type { ClassPerfRow, LevelPerfRow } from "@/lib/reports/class-performance-data";
-import { compareLevelLabel } from "@/lib/reports/class-performance-data";
+import { compareLevelLabel } from "@/lib/reports/level-order";
 import type { SubjectPerfRow } from "@/lib/reports/subject-performance-data";
 import type {
   CensusEnrolment,

--- a/omnischools/lib/reports/census-enrolment-data.ts
+++ b/omnischools/lib/reports/census-enrolment-data.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { and, asc, eq } from "drizzle-orm";
 import { withSchool } from "@/lib/db/rls";
 import { students, classes } from "@/db/schema";
+import { compareLevelLabel } from "./level-order";
 
 /**
  * GOV-8 · the census enrolment reader — the ONE net-new reader the GES census needs (Kofi §2). Server-only,
@@ -168,7 +169,7 @@ export function aggregateCensusEnrolment(
 
   const byLevel: CensusLevelRow[] = [...byLevelAcc.entries()]
     .map(([level, s]) => ({ level, ...totalOf(s) }))
-    .sort((a, b) => a.level.localeCompare(b.level));
+    .sort((a, b) => compareLevelLabel(a.level, b.level));
 
   const ageByLevel: CensusAgeByLevel[] = [...ageAcc.entries()]
     .map(([level, e]) => ({
@@ -176,11 +177,11 @@ export function aggregateCensusEnrolment(
       byAge: [...e.ages.entries()].map(([age, s]) => ({ age, ...totalOf(s) })).sort((a, b) => a.age - b.age),
       dobUnknown: e.dobUnknown,
     }))
-    .sort((a, b) => a.level.localeCompare(b.level));
+    .sort((a, b) => compareLevelLabel(a.level, b.level));
 
   const approvedAge: CensusApprovedAge[] = [...apprAcc.entries()]
     .map(([level, a]) => ({ level, officialAge: officialAgeForLevel(level)!, ...a }))
-    .sort((a, b) => a.level.localeCompare(b.level));
+    .sort((a, b) => compareLevelLabel(a.level, b.level));
 
   return {
     censusDate: censusDate.toISOString().slice(0, 10),

--- a/omnischools/lib/reports/class-performance-data.ts
+++ b/omnischools/lib/reports/class-performance-data.ts
@@ -15,6 +15,10 @@ import {
   previousTerm,
   type AcademicTerm,
 } from "./academic-term";
+// The canonical year-group ladder comparator lives in its own PURE module (#305); re-exported here
+// for the existing importers (insight-tiles, the level-performance test).
+import { UNSPECIFIED_LEVEL, compareLevelLabel } from "./level-order";
+export { UNSPECIFIED_LEVEL, compareLevelLabel };
 
 /**
  * "Class performance" — average of the pre-weighted `gradebook_score.total` per class for a
@@ -257,7 +261,6 @@ export async function getClassPerformance(
  * bucket under `"Unspecified"` (mirrors census UNSPECIFIED). A level with active classes but no graded
  * scores renders `null` (never 0) — INS-30.
  */
-export const UNSPECIFIED_LEVEL = "Unspecified";
 
 export type LevelPerfRow = {
   level: string;
@@ -293,16 +296,6 @@ export type LevelAgg = {
 export type LevelClassCount = { level: string | null; classes: number };
 
 const levelKey = (l: string | null): string => l ?? UNSPECIFIED_LEVEL;
-
-/** Ladder rank: JHS1<JHS2<JHS3 by the first integer in the label; `Unspecified` last. */
-export function compareLevelLabel(a: string, b: string): number {
-  const rank = (lvl: string) => {
-    if (lvl === UNSPECIFIED_LEVEL) return Number.POSITIVE_INFINITY;
-    const n = lvl.match(/\d+/);
-    return n ? parseInt(n[0], 10) : Number.MAX_SAFE_INTEGER - 1;
-  };
-  return rank(a) - rank(b) || a.localeCompare(b);
-}
 
 /**
  * The PURE assembly of the per-level rows from the SQL aggregates — no DB, so it is unit-tested

--- a/omnischools/lib/reports/level-order.ts
+++ b/omnischools/lib/reports/level-order.ts
@@ -1,0 +1,48 @@
+/**
+ * The ONE canonical Ghanaian year-group ladder comparator (issue #305). Levels sort by ladder
+ * TIER first — KG → Primary → JHS → SHS/Form — then by the year number WITHIN the tier
+ * ("Primary 2" before "Primary 10", numeric not lexical), with unknown levels and the literal
+ * "Unspecified" bucket last. PURE + DB-free so every reader/component routes through the SAME
+ * order; before this, sites sorted levels lexically ("JHS 1" landed before "Primary 2") or by the
+ * bare number (KG/Primary/JHS/Form 1 all collided at rank 1).
+ *
+ * Level strings are the seeded GES labels ("KG 1", "KG 2", "Primary 1"–"6", "JHS 1"–"3") and the
+ * senior tier's "Form 1"–"3" / "SHS 1"–"3". Matching is case-insensitive and tolerant of a section
+ * suffix ("JHS 1 A") so class labels sort on the same ladder as bare levels.
+ */
+
+/** Classes with no `level` bucket here (mirrors the census UNSPECIFIED). Sorts strictly last. */
+export const UNSPECIFIED_LEVEL = "Unspecified";
+
+// Ladder tiers in canonical order; first keyword hit wins (the keyword sets are mutually exclusive).
+const TIER_PATTERNS: RegExp[] = [
+  /\bKG\b|kindergarten/i, // 0 · KG 1, KG 2
+  /\bprimary\b|\bbasic\b/i, // 1 · Primary 1–6 (GES designates these "Basic 1–6")
+  /\bjhs\b|\bjss\b/i, // 2 · JHS 1–3
+  /\bshs\b|\bsss\b|\bform\b/i, // 3 · SHS / Form 1–3
+];
+
+function levelTier(lvl: string): number {
+  if (lvl === UNSPECIFIED_LEVEL) return TIER_PATTERNS.length + 1; // strictly last, after unknowns
+  const i = TIER_PATTERNS.findIndex((re) => re.test(lvl));
+  return i >= 0 ? i : TIER_PATTERNS.length; // unknown custom level → after the known ladder
+}
+
+function levelNumber(lvl: string): number {
+  const m = lvl.match(/\d+/);
+  return m ? parseInt(m[0], 10) : Number.MAX_SAFE_INTEGER; // a number-less label sorts last in its tier
+}
+
+/**
+ * Canonical ladder comparator: tier (KG<Primary<JHS<SHS) → numeric year within tier → the label as a
+ * stable tiebreak. `Unspecified` and unknown/custom levels sort after the ladder.
+ */
+export function compareLevelLabel(a: string, b: string): number {
+  const ta = levelTier(a);
+  const tb = levelTier(b);
+  if (ta !== tb) return ta - tb;
+  const na = levelNumber(a);
+  const nb = levelNumber(b);
+  if (na !== nb) return na - nb;
+  return a.localeCompare(b);
+}

--- a/omnischools/lib/reports/level-performance.test.ts
+++ b/omnischools/lib/reports/level-performance.test.ts
@@ -87,4 +87,19 @@ describe("compareLevelLabel · year-group ladder", () => {
     expect(compareLevelLabel("Form 1", "Form 2")).toBeLessThan(0);
     expect(compareLevelLabel("Form 2", UNSPECIFIED_LEVEL)).toBeLessThan(0);
   });
+
+  // #305 · a mixed ladder was sorted lexically ("JHS 1" before "Primary 2") or by number alone
+  // (KG/Primary/JHS/Form 1 collided). The canonical order is the GES tier then the year within it.
+  it("ranks the canonical tier KG → Primary → JHS → SHS, then numeric within tier (two-digit safe)", () => {
+    const shuffled = ["JHS 1", "Primary 2", "KG 2", "Primary 10", "Form 2", UNSPECIFIED_LEVEL, "KG 1"];
+    expect([...shuffled].sort(compareLevelLabel)).toEqual([
+      "KG 1",
+      "KG 2",
+      "Primary 2",
+      "Primary 10", // numeric, not lexical → after "Primary 2", not before it
+      "JHS 1",
+      "Form 2",
+      UNSPECIFIED_LEVEL,
+    ]);
+  });
 });

--- a/omnischools/lib/reports/level-performance.test.ts
+++ b/omnischools/lib/reports/level-performance.test.ts
@@ -102,4 +102,17 @@ describe("compareLevelLabel · year-group ladder", () => {
       UNSPECIFIED_LEVEL,
     ]);
   });
+
+  // #305 · the tail boundary: an unknown/custom level sorts AFTER the known ladder but BEFORE the
+  // literal "Unspecified" bucket (unknown < Unspecified, both after SHS/Form).
+  it("orders unknown custom levels after the ladder but before Unspecified", () => {
+    const shuffled = [UNSPECIFIED_LEVEL, "Creche", "Form 3", "KG 1"];
+    expect([...shuffled].sort(compareLevelLabel)).toEqual([
+      "KG 1",
+      "Form 3",
+      "Creche", // unknown → after the ladder
+      UNSPECIFIED_LEVEL, // literal bucket → strictly last
+    ]);
+    expect(compareLevelLabel("Creche", UNSPECIFIED_LEVEL)).toBeLessThan(0);
+  });
 });

--- a/omnischools/lib/reports/school-stats-data.ts
+++ b/omnischools/lib/reports/school-stats-data.ts
@@ -1,6 +1,7 @@
 import { and, asc, eq, isNull, ne, sql } from "drizzle-orm";
 import { withSchool } from "@/lib/db/rls";
 import { academicPeriod, classes, roleAssignments, roles, students, users } from "@/db/schema";
+import { compareLevelLabel } from "@/lib/reports/level-order";
 
 /**
  * "School at a glance" aggregates for Reports → School stats → At a glance.
@@ -91,9 +92,9 @@ function deriveFlag(utilisationPct: number | null): CapacityFlag | null {
   return utilisationPct < 100 ? "Ok" : "Full";
 }
 
-/** Build a short "JHS 1, 2, 3" style summary from distinct class levels. */
+/** Build a short "KG · Primary · JHS" style summary from distinct class levels, ladder-ordered. */
 function summariseLevels(levels: (string | null)[]): string {
-  const seen = Array.from(new Set(levels.filter((l): l is string => !!l)));
+  const seen = Array.from(new Set(levels.filter((l): l is string => !!l))).sort(compareLevelLabel);
   if (seen.length === 0) return "—";
   return seen.join(" · ");
 }

--- a/omnischools/lib/sen/register-data.ts
+++ b/omnischools/lib/sen/register-data.ts
@@ -14,6 +14,7 @@ import {
 import { liveSenGrantStudentIds } from "@/lib/sen/grants";
 import { isStaffRole } from "@/lib/access";
 import { ageAsOf } from "@/lib/reports/census-enrolment-data";
+import { compareLevelLabel } from "@/lib/reports/level-order";
 import {
   SEN_CATEGORIES,
   type SenCategory,
@@ -167,7 +168,7 @@ export async function getSenRegister(schoolId: string): Promise<SenRegisterView>
 
     const byLevel = [...levelCounts.entries()]
       .map(([level, count]) => ({ level, count }))
-      .sort((a, b) => a.level.localeCompare(b.level));
+      .sort((a, b) => compareLevelLabel(a.level, b.level));
 
     let largestCategory: { category: SenCategory; count: number } | null = null;
     for (const c of SEN_CATEGORIES) {


### PR DESCRIPTION
Closes #305.

The level comparator ranked by first-digit only, so mixed-ladder schools saw "JHS 1" before "Primary 2" and KG floated. Root-cause fix: one canonical comparator extracted to `lib/reports/level-order.ts` (a zero-import leaf), routing **all 8 sort sites** through it — KG < Primary(Basic) < JHS(JSS) < SHS/Form(SSS) < unknown < "Unspecified", numeric-within-tier (Primary 2 before Primary 10). Removes every ad-hoc `localeCompare` / SQL `asc(level)`.

**Gates:** Quinn GREEN (2075 tests; mutation-proven; boundary cases incl. two-digit + unknown-vs-Unspecified; census/SEN suites clean). Dex APPROVE (the leaf util severs a DB-value-import that the shared tile module previously carried; the one SQL→JS sort move is correct). Sarah N/A — pure sort logic, no security surface. No schema / prod-paste.

Follow-ups filed for the same bug class elsewhere: #318 (staff-import email), and the promotion-preview sort.