### PR TITLE
fix(attendance): make the Medical absent-SMS suppression an explicit audited decision (#265)

### DIFF
--- a/omnischools/lib/actions/attendance.ts
+++ b/omnischools/lib/actions/attendance.ts
@@ -7,7 +7,7 @@ import { requireSchool, resolveActor, assertWriteAccess } from "@/lib/auth/serve
 import { sendSms } from "@/lib/sms";
 import { safeRevalidate } from "@/lib/revalidate";
 import { ATTENDANCE_REASON_CODES, SICKBAY_REASON_CODE } from "@/lib/attendance-reasons";
-import { closedTermLabel, writeMarks } from "@/lib/attendance/mark";
+import { closedTermLabel, summariseMarks, writeMarks } from "@/lib/attendance/mark";
 import {
   classes,
   students,
@@ -188,7 +188,10 @@ export async function saveAttendance(input: unknown): Promise<SaveAttendanceResu
       // 🔴 R49b — the absent list (→ the parent SMS → the audit) comes from the EFFECTIVE statuses
       // the DB stored, NEVER from `d.entries`. A student the sickbay holds is not in it, so her
       // mother does not get "…was marked absent" while she is on bed 3 in the school's own sickbay.
-      const absent = res.marked.filter((m) => m.status === "ABSENT").map((m) => m.studentId);
+      // #265 — the same summary carries the MEDICAL split, so the (correct) SMS suppression is a
+      // recorded decision, not a silent fall-out of the absent filter (owner OC-MED-NOTIFY = NO).
+      const { absentStudentIds: absent, medicalTeacherMarked, medicalSickbayDeferred } =
+        summariseMarks(res.marked);
       await recordAudit(tx, {
         schoolId: school.id,
         actorUserId: actor.id ?? undefined,
@@ -201,6 +204,9 @@ export async function saveAttendance(input: unknown): Promise<SaveAttendanceResu
           marked: res.marked.length,
           absent: absent.length,
           heldMedical: res.held.length,
+          // MEDICAL rows that were NOT messaged, and why the silence is correct (#265 / #280).
+          medicalTeacherMarked, // teacher pressed Medical — suppressed by policy, no SMS
+          medicalSickbayDeferred, // reasonCode SICKBAY — notification deferred to the sickbay module
         },
         reason: "Attendance taken",
       });

--- a/omnischools/lib/attendance/mark-rules.ts
+++ b/omnischools/lib/attendance/mark-rules.ts
@@ -70,6 +70,47 @@ export function civilDate(at: Date): string {
   return at.toISOString().slice(0, 10);
 }
 
+/** One effective row as the DB returned it (R49b) — the only thing the save may reason about. */
+export interface EffectiveMark {
+  studentId: string;
+  status: AttendanceStatus;
+  reasonCode: string | null;
+}
+
+/**
+ * #265 / owner OC-MED-NOTIFY = NO — the post-write summary `saveAttendance` records and messages
+ * from, derived from the EFFECTIVE rows the DB stored (R49b), NEVER from teacher input.
+ *
+ * `absentStudentIds` is the ONLY set that gets an SMS. A MEDICAL row is never in it, so no parent is
+ * told "…was marked absent" about a child the school itself sent to the sickbay (AC-265-1). The two
+ * MEDICAL counts put that (correct) suppression on the audit record instead of leaving it a silent
+ * fall-out of the absent filter:
+ *   • medicalTeacherMarked   — a teacher pressed Medical (any non-sickbay reason). Suppressed by
+ *                              policy: NO SMS (owner OC-MED-NOTIFY = NO).
+ *   • medicalSickbayDeferred — reasonCode === SICKBAY (an R48-coerced hold). Any notification is the
+ *                              sickbay comms module's job (#280), never this register-save path's.
+ *
+ * 🔒 A7 — COUNTS only: no reason code, note, or clinical string ever leaves here. A sickbay-owned
+ * row is distinguished by `reasonCode === SICKBAY_REASON_CODE` and collapsed to a tally on the spot.
+ */
+export function summariseMarks(marked: readonly EffectiveMark[]): {
+  absentStudentIds: string[];
+  medicalTeacherMarked: number;
+  medicalSickbayDeferred: number;
+} {
+  const absentStudentIds: string[] = [];
+  let medicalTeacherMarked = 0;
+  let medicalSickbayDeferred = 0;
+  for (const m of marked) {
+    if (m.status === "ABSENT") absentStudentIds.push(m.studentId);
+    else if (m.status === "MEDICAL") {
+      if (m.reasonCode === SICKBAY_REASON_CODE) medicalSickbayDeferred++;
+      else medicalTeacherMarked++;
+    }
+  }
+  return { absentStudentIds, medicalTeacherMarked, medicalSickbayDeferred };
+}
+
 /**
  * R47 — ONE mark per student per day, civil date Africa/Accra, **TODAY ONLY, never backdated**.
  * Returns the date to write, or null when the clinical event is not today (the writer then skips with

--- a/omnischools/lib/attendance/mark.ts
+++ b/omnischools/lib/attendance/mark.ts
@@ -38,6 +38,7 @@ import {
  */
 
 export type { MarkEntry, MarkSkipReason } from "./mark-rules";
+export { summariseMarks } from "./mark-rules";
 
 /** What the DB actually stored for one student — the only thing callers may reason about (R49b). */
 export interface MarkedRow {

--- a/omnischools/lib/attendance/medical-audit-265.test.ts
+++ b/omnischools/lib/attendance/medical-audit-265.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { summariseMarks, type EffectiveMark } from "./mark-rules";
+import { SICKBAY_REASON_CODE } from "@/lib/attendance-reasons";
+import { readCode } from "@/lib/test-utils/source-shape";
+
+/**
+ * #265 — owner OC-MED-NOTIFY = NO. A teacher-marked Medical must NOT trigger a parent notification;
+ * this is audit-EXPLICITNESS only, no new SMS. Kofi's discriminator: a Medical row is sickbay-owned
+ * iff `status === "MEDICAL" && reasonCode === SICKBAY_REASON_CODE`; teacher-marked iff MEDICAL with
+ * any other/absent reason code.
+ */
+
+const row = (over: Partial<EffectiveMark>): EffectiveMark => ({
+  studentId: "s?",
+  status: "ABSENT",
+  reasonCode: null,
+  ...over,
+});
+
+// ============================================================================
+// AC-265-1 / AC-265-5 — the suppression is correct AND the split is derivable (behavioural)
+// ============================================================================
+
+describe("AC-265-1/5 · summariseMarks splits the effective rows the DB stored (R49b)", () => {
+  const marked: EffectiveMark[] = [
+    row({ studentId: "a", status: "ABSENT" }),
+    row({ studentId: "b", status: "ABSENT", reasonCode: "TRAVEL" }),
+    row({ studentId: "c", status: "MEDICAL", reasonCode: "MEDICAL" }), // teacher: medical appointment
+    row({ studentId: "d", status: "MEDICAL", reasonCode: "SICK" }), //    teacher: illness
+    row({ studentId: "e", status: "MEDICAL", reasonCode: null }), //       teacher: no reason
+    row({ studentId: "f", status: "MEDICAL", reasonCode: SICKBAY_REASON_CODE }), // sickbay-owned (R48 coerced)
+    row({ studentId: "g", status: "PRESENT" }),
+    row({ studentId: "h", status: "LATE" }),
+    row({ studentId: "i", status: "EXCUSED" }),
+  ];
+  const s = summariseMarks(marked);
+
+  it("a MEDICAL row is NEVER in absentStudentIds — no 'marked absent' SMS can reach it (AC-265-1)", () => {
+    expect(s.absentStudentIds).toEqual(["a", "b"]);
+    for (const id of ["c", "d", "e", "f"]) {
+      expect(s.absentStudentIds, `medical ${id} must not be absent`).not.toContain(id);
+    }
+  });
+
+  it("teacher-marked Medical (any non-sickbay reason) is counted as suppressed, not deferred", () => {
+    expect(s.medicalTeacherMarked).toBe(3); // c, d, e
+  });
+
+  it("sickbay-owned Medical (reasonCode SICKBAY) is counted as deferred to #280 (AC-265-5)", () => {
+    expect(s.medicalSickbayDeferred).toBe(1); // f
+  });
+
+  it("🔒 A7 · the summary carries COUNTS only — no reasonCode/note/clinical string leaks out", () => {
+    // studentIds are the absent list (already messaged by design); the medical arms are pure tallies.
+    expect(Object.keys(s).sort()).toEqual([
+      "absentStudentIds",
+      "medicalSickbayDeferred",
+      "medicalTeacherMarked",
+    ]);
+    expect(typeof s.medicalTeacherMarked).toBe("number");
+    expect(typeof s.medicalSickbayDeferred).toBe("number");
+  });
+
+  it("an all-present / empty register produces no absent and no medical", () => {
+    expect(summariseMarks([])).toEqual({
+      absentStudentIds: [],
+      medicalTeacherMarked: 0,
+      medicalSickbayDeferred: 0,
+    });
+  });
+});
+
+// ============================================================================
+// AC-265-2 — the audit `after` payload records the split (source-shape mutation lock)
+// ============================================================================
+
+describe("AC-265-2 · saveAttendance's audit payload carries the MEDICAL split", () => {
+  const src = () => readCode("lib/actions/attendance.ts");
+
+  /** The body of the `actionType: "marked"` recordAudit call, up to its reason. */
+  const markedAudit = (s: string): string => {
+    const at = s.indexOf('actionType: "marked"');
+    expect(at, "the register-save audit exists").toBeGreaterThan(-1);
+    const end = s.indexOf('reason: "Attendance taken"', at);
+    return s.slice(at, end === -1 ? undefined : end);
+  };
+
+  it("the absent list is derived from summariseMarks(res.marked) — the EFFECTIVE rows, not d.entries", () => {
+    // This is what makes the SMS suppression structural: the guardian loop only ever iterates the
+    // absent list, and a MEDICAL row can never be in it (proven behaviourally above).
+    expect(src()).toContain("summariseMarks(res.marked)");
+  });
+
+  it("records medicalTeacherMarked — removing it from the payload reds this test (mutation-check)", () => {
+    expect(markedAudit(src())).toContain("medicalTeacherMarked");
+  });
+
+  it("records medicalSickbayDeferred — removing it from the payload reds this test (mutation-check)", () => {
+    expect(markedAudit(src())).toContain("medicalSickbayDeferred");
+  });
+});
+
+// ============================================================================
+// AC-265-7 — no leakage: the sickbay mark writer sends NO attendance SMS (grep guard)
+// ============================================================================
+
+describe("AC-265-7 · lib/attendance/mark.ts never touches the SMS path — that stays #280's job", () => {
+  const src = readCode("lib/attendance/mark.ts");
+
+  it("does not import @/lib/sms", () => {
+    expect(src).not.toContain("@/lib/sms");
+  });
+
+  it("does not call sendSms", () => {
+    expect(src).not.toMatch(/\bsendSms\b/);
+  });
+});


### PR DESCRIPTION
Closes #265.

**Not the bug the title suggested** (Kofi's ruling): suppressing the false "marked absent" SMS for a child who is in the sickbay is *correct* and stays. The real defect was that the suppression was **silent** — a Medical row just fell out of the absent filter with no record a decision was made.

Fix (audit-explicitness only; **OC-MED-NOTIFY = keep silent**, per owner): a pure `summariseMarks(res.marked)` helper now derives both the absent list (feeding the unchanged SMS loop) and a Medical split, recorded on the `"marked"` audit: `medicalTeacherMarked` (suppressed by policy) and `medicalSickbayDeferred` (deferred to the sickbay module, #280). No new notification; sickbay-origin Medical is not double-sent; `markSickbayMedical` stays SMS-free.

**Gates:** Quinn GREEN (mutation-proven the audit records the split). Dex APPROVE (pure helper, single source, no new coupling). Sarah CLEAN (audit is counts+date only — no studentId/reasonCode/note/clinical string; A7 wall holds). No schema / prod-paste.