### PR TITLE
fix(auth): admin password reset works with CAPTCHA enabled (#303)

### DIFF
--- a/omnischools/lib/actions/users.ts
+++ b/omnischools/lib/actions/users.ts
@@ -1,8 +1,7 @@
 "use server";
 import { and, eq, gte, isNull, lte, or } from "drizzle-orm";
 import { requireSchool, resolveActor, assertAnyRole } from "@/lib/auth/server";
-import { signInWithPhone } from "@/lib/auth";
-import { captchaEnabled } from "@/lib/captcha";
+import { adminSendPhoneOtp } from "@/lib/auth/admin";
 import { sendSms } from "@/lib/sms";
 import { USER_ADMIN_ROLES, canManageTarget } from "@/lib/access";
 import { withSchool } from "@/lib/db/rls";
@@ -124,18 +123,11 @@ export async function activateUser(input: { targetUserId: string }): Promise<Res
 export async function initiatePasswordReset(input: { targetUserId: string }): Promise<Result> {
   const { user, school } = await requireSchool();
   await assertAnyRole(USER_ADMIN_ROLES);
-  // INCR-AUTH-CAPTCHA (up-front, before any audit/DB work): this admin-initiated OTP send hits GoTrue's
-  // captcha-gated signInWithOtp, but the TARGET user isn't here to solve a challenge. When captcha is on,
-  // refuse HONESTLY — no `reset_initiated` audit for a reset that won't happen, no SMS for a code GoTrue
-  // rejected — and point to the user's own captcha-solvable reset. (System-wide condition, target-agnostic
-  // message, so refusing before the target-gate leaks nothing.)
-  if (captchaEnabled()) {
-    return {
-      ok: false,
-      error:
-        "Bot-protection is on, so a reset code can't be sent from here. Ask this user to reset their own password from the sign-in screen (“Forgot password?”).",
-    };
-  }
+  // INCR-303: this admin-initiated reset is an AUTHENTICATED, role-gated action — NOT a public flow — so it
+  // must NOT be captcha-gated. The OTP is dispatched via the SERVICE-ROLE client (`adminSendPhoneOtp`), which
+  // GoTrue does not captcha-gate, so the admin can reset even with Turnstile enforced. The PUBLIC login/reset
+  // flows are untouched — they still call the anon, captcha-gated `signInWithPhone`. (An earlier honest-refusal
+  // guard here left the admin reset permanently dead once captcha was enabled — the #303 bug.)
   const targetUserId = input?.targetUserId ?? "";
   const actor = await resolveActor(school.id);
 
@@ -158,8 +150,9 @@ export async function initiatePasswordReset(input: { targetUserId: string }): Pr
   if (!gated.phone) return { ok: false, error: "That user has no phone on file to send a code to." };
 
   // Dispatch a one-time code to the target's OWN stored phone; they sign in and set a new password
-  // themselves (L2a). The admin never sets or sees a password. Console-degrades with no SMS creds.
-  await signInWithPhone(gated.phone);
+  // themselves (L2a). The admin never sets or sees a password. Service-role send (not captcha-gated).
+  const sent = await adminSendPhoneOtp(gated.phone);
+  if (!sent.ok) return sent;
   await sendSms(
     gated.phone,
     `${school.name}: an administrator has started a password reset for your account. Sign in with the one-time code sent to this number, then set a new password in Settings.`,

--- a/omnischools/lib/admin-reset-captcha-303.test.ts
+++ b/omnischools/lib/admin-reset-captcha-303.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { readCode } from "@/lib/test-utils/source-shape";
+
+/**
+ * #303 — the admin-initiated password reset must WORK once CAPTCHA (Turnstile) is enabled. An admin
+ * resetting ANOTHER user's password is an AUTHENTICATED, role-gated action, so the OTP is dispatched via
+ * the SERVICE-ROLE client (`adminSendPhoneOtp`), which GoTrue does not captcha-gate — never the PUBLIC,
+ * captcha-gated `signInWithPhone`. Proven here: the seam routes the send through the admin client and
+ * succeeds with captcha ON (runtime, mocked GoTrue), and the PUBLIC seam still forwards its token (source).
+ */
+
+// A capturing service-role admin client (mock of @/lib/supabase/admin, which adminSendPhoneOtp imports).
+const admin = vi.hoisted(() => {
+  const signInWithOtp = vi.fn(async () => ({ error: null as { message: string } | null }));
+  const client = { auth: { signInWithOtp } };
+  return { signInWithOtp, createAdminClient: vi.fn((): typeof client | null => client) };
+});
+vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: admin.createAdminClient }));
+
+// The ANON server client — adminSendPhoneOtp must NEVER touch this (it's the captcha-gated public path).
+const anon = vi.hoisted(() => ({ createClient: vi.fn(async () => ({ auth: {} })) }));
+vi.mock("@/lib/supabase/server", () => ({ createClient: anon.createClient }));
+
+describe("#303 · adminSendPhoneOtp — service-role OTP, works with CAPTCHA enabled", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    // authIsLive() true (reach GoTrue) + CAPTCHA enabled (the exact condition that broke the admin reset).
+    vi.stubEnv("AUTH_DEV_BYPASS", "false");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://x.supabase.co");
+    vi.stubEnv("NEXT_PUBLIC_TURNSTILE_SITE_KEY", "0x_test_sitekey");
+    admin.signInWithOtp.mockClear();
+    admin.createAdminClient.mockClear();
+    admin.createAdminClient.mockReturnValue({ auth: { signInWithOtp: admin.signInWithOtp } });
+    anon.createClient.mockClear();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("SUCCEEDS with captcha on, via the SERVICE-ROLE client — no captchaToken, no anon/public call", async () => {
+    const { captchaEnabled } = await import("@/lib/captcha");
+    expect(captchaEnabled()).toBe(true); // the condition that permanently killed the admin reset pre-fix
+
+    const { adminSendPhoneOtp } = await import("@/lib/auth/admin");
+    const res = await adminSendPhoneOtp("0200000000");
+
+    expect(res).toEqual({ ok: true });
+    expect(admin.createAdminClient).toHaveBeenCalledTimes(1); // routed through the service-role client
+    // The admin send carries NO captcha token — GoTrue bypasses captcha for service-role requests.
+    expect(admin.signInWithOtp).toHaveBeenCalledWith({ phone: "+233200000000" });
+    // MUTATION GUARD: revert the seam to the public `signInWithPhone` and this fails — the anon client is untouched.
+    expect(anon.createClient).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a real error (no swallowed lie) when the GoTrue send fails", async () => {
+    admin.signInWithOtp.mockResolvedValueOnce({ error: { message: "boom" } });
+    const { adminSendPhoneOtp } = await import("@/lib/auth/admin");
+    expect((await adminSendPhoneOtp("0200000000")).ok).toBe(false);
+  });
+
+  it("degrades to an error (not a false success) when the service key isn't configured", async () => {
+    admin.createAdminClient.mockReturnValueOnce(null);
+    const { adminSendPhoneOtp } = await import("@/lib/auth/admin");
+    expect((await adminSendPhoneOtp("0200000000")).ok).toBe(false);
+    expect(admin.signInWithOtp).not.toHaveBeenCalled();
+  });
+});
+
+describe("#303 · the PUBLIC path is UNCHANGED + the admin seam never CONFIRMS a phone (source)", () => {
+  const SEAM = readCode("lib/auth/index.ts");
+  const ADMIN = readCode("lib/auth/admin.ts");
+  const body = (src: string, name: string) => {
+    const s = src.indexOf(`export async function ${name}`);
+    const e = src.indexOf("\nexport ", s + 1);
+    return src.slice(s, e === -1 ? undefined : e);
+  };
+
+  it("signInWithPhone still forwards options.captchaToken (public flow keeps its token)", () => {
+    const b = body(SEAM, "signInWithPhone");
+    expect(b).toContain(".signInWithOtp({");
+    expect(b).toContain("options: captchaToken ? { captchaToken } : undefined");
+  });
+
+  it("adminSendPhoneOtp forwards NO captcha token — it relies on service-role bypass, not a token", () => {
+    expect(body(ADMIN, "adminSendPhoneOtp")).not.toContain("captchaToken");
+  });
+
+  // AUTH-OTP-05 (extended to the one new place a service-role client lives): the admin seam SENDS an OTP and
+  // never CONFIRMS a phone on create — else it would void OTP-first, exactly what create-password-user-anon
+  // guards for createPasswordUser. `readCode` strips comments so the docblock's mention can't self-trip this.
+  it("the admin seam uses ONLY signInWithOtp — never a confirm-on-create admin method", () => {
+    expect(ADMIN).toContain("signInWithOtp");
+    expect(ADMIN).not.toContain("createUser");
+    expect(ADMIN).not.toContain("updateUserById");
+    expect(ADMIN).not.toContain("phone_confirm");
+    expect(ADMIN).not.toContain("email_confirm");
+    expect(ADMIN).not.toContain("signUp");
+  });
+});

--- a/omnischools/lib/auth/admin.ts
+++ b/omnischools/lib/auth/admin.ts
@@ -1,0 +1,46 @@
+import "server-only";
+import { authIsLive, normalizeGhanaPhone } from "./index";
+
+/**
+ * INCR-303 — the SERVICE-ROLE auth seam. Kept in its OWN file, apart from `lib/auth/index.ts`, so the
+ * AUTH-OTP-05 guarantee holds visibly: the account-CREATION path (`createPasswordUser` in index.ts) still
+ * uses ONLY the anonymous `signUp` and constructs no admin client — see create-password-user-anon.test.ts.
+ * The one privileged capability here is SENDING an OTP, which is the OPPOSITE of confirming a phone: the
+ * target must still complete the code, so OTP-first is never voided. `admin-otp-send.test.ts` re-asserts
+ * that this file NEVER touches a confirm-on-create method (admin.createUser / updateUserById / *_confirm).
+ */
+
+/** Minimal view of the service-role auth client — only the send-OTP method, nothing that can confirm. */
+type AdminAuthApi = {
+  signInWithOtp(creds: { phone: string }): Promise<{ error: { message: string } | null }>;
+};
+
+/**
+ * Admin-INITIATED OTP send. An admin resetting ANOTHER user's password (see `initiatePasswordReset`) is an
+ * AUTHENTICATED, role-gated action: the target isn't present to solve a captcha, and the admin can't solve
+ * one on their behalf. GoTrue's captcha middleware BYPASSES validation for service-role (admin) credentials,
+ * so this dispatches the target's own OTP SMS with Turnstile enforced — WITHOUT a caller-supplied token and
+ * WITHOUT weakening the PUBLIC login/reset flows (those keep calling the anon, captcha-gated `signInWithPhone`).
+ * The admin never sets or sees a password: the target signs in with the code and sets their own (L2a).
+ * Dev-bypass no-op; a real error (never a swallowed lie — this is an authenticated actor, no enumeration
+ * oracle to protect) if the send fails or the service key isn't configured.
+ * ponytail: rests on GoTrue skipping captcha for service-role requests — confirm once in a live captcha env.
+ */
+export async function adminSendPhoneOtp(phone: string): Promise<{ ok: boolean; error?: string }> {
+  const normalized = normalizeGhanaPhone(phone);
+  if (!authIsLive()) {
+    console.info(`[auth:dev] admin OTP requested for ${normalized} (bypass enabled)`);
+    return { ok: true };
+  }
+  const { createAdminClient } = await import("@/lib/supabase/admin");
+  const client = createAdminClient();
+  if (!client) {
+    return { ok: false, error: "Password reset is unavailable — the auth service is not configured." };
+  }
+  const { error } = await (client.auth as unknown as AdminAuthApi).signInWithOtp({ phone: normalized });
+  if (error) {
+    console.error("[auth] admin OTP send error:", error.message);
+    return { ok: false, error: "Could not send the reset code. Please try again." };
+  }
+  return { ok: true };
+}

--- a/omnischools/lib/captcha-wiring.test.ts
+++ b/omnischools/lib/captcha-wiring.test.ts
@@ -230,10 +230,13 @@ describe("M1 · the non-form captcha-gated callers are handled (completeness)", 
     expect(CHANGE_FORM).toContain("captchaToken: captcha.token");
   });
 
-  it("initiatePasswordReset refuses honestly when captchaEnabled(), BEFORE the OTP send (no lie-SMS)", () => {
+  it("#303 · initiatePasswordReset routes the OTP through the SERVICE-ROLE admin send — NOT captcha-gated", () => {
     const b = body(USERS_ACTION, "initiatePasswordReset");
-    expect(b).toContain("captchaEnabled()");
-    expect(b.indexOf("captchaEnabled()")).toBeLessThan(b.indexOf("signInWithPhone(gated.phone)"));
+    // The authenticated, role-gated admin reset must WORK with captcha on: no honest-refusal guard, and the
+    // send goes via `adminSendPhoneOtp` (service-role, captcha-bypassed), never the PUBLIC `signInWithPhone`.
+    expect(b).not.toContain("captchaEnabled()");
+    expect(b).toContain("adminSendPhoneOtp(gated.phone)");
+    expect(b).not.toContain("signInWithPhone");
   });
 
   it("the onboarding OTP-finish panel is skipped when captchaEnabled() (routes to the /login card)", () => {

--- a/omnischools/lib/users-l2b.test.ts
+++ b/omnischools/lib/users-l2b.test.ts
@@ -89,7 +89,8 @@ describe("L2b · actions double-gated, reset-as-flow, reason-channel safe (sourc
   });
 
   it("L2-22/L2-23 · reset sends an OTP to the STORED phone, sets/reveals NO password, no caller-supplied dest", () => {
-    expect(USERS).toContain("signInWithPhone(gated.phone)");
+    // #303 — via the service-role admin send (not the public captcha-gated signInWithPhone).
+    expect(USERS).toContain("adminSendPhoneOtp(gated.phone)");
     expect(USERS).not.toContain("createPasswordUser");
     expect(USERS).not.toContain("updatePassword");
     expect(USERS).not.toMatch(/input\.(phone|email|destination)/);


### PR DESCRIPTION
Closes #303.

Admin-initiated password reset was **permanently dead once Turnstile CAPTCHA was enabled**: the action sends a phone OTP via the public captcha-gated GoTrue endpoint, and #246 had added a `captchaEnabled()` honest-refusal (the admin can't solve a captcha on the target's behalf), so it refused every call.

**Fix:** route the admin OTP send through a new service-role seam `lib/auth/admin.ts::adminSendPhoneOtp` (GoTrue exempts service-role from captcha) and drop the refusal. Public login / self-service reset are unchanged and still require the captcha token.

### ⚠️ Security note (please read before merging)
This bypasses captcha on an OTP-send path via **service-role credentials** — the automated build tripped a harness security warning for exactly this, so it was put through a **rigorous independent Sarah adjudication**, which ruled it **CLEAN, not a weakening**:
- The path is authenticated + role-gated (`USER_ADMIN_ROLES`, throws) + strict-outrank (`canManageTarget`) + tenant-scoped + **stored-phone-only** (no caller-supplied destination) + audited — so captcha (an *anonymous* bot defense) protected nothing the auth gate doesn't already cover more strongly.
- The authz gate is **byte-unchanged**; the two test edits only re-point the OTP-transport seam name, not any security assertion (so not self-blessing).
- AUTH-OTP-05 holds: `lib/auth/index.ts` is byte-unchanged; the new `admin.ts` uses **only** `signInWithOtp` (sends a code, never confirms a phone / sets a password), fails closed, no blast radius.
- **Fail-safe:** if GoTrue ever stopped exempting service-role, the reset would break back to the #303 symptom — it would not open a hole.

**Gates:** Sarah CLEAN (adjudicated the flag) · Dex APPROVE · Quinn GREEN (2080 tests, mutation-proven).

**Live-env verification (follow-up, pairs with #302):** the bypass rests on GoTrue skipping captcha for service-role — un-demoable in CI (GoTrue mocked). Do a one-time smoke test (admin reset → target receives the SMS code) with Turnstile enforced when provisioning CAPTCHA (#302), before relying on it in prod. No schema / prod-paste.