### PR TITLE
fix(promotion): order preview by the canonical year-group ladder (#320)

### DIFF
--- a/omnischools/lib/academic/promotion.test.ts
+++ b/omnischools/lib/academic/promotion.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { comparePromotionRows } from "./promotion";
+
+/**
+ * #320 · promotion-preview rows must order on the Ghanaian ladder (KG<Primary<JHS<SHS, numeric
+ * within tier), NOT lexically on the class label — the #305 mixed-ladder bug class. The old SQL
+ * `asc(currentClassLabel)` put "JHS 1" before "Primary 2" and "Primary 10" before "Primary 2".
+ */
+type Row = { fromLevel: string | null; fromClass: string };
+
+describe("comparePromotionRows · canonical ladder order", () => {
+  it("orders a mixed-ladder set by tier then numeric year, streams grouped, nulls last", () => {
+    // Deliberately in lexical order — the exact ordering the SQL bug produced.
+    const input: Row[] = [
+      { fromLevel: "JHS 1", fromClass: "JHS 1 A" },
+      { fromLevel: "JHS 1", fromClass: "JHS 1 B" }, // two streams in one year-group
+      { fromLevel: "KG 1", fromClass: "KG 1 A" },
+      { fromLevel: "Primary 10", fromClass: "Primary 10 Red" }, // two-digit year
+      { fromLevel: "Primary 2", fromClass: "Primary 2 Blue" },
+      { fromLevel: "SHS 1", fromClass: "SHS 1 Science" }, // senior tier
+      { fromLevel: null, fromClass: "—" }, // UNMATCHED / level-less → last
+    ];
+
+    const out = [...input].sort(comparePromotionRows).map((r) => r.fromClass);
+
+    expect(out).toEqual([
+      "KG 1 A",
+      "Primary 2 Blue",
+      "Primary 10 Red", // numeric, not lexical: 2 before 10
+      "JHS 1 A",
+      "JHS 1 B", // streams within JHS 1 stay grouped and ordered
+      "SHS 1 Science", // SHS after JHS
+      "—", // null level buckets last
+    ]);
+  });
+
+  it("is stable within an identical level+class (keeps the SQL lastName order)", () => {
+    const input: Row[] = [
+      { fromLevel: "JHS 1", fromClass: "JHS 1 A" }, // Adjei
+      { fromLevel: "JHS 1", fromClass: "JHS 1 A" }, // Boateng
+    ];
+    // Same key → comparator returns 0 → input order preserved.
+    expect(input.slice().sort(comparePromotionRows)).toEqual(input);
+    expect(comparePromotionRows(input[0], input[1])).toBe(0);
+  });
+});

--- a/omnischools/lib/academic/promotion.ts
+++ b/omnischools/lib/academic/promotion.ts
@@ -1,4 +1,5 @@
 import { GES_BASIC_CLASSES } from "@/lib/onboarding";
+import { compareLevelLabel, UNSPECIFIED_LEVEL } from "@/lib/reports/level-order";
 
 /**
  * Year-end promotion ladder — pure helpers shared by the promotion action and UI.
@@ -38,6 +39,23 @@ export function shiftYearIso(iso: string): string {
   d.setUTCFullYear(d.getUTCFullYear() + 1);
   if (d.getUTCMonth() !== month) d.setUTCDate(0); // overflowed (Feb 29) → last day of Feb
   return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Ladder-correct order for two promotion-preview rows (#320): canonical tier order on the level
+ * (#305's compareLevelLabel — KG<Primary<JHS<SHS, numeric within tier — because the ladder can't be
+ * expressed in SQL), then class name so streams within a year-group stay grouped. Null levels
+ * (UNMATCHED / level-less classes) bucket last via UNSPECIFIED_LEVEL. Callers `.sort()` a
+ * lastName-ordered array, so a stable sort keeps students in lastName order within a class.
+ */
+export function comparePromotionRows(
+  a: { fromLevel: string | null; fromClass: string },
+  b: { fromLevel: string | null; fromClass: string },
+): number {
+  return (
+    compareLevelLabel(a.fromLevel ?? UNSPECIFIED_LEVEL, b.fromLevel ?? UNSPECIFIED_LEVEL) ||
+    a.fromClass.localeCompare(b.fromClass)
+  );
 }
 
 /** The section suffix of a class name relative to its level, e.g. ("JHS 1 A","JHS 1") → "A". */

--- a/omnischools/lib/actions/promotion.ts
+++ b/omnischools/lib/actions/promotion.ts
@@ -12,6 +12,7 @@ import {
   nextAcademicYear,
   shiftYearIso,
   sectionSuffix,
+  comparePromotionRows,
 } from "@/lib/academic/promotion";
 import type { Tx } from "@/lib/db";
 import { students, classes, academicPeriod, academicPeriodConfig } from "@/db/schema";
@@ -60,9 +61,12 @@ async function buildPlan(tx: Tx, schoolId: string): Promise<PromotionRow[]> {
     })
     .from(students)
     .where(and(eq(students.schoolId, schoolId), eq(students.status, "ACTIVE")))
-    .orderBy(asc(students.currentClassLabel), asc(students.lastName));
+    // Fetch in lastName order only; the ladder-correct level ordering can't be expressed in SQL
+    // (currentClassLabel embeds the level and sorts lexically — "JHS 1" before "Primary 2", #320)
+    // so we order in JS below. No LIMIT/pagination here, so JS-side sorting is complete.
+    .orderBy(asc(students.lastName));
 
-  return studs.map((s): PromotionRow => {
+  const rows = studs.map((s): PromotionRow => {
     const name = `${s.firstName} ${s.lastName}`.trim();
     const from = s.classId ? clsById.get(s.classId) : undefined;
     const base = {
@@ -85,6 +89,9 @@ async function buildPlan(tx: Tx, schoolId: string): Promise<PromotionRow[]> {
       targets[0];
     return { ...base, action: "PROMOTE", toClassId: target.id, toClass: target.name };
   });
+
+  rows.sort(comparePromotionRows); // stable → keeps the SQL lastName order within a class
+  return rows;
 }
 
 /** Resolve the school's current academic year and whether the next year already exists. */


### PR DESCRIPTION
Closes #320.

The promotion preview sorted students with SQL `orderBy(asc(students.currentClassLabel))`, so a mixed-ladder school saw "JHS 1" before "Primary 2" — the same class as #305. Fix: drop the SQL sort, JS-sort via a pure `comparePromotionRows` that reuses #305's `compareLevelLabel` (keys on the real `level` field, class-name tiebreak, stable so lastName order survives within a class, level-less rows last). It lives in the shared `buildPlan`, so the preview and the runner can't diverge. The query has no pagination, so JS-side sorting is over the complete set.

**Gates:** Quinn GREEN (2106 tests; mutation reproduced the exact mis-order then restored). Dex APPROVE (pure helper, reuses the #305 leaf, single seam). No schema / prod-paste.