### PR TITLE
fix(import): unify the staff CSV email validator (preview == server) (#318)

### DIFF
--- a/omnischools/lib/actions/staff.ts
+++ b/omnischools/lib/actions/staff.ts
@@ -10,6 +10,7 @@ import { sendSms } from "@/lib/sms";
 import { sendEmail } from "@/lib/email";
 import { safeRevalidate } from "@/lib/revalidate";
 import { resolveRole } from "@/lib/staff-roles";
+import { staffEmailSchema } from "@/lib/import/staff-import";
 import type { Tx } from "@/lib/db";
 import {
   users,
@@ -142,7 +143,7 @@ async function assign(
 const AddStaffSchema = z.object({
   fullName: z.string().min(2, "Enter the staff member's name").max(120),
   phone: z.string().min(7, "Enter a valid phone number"),
-  email: z.string().email("Invalid email").optional().or(z.literal("")),
+  email: staffEmailSchema,
   role: z.string().min(2, "Choose or enter a role").max(60),
 });
 
@@ -199,7 +200,7 @@ const ImportStaffSchema = z.object({
       z.object({
         fullName: z.string().min(2).max(120),
         phone: z.string().min(7),
-        email: z.string().email().optional().or(z.literal("")),
+        email: staffEmailSchema,
         role: z.string().min(2).max(60),
         ...profileFields,
       }),
@@ -365,7 +366,7 @@ const UpdateStaffSchema = z.object({
   userId: z.string().uuid(),
   fullName: z.string().min(2, "Enter the staff member's name").max(120),
   phone: z.string().min(7, "Enter a valid phone number"),
-  email: z.string().email("Invalid email").optional().or(z.literal("")),
+  email: staffEmailSchema,
 });
 
 export async function updateStaff(input: unknown): Promise<Result> {

--- a/omnischools/lib/import/staff-email-validator.test.ts
+++ b/omnischools/lib/import/staff-email-validator.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { validateStaffRows, staffEmailSchema } from "@/lib/import/staff-import";
+
+/**
+ * #318 (same class as #308) — the STAFF CSV preview validator (client) once used a looser regex
+ * than the server's Zod `.email()`, so the review table could mark a row "Ready" that the server
+ * then rejected, failing the batch. Both sides now route through `staffEmailSchema` (the object
+ * `lib/actions/staff.ts` imports for add/edit/import). This test proves it: for every case it runs
+ * the REAL preview path (`validateStaffRows`) and the REAL server schema and asserts they
+ * accept/reject identically. Staff email is OPTIONAL (blank stays valid) and uncapped — no
+ * `.max(160)`, unlike the guardian schema.
+ */
+describe("staff email · preview validator agrees with server schema (#318)", () => {
+  // Full name, Phone (login), Email, Role — clean base so email is the only possible error.
+  const base = ["Ama Owusu", "0244000001", "", "Teacher"];
+
+  // The preview accepts an email when the row has no email error.
+  const previewAccepts = (email: string) => {
+    const cells = [...base];
+    cells[2] = email;
+    const { rows } = validateStaffRows([cells]);
+    return !rows[0].errors.includes("Email is invalid");
+  };
+  const serverAccepts = (email: string) => staffEmailSchema.safeParse(email).success;
+
+  const cases: { email: string; valid: boolean }[] = [
+    // valid
+    { email: "a@b.co", valid: true },
+    { email: "x.y+z@sub.example.com", valid: true },
+    { email: "ama.owusu@example.com", valid: true },
+    { email: "", valid: true }, // optional — blank stays valid on both
+    // invalid
+    { email: "no-at", valid: false },
+    { email: "a@b", valid: false }, // no TLD
+    { email: "a@ b.c", valid: false }, // space
+    { email: "a@b.c", valid: false }, // 1-char TLD — the old regex accepted this, server didn't
+    { email: "a@b.123", valid: false }, // numeric TLD
+    { email: ".a@b.co", valid: false }, // leading dot
+    { email: "a@b..com", valid: false }, // consecutive dots
+  ];
+
+  it.each(cases)("preview and server agree on $email", ({ email, valid }) => {
+    const p = previewAccepts(email);
+    const s = serverAccepts(email);
+    expect(p).toBe(s); // no divergence
+    expect(p).toBe(valid); // and both match the expected verdict
+  });
+
+  it("blank staff email is valid on both (optional field)", () => {
+    expect(previewAccepts("")).toBe(true);
+    expect(serverAccepts("")).toBe(true);
+  });
+});

--- a/omnischools/lib/import/staff-email-validator.test.ts
+++ b/omnischools/lib/import/staff-email-validator.test.ts
@@ -50,4 +50,14 @@ describe("staff email · preview validator agrees with server schema (#318)", ()
     expect(previewAccepts("")).toBe(true);
     expect(serverAccepts("")).toBe(true);
   });
+
+  // #318 guard: staff email is UNCAPPED (unlike the guardian schema's .max(160)). A 200+ char
+  // otherwise-valid email must be accepted by BOTH preview and server — proves no length cap was
+  // silently borrowed from the guardian schema, which would re-open divergence for 161+ char emails.
+  it("does not silently cap staff email length (no 160 regression)", () => {
+    const long = "a".repeat(190) + "@example.com"; // 202 chars, well over 160
+    expect(long.length).toBeGreaterThan(160);
+    expect(previewAccepts(long)).toBe(true);
+    expect(serverAccepts(long)).toBe(true);
+  });
 });

--- a/omnischools/lib/import/staff-import.ts
+++ b/omnischools/lib/import/staff-import.ts
@@ -1,6 +1,26 @@
+import { z } from "zod";
 import { isValidGhanaPhone, normalizePhone } from "./csv";
 import { STAFF_ROLES } from "@/lib/staff-roles";
 import { resolveQualification } from "@/lib/staff-qualifications";
+
+/**
+ * Staff email — the SINGLE source of truth shared by the CSV preview validator (below) and the
+ * server add/edit/import actions (`lib/actions/staff.ts`). Optional; blank stays valid. #318 (same
+ * class as #308): the preview ran a looser regex than the server's Zod `.email()`, so the review
+ * table could mark a row "Ready" that the server then rejected, failing the batch. Both sides now
+ * import this one schema, so no divergence is possible. Client-safe (zod runs on the client).
+ * NB: no `.max(160)` (unlike the guardian schema) — the staff `email` column is uncapped `text`
+ * and the staff server never capped it, so we keep parity with the actual staff field.
+ */
+export const staffEmailSchema = z
+  .string()
+  .email("Invalid email")
+  .optional()
+  .or(z.literal(""));
+
+/** True when a staff email is acceptable. Blank = acceptable (the field is optional). */
+export const isValidStaffEmail = (email: string): boolean =>
+  staffEmailSchema.safeParse(email).success;
 
 /**
  * Staff bulk-import spec + validator. Pure + client-safe so the review table can
@@ -113,8 +133,6 @@ for (const r of STAFF_ROLES) {
   ROLE_BY_KEY.set(r.label.toLowerCase(), r);
 }
 
-const isEmail = (s: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s);
-
 /** True for a real YYYY-MM-DD calendar date (rejects e.g. 2024-13-40). */
 const isIsoDate = (s: string): boolean => {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return false;
@@ -153,7 +171,7 @@ export function validateStaffRows(dataRows: string[][]): {
     }
 
     const email = get(2);
-    if (email && !isEmail(email)) errors.push("Email is invalid");
+    if (email && !isValidStaffEmail(email)) errors.push("Email is invalid");
 
     const roleRaw = get(3);
     let roleLabel = "Teacher";


### PR DESCRIPTION
Closes #318.

Same class as the merged #308, staff path: the staff CSV preview validated email with a loose regex while all three staff server schemas used Zod `.email()` — so a "Ready" row could be server-rejected. Fix: one `staffEmailSchema` + `isValidStaffEmail()` in the client-safe `lib/import/staff-import.ts`, shared by the preview AND `AddStaffSchema` / `ImportStaffSchema` / `UpdateStaffSchema`.

Deliberately a **staff-specific** validator (not #308's `guardianEmailSchema`): the staff email field was never length-capped, so reusing the guardian schema (`.max(160)`) would have silently added a cap and created a *new* divergence for 161+ char emails. Confirmed against main. Different error copy too.

**Gates:** Quinn GREEN (2117 tests; mutation-proven; +202-char no-cap regression). Dex APPROVE (single source of truth, client/server boundary clean, separate schema is the right call). No schema / prod-paste.