### PR TITLE
fix(boarding): move SMS sends out of DB transactions (post-commit) (#253)

### DIFF
--- a/omnischools/lib/actions/boarding-daily.ts
+++ b/omnischools/lib/actions/boarding-daily.ts
@@ -7,6 +7,7 @@ import { requireSchool, resolveActor, type ActiveSchool } from "@/lib/auth/serve
 import { getCurrentUser, type AppUser } from "@/lib/auth";
 import { hasAnyRole, BOARDING_ROLES, canAccessHouse } from "@/lib/access";
 import { safeRevalidate } from "@/lib/revalidate";
+import { flushSms, type SmsIntent } from "@/lib/sms";
 import type { Tx } from "@/lib/db";
 import {
   inspections,
@@ -96,6 +97,7 @@ async function escalateInspectionFail(
   scope: { dormId: string } | { houseId: string },
   anomalies: number,
   actor: { id: string | null; role: string },
+  sms: SmsIntent[],
 ): Promise<void> {
   const studentId = await resolveResponsiblePrefect(tx, schoolId, scope);
   if (!studentId) return;
@@ -110,7 +112,7 @@ async function escalateInspectionFail(
     sourceRefId: inspectionId,
     loggedByUserId: actor.id,
     actorRole: actor.role,
-  });
+  }, sms);
 }
 
 type ActionResult = { ok: boolean; error?: string; message?: string };
@@ -178,6 +180,7 @@ export async function recordDailyInspection(input: unknown): Promise<ActionResul
   }
   const anomalies = computeAnomalies(findings.data);
 
+  const sms: SmsIntent[] = [];
   await withSchool(school.id, async (tx) => {
     const [row] = await tx
       .insert(inspections)
@@ -213,10 +216,11 @@ export async function recordDailyInspection(input: unknown): Promise<ActionResul
     });
     // INCR-13 stub (b): a FAIL logs a NOTE against the dorm prefect (FAIL only, PARTIAL none).
     if (d.result === "FAIL") {
-      await escalateInspectionFail(tx, school.id, row.id, "INSPECTION_DAILY", { dormId: d.dormId }, anomalies, actor);
+      await escalateInspectionFail(tx, school.id, row.id, "INSPECTION_DAILY", { dormId: d.dormId }, anomalies, actor, sms);
     }
   });
 
+  await flushSms(sms); // #253 — any Warning+ parent-notify goes out only after the inspection tx commits.
   safeRevalidate(todayPath(dorm.houseId));
   return { ok: true, message: `Dorm inspection recorded (${d.result.toLowerCase()}).` };
 }
@@ -267,6 +271,7 @@ export async function recordWeeklyInspection(input: unknown): Promise<ActionResu
   }
   const anomalies = computeAnomalies(findings.data);
 
+  const sms: SmsIntent[] = [];
   await withSchool(school.id, async (tx) => {
     const [row] = await tx
       .insert(inspections)
@@ -305,10 +310,11 @@ export async function recordWeeklyInspection(input: unknown): Promise<ActionResu
     });
     // INCR-13 stub (b): a FAIL logs a WARNING against a House prefect (FAIL only, PARTIAL none).
     if (d.result === "FAIL") {
-      await escalateInspectionFail(tx, school.id, row.id, "INSPECTION_WEEKLY", { houseId: d.houseId }, anomalies, actor);
+      await escalateInspectionFail(tx, school.id, row.id, "INSPECTION_WEEKLY", { houseId: d.houseId }, anomalies, actor, sms);
     }
   });
 
+  await flushSms(sms); // #253 — the weekly-FAIL Warning parent-notify goes out only after commit.
   safeRevalidate(todayPath(d.houseId));
   return { ok: true, message: `Weekly inspection recorded (${d.result.toLowerCase()}).` };
 }

--- a/omnischools/lib/actions/boarding-discipline.ts
+++ b/omnischools/lib/actions/boarding-discipline.ts
@@ -7,6 +7,7 @@ import { requireSchool, resolveActor, type ActiveSchool } from "@/lib/auth/serve
 import { getCurrentUser, type AppUser } from "@/lib/auth";
 import { hasAnyRole, BOARDING_ROLES, canAccessHouse } from "@/lib/access";
 import { safeRevalidate } from "@/lib/revalidate";
+import { flushSms, type SmsIntent } from "@/lib/sms";
 import type { Tx } from "@/lib/db";
 import {
   boardingInfractions,
@@ -105,6 +106,7 @@ export async function logInfraction(input: unknown): Promise<ActionResult> {
   const { school, user } = c;
   const actor = await resolveActor(school.id);
 
+  const sms: SmsIntent[] = [];
   const out = await withSchool(school.id, async (tx): Promise<ActionResult> => {
     const access = await studentHouseAccess(tx, school.id, d.studentId, user.roles, user.id);
     if (!access.ok) return { ok: false, error: access.error };
@@ -118,7 +120,7 @@ export async function logInfraction(input: unknown): Promise<ActionResult> {
       sourceRefId: null,
       loggedByUserId: actor.id,
       actorRole: actor.role,
-    });
+    }, sms);
     if (res.status === "bypassed") {
       return { ok: true, message: "Student has an active pastoral case — routed to the Dean, not laddered (no infraction written)." };
     }
@@ -134,6 +136,7 @@ export async function logInfraction(input: unknown): Promise<ActionResult> {
     return { ok: true, message: `Logged a ${d.severity.toLowerCase()} · append-only.` };
   });
 
+  await flushSms(sms); // #253 — parent-notify SMS goes out only after the infraction tx commits.
   if (out.ok) safeRevalidate(DISCIPLINE_PATH);
   return out;
 }
@@ -235,6 +238,7 @@ export async function openDeboardinization(input: unknown): Promise<ActionResult
   const { school, user } = c;
   const actor = await resolveActor(school.id);
 
+  const sms: SmsIntent[] = [];
   const out = await withSchool(school.id, async (tx): Promise<ActionResult & { recordId?: string }> => {
     const access = await studentHouseAccess(tx, school.id, d.studentId, user.roles, user.id);
     if (!access.ok) return { ok: false, error: access.error };
@@ -248,7 +252,7 @@ export async function openDeboardinization(input: unknown): Promise<ActionResult
       sourceRefId: null,
       loggedByUserId: actor.id,
       actorRole: actor.role,
-    });
+    }, sms);
     if (res.status === "bypassed") {
       return { ok: true, message: "Student has an active pastoral case — routed to the Dean, not laddered." };
     }
@@ -278,6 +282,7 @@ export async function openDeboardinization(input: unknown): Promise<ActionResult
     return { ok: true, message: "Deboardinization draft opened — needs three co-signs.", recordId: rec.id };
   });
 
+  await flushSms(sms); // #253 — parent-notify SMS goes out only after the deboardinization tx commits.
   if (out.ok) safeRevalidate(DISCIPLINE_PATH);
   return out;
 }

--- a/omnischools/lib/actions/boarding-exeat.ts
+++ b/omnischools/lib/actions/boarding-exeat.ts
@@ -7,6 +7,7 @@ import { requireSchool, resolveActor, type ActiveSchool } from "@/lib/auth/serve
 import { getCurrentUser, type AppUser } from "@/lib/auth";
 import { hasAnyRole, BOARDING_ROLES, canAccessHouse } from "@/lib/access";
 import { safeRevalidate } from "@/lib/revalidate";
+import { flushSms, type SmsIntent } from "@/lib/sms";
 import type { Tx } from "@/lib/db";
 import { boardingExeat, students, houses } from "@/db/schema";
 import { getExeatPolicy } from "@/lib/boarding/config";
@@ -293,11 +294,14 @@ async function transition(
 
   if (out.ok) {
     safeRevalidate(EXEAT_PATH);
-    // Fire the departure SMS after the state change commits (idempotent, console provider).
+    // Fire the departure SMS after the state change commits (idempotent, console provider). #253 —
+    // the send itself now runs post-commit via flushSms; only the notification row touches the tx.
     if (to === "DEPARTED") {
+      const sms: SmsIntent[] = [];
       await withSchool(school.id, (tx) =>
-        sendExeatStage(tx, school.id, exeatId, "DEPARTURE", actor.id),
+        sendExeatStage(tx, school.id, exeatId, "DEPARTURE", actor.id, sms),
       );
+      await flushSms(sms);
     }
   }
   return out;

--- a/omnischools/lib/actions/boarding-resumption.ts
+++ b/omnischools/lib/actions/boarding-resumption.ts
@@ -7,6 +7,7 @@ import { requireSchool, resolveActor, type ActiveSchool } from "@/lib/auth/serve
 import { getCurrentUser, type AppUser } from "@/lib/auth";
 import { hasAnyRole, BOARDING_ROLES, canAccessHouse } from "@/lib/access";
 import { safeRevalidate } from "@/lib/revalidate";
+import { flushSms, type SmsIntent } from "@/lib/sms";
 import { boardingArrival, students, houses, schools } from "@/db/schema";
 import { getCurrentPeriod } from "@/lib/boarding/period";
 import { feeOwingForStudent } from "@/lib/boarding/exeat-data";
@@ -159,10 +160,13 @@ export async function recordGateCheck(input: unknown): Promise<ActionResult> {
   if (!out.ok) return out;
 
   // Fire the confirmation SMS (console) after commit, only on a first check-in (re-scan never re-sends).
+  // #253 — the send now runs post-commit via flushSms (the tx only resolves the recipient).
   if (out.isNew) {
+    const sms: SmsIntent[] = [];
     await withSchool(school.id, (tx) =>
-      sendArrivalNotification(tx, school.id, studentId, mode, out.schoolName ?? "School").then(() => undefined),
+      sendArrivalNotification(tx, school.id, studentId, mode, out.schoolName ?? "School", sms),
     );
+    await flushSms(sms);
   }
 
   safeRevalidate(opsPath(mode));

--- a/omnischools/lib/actions/boarding-visiting.ts
+++ b/omnischools/lib/actions/boarding-visiting.ts
@@ -8,6 +8,7 @@ import { requireSchool, resolveActor, type ActiveSchool } from "@/lib/auth/serve
 import { getCurrentUser, type AppUser } from "@/lib/auth";
 import { hasAnyRole, BOARDING_ROLES, BOARDING_SCHOOL_SCOPED_ROLES, canAccessHouse } from "@/lib/access";
 import { safeRevalidate } from "@/lib/revalidate";
+import { flushSms, type SmsIntent } from "@/lib/sms";
 import {
   boardingVisit,
   boardingApprovedVisitor,
@@ -372,9 +373,11 @@ export async function recordVisit(input: unknown): Promise<ActionResult> {
   if (!out.ok) return out;
   if (out.fireArrival && out.visitId) {
     const policy = await getVisitingPolicy(school.id);
+    const sms: SmsIntent[] = [];
     await withSchool(school.id, (tx) =>
-      sendVisitNotification(tx, school.id, out.visitId!, "ARRIVAL_CONFIRM", policy, actor.id).then(() => undefined),
+      sendVisitNotification(tx, school.id, out.visitId!, "ARRIVAL_CONFIRM", policy, actor.id, sms).then(() => undefined),
     );
+    await flushSms(sms);
   }
   safeRevalidate(PATH);
   return { ok: true, message: out.message };
@@ -434,9 +437,11 @@ export async function arriveVisit(visitId: string, zoneKey?: string): Promise<Ac
   if (!out.ok) return out;
   if (out.fire) {
     const policy = await getVisitingPolicy(school.id);
+    const sms: SmsIntent[] = [];
     await withSchool(school.id, (tx) =>
-      sendVisitNotification(tx, school.id, visitId, "ARRIVAL_CONFIRM", policy, actor.id).then(() => undefined),
+      sendVisitNotification(tx, school.id, visitId, "ARRIVAL_CONFIRM", policy, actor.id, sms).then(() => undefined),
     );
+    await flushSms(sms);
   }
   safeRevalidate(PATH);
   return { ok: true, message: out.message };

--- a/omnischools/lib/boarding/discipline-core.ts
+++ b/omnischools/lib/boarding/discipline-core.ts
@@ -13,15 +13,17 @@
  *     on-read sweep never double-logs. A MANUAL log (source_ref_id NULL) is exempt from the index and
  *     always inserts.
  *
- * Parent-notify SMS fires at Warning+ (AC I1) on a FRESH insert only, via sendSms() (console) — this
- * file NEVER provisions HUBTEL_* creds. It writes NO invoices/finance row (the #1 scope guard).
+ * Parent-notify SMS fires at Warning+ (AC I1) on a FRESH insert only. #253: the send is NOT issued
+ * here — the intent is collected onto the caller's `sms` array and delivered post-commit via flushSms
+ * (a rolled-back infraction must never leave a false alert out). This file NEVER provisions HUBTEL_*
+ * creds. It writes NO invoices/finance row (the #1 scope guard).
  */
 import "server-only";
 import { and, eq, sql } from "drizzle-orm";
 import type { Tx } from "@/lib/db";
 import { boardingInfractions, students, studentGuardians, schools } from "@/db/schema";
 import { recordAudit } from "@/lib/db/audit";
-import { sendSms } from "@/lib/sms";
+import type { SmsIntent } from "@/lib/sms";
 import { hasActivePastoralFlag } from "@/lib/vlc/pastoral-flags";
 import {
   disciplineParentSms,
@@ -54,8 +56,15 @@ export interface InsertInfractionArgs {
  * Insert one infraction, respecting the pastoral bypass + auto-log idempotency, and notify the parent
  * at Warning+. Runs inside the caller's tx (atomic with its own work). Returns a discriminated result
  * so callers can count inserted vs bypassed vs duplicate.
+ *
+ * #253 — the parent-notify SMS is NOT sent here: it is pushed onto `sms` and delivered by the caller
+ * via `flushSms` AFTER this tx commits (a rolled-back infraction must never leave a false alert out).
  */
-export async function insertInfraction(tx: Tx, args: InsertInfractionArgs): Promise<InsertInfractionResult> {
+export async function insertInfraction(
+  tx: Tx,
+  args: InsertInfractionArgs,
+  sms: SmsIntent[],
+): Promise<InsertInfractionResult> {
   const { schoolId, studentId, severity, sourceKind } = args;
   const sourceRefId = args.sourceRefId ?? null;
 
@@ -136,7 +145,9 @@ export async function insertInfraction(tx: Tx, args: InsertInfractionArgs): Prom
     if (g?.phone) {
       const [sch] = await tx.select({ name: schools.name }).from(schools).where(eq(schools.id, schoolId)).limit(1);
       const name = `${stu.firstName.charAt(0)}. ${stu.lastName}`;
-      await sendSms(g.phone, disciplineParentSms(name, severity, sch?.name ?? "School"));
+      // #253 — defer the send to post-commit. parents_notified_at stays in-tx: it stamps the DECISION
+      // to notify (atomic with the fresh insert), which is what keeps the send idempotent per infraction.
+      sms.push({ to: g.phone, body: disciplineParentSms(name, severity, sch?.name ?? "School") });
       await tx
         .update(boardingInfractions)
         .set({ parentsNotifiedAt: new Date() })

--- a/omnischools/lib/boarding/exeat-notify.ts
+++ b/omnischools/lib/boarding/exeat-notify.ts
@@ -19,7 +19,7 @@ import {
   students,
   studentGuardians,
 } from "@/db/schema";
-import { sendSms } from "@/lib/sms";
+import { flushSms, type SmsIntent } from "@/lib/sms";
 import { insertInfraction } from "./discipline-core";
 import { getExeatBoard } from "./exeat-data";
 import {
@@ -59,6 +59,7 @@ export async function sendExeatStage(
   exeatId: string,
   kind: NotificationKind,
   actorUserId: string | null,
+  sms: SmsIntent[],
 ): Promise<StageResult> {
   const existing = await tx
     .select({ id: exeatNotification.id })
@@ -126,20 +127,28 @@ export async function sendExeatStage(
     return "no_phone";
   }
 
-  // ponytail: sendSms runs inside the tx — negligible for the console provider; once Hubtel
-  // go-lives, move the send outside the tx (network call shouldn't hold a row lock).
-  const result = await sendSms(guardian.phone, body);
-  await tx.insert(exeatNotification).values({
-    schoolId,
-    exeatId,
-    kind,
-    toPhone: guardian.phone,
+  // #253 — defer the send to post-commit (network call must not hold the exeat's row lock, and a
+  // rolled-back tx must not leave an SMS out). The exeat_notification row records the REAL result, so
+  // it is written by the onSent hook in its own fresh tx once the send returns (never optimistically).
+  const toPhone = guardian.phone;
+  sms.push({
+    to: toPhone,
     body,
-    provider: result.provider,
-    providerMessageId: result.id,
-    error: result.error,
-    ok: result.ok,
-    sentByUserId: actorUserId ?? undefined,
+    onSent: (result) =>
+      withSchool(schoolId, (t) =>
+        t.insert(exeatNotification).values({
+          schoolId,
+          exeatId,
+          kind,
+          toPhone,
+          body,
+          provider: result.provider,
+          providerMessageId: result.id,
+          error: result.error,
+          ok: result.ok,
+          sentByUserId: actorUserId ?? undefined,
+        }),
+      ).then(() => undefined),
   });
   return "sent";
 }
@@ -168,9 +177,12 @@ export async function runOverdueChain(
   let stage3Stubs = 0;
 
   for (const row of board.late) {
+    // #253 — collect this row's sends in-tx, deliver them only after ITS tx commits (per-row, so an
+    // earlier committed row still sends even if a later row throws).
+    const sms: SmsIntent[] = [];
     await withSchool(schoolId, async (tx) => {
       for (const kind of row.dueStages) {
-        const res = await sendExeatStage(tx, schoolId, row.id, kind, actorUserId);
+        const res = await sendExeatStage(tx, schoolId, row.id, kind, actorUserId, sms);
         if (res === "sent" || res === "no_phone") {
           if (res === "sent") sent += 1;
           if (kind === "OVERDUE_STAGE_3") {
@@ -193,12 +205,13 @@ export async function runOverdueChain(
                 sourceRefId: row.id,
                 loggedByUserId: actorUserId,
                 actorRole,
-              });
+              }, sms);
             }
           }
         }
       }
     });
+    await flushSms(sms);
   }
   return { checked: board.late.length, sent, stage3Stubs };
 }

--- a/omnischools/lib/boarding/resumption-notify.ts
+++ b/omnischools/lib/boarding/resumption-notify.ts
@@ -16,7 +16,7 @@ import { and, eq } from "drizzle-orm";
 import type { Tx } from "@/lib/db";
 import { withSchool } from "@/lib/db/rls";
 import { students, studentGuardians } from "@/db/schema";
-import { sendSms, type SmsResult } from "@/lib/sms";
+import { flushSms, type SmsIntent } from "@/lib/sms";
 import { insertInfraction } from "./discipline-core";
 import { getCurrentPeriod } from "./period";
 import { getResumptionBoard } from "./resumption-data";
@@ -42,10 +42,10 @@ async function primaryGuardianPhone(
 }
 
 /**
- * Fire the arrival (RESUMPTION) / departure (VACATION) confirmation SMS to the boarder's primary
- * guardian (AC H4/I1). Console provider — no real send. Returns null when no phone is on file (the
- * SMS is skipped, never a hard failure that blocks the gate check). No notification row is written
- * (Kofi OQ5 — no arrival notification table).
+ * Collect the arrival (RESUMPTION) / departure (VACATION) confirmation SMS for the boarder's primary
+ * guardian (AC H4/I1). Console provider — no real send here: #253 pushes the intent onto `sms` and the
+ * caller delivers it via `flushSms` AFTER commit (a no-op when no phone is on file). No notification
+ * row is written (Kofi OQ5 — no arrival notification table).
  */
 export async function sendArrivalNotification(
   tx: Tx,
@@ -53,18 +53,19 @@ export async function sendArrivalNotification(
   studentId: string,
   mode: BoardingMode,
   schoolName: string,
-): Promise<SmsResult | null> {
+  sms: SmsIntent[],
+): Promise<void> {
   const [stu] = await tx
     .select({ firstName: students.firstName, lastName: students.lastName })
     .from(students)
     .where(and(eq(students.schoolId, schoolId), eq(students.id, studentId)))
     .limit(1);
-  if (!stu) return null;
+  if (!stu) return;
   const phone = await primaryGuardianPhone(tx, schoolId, studentId);
-  if (!phone) return null;
+  if (!phone) return;
   const name = `${stu.firstName.charAt(0)}. ${stu.lastName}`;
   const body = mode === "RESUMPTION" ? arrivalSms(name, schoolName) : departureSms(name, schoolName);
-  return sendSms(phone, body);
+  sms.push({ to: phone, body });
 }
 
 const UNACCOUNTED_PREFIX = "unaccounted-";
@@ -89,6 +90,9 @@ export async function runUnaccountedSweep(
   if (studentIds.length === 0) return { checked: 0, sent: 0 };
 
   let sent = 0;
+  // #253 — collect the unaccounted reminders (and any Warning+ parent-notify from insertInfraction)
+  // in-tx; deliver them via flushSms after the sweep commits (rollback → nothing goes out).
+  const sms: SmsIntent[] = [];
   await withSchool(schoolId, async (tx) => {
     const period = await getCurrentPeriod(tx, schoolId);
     for (const studentId of studentIds) {
@@ -105,7 +109,7 @@ export async function runUnaccountedSweep(
           sourceRefId: `${period.periodId}:${studentId}`,
           loggedByUserId: null,
           actorRole: "SYSTEM",
-        });
+        }, sms);
       }
       const [stu] = await tx
         .select({ firstName: students.firstName, lastName: students.lastName })
@@ -116,9 +120,10 @@ export async function runUnaccountedSweep(
       const phone = await primaryGuardianPhone(tx, schoolId, studentId);
       if (!phone) continue;
       const name = `${stu.firstName.charAt(0)}. ${stu.lastName}`;
-      await sendSms(phone, unaccountedSms(name, schoolName));
+      sms.push({ to: phone, body: unaccountedSms(name, schoolName) });
       sent += 1;
     }
   });
+  await flushSms(sms);
   return { checked: studentIds.length, sent };
 }

--- a/omnischools/lib/boarding/visiting-notify.ts
+++ b/omnischools/lib/boarding/visiting-notify.ts
@@ -29,7 +29,7 @@ import {
 } from "@/db/schema";
 import { canAccessHouse } from "@/lib/access";
 import { classFormNumber } from "@/lib/senior/form";
-import { sendSms } from "@/lib/sms";
+import { flushSms, type SmsIntent } from "@/lib/sms";
 import { insertInfraction } from "./discipline-core";
 import { hasActivePastoralFlag } from "@/lib/vlc/pastoral-flags";
 import {
@@ -98,7 +98,10 @@ export async function sendCohortReminder(
   kind: "INVITATION" | "REMINDER_T3" | "REMINDER_T1",
   actorUserId: string | null,
 ): Promise<CohortResult> {
-  return withSchool(schoolId, async (tx): Promise<CohortResult> => {
+  // #253 — collect the cohort sends in-tx, deliver them via flushSms after the guard row commits
+  // (rollback → the array is discarded, no parent is texted for a batch that never recorded).
+  const sms: SmsIntent[] = [];
+  const result = await withSchool(schoolId, async (tx): Promise<CohortResult> => {
     // Idempotency guard — one row per (event × kind), visit_id NULL.
     const existing = await tx
       .select({ id: boardingVisitNotification.id })
@@ -150,13 +153,10 @@ export async function sendCohortReminder(
       if (phone) phones.add(phone);
     }
 
-    let sent = 0;
-    for (const phone of phones) {
-      const r = await sendSms(phone, body);
-      if (r.ok) sent += 1;
-    }
+    for (const phone of phones) sms.push({ to: phone, body });
 
-    // The single event-scoped guard row (cohort marker — NO visitor PII).
+    // The single event-scoped guard row (cohort marker — NO visitor PII). Stays in-tx: it is a
+    // console marker, not a per-send result, so it never depended on the send outcome.
     await tx.insert(boardingVisitNotification).values({
       schoolId,
       visitId: null,
@@ -169,8 +169,10 @@ export async function sendCohortReminder(
       sentByUserId: actorUserId ?? undefined,
     });
 
-    return { ok: true, skipped: false, sent };
+    return { ok: true, skipped: false, sent: phones.size };
   });
+  await flushSms(sms);
+  return result;
 }
 
 export type PerVisitResult = "sent" | "skipped" | "no_phone";
@@ -188,6 +190,7 @@ export async function sendVisitNotification(
   kind: "ARRIVAL_CONFIRM" | "OVERSTAY",
   policy: VisitingPolicy,
   actorUserId: string | null,
+  sms: SmsIntent[],
 ): Promise<PerVisitResult> {
   const existing = await tx
     .select({ id: boardingVisitNotification.id })
@@ -228,7 +231,7 @@ export async function sendVisitNotification(
       sourceRefId: visitId,
       loggedByUserId: actorUserId,
       actorRole: "HOUSEMASTER",
-    });
+    }, sms);
   }
 
   const [school] = await tx.select({ name: schools.name }).from(schools).where(eq(schools.id, schoolId)).limit(1);
@@ -258,18 +261,28 @@ export async function sendVisitNotification(
     });
     return "no_phone";
   }
-  const r = await sendSms(phone, body);
-  await tx.insert(boardingVisitNotification).values({
-    schoolId,
-    visitId,
-    kind,
-    toPhone: phone,
+  // #253 — defer the HM send to post-commit (no network call under the visit's row lock; a rolled-back
+  // overstay/arrival leaves nothing out). The notification row records the REAL result via onSent, in
+  // its own fresh tx once the send returns.
+  const toPhone = phone;
+  sms.push({
+    to: toPhone,
     body,
-    provider: r.provider,
-    providerMessageId: r.id,
-    error: r.error,
-    ok: r.ok,
-    sentByUserId: actorUserId ?? undefined,
+    onSent: (r) =>
+      withSchool(schoolId, (t) =>
+        t.insert(boardingVisitNotification).values({
+          schoolId,
+          visitId,
+          kind,
+          toPhone,
+          body,
+          provider: r.provider,
+          providerMessageId: r.id,
+          error: r.error,
+          ok: r.ok,
+          sentByUserId: actorUserId ?? undefined,
+        }),
+      ).then(() => undefined),
   });
   return "sent";
 }
@@ -293,7 +306,9 @@ export async function runOverstaySweep(
   actorUserId: string | null,
   now: Date = new Date(),
 ): Promise<OverstaySummary> {
-  return withSchool(schoolId, async (tx): Promise<OverstaySummary> => {
+  // #253 — collect the overstay HM sends in-tx, deliver them via flushSms after the sweep commits.
+  const sms: SmsIntent[] = [];
+  const summary = await withSchool(schoolId, async (tx): Promise<OverstaySummary> => {
     const houseRows = await tx
       .select({ id: houses.id, hmUserId: houses.hmUserId })
       .from(houses)
@@ -323,11 +338,13 @@ export async function runOverstaySweep(
 
     let sent = 0;
     for (const r of overstaying) {
-      const res = await sendVisitNotification(tx, schoolId, r.id, "OVERSTAY", policy, actorUserId);
+      const res = await sendVisitNotification(tx, schoolId, r.id, "OVERSTAY", policy, actorUserId, sms);
       if (res === "sent") sent += 1;
     }
     return { checked: overstaying.length, sent };
   });
+  await flushSms(sms);
+  return summary;
 }
 
 // Re-export for the actions' kind typing.

--- a/omnischools/lib/sms/after-commit-253.test.ts
+++ b/omnischools/lib/sms/after-commit-253.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { cwd } from "node:process";
+import { flushSms, type SmsIntent } from "@/lib/sms";
+import { sendArrivalNotification } from "@/lib/boarding/resumption-notify";
+import type { Tx } from "@/lib/db";
+
+/**
+ * #253 — SMS sends must never run INSIDE a DB transaction: a rolled-back tx would have already fired an
+ * irreversible SMS, and holding the tx open across a slow external call blocks the real Hubtel provider.
+ * The fix collects `SmsIntent`s in-tx and delivers them via `flushSms` AFTER commit.
+ *
+ * This suite locks BOTH halves: (1) a structural guard that no `sendSms(` call survives lexically inside
+ * any tenant-tx wrapper across every SMS caller, and (2) a behavioural proof on a real site that the
+ * intent is only sent post-commit and a rollback sends nothing.
+ */
+
+const src = (rel: string) => readFileSync(resolve(cwd(), rel), "utf8");
+// Strip comments AND string/template-text so parens inside copy can't skew the brace scan.
+const strip = (s: string): string =>
+  s
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1")
+    .replace(/'(?:[^'\\]|\\.)*'/g, "''")
+    .replace(/"(?:[^"\\]|\\.)*"/g, '""');
+
+// Every module that calls sendSms (the whole SMS surface — not just the boarding sites this fix moved).
+const SMS_CALLERS = [
+  "lib/actions/attendance.ts",
+  "lib/actions/billing.ts",
+  "lib/actions/comms.ts",
+  "lib/actions/admissions.ts",
+  "lib/actions/fees.ts",
+  "lib/actions/invites.ts",
+  "lib/actions/onboarding.ts",
+  "lib/actions/inbox.ts",
+  "lib/actions/staff.ts",
+  "lib/actions/users.ts",
+  "lib/actions/wassce-readiness.ts",
+  "lib/boarding/discipline-core.ts",
+  "lib/boarding/exeat-notify.ts",
+  "lib/boarding/resumption-notify.ts",
+  "lib/boarding/visiting-notify.ts",
+];
+
+const TX_WRAPPER = /\b(withSchool|withStaffScope|withParentScope|withoutTenantScope|transaction)\s*\(/g;
+const REAL_SEND = /\bsendSms\s*\(\s*[^)\s]/; // a call with a real first arg (excludes bare `sendSms()` in prose)
+
+/** True if any `sendSms(...)` call sits inside a tenant-tx wrapper's argument list (its callback body). */
+function sendInsideTx(source: string): boolean {
+  const s = strip(source);
+  TX_WRAPPER.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = TX_WRAPPER.exec(s))) {
+    const open = m.index + m[0].length - 1; // index of the wrapper's '('
+    let depth = 0;
+    let i = open;
+    for (; i < s.length; i++) {
+      if (s[i] === "(") depth++;
+      else if (s[i] === ")" && --depth === 0) break;
+    }
+    if (REAL_SEND.test(s.slice(open, i + 1))) return true;
+  }
+  return false;
+}
+
+describe("#253 structural lock — no sendSms inside a DB transaction", () => {
+  it.each(SMS_CALLERS)("%s never calls sendSms inside a tenant-tx wrapper", (rel) => {
+    expect(sendInsideTx(src(rel))).toBe(false);
+  });
+
+  it("the moved boarding sites deliver via flushSms after commit", () => {
+    for (const rel of [
+      "lib/boarding/exeat-notify.ts",
+      "lib/boarding/resumption-notify.ts",
+      "lib/boarding/visiting-notify.ts",
+    ]) {
+      expect(src(rel)).toMatch(/flushSms\(/);
+    }
+    // discipline-core hands its intent up to the caller — no real sendSms call survives in it.
+    expect(strip(src("lib/boarding/discipline-core.ts"))).not.toMatch(REAL_SEND);
+  });
+});
+
+// A minimal drizzle-tx double: each `.limit(1)` resolves the next queued result row-set.
+function fakeTx(rowSets: unknown[][]): Tx {
+  let i = 0;
+  const chain: Record<string, unknown> = {};
+  for (const key of ["select", "from", "where", "innerJoin"]) chain[key] = () => chain;
+  chain.limit = () => Promise.resolve(rowSets[i++] ?? []);
+  return chain as unknown as Tx;
+}
+
+describe("#253 behavioural — sendArrivalNotification collects in-tx, sends post-commit", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  const STUDENT = [{ firstName: "Ama", lastName: "Boakye" }];
+  const GUARDIAN = [{ phone: "0244123456" }];
+  const BODY = "A. Boakye safely arrived at Test School. Items checked. Welcome back.";
+
+  it("happy path: nothing sends until flushSms runs after the tx commits", async () => {
+    const info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const sms: SmsIntent[] = [];
+
+    // Simulate the owner: run the in-tx work to completion (a "commit").
+    await sendArrivalNotification(fakeTx([STUDENT, GUARDIAN]), "school-1", "stu-1", "RESUMPTION", "Test School", sms);
+
+    // The intent is collected but NOT yet sent while "inside" the tx.
+    expect(sms).toEqual([{ to: "0244123456", body: BODY }]);
+    expect(info).not.toHaveBeenCalled();
+
+    // Post-commit delivery sends exactly once, to the same recipient/message.
+    await flushSms(sms);
+    expect(info).toHaveBeenCalledTimes(1);
+    expect(String(info.mock.calls[0]?.[0])).toContain(BODY);
+  });
+
+  it("rollback: the owner throws after collecting, so flushSms never runs and no SMS is sent", async () => {
+    const info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const sms: SmsIntent[] = [];
+
+    // The owner pattern is: `await withSchool(...work...); await flushSms(sms);`
+    // A tx that throws rejects BEFORE the flush line is reached.
+    const owner = async () => {
+      await sendArrivalNotification(fakeTx([STUDENT, GUARDIAN]), "school-1", "stu-1", "RESUMPTION", "Test School", sms);
+      throw new Error("tx rolled back");
+      // unreachable: await flushSms(sms)
+    };
+
+    await expect(owner()).rejects.toThrow("tx rolled back");
+    expect(info).not.toHaveBeenCalled(); // no false SMS followed the rolled-back tx
+  });
+});

--- a/omnischools/lib/sms/index.ts
+++ b/omnischools/lib/sms/index.ts
@@ -72,6 +72,33 @@ export async function sendSms(to: string, body: string): Promise<SmsResult> {
   return getSmsProvider().send({ to, body });
 }
 
+/**
+ * A deferred SMS send (#253). Collected INSIDE a DB transaction and delivered by `flushSms` only
+ * AFTER that transaction commits — so a rollback discards the array and nothing goes out (a false
+ * "was marked absent" can never follow a rolled-back write), and no external call is held while a
+ * row lock is open (the pre-req for switching the console stub to the real Hubtel provider).
+ *
+ * `onSent` is the optional "thread the result out" hook for sites that persist the send OUTCOME
+ * (e.g. an `exeat_notification` row): it runs post-commit with the real `SmsResult`, in its OWN
+ * fresh `withSchool` tx — never inside the committing one.
+ */
+export interface SmsIntent {
+  to: string;
+  body: string;
+  onSent?: (result: SmsResult) => Promise<void>;
+}
+
+/**
+ * Deliver intents collected in-tx, in order, after the tx has committed. Never call this INSIDE a
+ * `withSchool`/transaction callback — that would re-introduce the very bug #253 fixes.
+ */
+export async function flushSms(intents: readonly SmsIntent[]): Promise<void> {
+  for (const intent of intents) {
+    const result = await sendSms(intent.to, intent.body);
+    if (intent.onSent) await intent.onSent(result);
+  }
+}
+
 /** Estimated cost per SMS segment in GHS (Hubtel-style bulk rate). */
 export const SMS_SEGMENT_RATE_GHS = 0.035;
 


### PR DESCRIPTION
Closes #253.

SMS sends inside DB transactions are a correctness hazard (a rollback after the send = a false SMS already out; the tx is held open across a slow external call) and block switching to a real provider (Hubtel). Investigation: all `lib/actions/*` callers already sent post-commit — the genuine offenders were all in `lib/boarding` (discipline / exeat / visiting / resumption + boarding-daily).

**Fix:** a `SmsIntent` + `flushSms` collector in `lib/sms/index.ts`. In-tx code **pushes intents**; the tx-owner calls `flushSms(...)` **after** the `withSchool` block resolves. On rollback the collector is discarded → **nothing sends**. Happy-path recipients/messages/order are byte-identical; `onSent` records the real send result in its own post-commit tenant tx. Reuses the existing collect-in-tx/send-after idiom (`attendance.ts`, `staff.ts`).

**Gates:** Sarah CLEAN (no cross-tenant leak — flush does zero DB reads, recipients resolved in-scope; fails closed). Quinn GREEN (2122 tests; rollback-safety proven behaviourally; structural lock mutation-fires on re-nesting). Dex APPROVE (uniform across all 12 sites, minimal seam, advances the Hubtel migration path).

**Note for Hubtel go-live:** the notification guard row now writes in the post-commit `onSent` tx (a few-ms window vs. atomic-with-send). Idempotency stays the existing best-effort single-runner model — under a real *paid* provider, keep the sweeps single-runner so a duplicate never = real money (relates to #259/#276). No schema / prod-paste.