### PR TITLE
fix(onboarding): explicit hand-off when OTP auto-sign-in can't run under CAPTCHA (#304)

### DIFF
--- a/omnischools/components/onboarding/wizard.tsx
+++ b/omnischools/components/onboarding/wizard.tsx
@@ -704,9 +704,9 @@ export function DonePanel({
               we&apos;ll guide you through the rest from a checklist.
             </p>
           </div>
-          {/* When OTP-first is live AND captcha is off, the OTP card below is the sign-in action; else
-              link to /login (whose OTP send IS captcha-wired — the onboarding auto-send is not). */}
-          {(!result.otpLive || captchaEnabled()) && (
+          {/* Pre-OTP flow (otpLive=false): the plain terminal button. When OTP-first IS live the sign-in
+              action lives below — the inline OTP card (captcha off) or the explicit hand-off (captcha on). */}
+          {!result.otpLive && (
             <Link
               href="/login?accepted=1"
               className="rounded-lg bg-gold px-6 py-3.5 text-sm font-bold text-navy transition-colors hover:brightness-95"
@@ -719,8 +719,34 @@ export function DonePanel({
 
       {/* INCR-AUTH-OTP · auto-sign-in (Option A): verify the phone via OTP → confirms it + lands in /dashboard. */}
       {/* The onboarding auto-send is NOT captcha-wired (no user interaction before the send), so when
-          captcha is on we skip it and route to /login above, whose OTP send solves a captcha. */}
+          captcha is on we skip it and show the explicit hand-off below instead. */}
       {result.otpLive && !captchaEnabled() && <OnboardingOtpFinish phone={result.adminPhone} />}
+
+      {/* #304 — captcha on: the app-controlled OTP auto-send can't run (no user-solved token exists before
+          the send), so auto-sign-in is impossible here. Rather than SILENTLY drop the just-onboarded admin
+          at a generic button, make the hand-off EXPLICIT: name the school, the reason, and the phone, then
+          route to /login — whose OTP send IS captcha-gated. Captcha stays in force: onboarding sign-in is a
+          public, self-service action (a brand-new user signing THEMSELVES in), never an authenticated admin
+          action, so it must NOT reuse #303's captcha-exempt service-role path. */}
+      {result.otpLive && captchaEnabled() && (
+        <div className="mt-5 rounded-xl border border-gold-soft bg-gold-bg px-6 py-5">
+          <div className="font-display text-base font-semibold text-navy">
+            One more step — finish signing in
+          </div>
+          <p className="mt-1 max-w-[520px] text-[13px] leading-relaxed text-navy-2">
+            <b className="text-navy">{schoolName}</b> is ready. For security we ask everyone to pass a
+            quick verification, so we couldn&apos;t sign you in automatically. On the sign-in page, enter{" "}
+            <b className="text-navy">{result.adminPhone}</b> to get a one-time code — or use the password
+            you just set — and you&apos;ll land on your dashboard.
+          </p>
+          <Link
+            href="/login?accepted=1"
+            className="mt-3 inline-block rounded-lg bg-navy px-5 py-2.5 text-sm font-bold text-bg transition-colors hover:bg-navy-deep"
+          >
+            Go to sign in →
+          </Link>
+        </div>
+      )}
 
       <div className="mt-6">
         <div className="mb-3 font-display text-base font-medium text-navy">

--- a/omnischools/lib/onboarding-captcha-handoff-304.test.ts
+++ b/omnischools/lib/onboarding-captcha-handoff-304.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
@@ -11,31 +11,41 @@ import { renderToStaticMarkup } from "react-dom/server";
  * card would attempt a captcha-less send, and there is no bypass. With CAPTCHA off the inline auto-sign-in
  * is unchanged.
  *
- * `env` (→ `captchaEnabled`) is parsed once at module load, so we stub the site key then re-import the
- * wizard fresh per case. `renderToStaticMarkup` runs in node (no jsdom); mount effects do NOT fire, so the
- * render proves the STRUCTURE (which card shows, which route exists).
+ * `captchaEnabled()` is MOCKED per case (not env-stubbed with a module reset + dynamic re-import). The
+ * earlier resetModules/stubEnv/`await import` dance raced the once-at-load `env` parse under parallel
+ * suite contention (cold-transform timeout + non-hermetic env bleed — Dex/Quinn #304). A static
+ * `DonePanel` import + a per-case mock is hermetic and fast. `renderToStaticMarkup` runs in node (no
+ * jsdom): mount effects do NOT fire, so the render proves the STRUCTURE (which card shows, which route).
  */
-async function renderDone(opts: { otpLive: boolean; captcha: boolean }): Promise<string> {
-  vi.resetModules();
-  vi.stubEnv("NEXT_PUBLIC_TURNSTILE_SITE_KEY", opts.captcha ? "0x_test_sitekey" : undefined);
-  const { DonePanel } = await import("@/components/onboarding/wizard");
-  const result = {
-    ok: true as const,
-    schoolId: "sch_123",
-    academicYear: "2025/26",
-    periodsCreated: 3,
-    adminPhone: "+233241234567",
-    otpLive: opts.otpLive,
-  };
+vi.mock("@/lib/captcha", () => ({ captchaEnabled: vi.fn(() => false) }));
+import { captchaEnabled } from "@/lib/captcha";
+import { DonePanel } from "@/components/onboarding/wizard";
+
+const mockedCaptcha = vi.mocked(captchaEnabled);
+beforeEach(() => mockedCaptcha.mockReset());
+
+const renderDone = (opts: { otpLive: boolean; captcha: boolean }): string => {
+  mockedCaptcha.mockReturnValue(opts.captcha);
   return renderToStaticMarkup(
-    createElement(DonePanel, { result, schoolName: "St. Theresa's SHS" }),
+    createElement(DonePanel, {
+      result: {
+        ok: true as const,
+        schoolId: "sch_123",
+        academicYear: "2025/26",
+        periodsCreated: 3,
+        adminPhone: "+233241234567",
+        otpLive: opts.otpLive,
+      },
+      schoolName: "St. Theresa's SHS",
+    }),
   );
-}
+};
 
 const visible = (html: string): string =>
   html
     .replace(/<[^>]*>/g, " ")
     .replace(/&apos;|&#x27;/g, "'")
+    // Ampersand LAST: unescaping &amp; before the named entities can double-unescape (CodeQL js/double-escaping).
     .replace(/&amp;/g, "&")
     .replace(/\s+/g, " ")
     .trim();
@@ -45,14 +55,9 @@ const LOGIN_HREF = 'href="/login?accepted=1"';
 const AUTO_SEND_CARD = "Finish signing in — verify your number";
 const AUTO_SEND_CTA = "Verify & go to dashboard";
 
-afterEach(() => {
-  vi.unstubAllEnvs();
-  vi.resetModules();
-});
-
 describe("#304 · onboarding done phase — CAPTCHA on renders an EXPLICIT hand-off (no silent drop)", () => {
-  it("otpLive + captcha ON: explicit hand-off names the reason + phone, and does NOT auto-send an OTP", async () => {
-    const html = await renderDone({ otpLive: true, captcha: true });
+  it("otpLive + captcha ON: explicit hand-off names the reason + phone, and does NOT auto-send an OTP", () => {
+    const html = renderDone({ otpLive: true, captcha: true });
     const text = visible(html);
     // Explicit, not silent: the hand-off card, the security reason, and the phone to sign in with.
     expect(text).toContain("finish signing in");
@@ -65,8 +70,8 @@ describe("#304 · onboarding done phase — CAPTCHA on renders an EXPLICIT hand-
     expect(html).toContain(LOGIN_HREF);
   });
 
-  it("otpLive + captcha OFF: inline auto-sign-in is unchanged (card renders, no hand-off)", async () => {
-    const html = await renderDone({ otpLive: true, captcha: false });
+  it("otpLive + captcha OFF: inline auto-sign-in is unchanged (card renders, no hand-off)", () => {
+    const html = renderDone({ otpLive: true, captcha: false });
     const text = visible(html);
     expect(text).toContain(AUTO_SEND_CARD);
     expect(text).toContain(AUTO_SEND_CTA); // visible() unescapes &amp; → & ; raw html has &amp;
@@ -74,8 +79,8 @@ describe("#304 · onboarding done phase — CAPTCHA on renders an EXPLICIT hand-
     expect(text).not.toContain("quick verification");
   });
 
-  it("otpLive=false: pre-OTP terminal button, regardless of captcha", async () => {
-    const html = await renderDone({ otpLive: false, captcha: true });
+  it("otpLive=false: pre-OTP terminal button, regardless of captcha", () => {
+    const html = renderDone({ otpLive: false, captcha: true });
     const text = visible(html);
     expect(text).toContain("Sign in →");
     expect(text).not.toContain(AUTO_SEND_CARD);

--- a/omnischools/lib/onboarding-captcha-handoff-304.test.ts
+++ b/omnischools/lib/onboarding-captcha-handoff-304.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+/**
+ * #304 — onboarding OTP-first auto-sign-in must not SILENTLY degrade when CAPTCHA is on.
+ *
+ * With CAPTCHA enabled the app-controlled OTP auto-send can't run (there is no user-solved token before
+ * the mount-time send), so inline auto-sign-in is impossible. The done phase must instead render an
+ * EXPLICIT hand-off (why + phone + a /login route), and must NOT render the auto-send OTP card — that
+ * card would attempt a captcha-less send, and there is no bypass. With CAPTCHA off the inline auto-sign-in
+ * is unchanged.
+ *
+ * `env` (→ `captchaEnabled`) is parsed once at module load, so we stub the site key then re-import the
+ * wizard fresh per case. `renderToStaticMarkup` runs in node (no jsdom); mount effects do NOT fire, so the
+ * render proves the STRUCTURE (which card shows, which route exists).
+ */
+async function renderDone(opts: { otpLive: boolean; captcha: boolean }): Promise<string> {
+  vi.resetModules();
+  vi.stubEnv("NEXT_PUBLIC_TURNSTILE_SITE_KEY", opts.captcha ? "0x_test_sitekey" : undefined);
+  const { DonePanel } = await import("@/components/onboarding/wizard");
+  const result = {
+    ok: true as const,
+    schoolId: "sch_123",
+    academicYear: "2025/26",
+    periodsCreated: 3,
+    adminPhone: "+233241234567",
+    otpLive: opts.otpLive,
+  };
+  return renderToStaticMarkup(
+    createElement(DonePanel, { result, schoolName: "St. Theresa's SHS" }),
+  );
+}
+
+const visible = (html: string): string =>
+  html
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&apos;|&#x27;/g, "'")
+    .replace(/&amp;/g, "&")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const LOGIN_HREF = 'href="/login?accepted=1"';
+// The auto-send OTP card (OnboardingOtpFinish) — its title & CTA are distinct from the hand-off's copy.
+const AUTO_SEND_CARD = "Finish signing in — verify your number";
+const AUTO_SEND_CTA = "Verify & go to dashboard";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe("#304 · onboarding done phase — CAPTCHA on renders an EXPLICIT hand-off (no silent drop)", () => {
+  it("otpLive + captcha ON: explicit hand-off names the reason + phone, and does NOT auto-send an OTP", async () => {
+    const html = await renderDone({ otpLive: true, captcha: true });
+    const text = visible(html);
+    // Explicit, not silent: the hand-off card, the security reason, and the phone to sign in with.
+    expect(text).toContain("finish signing in");
+    expect(text).toContain("quick verification");
+    expect(text).toContain("+233241234567");
+    // The auto-send card must NOT render — it can't supply a captcha token (no bypass introduced).
+    expect(text).not.toContain(AUTO_SEND_CARD);
+    expect(text).not.toContain(AUTO_SEND_CTA); // text unescapes &amp; → &, catches the card either way
+    // Still routes to the captcha-gated /login OTP page — captcha stays in force.
+    expect(html).toContain(LOGIN_HREF);
+  });
+
+  it("otpLive + captcha OFF: inline auto-sign-in is unchanged (card renders, no hand-off)", async () => {
+    const html = await renderDone({ otpLive: true, captcha: false });
+    const text = visible(html);
+    expect(text).toContain(AUTO_SEND_CARD);
+    expect(text).toContain(AUTO_SEND_CTA); // visible() unescapes &amp; → & ; raw html has &amp;
+    // The captcha hand-off copy is absent when captcha is off.
+    expect(text).not.toContain("quick verification");
+  });
+
+  it("otpLive=false: pre-OTP terminal button, regardless of captcha", async () => {
+    const html = await renderDone({ otpLive: false, captcha: true });
+    const text = visible(html);
+    expect(text).toContain("Sign in →");
+    expect(text).not.toContain(AUTO_SEND_CARD);
+    expect(text).not.toContain("quick verification");
+    expect(html).toContain(LOGIN_HREF);
+  });
+});


### PR DESCRIPTION
Closes #304.

The onboarding done-phase auto-sign-in (OTP-first, #243) **silently** dropped when CAPTCHA was enabled: the mount-time auto-send has no user-solved token, so the card was suppressed (#246) and the just-onboarded admin got only a generic button with no explanation.

**Fix:** in the captcha-on state, render an EXPLICIT hand-off card (names the school, states the reason, shows the phone) with a link to the captcha-gated `/login?accepted=1`. **CAPTCHA stays in force** — no bypass. Unlike #303 (an *authenticated, role-gated admin* action, which correctly used a service-role captcha-exempt path), onboarding sign-in is a **public/self-service** flow, so captcha must apply; the fix reuses the existing captcha-gated `/login` rather than duplicating an inline OTP+captcha flow. States A (pre-OTP) and B (captcha-off auto-sign-in) are byte-unchanged.

**Gates:**
- **Sarah CLEAN** — no captcha bypass, no service-role path, OTP-first preserved, no info leak (own school + own phone only), no new auth surface.
- **Dex APPROVE** (production code) — clean non-overlapping states, correct reuse of `/login`. His one blocker was a *flaky test*, fixed here per his exact remedy (mock `captchaEnabled` per case, static import) — verified deterministic.
- **Quinn** — fix mutation-proven (state C falling back to the silent path reds); full suite green after the de-flake.

Client-only, no schema / prod-paste.