### PR TITLE
feat(auth): enforce the session-length security setting (session-hours) — part of #254

### DIFF
--- a/omnischools/lib/auth/enforce-session-age.test.ts
+++ b/omnischools/lib/auth/enforce-session-age.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * INCR-254 — end-to-end proof that the "Session length" setting now GATES. `requireSchool()` must
+ * bounce an over-age (or unreadable-age) live session to /login, and pass a fresh one through. Mocks
+ * mirror board-gov2.test.ts: identity, redirect, headers and the school read are stubbed so the guard
+ * runs with no database; the redirect is asserted from a thrown `REDIRECT:<url>` sentinel.
+ */
+
+vi.mock("@/lib/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/auth")>();
+  return {
+    ...actual,
+    getCurrentUser: vi.fn(),
+    authIsLive: vi.fn(() => true), // pretend real Supabase auth for these cases
+    sessionLoginAtMs: vi.fn(),
+  };
+});
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  }),
+}));
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => new Map([["x-pathname", "/dashboard"]])),
+}));
+
+const schoolRow = {
+  id: "sch-1",
+  name: "Test SHS",
+  shortName: null,
+  gesCode: "WR-X-001",
+  schoolType: "SENIOR",
+  sessionHours: 8 as number | null,
+  districtName: null,
+  regionName: null,
+};
+vi.mock("@/lib/db/rls", () => ({
+  withoutTenantScope: vi.fn(async () => schoolRow),
+  withSchool: vi.fn(),
+}));
+
+import { getCurrentUser, sessionLoginAtMs, type AppUser } from "@/lib/auth";
+import { requireSchool } from "@/lib/auth/server";
+
+const admin: AppUser = {
+  id: "u-1",
+  phone: "+233200000000",
+  roles: ["ADMIN"],
+  schoolId: "sch-1",
+};
+
+const HOUR = 3_600_000;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  schoolRow.sessionHours = 8;
+  vi.mocked(getCurrentUser).mockResolvedValue(admin);
+});
+
+describe("requireSchool enforces the session-length setting", () => {
+  it("redirects an over-age session to re-authenticate", async () => {
+    vi.mocked(sessionLoginAtMs).mockResolvedValue(Date.now() - 9 * HOUR);
+    await expect(requireSchool()).rejects.toThrow("REDIRECT:/login?expired=1");
+  });
+
+  it("FAILS CLOSED: an unreadable login time under a set limit is bounced too", async () => {
+    vi.mocked(sessionLoginAtMs).mockResolvedValue(null);
+    await expect(requireSchool()).rejects.toThrow("REDIRECT:/login?expired=1");
+  });
+
+  it("lets a session within the limit through", async () => {
+    vi.mocked(sessionLoginAtMs).mockResolvedValue(Date.now() - 1 * HOUR);
+    const { school } = await requireSchool();
+    expect(school.id).toBe("sch-1");
+    expect(sessionLoginAtMs).toHaveBeenCalled();
+  });
+
+  it("no-op when the school set no limit — never reads the session age", async () => {
+    schoolRow.sessionHours = null;
+    const { school } = await requireSchool();
+    expect(school.id).toBe("sch-1");
+    expect(sessionLoginAtMs).not.toHaveBeenCalled();
+  });
+});

--- a/omnischools/lib/auth/index.ts
+++ b/omnischools/lib/auth/index.ts
@@ -471,6 +471,32 @@ export async function sessionAuthMethods(): Promise<string[]> {
   return session?.access_token ? amrFromJwt(session.access_token) : [];
 }
 
+/**
+ * INCR-254 — the ORIGINAL login time (ms since epoch) of the CURRENT session, or null. Decoded from
+ * the access-token JWT UNVERIFIED, exactly like `sessionAuthMethods` — it only feeds the "Session
+ * length" security setting (ref_school.session_hours), never an authorization decision (RLS remains
+ * the boundary). The value is the earliest `amr` timestamp (see loginAtMsFromClaims: survives the
+ * hourly refresh, unlike `iat`). `getSession()` reads the local cookie (no GoTrue round-trip), so
+ * this stays cheap. Returns null under dev-bypass (no JWT) or when nothing is readable — the caller
+ * (enforceSessionAge) treats null-under-a-set-limit as fail-closed.
+ */
+export async function sessionLoginAtMs(): Promise<number | null> {
+  if (!authIsLive()) return null;
+  const {
+    data: { session },
+  } = await (await authApi()).getSession();
+  if (!session?.access_token) return null;
+  try {
+    const payload = session.access_token.split(".")[1];
+    if (!payload) return null;
+    const claims = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+    const { loginAtMsFromClaims } = await import("./session-age");
+    return loginAtMsFromClaims(claims);
+  } catch {
+    return null;
+  }
+}
+
 /** Decode the `amr[].method` list from a Supabase access-token JWT (unverified — R276 gate only). */
 function amrFromJwt(jwt: string): string[] {
   try {

--- a/omnischools/lib/auth/server.ts
+++ b/omnischools/lib/auth/server.ts
@@ -4,7 +4,8 @@ import { eq, and } from "drizzle-orm";
 import { env } from "@/lib/env";
 import { withoutTenantScope } from "@/lib/db/rls";
 import { schools, roleAssignments, roles, users, districts, regions } from "@/db/schema";
-import { getCurrentUser, type AppUser, type AppRole } from "@/lib/auth";
+import { getCurrentUser, authIsLive, sessionLoginAtMs, type AppUser, type AppRole } from "@/lib/auth";
+import { sessionAgeExceeded } from "@/lib/auth/session-age";
 import {
   isFinanceOnly,
   pathAllowedForFinance,
@@ -24,6 +25,8 @@ export interface ActiveSchool {
   schoolType: "BASIC" | "SENIOR" | "COMBINED";
   /** District (or region) name, for the sidebar "tier · location" line. */
   location: string | null;
+  /** "Session length" security setting (hours); null = the school never configured a limit. */
+  sessionHours: number | null;
 }
 
 /**
@@ -48,6 +51,7 @@ export async function getActiveSchool(forUser?: AppUser): Promise<ActiveSchool |
     shortName: schools.shortName,
     gesCode: schools.gesCode,
     schoolType: schools.schoolType,
+    sessionHours: schools.sessionHours,
     districtName: districts.name,
     regionName: regions.name,
   };
@@ -90,6 +94,27 @@ export async function getActiveSchool(forUser?: AppUser): Promise<ActiveSchool |
   if (!row) return null;
   const { districtName, regionName, ...rest } = row;
   return { ...rest, location: districtName ?? regionName ?? null };
+}
+
+/**
+ * INCR-254 — enforce the school's "Session length" security setting (ref_school.session_hours). The
+ * signed-in session must be younger than the configured number of hours, measured as an ABSOLUTE age
+ * from the original login (not idle time — the copy is "8 hours (a school day)", i.e. a wall-clock
+ * span). Over-age ⇒ redirect to /login to re-authenticate; the login page renders its form for an
+ * authed-but-stale session (it does not bounce back), so there is no loop, and every (app) guard keeps
+ * refusing the stale session until a fresh login resets its age.
+ *
+ * FAIL-CLOSED (Sarah): a configured limit whose age can't be read forces re-auth. Inert when the
+ * school set no limit (null) or under dev-bypass (no real session). ponytail: guard-level block — the
+ * GoTrue refresh token stays valid but reaches no (app) page; a hard token revocation would need a
+ * route handler (SC cookie writes are no-ops here), add if token-level kill is ever required.
+ */
+async function enforceSessionAge(school: ActiveSchool): Promise<void> {
+  if (school.sessionHours == null || !authIsLive()) return;
+  const loginAtMs = await sessionLoginAtMs();
+  if (sessionAgeExceeded({ limitHours: school.sessionHours, isLive: true, loginAtMs })) {
+    redirect("/login?expired=1");
+  }
 }
 
 /** For app pages: ensure a signed-in user, else send to login. */
@@ -142,6 +167,7 @@ export async function requireSchool(
   const user = await requireUser();
   const school = await getActiveSchool(user);
   if (!school) redirect("/start");
+  await enforceSessionAge(school);
   if (!opts?.allowNonStaff && !isStaff(user.roles)) {
     // A board-only session hitting a staff URL lands on its own read-only overview FIRST (GOV-2 / R334);
     // a parent has somewhere to be; a student-only session has no portal yet, and `/start` is the honest
@@ -207,6 +233,7 @@ export async function requireParent(): Promise<{ user: AppUser; school: ActiveSc
   if (!user.roles.includes("PARENT")) redirect("/dashboard");
   const school = await getActiveSchool(user);
   if (!school) redirect("/start");
+  await enforceSessionAge(school);
   return { user, school };
 }
 
@@ -224,6 +251,7 @@ export async function requireBoard(): Promise<{ user: AppUser; school: ActiveSch
   if (!user.roles.includes("BOARD_MEMBER")) redirect("/dashboard");
   const school = await getActiveSchool(user);
   if (!school) redirect("/start");
+  await enforceSessionAge(school);
   const pathname = (await headers()).get("x-pathname") ?? "";
   if (pathname && !pathAllowedForBoard(pathname)) redirect(BOARD_HOME);
   return { user, school };

--- a/omnischools/lib/auth/session-age.test.ts
+++ b/omnischools/lib/auth/session-age.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { loginAtMsFromClaims, sessionAgeExceeded } from "./session-age";
+
+/**
+ * INCR-254 — the "Session length" security setting (ref_school.session_hours), which used to be stored
+ * and shown but read by no enforcement path. These cover the pure decision surface: decoding the true
+ * login time from a GoTrue JWT's `amr` timestamps, and the FAIL-CLOSED age gate. The guard wiring is
+ * proven end-to-end in enforce-session-age.test.ts.
+ */
+
+const HOUR = 3_600_000;
+
+describe("loginAtMsFromClaims — the true (refresh-proof) login time", () => {
+  it("uses the EARLIEST amr timestamp, in ms (amr timestamps are unix seconds)", () => {
+    const login = 1_700_000_000; // seconds
+    const claims = {
+      iat: login + 7200, // an hourly-refreshed token — must be ignored
+      amr: [
+        { method: "password", timestamp: login + 60 },
+        { method: "otp", timestamp: login }, // earliest
+      ],
+    };
+    expect(loginAtMsFromClaims(claims)).toBe(login * 1000);
+  });
+
+  it("tolerates a single-factor amr", () => {
+    const claims = { amr: [{ method: "password", timestamp: 1_700_000_000 }] };
+    expect(loginAtMsFromClaims(claims)).toBe(1_700_000_000_000);
+  });
+
+  it("returns null when amr is missing / empty / has no numeric timestamp", () => {
+    expect(loginAtMsFromClaims({})).toBeNull();
+    expect(loginAtMsFromClaims({ amr: [] })).toBeNull();
+    expect(loginAtMsFromClaims({ amr: [{ method: "password" }] })).toBeNull();
+    expect(loginAtMsFromClaims({ amr: "password" })).toBeNull();
+    expect(loginAtMsFromClaims(null)).toBeNull();
+  });
+});
+
+describe("sessionAgeExceeded — fail-closed age gate", () => {
+  const now = 1_700_000_000_000;
+
+  it("no-op when the school set no limit (null/undefined)", () => {
+    expect(sessionAgeExceeded({ limitHours: null, isLive: true, loginAtMs: 0, now })).toBe(false);
+    expect(sessionAgeExceeded({ limitHours: undefined, isLive: true, loginAtMs: 0, now })).toBe(false);
+  });
+
+  it("no-op under dev-bypass (no real session age)", () => {
+    // Even a comically old "login" and a tight limit: dev has no session-age concept.
+    expect(sessionAgeExceeded({ limitHours: 1, isLive: false, loginAtMs: 0, now })).toBe(false);
+  });
+
+  it("FAILS CLOSED: a set limit + an unreadable login time ⇒ over-age", () => {
+    expect(sessionAgeExceeded({ limitHours: 8, isLive: true, loginAtMs: null, now })).toBe(true);
+  });
+
+  it("rejects a session older than the limit", () => {
+    expect(
+      sessionAgeExceeded({ limitHours: 8, isLive: true, loginAtMs: now - 9 * HOUR, now }),
+    ).toBe(true);
+  });
+
+  it("admits a session within the limit", () => {
+    expect(
+      sessionAgeExceeded({ limitHours: 8, isLive: true, loginAtMs: now - 1 * HOUR, now }),
+    ).toBe(false);
+  });
+
+  it("is a strict boundary (exactly at the limit is still valid)", () => {
+    expect(
+      sessionAgeExceeded({ limitHours: 8, isLive: true, loginAtMs: now - 8 * HOUR, now }),
+    ).toBe(false);
+    expect(
+      sessionAgeExceeded({ limitHours: 8, isLive: true, loginAtMs: now - 8 * HOUR - 1, now }),
+    ).toBe(true);
+  });
+});

--- a/omnischools/lib/auth/session-age.ts
+++ b/omnischools/lib/auth/session-age.ts
@@ -1,0 +1,47 @@
+/**
+ * INCR-254 — pure helpers for enforcing a school's "Session length" security setting (ref_school.
+ * session_hours). Kept free of next/navigation + Supabase so the fail-closed decision matrix is
+ * unit-testable without a live session. The wiring (read the JWT, redirect) lives in lib/auth.
+ */
+
+/**
+ * The ORIGINAL login time (ms since epoch) of a decoded GoTrue access-token payload, or null.
+ *
+ * We read the earliest `amr` (authentication-methods-references) entry timestamp — the time the
+ * session's first auth factor was verified. Unlike `iat`, an amr timestamp is NOT rewritten on the
+ * hourly access-token refresh, so it measures the true absolute age of the session (a 30-minute-old
+ * token can belong to an 8-hour-old session). amr timestamps are Unix SECONDS.
+ */
+export function loginAtMsFromClaims(claims: unknown): number | null {
+  const amr = (claims as { amr?: unknown })?.amr;
+  if (!Array.isArray(amr)) return null;
+  const seconds = amr
+    .map((e) =>
+      e && typeof e === "object" ? (e as { timestamp?: unknown }).timestamp : undefined,
+    )
+    .filter((t): t is number => typeof t === "number" && Number.isFinite(t) && t > 0);
+  return seconds.length ? Math.min(...seconds) * 1000 : null;
+}
+
+/**
+ * FAIL-CLOSED session-age gate. `true` ⇒ the session is older than the configured limit (or its age
+ * is unknowable while a limit is set) and the caller MUST force re-authentication.
+ *
+ *  - `limitHours` null/undefined  ⇒ false — the school never opted in, nothing to enforce.
+ *  - `!isLive` (dev-bypass shim)  ⇒ false — no real session, no age concept.
+ *  - live + limit + `loginAtMs` null ⇒ TRUE — a limit is set but we cannot read the session's age,
+ *    so we deny (more security, not less) rather than silently letting an unbounded session through.
+ *  - live + limit + a real login time ⇒ true once `now - loginAt` exceeds the limit.
+ */
+export function sessionAgeExceeded(a: {
+  limitHours: number | null | undefined;
+  isLive: boolean;
+  loginAtMs: number | null;
+  now?: number;
+}): boolean {
+  if (a.limitHours == null) return false;
+  if (!a.isLive) return false;
+  if (a.loginAtMs == null) return true; // fail closed: unreadable age under an active limit
+  const now = a.now ?? Date.now();
+  return now - a.loginAtMs > a.limitHours * 3_600_000;
+}


### PR DESCRIPTION
**Part of #254** (the session-hours half; require-2FA-for-admins is deferred — see below).

The "Session length" security setting (`ref_school.session_hours`) was stored + shown but enforced by nothing. This wires it: a signed-in session older than the configured hours (measured as ABSOLUTE age from the original login via the access-token's earliest `amr` timestamp — survives the hourly refresh, unlike `iat`) is redirected to `/login?expired=1` to re-authenticate. Enforced in every school-scoped guard (`requireSchool`/`requireParent`/`requireBoard`), **fail-closed** (a set limit whose age can't be read forces re-auth), inert when no limit is configured or under dev-bypass. Pure age-math in `lib/auth/session-age.ts`, unit-tested; the UNVERIFIED JWT decode only feeds the redirect decision (never authz — RLS stays the boundary), mirroring the existing `sessionAuthMethods`.

**Gates (all green):** Quinn GREEN (boundary math + wiring + mutation-proven; 2194 tests). Dex APPROVE (clean seam, loop-free redirect, no lock-in). Sarah CLEAN (fail-closed, server-side timestamp, no downgrade/lockout). No schema, no prod-paste.

### ⚠️ Scope: require-2FA-for-admins is NOT in this PR (deliberately)
The build left the "require 2FA for admins" setting unenforced on purpose: with real SMS still console-only (Hubtel not live), enforcing admin-2FA in prod would **lock admins out** — they couldn't receive the OTP. It should ride with the **phone-OTP go-live (#260)**. So **do not close #254 on this merge** — it stays open for the require-2FA half (awaiting the owner's steer on timing).

Non-blocking nits from review (optional follow-ups): a dynamic import of the pure `session-age` module could be static; `/login?expired=1` could show a "your session expired" cue.