### PR TITLE
feat(pta): officer-roster PDF export + State-1 console meeting-notify (#297)

### DIFF
--- a/omnischools/app/api/senior/pta/officers/route.ts
+++ b/omnischools/app/api/senior/pta/officers/route.ts
@@ -1,0 +1,63 @@
+import { requireSchoolRole } from "@/lib/auth/server";
+import { PTA_CONFIG_WRITE_ROLES } from "@/lib/access";
+import { getPtaOfficerMatrix } from "@/lib/pta/officers-data";
+import { renderPtaOfficerRosterPdf } from "@/lib/pdf/render-pta-officer-roster";
+import type { PtaOfficerRosterData } from "@/lib/pdf/pta-officer-roster-document";
+
+// @react-pdf/renderer is Node-only (fontkit); never run this on the edge.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/senior/pta/officers — the authenticated PTA officer-roster PDF download (#297 · Capability A).
+ * The reserved "PDF omitted (not a dead control)" slot on /senior/pta/officers now resolves here.
+ *
+ * GATE (R427, SAME as the officers PAGE — read == manage): `requireSchoolRole(PTA_CONFIG_WRITE_ROLES)`
+ * (ADMIN / HEADMASTER). A non-admin — INCLUDING a non-admin Secretary — is redirected by the gate, never
+ * served the PDF. NOT the meeting-register gate; officer-matrix access is admin-only. The school id is
+ * SESSION-derived (never a query param), so a tenant can only ever export its OWN roster.
+ *
+ * 🔴 PII FENCE (owner-ratified: roster only, NO contact). The ONLY data source is `getPtaOfficerMatrix`,
+ * whose `OfficersMatrix` shape carries no officer phone / email / address / studentGuardians field — so
+ * neither this route nor the document can select or render contact PII (structural: the field is absent
+ * from the type). pta-officer-roster.test.ts grep-guards the source of both.
+ */
+export async function GET() {
+  const { school } = await requireSchoolRole(PTA_CONFIG_WRITE_ROLES);
+
+  const matrix = await getPtaOfficerMatrix(school.id);
+
+  const nameForInitials = school.shortName ?? school.name;
+  const data: PtaOfficerRosterData = {
+    matrix,
+    meta: {
+      schoolName: school.name,
+      schoolInitials: initials(nameForInitials),
+      generatedAtLabel: new Intl.DateTimeFormat("en-GB", {
+        day: "numeric",
+        month: "long",
+        year: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+        timeZone: "UTC",
+      }).format(new Date()),
+    },
+  };
+
+  const pdf = await renderPtaOfficerRosterPdf(data);
+  const filename = `PTA-Officer-Roster-${nameForInitials}.pdf`.replace(/[^A-Za-z0-9._-]+/g, "-");
+  return new Response(new Uint8Array(pdf), {
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": `inline; filename="${filename}"`,
+      "Cache-Control": "private, no-store",
+    },
+  });
+}
+
+/** First letters of the first two words (e.g. "Asankrangwa SHS" → "AS"). */
+function initials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "PTA";
+  return (parts[0][0] + (parts[1]?.[0] ?? "")).toUpperCase();
+}

--- a/omnischools/components/pta/officer-matrix.tsx
+++ b/omnischools/components/pta/officer-matrix.tsx
@@ -68,17 +68,28 @@ export function OfficerMatrix({
               Housemaster as Secretary) are auto-populated and read-only.
             </p>
           </div>
-          {assignablePtas.length > 0 && (
-            <button
-              onClick={() => {
-                const first = assignablePtas[0];
-                setAssign({ ptaId: first.id, label: first.label, offices: first.offices });
-              }}
-              className="rounded-md bg-navy px-4 py-2 text-xs font-bold text-bg hover:bg-navy-deep"
+          <div className="flex items-center gap-2">
+            {/* The reserved roster-PDF slot — no longer a dead control (#297). The governance-file export
+                of THIS matrix: roster only, NO contact details. Served through /api/* (so the
+                no-html-link-for-pages rule stays satisfied); the route re-gates admin-only + session-scopes. */}
+            <a
+              href="/api/senior/pta/officers"
+              className="rounded-md border border-border-2 bg-surface px-4 py-2 text-xs font-bold text-navy hover:bg-gold-bg"
             >
-              + Assign officer
-            </button>
-          )}
+              Roster PDF
+            </a>
+            {assignablePtas.length > 0 && (
+              <button
+                onClick={() => {
+                  const first = assignablePtas[0];
+                  setAssign({ ptaId: first.id, label: first.label, offices: first.offices });
+                }}
+                className="rounded-md bg-navy px-4 py-2 text-xs font-bold text-bg hover:bg-navy-deep"
+              >
+                + Assign officer
+              </button>
+            )}
+          </div>
         </div>
       </header>
 

--- a/omnischools/db/migrations/0086_pta_meeting_parents_notified_at.sql
+++ b/omnischools/db/migrations/0086_pta_meeting_parents_notified_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "pta_meeting" ADD COLUMN "parents_notified_at" timestamp with time zone;

--- a/omnischools/db/migrations/meta/0086_snapshot.json
+++ b/omnischools/db/migrations/meta/0086_snapshot.json
@@ -1,0 +1,26048 @@
+{
+  "id": "d1e1c864-8946-4482-a585-118db0f6ec9c",
+  "prevId": "3c621f10-0bda-49f1-8fd9-a1629a29b1af",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ref_district": {
+      "name": "ref_district",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_district_region_id_ref_region_id_fk": {
+          "name": "ref_district_region_id_ref_region_id_fk",
+          "tableFrom": "ref_district",
+          "tableTo": "ref_region",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_district_code_unique": {
+          "name": "ref_district_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_region": {
+      "name": "ref_region",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_region_code_unique": {
+          "name": "ref_region_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_school_product": {
+      "name": "ref_school_product",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product": {
+          "name": "product",
+          "type": "product",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_school_product_school_id_ref_school_id_fk": {
+          "name": "ref_school_product_school_id_ref_school_id_fk",
+          "tableFrom": "ref_school_product",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_school_product": {
+          "name": "uniq_school_product",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "product"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_school": {
+      "name": "ref_school",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ges_code": {
+          "name": "ges_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cssps_code": {
+          "name": "cssps_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_type": {
+          "name": "school_type",
+          "type": "school_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'BASIC'"
+        },
+        "subtype": {
+          "name": "subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shs_category": {
+          "name": "shs_category",
+          "type": "shs_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownership_type": {
+          "name": "ownership_type",
+          "type": "ownership_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRIVATE'"
+        },
+        "year_founded": {
+          "name": "year_founded",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stamp_url": {
+          "name": "stamp_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_color": {
+          "name": "brand_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cadence": {
+          "name": "billing_cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_methods": {
+          "name": "payment_methods",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residency_model": {
+          "name": "residency_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "house_count": {
+          "name": "house_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visiting_day": {
+          "name": "visiting_day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waec_centre_code": {
+          "name": "waec_centre_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waec_office": {
+          "name": "waec_office",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_wassce_year": {
+          "name": "first_wassce_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_retention_months": {
+          "name": "record_retention_months",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audit_retention_months": {
+          "name": "audit_retention_months",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_2fa": {
+          "name": "require_2fa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_hours": {
+          "name": "session_hours",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "district_id": {
+          "name": "district_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_school_district_id_ref_district_id_fk": {
+          "name": "ref_school_district_id_ref_district_id_fk",
+          "tableFrom": "ref_school",
+          "tableTo": "ref_district",
+          "columnsFrom": [
+            "district_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ref_school_region_id_ref_region_id_fk": {
+          "name": "ref_school_region_id_ref_region_id_fk",
+          "tableFrom": "ref_school",
+          "tableTo": "ref_region",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_school_ges_code_unique": {
+          "name": "ref_school_ges_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "ges_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_assignment": {
+      "name": "role_assignment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_ref": {
+          "name": "scope_ref",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_assignment_user_id_ref_user_id_fk": {
+          "name": "role_assignment_user_id_ref_user_id_fk",
+          "tableFrom": "role_assignment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_assignment_school_id_ref_school_id_fk": {
+          "name": "role_assignment_school_id_ref_school_id_fk",
+          "tableFrom": "role_assignment",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_assignment_role_id_ref_role_id_fk": {
+          "name": "role_assignment_role_id_ref_role_id_fk",
+          "tableFrom": "role_assignment",
+          "tableTo": "ref_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_role": {
+      "name": "ref_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_role_code_unique": {
+          "name": "ref_role_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_school_block": {
+      "name": "user_school_block",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_by": {
+          "name": "blocked_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_at": {
+          "name": "blocked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_school_block_school_id_ref_school_id_fk": {
+          "name": "user_school_block_school_id_ref_school_id_fk",
+          "tableFrom": "user_school_block",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_school_block_user_id_ref_user_id_fk": {
+          "name": "user_school_block_user_id_ref_user_id_fk",
+          "tableFrom": "user_school_block",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_school_block_blocked_by_ref_user_id_fk": {
+          "name": "user_school_block_blocked_by_ref_user_id_fk",
+          "tableFrom": "user_school_block",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "blocked_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_school_block_school_user_uk": {
+          "name": "user_school_block_school_user_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_user": {
+      "name": "ref_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_user_phone_unique": {
+          "name": "ref_user_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_compensation": {
+      "name": "staff_compensation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "salary_status": {
+          "name": "salary_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SCHOOL_PAID'"
+        },
+        "monthly_amount": {
+          "name": "monthly_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "pay_method": {
+          "name": "pay_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'BANK'"
+        },
+        "pay_cadence": {
+          "name": "pay_cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MONTHLY'"
+        },
+        "ssnit_deduction": {
+          "name": "ssnit_deduction",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "paye_deduction": {
+          "name": "paye_deduction",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "staff_compensation_school_idx": {
+          "name": "staff_compensation_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_compensation_school_id_ref_school_id_fk": {
+          "name": "staff_compensation_school_id_ref_school_id_fk",
+          "tableFrom": "staff_compensation",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "staff_compensation_user_id_ref_user_id_fk": {
+          "name": "staff_compensation_user_id_ref_user_id_fk",
+          "tableFrom": "staff_compensation",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_staff_compensation_per_school": {
+          "name": "uniq_staff_compensation_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_profile": {
+      "name": "staff_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qualification_level": {
+          "name": "qualification_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highest_qualification": {
+          "name": "highest_qualification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "undergraduate": {
+          "name": "undergraduate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ntc_licence_number": {
+          "name": "ntc_licence_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ntc_licence_expiry": {
+          "name": "ntc_licence_expiry",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nmc_licence_number": {
+          "name": "nmc_licence_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nmc_licence_expiry": {
+          "name": "nmc_licence_expiry",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialisations": {
+          "name": "specialisations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "staff_profile_school_idx": {
+          "name": "staff_profile_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_profile_school_id_ref_school_id_fk": {
+          "name": "staff_profile_school_id_ref_school_id_fk",
+          "tableFrom": "staff_profile",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "staff_profile_user_id_ref_user_id_fk": {
+          "name": "staff_profile_user_id_ref_user_id_fk",
+          "tableFrom": "staff_profile",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_staff_profile_per_school": {
+          "name": "uniq_staff_profile_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.academic_period": {
+      "name": "academic_period",
+      "schema": "",
+      "columns": {
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_number": {
+          "name": "period_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_label": {
+          "name": "period_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_on": {
+          "name": "ends_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_line": {
+          "name": "product_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by_user_id": {
+          "name": "closed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "academic_period_closed_by_user_id_ref_user_id_fk": {
+          "name": "academic_period_closed_by_user_id_ref_user_id_fk",
+          "tableFrom": "academic_period",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "closed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "academic_period_school_id_academic_year_ref_academic_period_config_school_id_academic_year_fk": {
+          "name": "academic_period_school_id_academic_year_ref_academic_period_config_school_id_academic_year_fk",
+          "tableFrom": "academic_period",
+          "tableTo": "ref_academic_period_config",
+          "columnsFrom": [
+            "school_id",
+            "academic_year"
+          ],
+          "columnsTo": [
+            "school_id",
+            "academic_year"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "academic_period_tenant_uk": {
+          "name": "academic_period_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_academic_period_config": {
+      "name": "ref_academic_period_config",
+      "schema": "",
+      "columns": {
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_type": {
+          "name": "period_type",
+          "type": "period_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_count": {
+          "name": "period_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "period_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured_at": {
+          "name": "configured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "configured_by": {
+          "name": "configured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_academic_period_config_school_id_ref_school_id_fk": {
+          "name": "ref_academic_period_config_school_id_ref_school_id_fk",
+          "tableFrom": "ref_academic_period_config",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ref_academic_period_config_configured_by_ref_user_id_fk": {
+          "name": "ref_academic_period_config_configured_by_ref_user_id_fk",
+          "tableFrom": "ref_academic_period_config",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "configured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ref_academic_period_config_school_id_academic_year_pk": {
+          "name": "ref_academic_period_config_school_id_academic_year_pk",
+          "columns": [
+            "school_id",
+            "academic_year"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gen_period_defaults": {
+      "name": "gen_period_defaults",
+      "schema": "",
+      "columns": {
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_line": {
+          "name": "product_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_number": {
+          "name": "period_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_label": {
+          "name": "period_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_on": {
+          "name": "ends_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_at": {
+          "name": "extracted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gen_period_defaults_reviewed_by_ref_user_id_fk": {
+          "name": "gen_period_defaults_reviewed_by_ref_user_id_fk",
+          "tableFrom": "gen_period_defaults",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gen_period_defaults_academic_year_product_line_period_number_pk": {
+          "name": "gen_period_defaults_academic_year_product_line_period_number_pk",
+          "columns": [
+            "academic_year",
+            "product_line",
+            "period_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.school_holiday": {
+      "name": "school_holiday",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_on": {
+          "name": "ends_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PUBLIC'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "school_holiday_school_idx": {
+          "name": "school_holiday_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "school_holiday_school_id_ref_school_id_fk": {
+          "name": "school_holiday_school_id_ref_school_id_fk",
+          "tableFrom": "school_holiday",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "audit_id": {
+          "name": "audit_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_role": {
+          "name": "actor_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before_jsonb": {
+          "name": "before_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_jsonb": {
+          "name": "after_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_school_time_idx": {
+          "name": "audit_school_time_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_entity_idx": {
+          "name": "audit_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_school_id_ref_school_id_fk": {
+          "name": "audit_log_school_id_ref_school_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_log_actor_user_id_ref_user_id_fk": {
+          "name": "audit_log_actor_user_id_ref_user_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_anomaly_rule": {
+      "name": "ref_anomaly_rule",
+      "schema": "",
+      "columns": {
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_code": {
+          "name": "rule_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "anomaly_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applies_to": {
+          "name": "applies_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold_jsonb": {
+          "name": "threshold_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_anomaly_rule_rule_code_unique": {
+          "name": "ref_anomaly_rule_rule_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rule_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.marketing_lead": {
+      "name": "marketing_lead",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organisation": {
+          "name": "organisation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'demo_form'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.class": {
+      "name": "class",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "programme": {
+          "name": "programme",
+          "type": "programme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_teacher_user_id": {
+          "name": "class_teacher_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_capacity": {
+          "name": "target_capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "class_school_id_ref_school_id_fk": {
+          "name": "class_school_id_ref_school_id_fk",
+          "tableFrom": "class",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "class_class_teacher_user_id_ref_user_id_fk": {
+          "name": "class_class_teacher_user_id_ref_user_id_fk",
+          "tableFrom": "class",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "class_teacher_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_class_per_school": {
+          "name": "uniq_class_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        },
+        "class_tenant_uk": {
+          "name": "class_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.household": {
+      "name": "household",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "household_school_idx": {
+          "name": "household_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "household_school_id_ref_school_id_fk": {
+          "name": "household_school_id_ref_school_id_fk",
+          "tableFrom": "household",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "household_tenant_uk": {
+          "name": "household_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.house": {
+      "name": "house",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "colour": {
+          "name": "colour",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "house_gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "founded_year": {
+          "name": "founded_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "named_after": {
+          "name": "named_after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hm_user_id": {
+          "name": "hm_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "house_school_id_ref_school_id_fk": {
+          "name": "house_school_id_ref_school_id_fk",
+          "tableFrom": "house",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "house_hm_user_id_ref_user_id_fk": {
+          "name": "house_hm_user_id_ref_user_id_fk",
+          "tableFrom": "house",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "hm_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_house_per_school": {
+          "name": "uniq_house_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        },
+        "house_tenant_uk": {
+          "name": "house_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_guardian": {
+      "name": "student_guardian",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "guardian_relation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GUARDIAN'"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "guardian_student_idx": {
+          "name": "guardian_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "guardian_user_idx": {
+          "name": "guardian_user_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_guardian_user_per_child": {
+          "name": "uniq_guardian_user_per_child",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"student_guardian\".\"user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_guardian_school_id_ref_school_id_fk": {
+          "name": "student_guardian_school_id_ref_school_id_fk",
+          "tableFrom": "student_guardian",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_guardian_user_id_ref_user_id_fk": {
+          "name": "student_guardian_user_id_ref_user_id_fk",
+          "tableFrom": "student_guardian",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "student_guardian_school_id_student_id_students_school_id_id_fk": {
+          "name": "student_guardian_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "student_guardian",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_health_record": {
+      "name": "student_health_record",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blood_group": {
+          "name": "blood_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medications": {
+          "name": "medications",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_relation": {
+          "name": "emergency_contact_relation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "health_student_idx": {
+          "name": "health_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_health_record_school_id_ref_school_id_fk": {
+          "name": "student_health_record_school_id_ref_school_id_fk",
+          "tableFrom": "student_health_record",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_health_record_updated_by_user_id_ref_user_id_fk": {
+          "name": "student_health_record_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "student_health_record",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "student_health_record_school_id_student_id_students_school_id_id_fk": {
+          "name": "student_health_record_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "student_health_record",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "student_health_record_student_id_unique": {
+          "name": "student_health_record_student_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.students": {
+      "name": "students",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_code": {
+          "name": "student_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "other_names": {
+          "name": "other_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "student_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "current_class_label": {
+          "name": "current_class_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "programme": {
+          "name": "programme",
+          "type": "programme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residency": {
+          "name": "residency",
+          "type": "residency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "house_id": {
+          "name": "house_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_bunk_id": {
+          "name": "current_bunk_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stpshs_ref": {
+          "name": "stpshs_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrolled_on": {
+          "name": "enrolled_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admission_application_id": {
+          "name": "admission_application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "students_school_idx": {
+          "name": "students_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_student_current_bunk": {
+          "name": "uniq_student_current_bunk",
+          "columns": [
+            {
+              "expression": "current_bunk_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"students\".\"current_bunk_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "students_school_id_ref_school_id_fk": {
+          "name": "students_school_id_ref_school_id_fk",
+          "tableFrom": "students",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "students_household_id_household_id_fk": {
+          "name": "students_household_id_household_id_fk",
+          "tableFrom": "students",
+          "tableTo": "household",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "students_school_id_class_id_class_school_id_id_fk": {
+          "name": "students_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "students",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "students_school_id_house_id_house_school_id_id_fk": {
+          "name": "students_school_id_house_id_house_school_id_id_fk",
+          "tableFrom": "students",
+          "tableTo": "house",
+          "columnsFrom": [
+            "school_id",
+            "house_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "students_school_id_current_bunk_id_boarding_bunk_school_id_id_fk": {
+          "name": "students_school_id_current_bunk_id_boarding_bunk_school_id_id_fk",
+          "tableFrom": "students",
+          "tableTo": "boarding_bunk",
+          "columnsFrom": [
+            "school_id",
+            "current_bunk_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_student_code_per_school": {
+          "name": "uniq_student_code_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_code"
+          ]
+        },
+        "students_tenant_uk": {
+          "name": "students_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boarding_approved_visitor": {
+      "name": "boarding_approved_visitor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id_hint": {
+          "name": "id_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "visitor_approval_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING_REVIEW'"
+        },
+        "pastoral_review": {
+          "name": "pastoral_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_by_user_id": {
+          "name": "added_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "boarding_approved_visitor_student_idx": {
+          "name": "boarding_approved_visitor_student_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "boarding_approved_visitor_school_id_ref_school_id_fk": {
+          "name": "boarding_approved_visitor_school_id_ref_school_id_fk",
+          "tableFrom": "boarding_approved_visitor",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_approved_visitor_added_by_user_id_ref_user_id_fk": {
+          "name": "boarding_approved_visitor_added_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_approved_visitor",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "added_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_approved_visitor_approved_by_user_id_ref_user_id_fk": {
+          "name": "boarding_approved_visitor_approved_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_approved_visitor",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_approved_visitor_school_id_student_id_students_school_id_id_fk": {
+          "name": "boarding_approved_visitor_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "boarding_approved_visitor",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boarding_approved_visitor_tenant_uk": {
+          "name": "boarding_approved_visitor_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boarding_arrival": {
+      "name": "boarding_arrival",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "house_id": {
+          "name": "house_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_period_id": {
+          "name": "academic_period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "boarding_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checklist_json": {
+          "name": "checklist_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_owing_snapshot": {
+          "name": "fee_owing_snapshot",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "checked_by_user_id": {
+          "name": "checked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "boarding_arrival_house_period_mode_idx": {
+          "name": "boarding_arrival_house_period_mode_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "house_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "boarding_arrival_school_id_ref_school_id_fk": {
+          "name": "boarding_arrival_school_id_ref_school_id_fk",
+          "tableFrom": "boarding_arrival",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_arrival_checked_by_user_id_ref_user_id_fk": {
+          "name": "boarding_arrival_checked_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_arrival",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "checked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_arrival_school_id_student_id_students_school_id_id_fk": {
+          "name": "boarding_arrival_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "boarding_arrival",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_arrival_school_id_house_id_house_school_id_id_fk": {
+          "name": "boarding_arrival_school_id_house_id_house_school_id_id_fk",
+          "tableFrom": "boarding_arrival",
+          "tableTo": "house",
+          "columnsFrom": [
+            "school_id",
+            "house_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_arrival_school_id_academic_period_id_academic_period_school_id_period_id_fk": {
+          "name": "boarding_arrival_school_id_academic_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "boarding_arrival",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "academic_period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_boarding_arrival": {
+          "name": "uniq_boarding_arrival",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "academic_period_id",
+            "mode"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boarding_bunk": {
+      "name": "boarding_bunk",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dormitory_id": {
+          "name": "dormitory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_number": {
+          "name": "position_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefect_role": {
+          "name": "prefect_role",
+          "type": "prefect_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "boarding_bunk_school_id_ref_school_id_fk": {
+          "name": "boarding_bunk_school_id_ref_school_id_fk",
+          "tableFrom": "boarding_bunk",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_bunk_school_id_dormitory_id_boarding_dormitory_school_id_id_fk": {
+          "name": "boarding_bunk_school_id_dormitory_id_boarding_dormitory_school_id_id_fk",
+          "tableFrom": "boarding_bunk",
+          "tableTo": "boarding_dormitory",
+          "columnsFrom": [
+            "school_id",
+            "dormitory_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_bunk_per_dormitory": {
+          "name": "uniq_bunk_per_dormitory",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "dormitory_id",
+            "position_number"
+          ]
+        },
+        "boarding_bunk_tenant_uk": {
+          "name": "boarding_bunk_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boarding_calendar_event": {
+      "name": "boarding_calendar_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "boarding_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form_scope": {
+          "name": "form_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "boarding_calendar_event_year_idx": {
+          "name": "boarding_calendar_event_year_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "boarding_calendar_event_school_id_ref_school_id_fk": {
+          "name": "boarding_calendar_event_school_id_ref_school_id_fk",
+          "tableFrom": "boarding_calendar_event",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_boarding_calendar_event": {
+          "name": "uniq_boarding_calendar_event",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "academic_year",
+            "event_type",
+            "event_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boarding_dormitory": {
+      "name": "boarding_dormitory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "house_id": {
+          "name": "house_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_label": {
+          "name": "section_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bunk_count": {
+          "name": "bunk_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "boarding_dormitory_school_id_ref_school_id_fk": {
+          "name": "boarding_dormitory_school_id_ref_school_id_fk",
+          "tableFrom": "boarding_dormitory",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_dormitory_school_id_house_id_house_school_id_id_fk": {
+          "name": "boarding_dormitory_school_id_house_id_house_school_id_id_fk",
+          "tableFrom": "boarding_dormitory",
+          "tableTo": "house",
+          "columnsFrom": [
+            "school_id",
+            "house_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_dormitory_per_house": {
+          "name": "uniq_dormitory_per_house",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "house_id",
+            "name"
+          ]
+        },
+        "boarding_dormitory_tenant_uk": {
+          "name": "boarding_dormitory_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boarding_exeat": {
+      "name": "boarding_exeat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "house_id": {
+          "name": "house_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_period_id": {
+          "name": "academic_period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_event_id": {
+          "name": "calendar_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exeat_type": {
+          "name": "exeat_type",
+          "type": "exeat_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "exeat_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REQUESTED'"
+        },
+        "ref_code": {
+          "name": "ref_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_initiated": {
+          "name": "parent_initiated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "depart_at": {
+          "name": "depart_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "return_by": {
+          "name": "return_by",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hm_approved_at": {
+          "name": "hm_approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hm_approved_by_user_id": {
+          "name": "hm_approved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sr_hm_signed_at": {
+          "name": "sr_hm_signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sr_hm_signed_by_user_id": {
+          "name": "sr_hm_signed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "departed_at": {
+          "name": "departed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "departed_by_user_id": {
+          "name": "departed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "returned_at": {
+          "name": "returned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "returned_by_user_id": {
+          "name": "returned_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "declined_at": {
+          "name": "declined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "declined_by_user_id": {
+          "name": "declined_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decline_reason": {
+          "name": "decline_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_owing_snapshot": {
+          "name": "fee_owing_snapshot",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "boarding_exeat_student_period_idx": {
+          "name": "boarding_exeat_student_period_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "boarding_exeat_school_id_ref_school_id_fk": {
+          "name": "boarding_exeat_school_id_ref_school_id_fk",
+          "tableFrom": "boarding_exeat",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_exeat_calendar_event_id_boarding_calendar_event_id_fk": {
+          "name": "boarding_exeat_calendar_event_id_boarding_calendar_event_id_fk",
+          "tableFrom": "boarding_exeat",
+          "tableTo": "boarding_calendar_event",
+          "columnsFrom": [
+            "calendar_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_exeat_requested_by_user_id_ref_user_id_fk": {
+          "name": "boarding_exeat_requested_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_exeat",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_exeat_hm_approved_by_user_id_ref_user_id_fk": {
+          "name": "boarding_exeat_hm_approved_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_exeat",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "hm_approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_exeat_sr_hm_signed_by_user_id_ref_user_id_fk": {
+          "name": "boarding_exeat_sr_hm_signed_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_exeat",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "sr_hm_signed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_exeat_departed_by_user_id_ref_user_id_fk": {
+          "name": "boarding_exeat_departed_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_exeat",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "departed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_exeat_returned_by_user_id_ref_user_id_fk": {
+          "name": "boarding_exeat_returned_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_exeat",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "returned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_exeat_declined_by_user_id_ref_user_id_fk": {
+          "name": "boarding_exeat_declined_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_exeat",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "declined_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_exeat_school_id_student_id_students_school_id_id_fk": {
+          "name": "boarding_exeat_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "boarding_exeat",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_exeat_school_id_house_id_house_school_id_id_fk": {
+          "name": "boarding_exeat_school_id_house_id_house_school_id_id_fk",
+          "tableFrom": "boarding_exeat",
+          "tableTo": "house",
+          "columnsFrom": [
+            "school_id",
+            "house_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_exeat_school_id_academic_period_id_academic_period_school_id_period_id_fk": {
+          "name": "boarding_exeat_school_id_academic_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "boarding_exeat",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "academic_period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boarding_exeat_tenant_uk": {
+          "name": "boarding_exeat_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        },
+        "uniq_exeat_ref_code": {
+          "name": "uniq_exeat_ref_code",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "ref_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boarding_infractions": {
+      "name": "boarding_infractions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "house_id": {
+          "name": "house_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "infraction_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "narrative_text": {
+          "name": "narrative_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "infraction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "co_signs_json": {
+          "name": "co_signs_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_infraction_id": {
+          "name": "parent_infraction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "infraction_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MANUAL'"
+        },
+        "source_ref_id": {
+          "name": "source_ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logged_by_user_id": {
+          "name": "logged_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "parents_notified_at": {
+          "name": "parents_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_infraction_source": {
+          "name": "uniq_infraction_source",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"boarding_infractions\".\"source_ref_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boarding_infractions_student_idx": {
+          "name": "boarding_infractions_student_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boarding_infractions_status_idx": {
+          "name": "boarding_infractions_status_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "boarding_infractions_school_id_ref_school_id_fk": {
+          "name": "boarding_infractions_school_id_ref_school_id_fk",
+          "tableFrom": "boarding_infractions",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_infractions_logged_by_user_id_ref_user_id_fk": {
+          "name": "boarding_infractions_logged_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_infractions",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "logged_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_infractions_school_id_student_id_students_school_id_id_fk": {
+          "name": "boarding_infractions_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "boarding_infractions",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_infractions_school_id_house_id_house_school_id_id_fk": {
+          "name": "boarding_infractions_school_id_house_id_house_school_id_id_fk",
+          "tableFrom": "boarding_infractions",
+          "tableTo": "house",
+          "columnsFrom": [
+            "school_id",
+            "house_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_infractions_school_id_parent_infraction_id_boarding_infractions_school_id_id_fk": {
+          "name": "boarding_infractions_school_id_parent_infraction_id_boarding_infractions_school_id_id_fk",
+          "tableFrom": "boarding_infractions",
+          "tableTo": "boarding_infractions",
+          "columnsFrom": [
+            "school_id",
+            "parent_infraction_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boarding_infractions_tenant_uk": {
+          "name": "boarding_infractions_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boarding_settings": {
+      "name": "boarding_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exeat_scheduled_per_term": {
+          "name": "exeat_scheduled_per_term",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "exeat_return_by": {
+          "name": "exeat_return_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'16:00'"
+        },
+        "exeat_fee_owing_must_collect": {
+          "name": "exeat_fee_owing_must_collect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "exeat_special_approver": {
+          "name": "exeat_special_approver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Senior HM only'"
+        },
+        "exeat_parent_initiated": {
+          "name": "exeat_parent_initiated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "exeat_dress_code": {
+          "name": "exeat_dress_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Uniform or outing dress'"
+        },
+        "exeat_card_signer": {
+          "name": "exeat_card_signer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Signed by Housemaster'"
+        },
+        "visiting_cadence": {
+          "name": "visiting_cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2nd Sun · monthly'"
+        },
+        "visiting_hours_start": {
+          "name": "visiting_hours_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'12:00'"
+        },
+        "visiting_hours_end": {
+          "name": "visiting_hours_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'16:00'"
+        },
+        "visiting_lunch_time": {
+          "name": "visiting_lunch_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'11:30'"
+        },
+        "visiting_dormitories_rule": {
+          "name": "visiting_dormitories_rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Out of bounds'"
+        },
+        "visiting_approved_visitors": {
+          "name": "visiting_approved_visitors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Parent · guardian · sibling'"
+        },
+        "visiting_book_owner": {
+          "name": "visiting_book_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Digital · SoD owns'"
+        },
+        "inspection_daily_start": {
+          "name": "inspection_daily_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'06:10'"
+        },
+        "inspection_daily_end": {
+          "name": "inspection_daily_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'06:20'"
+        },
+        "inspection_daily_scope": {
+          "name": "inspection_daily_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Bunks · lockers · attire'"
+        },
+        "inspection_weekly": {
+          "name": "inspection_weekly",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Saturday 08:00'"
+        },
+        "inspection_weekly_scope": {
+          "name": "inspection_weekly_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Whole House · top to bottom'"
+        },
+        "inspection_scrubbing": {
+          "name": "inspection_scrubbing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Wed 16:00 — 17:00'"
+        },
+        "inspection_washing_days": {
+          "name": "inspection_washing_days",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Wed & Fri afternoons'"
+        },
+        "inspection_inspector": {
+          "name": "inspection_inspector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'HM & House Prefects'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "boarding_settings_school_id_ref_school_id_fk": {
+          "name": "boarding_settings_school_id_ref_school_id_fk",
+          "tableFrom": "boarding_settings",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boarding_settings_school_id_unique": {
+          "name": "boarding_settings_school_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boarding_visit": {
+      "name": "boarding_visit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "house_id": {
+          "name": "house_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_event_id": {
+          "name": "calendar_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_visitor_id": {
+          "name": "approved_visitor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitor_name": {
+          "name": "visitor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visitor_phone": {
+          "name": "visitor_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'RSVP'"
+        },
+        "verification": {
+          "name": "verification",
+          "type": "visit_verification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'FLAGGED'"
+        },
+        "zone_key": {
+          "name": "zone_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rsvp_by_user_id": {
+          "name": "rsvp_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arrived_by_user_id": {
+          "name": "arrived_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "departed_at": {
+          "name": "departed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "departed_by_user_id": {
+          "name": "departed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorised_at": {
+          "name": "authorised_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorised_by_user_id": {
+          "name": "authorised_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "boarding_visit_event_house_idx": {
+          "name": "boarding_visit_event_house_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "calendar_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "house_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "boarding_visit_school_id_ref_school_id_fk": {
+          "name": "boarding_visit_school_id_ref_school_id_fk",
+          "tableFrom": "boarding_visit",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_calendar_event_id_boarding_calendar_event_id_fk": {
+          "name": "boarding_visit_calendar_event_id_boarding_calendar_event_id_fk",
+          "tableFrom": "boarding_visit",
+          "tableTo": "boarding_calendar_event",
+          "columnsFrom": [
+            "calendar_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_approved_visitor_id_boarding_approved_visitor_id_fk": {
+          "name": "boarding_visit_approved_visitor_id_boarding_approved_visitor_id_fk",
+          "tableFrom": "boarding_visit",
+          "tableTo": "boarding_approved_visitor",
+          "columnsFrom": [
+            "approved_visitor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_rsvp_by_user_id_ref_user_id_fk": {
+          "name": "boarding_visit_rsvp_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_visit",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "rsvp_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_arrived_by_user_id_ref_user_id_fk": {
+          "name": "boarding_visit_arrived_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_visit",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "arrived_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_departed_by_user_id_ref_user_id_fk": {
+          "name": "boarding_visit_departed_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_visit",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "departed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_authorised_by_user_id_ref_user_id_fk": {
+          "name": "boarding_visit_authorised_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_visit",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "authorised_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_school_id_student_id_students_school_id_id_fk": {
+          "name": "boarding_visit_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "boarding_visit",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_school_id_house_id_house_school_id_id_fk": {
+          "name": "boarding_visit_school_id_house_id_house_school_id_id_fk",
+          "tableFrom": "boarding_visit",
+          "tableTo": "house",
+          "columnsFrom": [
+            "school_id",
+            "house_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boarding_visit_tenant_uk": {
+          "name": "boarding_visit_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        },
+        "uniq_boarding_visit_rsvp": {
+          "name": "uniq_boarding_visit_rsvp",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "calendar_event_id",
+            "approved_visitor_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boarding_visit_notification": {
+      "name": "boarding_visit_notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visit_id": {
+          "name": "visit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_event_id": {
+          "name": "calendar_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "visit_notification_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_phone": {
+          "name": "to_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sent_by_user_id": {
+          "name": "sent_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "boarding_visit_notification_visit_idx": {
+          "name": "boarding_visit_notification_visit_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boarding_visit_notification_event_idx": {
+          "name": "boarding_visit_notification_event_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "calendar_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "boarding_visit_notification_school_id_ref_school_id_fk": {
+          "name": "boarding_visit_notification_school_id_ref_school_id_fk",
+          "tableFrom": "boarding_visit_notification",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_notification_calendar_event_id_boarding_calendar_event_id_fk": {
+          "name": "boarding_visit_notification_calendar_event_id_boarding_calendar_event_id_fk",
+          "tableFrom": "boarding_visit_notification",
+          "tableTo": "boarding_calendar_event",
+          "columnsFrom": [
+            "calendar_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_notification_sent_by_user_id_ref_user_id_fk": {
+          "name": "boarding_visit_notification_sent_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_visit_notification",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "sent_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_notification_school_id_visit_id_boarding_visit_school_id_id_fk": {
+          "name": "boarding_visit_notification_school_id_visit_id_boarding_visit_school_id_id_fk",
+          "tableFrom": "boarding_visit_notification",
+          "tableTo": "boarding_visit",
+          "columnsFrom": [
+            "school_id",
+            "visit_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bond_artefacts": {
+      "name": "bond_artefacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "infraction_id": {
+          "name": "infraction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_signature_at": {
+          "name": "student_signature_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hm_witness_user_id": {
+          "name": "hm_witness_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hm_witness_at": {
+          "name": "hm_witness_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "senior_hm_witness_user_id": {
+          "name": "senior_hm_witness_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "senior_hm_witness_at": {
+          "name": "senior_hm_witness_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scanned_pdf_file_id": {
+          "name": "scanned_pdf_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bond_text": {
+          "name": "bond_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bond_artefacts_school_id_ref_school_id_fk": {
+          "name": "bond_artefacts_school_id_ref_school_id_fk",
+          "tableFrom": "bond_artefacts",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bond_artefacts_hm_witness_user_id_ref_user_id_fk": {
+          "name": "bond_artefacts_hm_witness_user_id_ref_user_id_fk",
+          "tableFrom": "bond_artefacts",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "hm_witness_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bond_artefacts_senior_hm_witness_user_id_ref_user_id_fk": {
+          "name": "bond_artefacts_senior_hm_witness_user_id_ref_user_id_fk",
+          "tableFrom": "bond_artefacts",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "senior_hm_witness_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bond_artefacts_school_id_infraction_id_boarding_infractions_school_id_id_fk": {
+          "name": "bond_artefacts_school_id_infraction_id_boarding_infractions_school_id_id_fk",
+          "tableFrom": "bond_artefacts",
+          "tableTo": "boarding_infractions",
+          "columnsFrom": [
+            "school_id",
+            "infraction_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_bond_per_infraction": {
+          "name": "uniq_bond_per_infraction",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "infraction_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bunk_allocation": {
+      "name": "bunk_allocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bunk_id": {
+          "name": "bunk_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_at": {
+          "name": "from_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "to_at": {
+          "name": "to_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allocated_by_user_id": {
+          "name": "allocated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bunk_allocation_student_idx": {
+          "name": "bunk_allocation_student_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bunk_allocation_school_id_ref_school_id_fk": {
+          "name": "bunk_allocation_school_id_ref_school_id_fk",
+          "tableFrom": "bunk_allocation",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bunk_allocation_allocated_by_user_id_ref_user_id_fk": {
+          "name": "bunk_allocation_allocated_by_user_id_ref_user_id_fk",
+          "tableFrom": "bunk_allocation",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "allocated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bunk_allocation_school_id_student_id_students_school_id_id_fk": {
+          "name": "bunk_allocation_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "bunk_allocation",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bunk_allocation_school_id_bunk_id_boarding_bunk_school_id_id_fk": {
+          "name": "bunk_allocation_school_id_bunk_id_boarding_bunk_school_id_id_fk",
+          "tableFrom": "bunk_allocation",
+          "tableTo": "boarding_bunk",
+          "columnsFrom": [
+            "school_id",
+            "bunk_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_schedule_template": {
+      "name": "daily_schedule_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_type": {
+          "name": "day_type",
+          "type": "boarding_day_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form_scope": {
+          "name": "form_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ALL'"
+        },
+        "activities_json": {
+          "name": "activities_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "daily_schedule_template_school_id_ref_school_id_fk": {
+          "name": "daily_schedule_template_school_id_ref_school_id_fk",
+          "tableFrom": "daily_schedule_template",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_schedule_template": {
+          "name": "uniq_schedule_template",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "day_type",
+            "form_scope"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deboardinization_records": {
+      "name": "deboardinization_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "infraction_id": {
+          "name": "infraction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hm_sign_user_id": {
+          "name": "hm_sign_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hm_sign_at": {
+          "name": "hm_sign_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "senior_hm_sign_user_id": {
+          "name": "senior_hm_sign_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "senior_hm_sign_at": {
+          "name": "senior_hm_sign_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headmaster_sign_user_id": {
+          "name": "headmaster_sign_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headmaster_sign_at": {
+          "name": "headmaster_sign_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_review_at": {
+          "name": "board_review_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_decision_text": {
+          "name": "board_decision_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstated_at": {
+          "name": "reinstated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstated_by_user_id": {
+          "name": "reinstated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_penalty_invoice_id": {
+          "name": "fee_penalty_invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "penalty_days": {
+          "name": "penalty_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "penalty_per_day_amount": {
+          "name": "penalty_per_day_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "penalty_adjusted_amount": {
+          "name": "penalty_adjusted_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "penalty_adjustment_reason": {
+          "name": "penalty_adjustment_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "one_active_deboard_per_student": {
+          "name": "one_active_deboard_per_student",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"deboardinization_records\".\"effective_at\" IS NOT NULL AND \"deboardinization_records\".\"reinstated_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deboardinization_records_school_id_ref_school_id_fk": {
+          "name": "deboardinization_records_school_id_ref_school_id_fk",
+          "tableFrom": "deboardinization_records",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deboardinization_records_hm_sign_user_id_ref_user_id_fk": {
+          "name": "deboardinization_records_hm_sign_user_id_ref_user_id_fk",
+          "tableFrom": "deboardinization_records",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "hm_sign_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "deboardinization_records_senior_hm_sign_user_id_ref_user_id_fk": {
+          "name": "deboardinization_records_senior_hm_sign_user_id_ref_user_id_fk",
+          "tableFrom": "deboardinization_records",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "senior_hm_sign_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "deboardinization_records_headmaster_sign_user_id_ref_user_id_fk": {
+          "name": "deboardinization_records_headmaster_sign_user_id_ref_user_id_fk",
+          "tableFrom": "deboardinization_records",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "headmaster_sign_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "deboardinization_records_reinstated_by_user_id_ref_user_id_fk": {
+          "name": "deboardinization_records_reinstated_by_user_id_ref_user_id_fk",
+          "tableFrom": "deboardinization_records",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "reinstated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "deboardinization_records_school_id_student_id_students_school_id_id_fk": {
+          "name": "deboardinization_records_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "deboardinization_records",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deboardinization_records_school_id_infraction_id_boarding_infractions_school_id_id_fk": {
+          "name": "deboardinization_records_school_id_infraction_id_boarding_infractions_school_id_id_fk",
+          "tableFrom": "deboardinization_records",
+          "tableTo": "boarding_infractions",
+          "columnsFrom": [
+            "school_id",
+            "infraction_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "deboard_effective_needs_all_signs": {
+          "name": "deboard_effective_needs_all_signs",
+          "value": "\"deboardinization_records\".\"effective_at\" IS NULL OR (\"deboardinization_records\".\"hm_sign_at\" IS NOT NULL AND \"deboardinization_records\".\"senior_hm_sign_at\" IS NOT NULL AND \"deboardinization_records\".\"headmaster_sign_at\" IS NOT NULL)"
+        },
+        "reinstate_needs_board_decision": {
+          "name": "reinstate_needs_board_decision",
+          "value": "\"deboardinization_records\".\"reinstated_at\" IS NULL OR \"deboardinization_records\".\"board_decision_text\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.exeat_notification": {
+      "name": "exeat_notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exeat_id": {
+          "name": "exeat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "exeat_notification_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_phone": {
+          "name": "to_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sent_by_user_id": {
+          "name": "sent_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "exeat_notification_exeat_idx": {
+          "name": "exeat_notification_exeat_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "exeat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exeat_notification_school_id_ref_school_id_fk": {
+          "name": "exeat_notification_school_id_ref_school_id_fk",
+          "tableFrom": "exeat_notification",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exeat_notification_sent_by_user_id_ref_user_id_fk": {
+          "name": "exeat_notification_sent_by_user_id_ref_user_id_fk",
+          "tableFrom": "exeat_notification",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "sent_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "exeat_notification_school_id_exeat_id_boarding_exeat_school_id_id_fk": {
+          "name": "exeat_notification_school_id_exeat_id_boarding_exeat_school_id_id_fk",
+          "tableFrom": "exeat_notification",
+          "tableTo": "boarding_exeat",
+          "columnsFrom": [
+            "school_id",
+            "exeat_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inspections": {
+      "name": "inspections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dormitory_id": {
+          "name": "dormitory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "house_id": {
+          "name": "house_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "inspection_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "inspection_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bunks_clean": {
+          "name": "bunks_clean",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bunks_total": {
+          "name": "bunks_total",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings_json": {
+          "name": "findings_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anomalies_count": {
+          "name": "anomalies_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "inspected_at": {
+          "name": "inspected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inspected_by_user_id": {
+          "name": "inspected_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inspections_dorm_time_idx": {
+          "name": "inspections_dorm_time_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dormitory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "inspected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inspections_house_time_idx": {
+          "name": "inspections_house_time_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "house_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "inspected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inspections_school_id_ref_school_id_fk": {
+          "name": "inspections_school_id_ref_school_id_fk",
+          "tableFrom": "inspections",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inspections_inspected_by_user_id_ref_user_id_fk": {
+          "name": "inspections_inspected_by_user_id_ref_user_id_fk",
+          "tableFrom": "inspections",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "inspected_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inspections_school_id_dormitory_id_boarding_dormitory_school_id_id_fk": {
+          "name": "inspections_school_id_dormitory_id_boarding_dormitory_school_id_id_fk",
+          "tableFrom": "inspections",
+          "tableTo": "boarding_dormitory",
+          "columnsFrom": [
+            "school_id",
+            "dormitory_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inspections_school_id_house_id_house_school_id_id_fk": {
+          "name": "inspections_school_id_house_id_house_school_id_id_fk",
+          "tableFrom": "inspections",
+          "tableTo": "house",
+          "columnsFrom": [
+            "school_id",
+            "house_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prep_attendance": {
+      "name": "prep_attendance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "house_id": {
+          "name": "house_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_date": {
+          "name": "session_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "attendance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minutes_late": {
+          "name": "minutes_late",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "logged_by_user_id": {
+          "name": "logged_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "prep_attendance_house_date_idx": {
+          "name": "prep_attendance_house_date_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "house_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prep_attendance_school_id_ref_school_id_fk": {
+          "name": "prep_attendance_school_id_ref_school_id_fk",
+          "tableFrom": "prep_attendance",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "prep_attendance_logged_by_user_id_ref_user_id_fk": {
+          "name": "prep_attendance_logged_by_user_id_ref_user_id_fk",
+          "tableFrom": "prep_attendance",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "logged_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "prep_attendance_school_id_student_id_students_school_id_id_fk": {
+          "name": "prep_attendance_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "prep_attendance",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "prep_attendance_school_id_house_id_house_school_id_id_fk": {
+          "name": "prep_attendance_school_id_house_id_house_school_id_id_fk",
+          "tableFrom": "prep_attendance",
+          "tableTo": "house",
+          "columnsFrom": [
+            "school_id",
+            "house_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_prep_attendance": {
+          "name": "uniq_prep_attendance",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "session_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admission_application": {
+      "name": "admission_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_first_name": {
+          "name": "applicant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_last_name": {
+          "name": "applicant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_other_names": {
+          "name": "applicant_other_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desired_class_label": {
+          "name": "desired_class_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guardian_name": {
+          "name": "guardian_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guardian_phone": {
+          "name": "guardian_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guardian_email": {
+          "name": "guardian_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "admission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SUBMITTED'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admission_school_status_idx": {
+          "name": "admission_school_status_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admission_application_school_id_ref_school_id_fk": {
+          "name": "admission_application_school_id_ref_school_id_fk",
+          "tableFrom": "admission_application",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admission_application_decided_by_user_id_ref_user_id_fk": {
+          "name": "admission_application_decided_by_user_id_ref_user_id_fk",
+          "tableFrom": "admission_application",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "admission_application_school_id_student_id_students_school_id_id_fk": {
+          "name": "admission_application_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "admission_application",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admission_application_tenant_uk": {
+          "name": "admission_application_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admission_document": {
+      "name": "admission_document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admission_document_school_id_ref_school_id_fk": {
+          "name": "admission_document_school_id_ref_school_id_fk",
+          "tableFrom": "admission_document",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admission_document_school_id_application_id_admission_application_school_id_id_fk": {
+          "name": "admission_document_school_id_application_id_admission_application_school_id_id_fk",
+          "tableFrom": "admission_document",
+          "tableTo": "admission_application",
+          "columnsFrom": [
+            "school_id",
+            "application_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_category": {
+      "name": "fee_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_category_school_id_ref_school_id_fk": {
+          "name": "fee_category_school_id_ref_school_id_fk",
+          "tableFrom": "fee_category",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_fee_category_per_school": {
+          "name": "uniq_fee_category_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        },
+        "fee_category_tenant_uk": {
+          "name": "fee_category_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_line_item": {
+      "name": "invoice_line_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_category_id": {
+          "name": "fee_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_optional": {
+          "name": "is_optional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_line_item_school_id_ref_school_id_fk": {
+          "name": "invoice_line_item_school_id_ref_school_id_fk",
+          "tableFrom": "invoice_line_item",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_line_item_school_id_invoice_id_invoice_school_id_id_fk": {
+          "name": "invoice_line_item_school_id_invoice_id_invoice_school_id_id_fk",
+          "tableFrom": "invoice_line_item",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "school_id",
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_line_item_school_id_fee_category_id_fee_category_school_id_id_fk": {
+          "name": "invoice_line_item_school_id_fee_category_id_fee_category_school_id_id_fk",
+          "tableFrom": "invoice_line_item",
+          "tableTo": "fee_category",
+          "columnsFrom": [
+            "school_id",
+            "fee_category_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoice_line_item_tenant_uk": {
+          "name": "invoice_line_item_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice": {
+      "name": "invoice",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal_amount": {
+          "name": "subtotal_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "billed_amount": {
+          "name": "billed_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "balance_amount": {
+          "name": "balance_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ISSUED'"
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_student_idx": {
+          "name": "invoice_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_school_id_ref_school_id_fk": {
+          "name": "invoice_school_id_ref_school_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_school_id_student_id_students_school_id_id_fk": {
+          "name": "invoice_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "invoice_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_invoice_number_per_school": {
+          "name": "uniq_invoice_number_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "invoice_number"
+          ]
+        },
+        "invoice_tenant_uk": {
+          "name": "invoice_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_allocation": {
+      "name": "payment_allocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allocation_type": {
+          "name": "allocation_type",
+          "type": "allocation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INVOICE'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allocation_method": {
+          "name": "allocation_method",
+          "type": "allocation_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MANUAL'"
+        },
+        "allocated_by_user_id": {
+          "name": "allocated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allocated_at": {
+          "name": "allocated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payment_allocation_school_id_ref_school_id_fk": {
+          "name": "payment_allocation_school_id_ref_school_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_allocation_allocated_by_user_id_ref_user_id_fk": {
+          "name": "payment_allocation_allocated_by_user_id_ref_user_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "allocated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_allocation_school_id_payment_id_payment_school_id_id_fk": {
+          "name": "payment_allocation_school_id_payment_id_payment_school_id_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "payment",
+          "columnsFrom": [
+            "school_id",
+            "payment_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_allocation_school_id_invoice_id_invoice_school_id_id_fk": {
+          "name": "payment_allocation_school_id_invoice_id_invoice_school_id_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "school_id",
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_audit_log": {
+      "name": "payment_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "payment_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "payment_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ADMIN'"
+        },
+        "before_state": {
+          "name": "before_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_state": {
+          "name": "after_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_audit_school_time_idx": {
+          "name": "payment_audit_school_time_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_audit_log_school_id_ref_school_id_fk": {
+          "name": "payment_audit_log_school_id_ref_school_id_fk",
+          "tableFrom": "payment_audit_log",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_audit_log_actor_user_id_ref_user_id_fk": {
+          "name": "payment_audit_log_actor_user_id_ref_user_id_fk",
+          "tableFrom": "payment_audit_log",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment": {
+      "name": "payment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gross_amount": {
+          "name": "gross_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_amount": {
+          "name": "fee_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "net_amount": {
+          "name": "net_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GHS'"
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method_reference": {
+          "name": "method_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregator": {
+          "name": "aggregator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settlement_status": {
+          "name": "settlement_status",
+          "type": "settlement_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_by_user_id": {
+          "name": "voided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_is_refund": {
+          "name": "void_is_refund",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "payment_student_idx": {
+          "name": "payment_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_school_id_ref_school_id_fk": {
+          "name": "payment_school_id_ref_school_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_recorded_by_user_id_ref_user_id_fk": {
+          "name": "payment_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_voided_by_user_id_ref_user_id_fk": {
+          "name": "payment_voided_by_user_id_ref_user_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "voided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_school_id_student_id_students_school_id_id_fk": {
+          "name": "payment_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "payment_tenant_uk": {
+          "name": "payment_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.receipt": {
+      "name": "receipt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receipt_number": {
+          "name": "receipt_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_token": {
+          "name": "public_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_replacement_id": {
+          "name": "void_replacement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "receipt_school_id_ref_school_id_fk": {
+          "name": "receipt_school_id_ref_school_id_fk",
+          "tableFrom": "receipt",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "receipt_school_id_payment_id_payment_school_id_id_fk": {
+          "name": "receipt_school_id_payment_id_payment_school_id_id_fk",
+          "tableFrom": "receipt",
+          "tableTo": "payment",
+          "columnsFrom": [
+            "school_id",
+            "payment_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "receipt_school_id_student_id_students_school_id_id_fk": {
+          "name": "receipt_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "receipt",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "receipt_payment_id_unique": {
+          "name": "receipt_payment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "payment_id"
+          ]
+        },
+        "receipt_public_token_unique": {
+          "name": "receipt_public_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_token"
+          ]
+        },
+        "uniq_receipt_number_per_school": {
+          "name": "uniq_receipt_number_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "receipt_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discount_tier": {
+      "name": "discount_tier",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_id": {
+          "name": "discount_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "discount_tier_school_id_ref_school_id_fk": {
+          "name": "discount_tier_school_id_ref_school_id_fk",
+          "tableFrom": "discount_tier",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discount_tier_school_id_discount_id_discount_school_id_id_fk": {
+          "name": "discount_tier_school_id_discount_id_discount_school_id_id_fk",
+          "tableFrom": "discount_tier",
+          "tableTo": "discount",
+          "columnsFrom": [
+            "school_id",
+            "discount_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_discount_tier_rank": {
+          "name": "uniq_discount_tier_rank",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discount_id",
+            "rank"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discount": {
+      "name": "discount",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "discount_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'FIXED'"
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applies_to_category_id": {
+          "name": "applies_to_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_label": {
+          "name": "duration_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_approval": {
+          "name": "requires_approval",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stackable": {
+          "name": "stackable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_tiered": {
+          "name": "is_tiered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "applied_count": {
+          "name": "applied_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "discount_school_id_ref_school_id_fk": {
+          "name": "discount_school_id_ref_school_id_fk",
+          "tableFrom": "discount",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discount_applies_to_category_id_fee_category_id_fk": {
+          "name": "discount_applies_to_category_id_fee_category_id_fk",
+          "tableFrom": "discount",
+          "tableTo": "fee_category",
+          "columnsFrom": [
+            "applies_to_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "discount_approved_by_user_id_ref_user_id_fk": {
+          "name": "discount_approved_by_user_id_ref_user_id_fk",
+          "tableFrom": "discount",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_discount_per_school": {
+          "name": "uniq_discount_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        },
+        "discount_tenant_uk": {
+          "name": "discount_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_structure_item": {
+      "name": "fee_structure_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_structure_id": {
+          "name": "fee_structure_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_category_id": {
+          "name": "fee_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_structure_item_school_id_ref_school_id_fk": {
+          "name": "fee_structure_item_school_id_ref_school_id_fk",
+          "tableFrom": "fee_structure_item",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fee_structure_item_fee_category_id_fee_category_id_fk": {
+          "name": "fee_structure_item_fee_category_id_fee_category_id_fk",
+          "tableFrom": "fee_structure_item",
+          "tableTo": "fee_category",
+          "columnsFrom": [
+            "fee_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "fee_structure_item_school_id_fee_structure_id_fee_structure_school_id_id_fk": {
+          "name": "fee_structure_item_school_id_fee_structure_id_fee_structure_school_id_id_fk",
+          "tableFrom": "fee_structure_item",
+          "tableTo": "fee_structure",
+          "columnsFrom": [
+            "school_id",
+            "fee_structure_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_structure": {
+      "name": "fee_structure",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_structure_school_id_ref_school_id_fk": {
+          "name": "fee_structure_school_id_ref_school_id_fk",
+          "tableFrom": "fee_structure",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_fee_structure_per_school": {
+          "name": "uniq_fee_structure_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        },
+        "fee_structure_tenant_uk": {
+          "name": "fee_structure_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_discount_application": {
+      "name": "invoice_discount_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_id": {
+          "name": "discount_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind_snapshot": {
+          "name": "kind_snapshot",
+          "type": "discount_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "applied_by_user_id": {
+          "name": "applied_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_discount_app_school_idx": {
+          "name": "invoice_discount_app_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_discount_app_invoice_idx": {
+          "name": "invoice_discount_app_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_discount_app_discount_idx": {
+          "name": "invoice_discount_app_discount_idx",
+          "columns": [
+            {
+              "expression": "discount_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_discount_application_school_id_ref_school_id_fk": {
+          "name": "invoice_discount_application_school_id_ref_school_id_fk",
+          "tableFrom": "invoice_discount_application",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_discount_application_applied_by_user_id_ref_user_id_fk": {
+          "name": "invoice_discount_application_applied_by_user_id_ref_user_id_fk",
+          "tableFrom": "invoice_discount_application",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "applied_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_discount_application_school_id_invoice_id_invoice_school_id_id_fk": {
+          "name": "invoice_discount_application_school_id_invoice_id_invoice_school_id_id_fk",
+          "tableFrom": "invoice_discount_application",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "school_id",
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_discount_application_school_id_student_id_students_school_id_id_fk": {
+          "name": "invoice_discount_application_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "invoice_discount_application",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_discount_application_school_id_discount_id_discount_school_id_id_fk": {
+          "name": "invoice_discount_application_school_id_discount_id_discount_school_id_id_fk",
+          "tableFrom": "invoice_discount_application",
+          "tableTo": "discount",
+          "columnsFrom": [
+            "school_id",
+            "discount_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attendance_correction": {
+      "name": "attendance_correction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_record_id": {
+          "name": "attendance_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_status": {
+          "name": "requested_status",
+          "type": "attendance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "correction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "decision_note": {
+          "name": "decision_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attendance_correction_school_id_ref_school_id_fk": {
+          "name": "attendance_correction_school_id_ref_school_id_fk",
+          "tableFrom": "attendance_correction",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_correction_requested_by_user_id_ref_user_id_fk": {
+          "name": "attendance_correction_requested_by_user_id_ref_user_id_fk",
+          "tableFrom": "attendance_correction",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attendance_correction_decided_by_user_id_ref_user_id_fk": {
+          "name": "attendance_correction_decided_by_user_id_ref_user_id_fk",
+          "tableFrom": "attendance_correction",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attendance_correction_school_id_attendance_record_id_attendance_record_school_id_id_fk": {
+          "name": "attendance_correction_school_id_attendance_record_id_attendance_record_school_id_id_fk",
+          "tableFrom": "attendance_correction",
+          "tableTo": "attendance_record",
+          "columnsFrom": [
+            "school_id",
+            "attendance_record_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attendance_record": {
+      "name": "attendance_record",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "attendance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marked_by_user_id": {
+          "name": "marked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marked_at": {
+          "name": "marked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attendance_class_date_idx": {
+          "name": "attendance_class_date_idx",
+          "columns": [
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attendance_record_school_id_ref_school_id_fk": {
+          "name": "attendance_record_school_id_ref_school_id_fk",
+          "tableFrom": "attendance_record",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_record_marked_by_user_id_ref_user_id_fk": {
+          "name": "attendance_record_marked_by_user_id_ref_user_id_fk",
+          "tableFrom": "attendance_record",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "marked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attendance_record_school_id_student_id_students_school_id_id_fk": {
+          "name": "attendance_record_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "attendance_record",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_record_school_id_class_id_class_school_id_id_fk": {
+          "name": "attendance_record_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "attendance_record",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_attendance_student_day": {
+          "name": "uniq_attendance_student_day",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "date"
+          ]
+        },
+        "attendance_record_tenant_uk": {
+          "name": "attendance_record_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attendance_settings": {
+      "name": "attendance_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_start": {
+          "name": "day_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'08:00'"
+        },
+        "late_threshold": {
+          "name": "late_threshold",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'08:15'"
+        },
+        "day_end": {
+          "name": "day_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'15:00'"
+        },
+        "edit_window_hours": {
+          "name": "edit_window_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 24
+        },
+        "absence_sms": {
+          "name": "absence_sms",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "abs_watch_days": {
+          "name": "abs_watch_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "abs_critical_days": {
+          "name": "abs_critical_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "pct_watch": {
+          "name": "pct_watch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 70
+        },
+        "pct_critical": {
+          "name": "pct_critical",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attendance_settings_school_id_ref_school_id_fk": {
+          "name": "attendance_settings_school_id_ref_school_id_fk",
+          "tableFrom": "attendance_settings",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "attendance_settings_school_id_unique": {
+          "name": "attendance_settings_school_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.grade_scale": {
+      "name": "grade_scale",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_score": {
+          "name": "min_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grade_scale_school_idx": {
+          "name": "grade_scale_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grade_scale_school_id_ref_school_id_fk": {
+          "name": "grade_scale_school_id_ref_school_id_fk",
+          "tableFrom": "grade_scale",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_grade_per_school": {
+          "name": "uniq_grade_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "grade"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gradebook_column_score": {
+      "name": "gradebook_column_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_score": {
+          "name": "raw_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gradebook_column_score_column_idx": {
+          "name": "gradebook_column_score_column_idx",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gradebook_column_score_school_id_ref_school_id_fk": {
+          "name": "gradebook_column_score_school_id_ref_school_id_fk",
+          "tableFrom": "gradebook_column_score",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_score_updated_by_user_id_ref_user_id_fk": {
+          "name": "gradebook_column_score_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "gradebook_column_score",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_score_school_id_column_id_gradebook_column_school_id_id_fk": {
+          "name": "gradebook_column_score_school_id_column_id_gradebook_column_school_id_id_fk",
+          "tableFrom": "gradebook_column_score",
+          "tableTo": "gradebook_column",
+          "columnsFrom": [
+            "school_id",
+            "column_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_score_school_id_student_id_students_school_id_id_fk": {
+          "name": "gradebook_column_score_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "gradebook_column_score",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_column_score_per_student": {
+          "name": "uniq_column_score_per_student",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "column_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gradebook_column": {
+      "name": "gradebook_column",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CA'"
+        },
+        "max_score": {
+          "name": "max_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gradebook_column_context_idx": {
+          "name": "gradebook_column_context_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gradebook_column_school_id_ref_school_id_fk": {
+          "name": "gradebook_column_school_id_ref_school_id_fk",
+          "tableFrom": "gradebook_column",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_created_by_user_id_ref_user_id_fk": {
+          "name": "gradebook_column_created_by_user_id_ref_user_id_fk",
+          "tableFrom": "gradebook_column",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_school_id_class_id_class_school_id_id_fk": {
+          "name": "gradebook_column_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "gradebook_column",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "gradebook_column_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "gradebook_column",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "gradebook_column_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "gradebook_column",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_column_per_class_subject_period": {
+          "name": "uniq_column_per_class_subject_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "class_id",
+            "subject_id",
+            "period_id",
+            "name"
+          ]
+        },
+        "gradebook_column_tenant_uk": {
+          "name": "gradebook_column_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gradebook_config": {
+      "name": "gradebook_config",
+      "schema": "",
+      "columns": {
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "class_weight": {
+          "name": "class_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "exam_weight": {
+          "name": "exam_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gradebook_config_school_id_ref_school_id_fk": {
+          "name": "gradebook_config_school_id_ref_school_id_fk",
+          "tableFrom": "gradebook_config",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gradebook_score": {
+      "name": "gradebook_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_score": {
+          "name": "class_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exam_score": {
+          "name": "exam_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "score_period_subject_idx": {
+          "name": "score_period_subject_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gradebook_score_school_id_ref_school_id_fk": {
+          "name": "gradebook_score_school_id_ref_school_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_score_updated_by_user_id_ref_user_id_fk": {
+          "name": "gradebook_score_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gradebook_score_school_id_student_id_students_school_id_id_fk": {
+          "name": "gradebook_score_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_score_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "gradebook_score_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_score_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "gradebook_score_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_score_student_subject_period": {
+          "name": "uniq_score_student_subject_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "subject_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_card": {
+      "name": "report_card",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overall_total": {
+          "name": "overall_total",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overall_grade": {
+          "name": "overall_grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_count": {
+          "name": "subject_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "report_card_school_id_ref_school_id_fk": {
+          "name": "report_card_school_id_ref_school_id_fk",
+          "tableFrom": "report_card",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "report_card_generated_by_user_id_ref_user_id_fk": {
+          "name": "report_card_generated_by_user_id_ref_user_id_fk",
+          "tableFrom": "report_card",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "report_card_school_id_student_id_students_school_id_id_fk": {
+          "name": "report_card_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "report_card",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "report_card_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "report_card_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "report_card",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_report_student_period": {
+          "name": "uniq_report_student_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subject": {
+      "name": "subject",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subject_school_id_ref_school_id_fk": {
+          "name": "subject_school_id_ref_school_id_fk",
+          "tableFrom": "subject",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_subject_per_school": {
+          "name": "uniq_subject_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        },
+        "subject_tenant_uk": {
+          "name": "subject_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_assessment_weights": {
+      "name": "ref_assessment_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asgn_weight": {
+          "name": "asgn_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "mid_sem_weight": {
+          "name": "mid_sem_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "end_sem_weight": {
+          "name": "end_sem_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 40
+        },
+        "project_weight": {
+          "name": "project_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "portfolio_weight": {
+          "name": "portfolio_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "asgn_denominator": {
+          "name": "asgn_denominator",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "mid_sem_denominator": {
+          "name": "mid_sem_denominator",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "end_sem_denominator": {
+          "name": "end_sem_denominator",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "project_denominator": {
+          "name": "project_denominator",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "portfolio_denominator": {
+          "name": "portfolio_denominator",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_school_default_weights": {
+          "name": "uniq_school_default_weights",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"ref_assessment_weights\".\"subject_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ref_assessment_weights_school_id_ref_school_id_fk": {
+          "name": "ref_assessment_weights_school_id_ref_school_id_fk",
+          "tableFrom": "ref_assessment_weights",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ref_assessment_weights_updated_by_user_id_ref_user_id_fk": {
+          "name": "ref_assessment_weights_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "ref_assessment_weights",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ref_assessment_weights_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "ref_assessment_weights_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "ref_assessment_weights",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_weights_per_school_subject": {
+          "name": "uniq_weights_per_school_subject",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "subject_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "assessment_weights_sum_100": {
+          "name": "assessment_weights_sum_100",
+          "value": "\"ref_assessment_weights\".\"asgn_weight\" + \"ref_assessment_weights\".\"mid_sem_weight\" + \"ref_assessment_weights\".\"end_sem_weight\" + \"ref_assessment_weights\".\"project_weight\" + \"ref_assessment_weights\".\"portfolio_weight\" = 100"
+        },
+        "assessment_denominators_positive": {
+          "name": "assessment_denominators_positive",
+          "value": "\"ref_assessment_weights\".\"asgn_denominator\" > 0 AND \"ref_assessment_weights\".\"mid_sem_denominator\" > 0 AND \"ref_assessment_weights\".\"end_sem_denominator\" > 0 AND \"ref_assessment_weights\".\"project_denominator\" > 0 AND \"ref_assessment_weights\".\"portfolio_denominator\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.senior_assessment_score": {
+      "name": "senior_assessment_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assessment_id": {
+          "name": "assessment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_mark": {
+          "name": "raw_mark",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "senior_assessment_score_assessment_idx": {
+          "name": "senior_assessment_score_assessment_idx",
+          "columns": [
+            {
+              "expression": "assessment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "senior_assessment_score_school_id_ref_school_id_fk": {
+          "name": "senior_assessment_score_school_id_ref_school_id_fk",
+          "tableFrom": "senior_assessment_score",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_score_updated_by_user_id_ref_user_id_fk": {
+          "name": "senior_assessment_score_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "senior_assessment_score",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_score_school_id_assessment_id_senior_assessment_school_id_id_fk": {
+          "name": "senior_assessment_score_school_id_assessment_id_senior_assessment_school_id_id_fk",
+          "tableFrom": "senior_assessment_score",
+          "tableTo": "senior_assessment",
+          "columnsFrom": [
+            "school_id",
+            "assessment_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_score_school_id_student_id_students_school_id_id_fk": {
+          "name": "senior_assessment_score_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "senior_assessment_score",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_assessment_score_per_student": {
+          "name": "uniq_assessment_score_per_student",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "assessment_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.senior_assessment": {
+      "name": "senior_assessment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "assessment_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_mark": {
+          "name": "max_mark",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assessed_on": {
+          "name": "assessed_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_one_mid_sem_per_context": {
+          "name": "uniq_one_mid_sem_per_context",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"senior_assessment\".\"category\" = 'MID_SEM_EXAM'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_one_end_sem_per_context": {
+          "name": "uniq_one_end_sem_per_context",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"senior_assessment\".\"category\" = 'END_SEM_EXAM'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "senior_assessment_context_idx": {
+          "name": "senior_assessment_context_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "senior_assessment_school_id_ref_school_id_fk": {
+          "name": "senior_assessment_school_id_ref_school_id_fk",
+          "tableFrom": "senior_assessment",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_created_by_user_id_ref_user_id_fk": {
+          "name": "senior_assessment_created_by_user_id_ref_user_id_fk",
+          "tableFrom": "senior_assessment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_school_id_class_id_class_school_id_id_fk": {
+          "name": "senior_assessment_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "senior_assessment",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "senior_assessment_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "senior_assessment",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "senior_assessment_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "senior_assessment",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_assessment_per_context": {
+          "name": "uniq_assessment_per_context",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "class_id",
+            "subject_id",
+            "period_id",
+            "category",
+            "title"
+          ]
+        },
+        "senior_assessment_tenant_uk": {
+          "name": "senior_assessment_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.senior_ledger_path": {
+      "name": "senior_ledger_path",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "capture_path",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AUTO_COMPILE'"
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "senior_ledger_path_school_id_ref_school_id_fk": {
+          "name": "senior_ledger_path_school_id_ref_school_id_fk",
+          "tableFrom": "senior_ledger_path",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_ledger_path_updated_by_user_id_ref_user_id_fk": {
+          "name": "senior_ledger_path_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "senior_ledger_path",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "senior_ledger_path_school_id_class_id_class_school_id_id_fk": {
+          "name": "senior_ledger_path_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "senior_ledger_path",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_ledger_path_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "senior_ledger_path_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "senior_ledger_path",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_ledger_path_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "senior_ledger_path_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "senior_ledger_path",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_ledger_path_context": {
+          "name": "uniq_ledger_path_context",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "class_id",
+            "subject_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.senior_score_ledger": {
+      "name": "senior_score_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asgn_score": {
+          "name": "asgn_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mid_sem_score": {
+          "name": "mid_sem_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_sem_score": {
+          "name": "end_sem_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_score": {
+          "name": "project_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "portfolio_score": {
+          "name": "portfolio_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weighted_total": {
+          "name": "weighted_total",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asgn_weight_used": {
+          "name": "asgn_weight_used",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mid_sem_weight_used": {
+          "name": "mid_sem_weight_used",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_sem_weight_used": {
+          "name": "end_sem_weight_used",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_weight_used": {
+          "name": "project_weight_used",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "portfolio_weight_used": {
+          "name": "portfolio_weight_used",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "portfolio_manual": {
+          "name": "portfolio_manual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ledger_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "compiled_by_user_id": {
+          "name": "compiled_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compiled_at": {
+          "name": "compiled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "senior_ledger_period_subject_idx": {
+          "name": "senior_ledger_period_subject_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "senior_score_ledger_school_id_ref_school_id_fk": {
+          "name": "senior_score_ledger_school_id_ref_school_id_fk",
+          "tableFrom": "senior_score_ledger",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_compiled_by_user_id_ref_user_id_fk": {
+          "name": "senior_score_ledger_compiled_by_user_id_ref_user_id_fk",
+          "tableFrom": "senior_score_ledger",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "compiled_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_school_id_student_id_students_school_id_id_fk": {
+          "name": "senior_score_ledger_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "senior_score_ledger",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "senior_score_ledger_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "senior_score_ledger",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "senior_score_ledger_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "senior_score_ledger",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_ledger_student_subject_period": {
+          "name": "uniq_ledger_student_subject_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "subject_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.senior_score_ledger_version": {
+      "name": "senior_score_ledger_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asgn_score": {
+          "name": "asgn_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mid_sem_score": {
+          "name": "mid_sem_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_sem_score": {
+          "name": "end_sem_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_score": {
+          "name": "project_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "portfolio_score": {
+          "name": "portfolio_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weighted_total": {
+          "name": "weighted_total",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ledger_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_used": {
+          "name": "path_used",
+          "type": "capture_path",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "committed_by_user_id": {
+          "name": "committed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "supersedes_id": {
+          "name": "supersedes_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "senior_ledger_version_prune_idx": {
+          "name": "senior_ledger_version_prune_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "senior_score_ledger_version_school_id_ref_school_id_fk": {
+          "name": "senior_score_ledger_version_school_id_ref_school_id_fk",
+          "tableFrom": "senior_score_ledger_version",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_version_committed_by_user_id_ref_user_id_fk": {
+          "name": "senior_score_ledger_version_committed_by_user_id_ref_user_id_fk",
+          "tableFrom": "senior_score_ledger_version",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "committed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_version_school_id_student_id_students_school_id_id_fk": {
+          "name": "senior_score_ledger_version_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "senior_score_ledger_version",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_version_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "senior_score_ledger_version_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "senior_score_ledger_version",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_version_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "senior_score_ledger_version_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "senior_score_ledger_version",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_version_school_id_supersedes_id_senior_score_ledger_version_school_id_id_fk": {
+          "name": "senior_score_ledger_version_school_id_supersedes_id_senior_score_ledger_version_school_id_id_fk",
+          "tableFrom": "senior_score_ledger_version",
+          "tableTo": "senior_score_ledger_version",
+          "columnsFrom": [
+            "school_id",
+            "supersedes_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "senior_score_ledger_version_tenant_uk": {
+          "name": "senior_score_ledger_version_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        },
+        "uniq_ledger_version_grain_number": {
+          "name": "uniq_ledger_version_grain_number",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "subject_id",
+            "period_id",
+            "version_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.senior_subject_teacher": {
+      "name": "senior_subject_teacher",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teacher_user_id": {
+          "name": "teacher_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "senior_subject_teacher_school_id_ref_school_id_fk": {
+          "name": "senior_subject_teacher_school_id_ref_school_id_fk",
+          "tableFrom": "senior_subject_teacher",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_subject_teacher_teacher_user_id_ref_user_id_fk": {
+          "name": "senior_subject_teacher_teacher_user_id_ref_user_id_fk",
+          "tableFrom": "senior_subject_teacher",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "teacher_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "senior_subject_teacher_school_id_class_id_class_school_id_id_fk": {
+          "name": "senior_subject_teacher_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "senior_subject_teacher",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_subject_teacher_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "senior_subject_teacher_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "senior_subject_teacher",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_subject_teacher_context": {
+          "name": "uniq_subject_teacher_context",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "class_id",
+            "subject_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_subject_enrolment": {
+      "name": "student_subject_enrolment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "student_subject_enrolment_subject_idx": {
+          "name": "student_subject_enrolment_subject_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_subject_enrolment_school_id_ref_school_id_fk": {
+          "name": "student_subject_enrolment_school_id_ref_school_id_fk",
+          "tableFrom": "student_subject_enrolment",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_subject_enrolment_created_by_user_id_ref_user_id_fk": {
+          "name": "student_subject_enrolment_created_by_user_id_ref_user_id_fk",
+          "tableFrom": "student_subject_enrolment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "student_subject_enrolment_school_id_student_id_students_school_id_id_fk": {
+          "name": "student_subject_enrolment_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "student_subject_enrolment",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_subject_enrolment_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "student_subject_enrolment_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "student_subject_enrolment",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_student_subject_enrolment": {
+          "name": "uniq_student_subject_enrolment",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "subject_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.benchmark_data_points": {
+      "name": "benchmark_data_points",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "benchmark_metric",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "benchmark_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "benchmark_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quality": {
+          "name": "quality",
+          "type": "benchmark_quality",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence_interval_pp": {
+          "name": "confidence_interval_pp",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_year": {
+          "name": "reference_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "benchmark_data_points_school_id_ref_school_id_fk": {
+          "name": "benchmark_data_points_school_id_ref_school_id_fk",
+          "tableFrom": "benchmark_data_points",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "benchmark_data_points_school_id_subject_id_wassce_subjects_school_id_id_fk": {
+          "name": "benchmark_data_points_school_id_subject_id_wassce_subjects_school_id_id_fk",
+          "tableFrom": "benchmark_data_points",
+          "tableTo": "wassce_subjects",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.benchmark_reference": {
+      "name": "benchmark_reference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_name": {
+          "name": "subject_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "benchmark_metric",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "benchmark_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "benchmark_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quality": {
+          "name": "quality",
+          "type": "benchmark_quality",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence_interval_pp": {
+          "name": "confidence_interval_pp",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_year": {
+          "name": "reference_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mock_exams": {
+      "name": "mock_exams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cohort_id": {
+          "name": "cohort_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mock_number": {
+          "name": "mock_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_predictor": {
+          "name": "is_predictor",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "scheduled_start": {
+          "name": "scheduled_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_end": {
+          "name": "scheduled_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marking_complete_at": {
+          "name": "marking_complete_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_mock_exam_predictor": {
+          "name": "uniq_mock_exam_predictor",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cohort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mock_exams\".\"is_predictor\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mock_exams_school_id_ref_school_id_fk": {
+          "name": "mock_exams_school_id_ref_school_id_fk",
+          "tableFrom": "mock_exams",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_exams_school_id_cohort_id_wassce_cohort_school_id_id_fk": {
+          "name": "mock_exams_school_id_cohort_id_wassce_cohort_school_id_id_fk",
+          "tableFrom": "mock_exams",
+          "tableTo": "wassce_cohort",
+          "columnsFrom": [
+            "school_id",
+            "cohort_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_mock_exam_number": {
+          "name": "uniq_mock_exam_number",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "cohort_id",
+            "mock_number"
+          ]
+        },
+        "mock_exams_tenant_uk": {
+          "name": "mock_exams_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mock_results": {
+      "name": "mock_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mock_id": {
+          "name": "mock_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade": {
+          "name": "grade",
+          "type": "wassce_grade",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_score": {
+          "name": "raw_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_score": {
+          "name": "max_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marked_by_user_id": {
+          "name": "marked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marked_at": {
+          "name": "marked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderated_grade": {
+          "name": "moderated_grade",
+          "type": "wassce_grade",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderator_user_id": {
+          "name": "moderator_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderated_at": {
+          "name": "moderated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderation_reason": {
+          "name": "moderation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mock_results_mock_subject_idx": {
+          "name": "mock_results_mock_subject_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mock_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mock_results_candidate_idx": {
+          "name": "mock_results_candidate_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mock_results_school_id_ref_school_id_fk": {
+          "name": "mock_results_school_id_ref_school_id_fk",
+          "tableFrom": "mock_results",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_results_marked_by_user_id_ref_user_id_fk": {
+          "name": "mock_results_marked_by_user_id_ref_user_id_fk",
+          "tableFrom": "mock_results",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "marked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mock_results_moderator_user_id_ref_user_id_fk": {
+          "name": "mock_results_moderator_user_id_ref_user_id_fk",
+          "tableFrom": "mock_results",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "moderator_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mock_results_school_id_mock_id_mock_exams_school_id_id_fk": {
+          "name": "mock_results_school_id_mock_id_mock_exams_school_id_id_fk",
+          "tableFrom": "mock_results",
+          "tableTo": "mock_exams",
+          "columnsFrom": [
+            "school_id",
+            "mock_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_results_school_id_candidate_id_wassce_candidates_school_id_id_fk": {
+          "name": "mock_results_school_id_candidate_id_wassce_candidates_school_id_id_fk",
+          "tableFrom": "mock_results",
+          "tableTo": "wassce_candidates",
+          "columnsFrom": [
+            "school_id",
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_results_school_id_subject_id_wassce_subjects_school_id_id_fk": {
+          "name": "mock_results_school_id_subject_id_wassce_subjects_school_id_id_fk",
+          "tableFrom": "mock_results",
+          "tableTo": "wassce_subjects",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_mock_result": {
+          "name": "uniq_mock_result",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "mock_id",
+            "candidate_id",
+            "subject_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mock_results_moderation_trail": {
+          "name": "mock_results_moderation_trail",
+          "value": "\"mock_results\".\"moderated_grade\" IS NULL OR (\"mock_results\".\"moderator_user_id\" IS NOT NULL AND \"mock_results\".\"moderated_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.readiness_statements": {
+      "name": "readiness_statements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mock_2_id": {
+          "name": "mock_2_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projected_aggregate": {
+          "name": "projected_aggregate",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projected_band": {
+          "name": "projected_band",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projection_snapshot_json": {
+          "name": "projection_snapshot_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_universities_json": {
+          "name": "target_universities_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_acknowledged_at": {
+          "name": "parent_acknowledged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_acknowledged_signature_method": {
+          "name": "parent_acknowledged_signature_method",
+          "type": "parent_ack_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_acknowledged_phone": {
+          "name": "parent_acknowledged_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_concerns_text": {
+          "name": "parent_concerns_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_signature_pdf_file_id": {
+          "name": "parent_signature_pdf_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "readiness_statements_candidate_idx": {
+          "name": "readiness_statements_candidate_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "readiness_statements_current_idx": {
+          "name": "readiness_statements_current_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"readiness_statements\".\"superseded_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "readiness_statements_school_id_ref_school_id_fk": {
+          "name": "readiness_statements_school_id_ref_school_id_fk",
+          "tableFrom": "readiness_statements",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "readiness_statements_generated_by_user_id_ref_user_id_fk": {
+          "name": "readiness_statements_generated_by_user_id_ref_user_id_fk",
+          "tableFrom": "readiness_statements",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "readiness_statements_school_id_candidate_id_wassce_candidates_school_id_id_fk": {
+          "name": "readiness_statements_school_id_candidate_id_wassce_candidates_school_id_id_fk",
+          "tableFrom": "readiness_statements",
+          "tableTo": "wassce_candidates",
+          "columnsFrom": [
+            "school_id",
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "readiness_statements_school_id_mock_2_id_mock_exams_school_id_id_fk": {
+          "name": "readiness_statements_school_id_mock_2_id_mock_exams_school_id_id_fk",
+          "tableFrom": "readiness_statements",
+          "tableTo": "mock_exams",
+          "columnsFrom": [
+            "school_id",
+            "mock_2_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "readiness_statements_projected_aggregate_range": {
+          "name": "readiness_statements_projected_aggregate_range",
+          "value": "\"readiness_statements\".\"projected_aggregate\" IS NULL OR (\"readiness_statements\".\"projected_aggregate\" BETWEEN 6 AND 54)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.universities": {
+      "name": "universities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "university_type": {
+          "name": "university_type",
+          "type": "university_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.university_programmes": {
+      "name": "university_programmes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "university_id": {
+          "name": "university_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qualification": {
+          "name": "qualification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_years": {
+          "name": "duration_years",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_cut_off": {
+          "name": "current_cut_off",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cut_off_reference_year": {
+          "name": "cut_off_reference_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cut_off_history_json": {
+          "name": "cut_off_history_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prerequisite_subjects_json": {
+          "name": "prerequisite_subjects_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "university_programmes_university_idx": {
+          "name": "university_programmes_university_idx",
+          "columns": [
+            {
+              "expression": "university_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "university_programmes_university_id_universities_id_fk": {
+          "name": "university_programmes_university_id_universities_id_fk",
+          "tableFrom": "university_programmes",
+          "tableTo": "universities",
+          "columnsFrom": [
+            "university_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "university_programmes_current_cut_off_range": {
+          "name": "university_programmes_current_cut_off_range",
+          "value": "\"university_programmes\".\"current_cut_off\" BETWEEN 6 AND 54"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.university_targets": {
+      "name": "university_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "university_programme_id": {
+          "name": "university_programme_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_rank": {
+          "name": "target_rank",
+          "type": "target_rank",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tagged_at": {
+          "name": "tagged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tagged_by_user_id": {
+          "name": "tagged_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_acknowledged_at": {
+          "name": "parent_acknowledged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_university_target_rank": {
+          "name": "uniq_university_target_rank",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"university_targets\".\"target_rank\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "university_targets_candidate_idx": {
+          "name": "university_targets_candidate_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "university_targets_school_id_ref_school_id_fk": {
+          "name": "university_targets_school_id_ref_school_id_fk",
+          "tableFrom": "university_targets",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "university_targets_university_programme_id_university_programmes_id_fk": {
+          "name": "university_targets_university_programme_id_university_programmes_id_fk",
+          "tableFrom": "university_targets",
+          "tableTo": "university_programmes",
+          "columnsFrom": [
+            "university_programme_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "university_targets_tagged_by_user_id_ref_user_id_fk": {
+          "name": "university_targets_tagged_by_user_id_ref_user_id_fk",
+          "tableFrom": "university_targets",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "tagged_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "university_targets_school_id_candidate_id_wassce_candidates_school_id_id_fk": {
+          "name": "university_targets_school_id_candidate_id_wassce_candidates_school_id_id_fk",
+          "tableFrom": "university_targets",
+          "tableTo": "wassce_candidates",
+          "columnsFrom": [
+            "school_id",
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_university_target_programme": {
+          "name": "uniq_university_target_programme",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "candidate_id",
+            "university_programme_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.waec_special_consideration": {
+      "name": "waec_special_consideration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sc_form": {
+          "name": "sc_form",
+          "type": "sc_form",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "sc_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filed_by_user_id": {
+          "name": "filed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_cert_file_id": {
+          "name": "medical_cert_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinician_letter_file_id": {
+          "name": "clinician_letter_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waec_acknowledged_at": {
+          "name": "waec_acknowledged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waec_ref": {
+          "name": "waec_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "make_up_scheduled_at": {
+          "name": "make_up_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "make_up_centre": {
+          "name": "make_up_centre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "waec_special_consideration_school_id_ref_school_id_fk": {
+          "name": "waec_special_consideration_school_id_ref_school_id_fk",
+          "tableFrom": "waec_special_consideration",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "waec_special_consideration_filed_by_user_id_ref_user_id_fk": {
+          "name": "waec_special_consideration_filed_by_user_id_ref_user_id_fk",
+          "tableFrom": "waec_special_consideration",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "filed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "waec_special_consideration_school_id_candidate_id_wassce_candidates_school_id_id_fk": {
+          "name": "waec_special_consideration_school_id_candidate_id_wassce_candidates_school_id_id_fk",
+          "tableFrom": "waec_special_consideration",
+          "tableTo": "wassce_candidates",
+          "columnsFrom": [
+            "school_id",
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_waec_sc_candidate_form": {
+          "name": "uniq_waec_sc_candidate_form",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "candidate_id",
+            "sc_form"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wassce_candidate_subject": {
+      "name": "wassce_candidate_subject",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wassce_candidate_subject_subject_idx": {
+          "name": "wassce_candidate_subject_subject_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wassce_candidate_subject_school_id_ref_school_id_fk": {
+          "name": "wassce_candidate_subject_school_id_ref_school_id_fk",
+          "tableFrom": "wassce_candidate_subject",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wassce_candidate_subject_school_id_candidate_id_wassce_candidates_school_id_id_fk": {
+          "name": "wassce_candidate_subject_school_id_candidate_id_wassce_candidates_school_id_id_fk",
+          "tableFrom": "wassce_candidate_subject",
+          "tableTo": "wassce_candidates",
+          "columnsFrom": [
+            "school_id",
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wassce_candidate_subject_school_id_subject_id_wassce_subjects_school_id_id_fk": {
+          "name": "wassce_candidate_subject_school_id_subject_id_wassce_subjects_school_id_id_fk",
+          "tableFrom": "wassce_candidate_subject",
+          "tableTo": "wassce_subjects",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_wassce_candidate_subject": {
+          "name": "uniq_wassce_candidate_subject",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "candidate_id",
+            "subject_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wassce_candidates": {
+      "name": "wassce_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cohort_id": {
+          "name": "cohort_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "programme_id": {
+          "name": "programme_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index_number": {
+          "name": "index_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "centre_code": {
+          "name": "centre_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_status": {
+          "name": "candidate_status",
+          "type": "wassce_candidate_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REGISTERED'"
+        },
+        "reg_flag": {
+          "name": "reg_flag",
+          "type": "wassce_reg_flag",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodations_json": {
+          "name": "accommodations_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mock_2_aggregate": {
+          "name": "mock_2_aggregate",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projected_aggregate": {
+          "name": "projected_aggregate",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wassce_candidates_cohort_idx": {
+          "name": "wassce_candidates_cohort_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cohort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wassce_candidates_programme_idx": {
+          "name": "wassce_candidates_programme_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "programme_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wassce_candidates_school_id_ref_school_id_fk": {
+          "name": "wassce_candidates_school_id_ref_school_id_fk",
+          "tableFrom": "wassce_candidates",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wassce_candidates_school_id_cohort_id_wassce_cohort_school_id_id_fk": {
+          "name": "wassce_candidates_school_id_cohort_id_wassce_cohort_school_id_id_fk",
+          "tableFrom": "wassce_candidates",
+          "tableTo": "wassce_cohort",
+          "columnsFrom": [
+            "school_id",
+            "cohort_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wassce_candidates_school_id_student_id_students_school_id_id_fk": {
+          "name": "wassce_candidates_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "wassce_candidates",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wassce_candidates_school_id_programme_id_wassce_programmes_school_id_id_fk": {
+          "name": "wassce_candidates_school_id_programme_id_wassce_programmes_school_id_id_fk",
+          "tableFrom": "wassce_candidates",
+          "tableTo": "wassce_programmes",
+          "columnsFrom": [
+            "school_id",
+            "programme_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_wassce_index_number": {
+          "name": "uniq_wassce_index_number",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "index_number"
+          ]
+        },
+        "uniq_wassce_candidate_student_cohort": {
+          "name": "uniq_wassce_candidate_student_cohort",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "cohort_id",
+            "student_id"
+          ]
+        },
+        "wassce_candidates_tenant_uk": {
+          "name": "wassce_candidates_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wassce_cohort": {
+      "name": "wassce_cohort",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exam_year": {
+          "name": "exam_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setup_frozen_at": {
+          "name": "setup_frozen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headmaster_cosign_user_id": {
+          "name": "headmaster_cosign_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headmaster_cosign_at": {
+          "name": "headmaster_cosign_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_cosign_user_id": {
+          "name": "academic_cosign_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_cosign_at": {
+          "name": "academic_cosign_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wassce_cohort_school_id_ref_school_id_fk": {
+          "name": "wassce_cohort_school_id_ref_school_id_fk",
+          "tableFrom": "wassce_cohort",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wassce_cohort_headmaster_cosign_user_id_ref_user_id_fk": {
+          "name": "wassce_cohort_headmaster_cosign_user_id_ref_user_id_fk",
+          "tableFrom": "wassce_cohort",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "headmaster_cosign_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "wassce_cohort_academic_cosign_user_id_ref_user_id_fk": {
+          "name": "wassce_cohort_academic_cosign_user_id_ref_user_id_fk",
+          "tableFrom": "wassce_cohort",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "academic_cosign_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_wassce_cohort_per_year": {
+          "name": "uniq_wassce_cohort_per_year",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "exam_year"
+          ]
+        },
+        "wassce_cohort_tenant_uk": {
+          "name": "wassce_cohort_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "wassce_cohort_freeze_needs_both_cosigns": {
+          "name": "wassce_cohort_freeze_needs_both_cosigns",
+          "value": "\"wassce_cohort\".\"setup_frozen_at\" IS NULL OR (\"wassce_cohort\".\"headmaster_cosign_at\" IS NOT NULL AND \"wassce_cohort\".\"academic_cosign_at\" IS NOT NULL)"
+        },
+        "wassce_cohort_distinct_cosigners": {
+          "name": "wassce_cohort_distinct_cosigners",
+          "value": "\"wassce_cohort\".\"headmaster_cosign_user_id\" IS NULL OR \"wassce_cohort\".\"academic_cosign_user_id\" IS NULL OR \"wassce_cohort\".\"headmaster_cosign_user_id\" <> \"wassce_cohort\".\"academic_cosign_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.wassce_paper_sittings": {
+      "name": "wassce_paper_sittings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paper_id": {
+          "name": "paper_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sat_at": {
+          "name": "sat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exempted_at": {
+          "name": "exempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exemption_reason_text": {
+          "name": "exemption_reason_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "make_up_at": {
+          "name": "make_up_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "make_up_centre": {
+          "name": "make_up_centre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wassce_paper_sittings_paper_idx": {
+          "name": "wassce_paper_sittings_paper_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "paper_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wassce_paper_sittings_school_id_ref_school_id_fk": {
+          "name": "wassce_paper_sittings_school_id_ref_school_id_fk",
+          "tableFrom": "wassce_paper_sittings",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wassce_paper_sittings_school_id_candidate_id_wassce_candidates_school_id_id_fk": {
+          "name": "wassce_paper_sittings_school_id_candidate_id_wassce_candidates_school_id_id_fk",
+          "tableFrom": "wassce_paper_sittings",
+          "tableTo": "wassce_candidates",
+          "columnsFrom": [
+            "school_id",
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wassce_paper_sittings_school_id_paper_id_wassce_papers_school_id_id_fk": {
+          "name": "wassce_paper_sittings_school_id_paper_id_wassce_papers_school_id_id_fk",
+          "tableFrom": "wassce_paper_sittings",
+          "tableTo": "wassce_papers",
+          "columnsFrom": [
+            "school_id",
+            "paper_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_wassce_paper_sitting": {
+          "name": "uniq_wassce_paper_sitting",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "candidate_id",
+            "paper_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wassce_papers": {
+      "name": "wassce_papers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cohort_id": {
+          "name": "cohort_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paper_number": {
+          "name": "paper_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paper_type": {
+          "name": "paper_type",
+          "type": "wassce_paper_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "waec_paper_code": {
+          "name": "waec_paper_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_date": {
+          "name": "scheduled_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_time": {
+          "name": "scheduled_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wassce_papers_cohort_subject_idx": {
+          "name": "wassce_papers_cohort_subject_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cohort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wassce_papers_school_id_ref_school_id_fk": {
+          "name": "wassce_papers_school_id_ref_school_id_fk",
+          "tableFrom": "wassce_papers",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wassce_papers_school_id_cohort_id_wassce_cohort_school_id_id_fk": {
+          "name": "wassce_papers_school_id_cohort_id_wassce_cohort_school_id_id_fk",
+          "tableFrom": "wassce_papers",
+          "tableTo": "wassce_cohort",
+          "columnsFrom": [
+            "school_id",
+            "cohort_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wassce_papers_school_id_subject_id_wassce_subjects_school_id_id_fk": {
+          "name": "wassce_papers_school_id_subject_id_wassce_subjects_school_id_id_fk",
+          "tableFrom": "wassce_papers",
+          "tableTo": "wassce_subjects",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_wassce_paper": {
+          "name": "uniq_wassce_paper",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "cohort_id",
+            "subject_id",
+            "name"
+          ]
+        },
+        "wassce_papers_tenant_uk": {
+          "name": "wassce_papers_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wassce_programmes": {
+      "name": "wassce_programmes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "programme": {
+          "name": "programme",
+          "type": "programme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_flag": {
+          "name": "active_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wassce_programmes_school_id_ref_school_id_fk": {
+          "name": "wassce_programmes_school_id_ref_school_id_fk",
+          "tableFrom": "wassce_programmes",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_wassce_programme_per_school": {
+          "name": "uniq_wassce_programme_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "programme"
+          ]
+        },
+        "wassce_programmes_tenant_uk": {
+          "name": "wassce_programmes_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wassce_subjects": {
+      "name": "wassce_subjects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "programme_id": {
+          "name": "programme_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "wassce_subject_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_flag": {
+          "name": "active_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wassce_subjects_programme_idx": {
+          "name": "wassce_subjects_programme_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "programme_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wassce_subjects_school_id_ref_school_id_fk": {
+          "name": "wassce_subjects_school_id_ref_school_id_fk",
+          "tableFrom": "wassce_subjects",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wassce_subjects_school_id_programme_id_wassce_programmes_school_id_id_fk": {
+          "name": "wassce_subjects_school_id_programme_id_wassce_programmes_school_id_id_fk",
+          "tableFrom": "wassce_subjects",
+          "tableTo": "wassce_programmes",
+          "columnsFrom": [
+            "school_id",
+            "programme_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_wassce_subject_per_programme": {
+          "name": "uniq_wassce_subject_per_programme",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "programme_id",
+            "name"
+          ]
+        },
+        "wassce_subjects_tenant_uk": {
+          "name": "wassce_subjects_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_admission": {
+      "name": "sickbay_admission",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visit_id": {
+          "name": "visit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bed_id": {
+          "name": "bed_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admitted_at": {
+          "name": "admitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admitted_by_user_id": {
+          "name": "admitted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_isolation": {
+          "name": "is_isolation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expected_discharge_at": {
+          "name": "expected_discharge_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discharge_criteria": {
+          "name": "discharge_criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overnight_plan": {
+          "name": "overnight_plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discharged_at": {
+          "name": "discharged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discharged_by_user_id": {
+          "name": "discharged_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discharge_note": {
+          "name": "discharge_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_sickbay_open_admission_bed": {
+          "name": "uniq_sickbay_open_admission_bed",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sickbay_admission\".\"discharged_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_sickbay_open_admission_student": {
+          "name": "uniq_sickbay_open_admission_student",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sickbay_admission\".\"discharged_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sickbay_admission_student_admitted_idx": {
+          "name": "sickbay_admission_student_admitted_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "admitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_admission_school_id_ref_school_id_fk": {
+          "name": "sickbay_admission_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_admission",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_admission_admitted_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_admission_admitted_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_admission",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "admitted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_admission_discharged_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_admission_discharged_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_admission",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "discharged_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_admission_school_id_visit_id_sickbay_visit_school_id_id_fk": {
+          "name": "sickbay_admission_school_id_visit_id_sickbay_visit_school_id_id_fk",
+          "tableFrom": "sickbay_admission",
+          "tableTo": "sickbay_visit",
+          "columnsFrom": [
+            "school_id",
+            "visit_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_admission_school_id_student_id_students_school_id_id_fk": {
+          "name": "sickbay_admission_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "sickbay_admission",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_admission_school_id_bed_id_sickbay_bed_school_id_id_fk": {
+          "name": "sickbay_admission_school_id_bed_id_sickbay_bed_school_id_id_fk",
+          "tableFrom": "sickbay_admission",
+          "tableTo": "sickbay_bed",
+          "columnsFrom": [
+            "school_id",
+            "bed_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_admission_tenant_uk": {
+          "name": "sickbay_admission_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        },
+        "uniq_sickbay_admission_visit": {
+          "name": "uniq_sickbay_admission_visit",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "visit_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_bed": {
+      "name": "sickbay_bed",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bed_number": {
+          "name": "bed_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_isolation": {
+          "name": "is_isolation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sickbay_bed_school_id_ref_school_id_fk": {
+          "name": "sickbay_bed_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_bed",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_sickbay_bed_number": {
+          "name": "uniq_sickbay_bed_number",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "bed_number"
+          ]
+        },
+        "sickbay_bed_tenant_uk": {
+          "name": "sickbay_bed_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_chronic_entry": {
+      "name": "sickbay_chronic_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition": {
+          "name": "condition",
+          "type": "chronic_condition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hm_restricted": {
+          "name": "hm_restricted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "\"condition\" = 'MENTAL_HEALTH'",
+            "type": "stored"
+          }
+        },
+        "condition_label": {
+          "name": "condition_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition_detail": {
+          "name": "condition_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "chronic_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'STABLE'"
+        },
+        "on_site_treatable": {
+          "name": "on_site_treatable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "referral_managed": {
+          "name": "referral_managed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "baseline_status": {
+          "name": "baseline_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "care_goals": {
+          "name": "care_goals",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_protocol": {
+          "name": "emergency_protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discharge_criteria": {
+          "name": "discharge_criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggers": {
+          "name": "triggers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "red_flags": {
+          "name": "red_flags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_action": {
+          "name": "first_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_clinical_home": {
+          "name": "external_clinical_home",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_pastoral_home": {
+          "name": "external_pastoral_home",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_care_cadence": {
+          "name": "external_care_cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_next_visit_at": {
+          "name": "external_next_visit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_user_id": {
+          "name": "reviewed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "co_reviewer_note": {
+          "name": "co_reviewer_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_sickbay_chronic_entry_condition": {
+          "name": "uniq_sickbay_chronic_entry_condition",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "condition",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sickbay_chronic_entry\".\"active\" AND \"sickbay_chronic_entry\".\"condition\" <> 'OTHER'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sickbay_chronic_entry_student_idx": {
+          "name": "sickbay_chronic_entry_student_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_chronic_entry_school_id_ref_school_id_fk": {
+          "name": "sickbay_chronic_entry_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_chronic_entry",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_chronic_entry_reviewed_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_chronic_entry_reviewed_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_chronic_entry",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "reviewed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_chronic_entry_school_id_student_id_students_school_id_id_fk": {
+          "name": "sickbay_chronic_entry_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "sickbay_chronic_entry",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_chronic_entry_tenant_uk": {
+          "name": "sickbay_chronic_entry_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        },
+        "sickbay_chronic_entry_hm_uk": {
+          "name": "sickbay_chronic_entry_hm_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id",
+            "hm_restricted"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "chronic_mental_health_referral_managed": {
+          "name": "chronic_mental_health_referral_managed",
+          "value": "\"sickbay_chronic_entry\".\"condition\" <> 'MENTAL_HEALTH' OR (\"sickbay_chronic_entry\".\"on_site_treatable\" = false AND \"sickbay_chronic_entry\".\"referral_managed\" = true)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sickbay_chronic_grant": {
+      "name": "sickbay_chronic_grant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hm_restricted": {
+          "name": "hm_restricted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_user_id": {
+          "name": "grantee_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "sickbay_grant_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_label": {
+          "name": "scope_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "directive_note": {
+          "name": "directive_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "house_id": {
+          "name": "house_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sickbay_chronic_grant_entry_idx": {
+          "name": "sickbay_chronic_grant_entry_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sickbay_chronic_grant_grantee_idx": {
+          "name": "sickbay_chronic_grant_grantee_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "grantee_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_chronic_grant_school_id_ref_school_id_fk": {
+          "name": "sickbay_chronic_grant_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_chronic_grant",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_chronic_grant_grantee_user_id_ref_user_id_fk": {
+          "name": "sickbay_chronic_grant_grantee_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_chronic_grant",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "grantee_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_chronic_grant_granted_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_chronic_grant_granted_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_chronic_grant",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "granted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_chronic_grant_revoked_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_chronic_grant_revoked_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_chronic_grant",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_chronic_grant_entry_hm_fk": {
+          "name": "sickbay_chronic_grant_entry_hm_fk",
+          "tableFrom": "sickbay_chronic_grant",
+          "tableTo": "sickbay_chronic_entry",
+          "columnsFrom": [
+            "school_id",
+            "entry_id",
+            "hm_restricted"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id",
+            "hm_restricted"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "sickbay_chronic_grant_school_id_house_id_house_school_id_id_fk": {
+          "name": "sickbay_chronic_grant_school_id_house_id_house_school_id_id_fk",
+          "tableFrom": "sickbay_chronic_grant",
+          "tableTo": "house",
+          "columnsFrom": [
+            "school_id",
+            "house_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chronic_grant_directive_needs_note": {
+          "name": "chronic_grant_directive_needs_note",
+          "value": "\"sickbay_chronic_grant\".\"scope\" <> 'DIRECTIVE' OR \"sickbay_chronic_grant\".\"directive_note\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sickbay_chronic_med": {
+      "name": "sickbay_chronic_med",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_name": {
+          "name": "drug_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dose_label": {
+          "name": "dose_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_prn": {
+          "name": "is_prn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "slot_id": {
+          "name": "slot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sickbay_chronic_med_slot_idx": {
+          "name": "sickbay_chronic_med_slot_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_chronic_med_school_id_ref_school_id_fk": {
+          "name": "sickbay_chronic_med_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_chronic_med",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_chronic_med_school_id_entry_id_sickbay_chronic_entry_school_id_id_fk": {
+          "name": "sickbay_chronic_med_school_id_entry_id_sickbay_chronic_entry_school_id_id_fk",
+          "tableFrom": "sickbay_chronic_med",
+          "tableTo": "sickbay_chronic_entry",
+          "columnsFrom": [
+            "school_id",
+            "entry_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_chronic_med_school_id_slot_id_sickbay_schedule_slot_school_id_id_fk": {
+          "name": "sickbay_chronic_med_school_id_slot_id_sickbay_schedule_slot_school_id_id_fk",
+          "tableFrom": "sickbay_chronic_med",
+          "tableTo": "sickbay_schedule_slot",
+          "columnsFrom": [
+            "school_id",
+            "slot_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_chronic_med_tenant_uk": {
+          "name": "sickbay_chronic_med_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        },
+        "uniq_sickbay_chronic_med_dose": {
+          "name": "uniq_sickbay_chronic_med_dose",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "entry_id",
+            "drug_name",
+            "slot_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "chronic_med_prn_xor_slot": {
+          "name": "chronic_med_prn_xor_slot",
+          "value": "\"sickbay_chronic_med\".\"is_prn\" = (\"sickbay_chronic_med\".\"slot_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sickbay_chronic_read": {
+      "name": "sickbay_chronic_read",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_on": {
+          "name": "read_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "sickbay_grant_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sickbay_chronic_read_school_id_ref_school_id_fk": {
+          "name": "sickbay_chronic_read_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_chronic_read",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_chronic_read_actor_user_id_ref_user_id_fk": {
+          "name": "sickbay_chronic_read_actor_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_chronic_read",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_chronic_read_school_id_entry_id_sickbay_chronic_entry_school_id_id_fk": {
+          "name": "sickbay_chronic_read_school_id_entry_id_sickbay_chronic_entry_school_id_id_fk",
+          "tableFrom": "sickbay_chronic_read",
+          "tableTo": "sickbay_chronic_entry",
+          "columnsFrom": [
+            "school_id",
+            "entry_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_sickbay_chronic_read_day": {
+          "name": "uniq_sickbay_chronic_read_day",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "entry_id",
+            "actor_user_id",
+            "read_on"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_controlled_movement": {
+      "name": "sickbay_controlled_movement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock_item_id": {
+          "name": "stock_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "movement_type": {
+          "name": "movement_type",
+          "type": "sickbay_stock_movement_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "witness_user_id": {
+          "name": "witness_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_ref": {
+          "name": "batch_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sickbay_controlled_movement_item_idx": {
+          "name": "sickbay_controlled_movement_item_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stock_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_controlled_movement_school_id_ref_school_id_fk": {
+          "name": "sickbay_controlled_movement_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_controlled_movement",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_controlled_movement_actor_user_id_ref_user_id_fk": {
+          "name": "sickbay_controlled_movement_actor_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_controlled_movement",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_controlled_movement_witness_user_id_ref_user_id_fk": {
+          "name": "sickbay_controlled_movement_witness_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_controlled_movement",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "witness_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_controlled_movement_school_id_stock_item_id_sickbay_stock_item_school_id_id_fk": {
+          "name": "sickbay_controlled_movement_school_id_stock_item_id_sickbay_stock_item_school_id_id_fk",
+          "tableFrom": "sickbay_controlled_movement",
+          "tableTo": "sickbay_stock_item",
+          "columnsFrom": [
+            "school_id",
+            "stock_item_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_doctor_consult": {
+      "name": "sickbay_doctor_consult",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visit_id": {
+          "name": "visit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "sickbay_consult_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clinician_name": {
+          "name": "clinician_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clinician_affiliation": {
+          "name": "clinician_affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sickbay_doctor_consult_visit_idx": {
+          "name": "sickbay_doctor_consult_visit_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_doctor_consult_school_id_ref_school_id_fk": {
+          "name": "sickbay_doctor_consult_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_doctor_consult",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_doctor_consult_recorded_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_doctor_consult_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_doctor_consult",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_doctor_consult_school_id_visit_id_sickbay_visit_school_id_id_fk": {
+          "name": "sickbay_doctor_consult_school_id_visit_id_sickbay_visit_school_id_id_fk",
+          "tableFrom": "sickbay_doctor_consult",
+          "tableTo": "sickbay_visit",
+          "columnsFrom": [
+            "school_id",
+            "visit_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_doctor_consult_tenant_uk": {
+          "name": "sickbay_doctor_consult_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_hospital": {
+      "name": "sickbay_hospital",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance_km": {
+          "name": "distance_km",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "services": {
+          "name": "services",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_nhis": {
+          "name": "accepts_nhis",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sickbay_hospital_school_id_ref_school_id_fk": {
+          "name": "sickbay_hospital_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_hospital",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_hospital_tenant_uk": {
+          "name": "sickbay_hospital_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_med_admin": {
+      "name": "sickbay_med_admin",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visit_id": {
+          "name": "visit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slot_id": {
+          "name": "slot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "sickbay_med_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chronic_med_id": {
+          "name": "chronic_med_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standing_order_id": {
+          "name": "standing_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consult_id": {
+          "name": "consult_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drug_name": {
+          "name": "drug_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dose_label": {
+          "name": "dose_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_controlled": {
+          "name": "is_controlled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dispensed_qty": {
+          "name": "dispensed_qty",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock_item_id": {
+          "name": "stock_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "sickbay_med_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "administered_at": {
+          "name": "administered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "administered_by_user_id": {
+          "name": "administered_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "witness_user_id": {
+          "name": "witness_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "witness_override_reason": {
+          "name": "witness_override_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corrects_admin_id": {
+          "name": "corrects_admin_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amendment_note": {
+          "name": "amendment_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sickbay_med_admin_student_idx": {
+          "name": "sickbay_med_admin_student_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "administered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sickbay_med_admin_slot_idx": {
+          "name": "sickbay_med_admin_slot_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "administered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sickbay_med_admin_visit_idx": {
+          "name": "sickbay_med_admin_visit_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_med_admin_school_id_ref_school_id_fk": {
+          "name": "sickbay_med_admin_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_med_admin",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_med_admin_administered_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_med_admin_administered_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_med_admin",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "administered_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_med_admin_witness_user_id_ref_user_id_fk": {
+          "name": "sickbay_med_admin_witness_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_med_admin",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "witness_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_med_admin_school_id_student_id_students_school_id_id_fk": {
+          "name": "sickbay_med_admin_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "sickbay_med_admin",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_med_admin_school_id_visit_id_sickbay_visit_school_id_id_fk": {
+          "name": "sickbay_med_admin_school_id_visit_id_sickbay_visit_school_id_id_fk",
+          "tableFrom": "sickbay_med_admin",
+          "tableTo": "sickbay_visit",
+          "columnsFrom": [
+            "school_id",
+            "visit_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_med_admin_school_id_slot_id_sickbay_schedule_slot_school_id_id_fk": {
+          "name": "sickbay_med_admin_school_id_slot_id_sickbay_schedule_slot_school_id_id_fk",
+          "tableFrom": "sickbay_med_admin",
+          "tableTo": "sickbay_schedule_slot",
+          "columnsFrom": [
+            "school_id",
+            "slot_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sickbay_med_admin_school_id_chronic_med_id_sickbay_chronic_med_school_id_id_fk": {
+          "name": "sickbay_med_admin_school_id_chronic_med_id_sickbay_chronic_med_school_id_id_fk",
+          "tableFrom": "sickbay_med_admin",
+          "tableTo": "sickbay_chronic_med",
+          "columnsFrom": [
+            "school_id",
+            "chronic_med_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sickbay_med_admin_school_id_standing_order_id_sickbay_standing_order_school_id_id_fk": {
+          "name": "sickbay_med_admin_school_id_standing_order_id_sickbay_standing_order_school_id_id_fk",
+          "tableFrom": "sickbay_med_admin",
+          "tableTo": "sickbay_standing_order",
+          "columnsFrom": [
+            "school_id",
+            "standing_order_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sickbay_med_admin_school_id_consult_id_sickbay_doctor_consult_school_id_id_fk": {
+          "name": "sickbay_med_admin_school_id_consult_id_sickbay_doctor_consult_school_id_id_fk",
+          "tableFrom": "sickbay_med_admin",
+          "tableTo": "sickbay_doctor_consult",
+          "columnsFrom": [
+            "school_id",
+            "consult_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sickbay_med_admin_school_id_stock_item_id_sickbay_stock_item_school_id_id_fk": {
+          "name": "sickbay_med_admin_school_id_stock_item_id_sickbay_stock_item_school_id_id_fk",
+          "tableFrom": "sickbay_med_admin",
+          "tableTo": "sickbay_stock_item",
+          "columnsFrom": [
+            "school_id",
+            "stock_item_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sickbay_med_admin_corrects_fk": {
+          "name": "sickbay_med_admin_corrects_fk",
+          "tableFrom": "sickbay_med_admin",
+          "tableTo": "sickbay_med_admin",
+          "columnsFrom": [
+            "school_id",
+            "corrects_admin_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_med_admin_tenant_uk": {
+          "name": "sickbay_med_admin_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "med_admin_controlled_needs_qty": {
+          "name": "med_admin_controlled_needs_qty",
+          "value": "\"sickbay_med_admin\".\"is_controlled\" = false OR \"sickbay_med_admin\".\"dispensed_qty\" IS NOT NULL"
+        },
+        "med_admin_controlled_needs_stock_item": {
+          "name": "med_admin_controlled_needs_stock_item",
+          "value": "NOT \"sickbay_med_admin\".\"is_controlled\" OR \"sickbay_med_admin\".\"stock_item_id\" IS NOT NULL"
+        },
+        "med_admin_controlled_given_witness": {
+          "name": "med_admin_controlled_given_witness",
+          "value": "NOT (\"sickbay_med_admin\".\"is_controlled\" AND \"sickbay_med_admin\".\"status\" = 'GIVEN') OR \"sickbay_med_admin\".\"witness_user_id\" IS NOT NULL OR \"sickbay_med_admin\".\"witness_override_reason\" IS NOT NULL"
+        },
+        "med_admin_witness_not_self": {
+          "name": "med_admin_witness_not_self",
+          "value": "\"sickbay_med_admin\".\"witness_user_id\" IS NULL OR \"sickbay_med_admin\".\"witness_user_id\" <> \"sickbay_med_admin\".\"administered_by_user_id\""
+        },
+        "med_admin_source_pointer_match": {
+          "name": "med_admin_source_pointer_match",
+          "value": "(\"sickbay_med_admin\".\"source\" = 'CHRONIC' AND \"sickbay_med_admin\".\"standing_order_id\" IS NULL AND \"sickbay_med_admin\".\"consult_id\" IS NULL)\n       OR (\"sickbay_med_admin\".\"source\" = 'STANDING_ORDER' AND \"sickbay_med_admin\".\"standing_order_id\" IS NOT NULL AND \"sickbay_med_admin\".\"chronic_med_id\" IS NULL AND \"sickbay_med_admin\".\"consult_id\" IS NULL)\n       OR (\"sickbay_med_admin\".\"source\" = 'DOCTOR_ORDERED' AND \"sickbay_med_admin\".\"consult_id\" IS NOT NULL AND \"sickbay_med_admin\".\"chronic_med_id\" IS NULL AND \"sickbay_med_admin\".\"standing_order_id\" IS NULL)\n       OR (\"sickbay_med_admin\".\"source\" = 'AD_HOC' AND \"sickbay_med_admin\".\"chronic_med_id\" IS NULL AND \"sickbay_med_admin\".\"standing_order_id\" IS NULL AND \"sickbay_med_admin\".\"consult_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sickbay_notification": {
+      "name": "sickbay_notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visit_id": {
+          "name": "visit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_id": {
+          "name": "referral_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_log_id": {
+          "name": "notification_log_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_of_id": {
+          "name": "retry_of_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "sickbay_notify_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "sickbay_notify_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "sickbay_notify_recipient",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_label": {
+          "name": "trigger_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "private_note": {
+          "name": "private_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "call_duration_seconds": {
+          "name": "call_duration_seconds",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered": {
+          "name": "answered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sickbay_notification_referral_idx": {
+          "name": "sickbay_notification_referral_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "referral_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sickbay_notification_student_idx": {
+          "name": "sickbay_notification_student_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_notification_school_id_ref_school_id_fk": {
+          "name": "sickbay_notification_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_notification",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_notification_notification_log_id_notification_log_id_fk": {
+          "name": "sickbay_notification_notification_log_id_notification_log_id_fk",
+          "tableFrom": "sickbay_notification",
+          "tableTo": "notification_log",
+          "columnsFrom": [
+            "notification_log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_notification_created_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_notification_created_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_notification",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_notification_school_id_student_id_students_school_id_id_fk": {
+          "name": "sickbay_notification_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "sickbay_notification",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_notification_school_id_visit_id_sickbay_visit_school_id_id_fk": {
+          "name": "sickbay_notification_school_id_visit_id_sickbay_visit_school_id_id_fk",
+          "tableFrom": "sickbay_notification",
+          "tableTo": "sickbay_visit",
+          "columnsFrom": [
+            "school_id",
+            "visit_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_notification_school_id_referral_id_sickbay_referral_school_id_id_fk": {
+          "name": "sickbay_notification_school_id_referral_id_sickbay_referral_school_id_id_fk",
+          "tableFrom": "sickbay_notification",
+          "tableTo": "sickbay_referral",
+          "columnsFrom": [
+            "school_id",
+            "referral_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_notification_retry_of_fk": {
+          "name": "sickbay_notification_retry_of_fk",
+          "tableFrom": "sickbay_notification",
+          "tableTo": "sickbay_notification",
+          "columnsFrom": [
+            "school_id",
+            "retry_of_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_notification_tenant_uk": {
+          "name": "sickbay_notification_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "sickbay_notification_tier_range": {
+          "name": "sickbay_notification_tier_range",
+          "value": "\"sickbay_notification\".\"tier\" BETWEEN 1 AND 3"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sickbay_referral": {
+      "name": "sickbay_referral",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visit_id": {
+          "name": "visit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hospital_id": {
+          "name": "hospital_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accompanied_by_user_id": {
+          "name": "accompanied_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hm_authorised_by_user_id": {
+          "name": "hm_authorised_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "sickbay_referral_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REFERRED'"
+        },
+        "transport_mode": {
+          "name": "transport_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hospital_ward": {
+          "name": "hospital_ward",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hospital_bed": {
+          "name": "hospital_bed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attending_clinician_name": {
+          "name": "attending_clinician_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hm_authorised_at": {
+          "name": "hm_authorised_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "departed_at": {
+          "name": "departed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_return_at": {
+          "name": "expected_return_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "returned_at": {
+          "name": "returned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "return_note": {
+          "name": "return_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_by_user_id": {
+          "name": "voided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nhis_card_number": {
+          "name": "nhis_card_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nhis_valid": {
+          "name": "nhis_valid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_referred_out": {
+          "name": "reason_referred_out",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pre_referral_care": {
+          "name": "pre_referral_care",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_labs": {
+          "name": "handoff_labs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_meal": {
+          "name": "last_meal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "menses_note": {
+          "name": "menses_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "travel_note": {
+          "name": "travel_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sickbay_referral_status_idx": {
+          "name": "sickbay_referral_status_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sickbay_referral_departed_idx": {
+          "name": "sickbay_referral_departed_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "departed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_referral_school_id_ref_school_id_fk": {
+          "name": "sickbay_referral_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_referral",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_referral_accompanied_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_referral_accompanied_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_referral",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "accompanied_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_referral_hm_authorised_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_referral_hm_authorised_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_referral",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "hm_authorised_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_referral_recorded_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_referral_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_referral",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_referral_voided_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_referral_voided_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_referral",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "voided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_referral_school_id_student_id_students_school_id_id_fk": {
+          "name": "sickbay_referral_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "sickbay_referral",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_referral_school_id_visit_id_sickbay_visit_school_id_id_fk": {
+          "name": "sickbay_referral_school_id_visit_id_sickbay_visit_school_id_id_fk",
+          "tableFrom": "sickbay_referral",
+          "tableTo": "sickbay_visit",
+          "columnsFrom": [
+            "school_id",
+            "visit_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_referral_school_id_hospital_id_sickbay_hospital_school_id_id_fk": {
+          "name": "sickbay_referral_school_id_hospital_id_sickbay_hospital_school_id_id_fk",
+          "tableFrom": "sickbay_referral",
+          "tableTo": "sickbay_hospital",
+          "columnsFrom": [
+            "school_id",
+            "hospital_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_referral_tenant_uk": {
+          "name": "sickbay_referral_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_referral_cost_line": {
+      "name": "sickbay_referral_cost_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referral_id": {
+          "name": "referral_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_label": {
+          "name": "item_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nhis_covered": {
+          "name": "nhis_covered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "out_of_pocket_amount": {
+          "name": "out_of_pocket_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_line_item_id": {
+          "name": "billing_line_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sickbay_referral_cost_line_referral_idx": {
+          "name": "sickbay_referral_cost_line_referral_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "referral_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_referral_cost_line_school_id_ref_school_id_fk": {
+          "name": "sickbay_referral_cost_line_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_referral_cost_line",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_referral_cost_line_billing_line_item_id_invoice_line_item_id_fk": {
+          "name": "sickbay_referral_cost_line_billing_line_item_id_invoice_line_item_id_fk",
+          "tableFrom": "sickbay_referral_cost_line",
+          "tableTo": "invoice_line_item",
+          "columnsFrom": [
+            "billing_line_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_referral_cost_line_school_id_referral_id_sickbay_referral_school_id_id_fk": {
+          "name": "sickbay_referral_cost_line_school_id_referral_id_sickbay_referral_school_id_id_fk",
+          "tableFrom": "sickbay_referral_cost_line",
+          "tableTo": "sickbay_referral",
+          "columnsFrom": [
+            "school_id",
+            "referral_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_referral_update": {
+      "name": "sickbay_referral_update",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referral_id": {
+          "name": "referral_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clinician_name": {
+          "name": "clinician_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinician_affiliation": {
+          "name": "clinician_affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sickbay_referral_update_referral_idx": {
+          "name": "sickbay_referral_update_referral_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "referral_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_referral_update_school_id_ref_school_id_fk": {
+          "name": "sickbay_referral_update_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_referral_update",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_referral_update_recorded_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_referral_update_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_referral_update",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_referral_update_school_id_referral_id_sickbay_referral_school_id_id_fk": {
+          "name": "sickbay_referral_update_school_id_referral_id_sickbay_referral_school_id_id_fk",
+          "tableFrom": "sickbay_referral_update",
+          "tableTo": "sickbay_referral",
+          "columnsFrom": [
+            "school_id",
+            "referral_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_schedule_slot": {
+      "name": "sickbay_schedule_slot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "sickbay_slot_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staffing": {
+          "name": "staffing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "days_of_week": {
+          "name": "days_of_week",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runs_on_holidays": {
+          "name": "runs_on_holidays",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_anchor": {
+          "name": "is_anchor",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_sickbay_anchor_slot": {
+          "name": "uniq_sickbay_anchor_slot",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sickbay_schedule_slot\".\"is_anchor\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_schedule_slot_school_id_ref_school_id_fk": {
+          "name": "sickbay_schedule_slot_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_schedule_slot",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_schedule_slot_tenant_uk": {
+          "name": "sickbay_schedule_slot_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_settings": {
+      "name": "sickbay_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "sickbay_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REFERRAL_ONLY'"
+        },
+        "matron_user_id": {
+          "name": "matron_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assistant_matron_user_id": {
+          "name": "assistant_matron_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visiting_doctor_name": {
+          "name": "visiting_doctor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visiting_doctor_affiliation": {
+          "name": "visiting_doctor_affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configured_at": {
+          "name": "configured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sickbay_settings_school_id_ref_school_id_fk": {
+          "name": "sickbay_settings_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_settings",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_settings_matron_user_id_ref_user_id_fk": {
+          "name": "sickbay_settings_matron_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_settings",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "matron_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_settings_assistant_matron_user_id_ref_user_id_fk": {
+          "name": "sickbay_settings_assistant_matron_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_settings",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "assistant_matron_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_settings_school_id_unique": {
+          "name": "sickbay_settings_school_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_standing_order": {
+      "name": "sickbay_standing_order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "complaint": {
+          "name": "complaint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "treatment": {
+          "name": "treatment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "escalation": {
+          "name": "escalation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ordered_by_doctor_name": {
+          "name": "ordered_by_doctor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sickbay_standing_order_school_id_ref_school_id_fk": {
+          "name": "sickbay_standing_order_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_standing_order",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_standing_order_created_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_standing_order_created_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_standing_order",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_standing_order_tenant_uk": {
+          "name": "sickbay_standing_order_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_stock_item": {
+      "name": "sickbay_stock_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_name": {
+          "name": "drug_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form_label": {
+          "name": "form_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qty_on_hand": {
+          "name": "qty_on_hand",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "reorder_point": {
+          "name": "reorder_point",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_restocked_at": {
+          "name": "last_restocked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_controlled": {
+          "name": "is_controlled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sickbay_stock_item_school_id_ref_school_id_fk": {
+          "name": "sickbay_stock_item_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_stock_item",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_stock_item_tenant_uk": {
+          "name": "sickbay_stock_item_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_visit": {
+      "name": "sickbay_visit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "presented_at": {
+          "name": "presented_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "presenting_complaint": {
+          "name": "presenting_complaint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intake_reported_by": {
+          "name": "intake_reported_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attending_user_id": {
+          "name": "attending_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "working_impression": {
+          "name": "working_impression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "red_flags_screened": {
+          "name": "red_flags_screened",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hydration_status": {
+          "name": "hydration_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "escalation_triggers": {
+          "name": "escalation_triggers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "surveillance_category": {
+          "name": "surveillance_category",
+          "type": "sickbay_surveillance_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessed_at": {
+          "name": "assessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "sickbay_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disposition_at": {
+          "name": "disposition_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_by_user_id": {
+          "name": "voided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_sickbay_open_visit_student": {
+          "name": "uniq_sickbay_open_visit_student",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sickbay_visit\".\"disposition\" IS NULL AND \"sickbay_visit\".\"voided_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sickbay_visit_presented_idx": {
+          "name": "sickbay_visit_presented_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "presented_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_visit_school_id_ref_school_id_fk": {
+          "name": "sickbay_visit_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_visit",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_visit_recorded_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_visit_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_visit",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_visit_attending_user_id_ref_user_id_fk": {
+          "name": "sickbay_visit_attending_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_visit",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "attending_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_visit_voided_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_visit_voided_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_visit",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "voided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_visit_school_id_student_id_students_school_id_id_fk": {
+          "name": "sickbay_visit_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "sickbay_visit",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_visit_tenant_uk": {
+          "name": "sickbay_visit_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_vital_reading": {
+      "name": "sickbay_vital_reading",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visit_id": {
+          "name": "visit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taken_at": {
+          "name": "taken_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taken_by_user_id": {
+          "name": "taken_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_c": {
+          "name": "temp_c",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "systolic": {
+          "name": "systolic",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diastolic": {
+          "name": "diastolic",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pulse_bpm": {
+          "name": "pulse_bpm",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spo2_pct": {
+          "name": "spo2_pct",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pain_score": {
+          "name": "pain_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sickbay_vital_reading_visit_idx": {
+          "name": "sickbay_vital_reading_visit_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "taken_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_vital_reading_school_id_ref_school_id_fk": {
+          "name": "sickbay_vital_reading_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_vital_reading",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_vital_reading_taken_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_vital_reading_taken_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_vital_reading",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "taken_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_vital_reading_school_id_visit_id_sickbay_visit_school_id_id_fk": {
+          "name": "sickbay_vital_reading_school_id_visit_id_sickbay_visit_school_id_id_fk",
+          "tableFrom": "sickbay_vital_reading",
+          "tableTo": "sickbay_visit",
+          "columnsFrom": [
+            "school_id",
+            "visit_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_nhis_card": {
+      "name": "student_nhis_card",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_number": {
+          "name": "card_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "holder_name": {
+          "name": "holder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "holder_kind": {
+          "name": "holder_kind",
+          "type": "nhis_holder_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'STUDENT'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_to": {
+          "name": "valid_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_guardian_id": {
+          "name": "student_guardian_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "student_nhis_card_school_id_ref_school_id_fk": {
+          "name": "student_nhis_card_school_id_ref_school_id_fk",
+          "tableFrom": "student_nhis_card",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_nhis_card_student_guardian_id_student_guardian_id_fk": {
+          "name": "student_nhis_card_student_guardian_id_student_guardian_id_fk",
+          "tableFrom": "student_nhis_card",
+          "tableTo": "student_guardian",
+          "columnsFrom": [
+            "student_guardian_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "student_nhis_card_school_id_student_id_students_school_id_id_fk": {
+          "name": "student_nhis_card_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "student_nhis_card",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_student_nhis_card": {
+          "name": "uniq_student_nhis_card",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vlc_pastoral_case": {
+      "name": "vlc_pastoral_case",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flag_id": {
+          "name": "flag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_revised_at": {
+          "name": "last_revised_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_revised_by_user_id": {
+          "name": "last_revised_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vlc_pastoral_case_school_id_ref_school_id_fk": {
+          "name": "vlc_pastoral_case_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_pastoral_case",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_case_last_revised_by_user_id_ref_user_id_fk": {
+          "name": "vlc_pastoral_case_last_revised_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_pastoral_case",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "last_revised_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_case_school_id_flag_id_vlc_pastoral_flag_school_id_id_fk": {
+          "name": "vlc_pastoral_case_school_id_flag_id_vlc_pastoral_flag_school_id_id_fk",
+          "tableFrom": "vlc_pastoral_case",
+          "tableTo": "vlc_pastoral_flag",
+          "columnsFrom": [
+            "school_id",
+            "flag_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_vlc_pastoral_case_flag": {
+          "name": "uniq_vlc_pastoral_case_flag",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "flag_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vlc_pastoral_case_summary_len": {
+          "name": "vlc_pastoral_case_summary_len",
+          "value": "char_length(\"vlc_pastoral_case\".\"summary\") <= 8000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vlc_pastoral_flag": {
+      "name": "vlc_pastoral_flag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_at": {
+          "name": "raised_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "raised_by_user_id": {
+          "name": "raised_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "surfaced_by": {
+          "name": "surfaced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vlc_pastoral_flag_active_idx": {
+          "name": "vlc_pastoral_flag_active_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"vlc_pastoral_flag\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vlc_pastoral_flag_school_id_ref_school_id_fk": {
+          "name": "vlc_pastoral_flag_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_pastoral_flag",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_flag_raised_by_user_id_ref_user_id_fk": {
+          "name": "vlc_pastoral_flag_raised_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_pastoral_flag",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "raised_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_flag_resolved_by_user_id_ref_user_id_fk": {
+          "name": "vlc_pastoral_flag_resolved_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_pastoral_flag",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_flag_school_id_student_id_students_school_id_id_fk": {
+          "name": "vlc_pastoral_flag_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "vlc_pastoral_flag",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_flag_school_id_session_id_vlc_session_school_id_id_fk": {
+          "name": "vlc_pastoral_flag_school_id_session_id_vlc_session_school_id_id_fk",
+          "tableFrom": "vlc_pastoral_flag",
+          "tableTo": "vlc_session",
+          "columnsFrom": [
+            "school_id",
+            "session_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vlc_pastoral_flag_tenant_uk": {
+          "name": "vlc_pastoral_flag_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vlc_pastoral_flag_surfaced_by_len": {
+          "name": "vlc_pastoral_flag_surfaced_by_len",
+          "value": "char_length(\"vlc_pastoral_flag\".\"surfaced_by\") <= 80"
+        },
+        "vlc_pastoral_flag_severity_valid": {
+          "name": "vlc_pastoral_flag_severity_valid",
+          "value": "\"vlc_pastoral_flag\".\"severity\" IN ('NOTE', 'CONCERN', 'CRISIS')"
+        },
+        "vlc_pastoral_flag_context_len": {
+          "name": "vlc_pastoral_flag_context_len",
+          "value": "char_length(\"vlc_pastoral_flag\".\"context\") <= 280"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vlc_pastoral_journal": {
+      "name": "vlc_pastoral_journal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vlc_pastoral_journal_student_idx": {
+          "name": "vlc_pastoral_journal_student_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vlc_pastoral_journal_school_id_ref_school_id_fk": {
+          "name": "vlc_pastoral_journal_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_pastoral_journal",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_journal_recorded_by_user_id_ref_user_id_fk": {
+          "name": "vlc_pastoral_journal_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_pastoral_journal",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_journal_school_id_student_id_students_school_id_id_fk": {
+          "name": "vlc_pastoral_journal_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "vlc_pastoral_journal",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_journal_school_id_session_id_vlc_session_school_id_id_fk": {
+          "name": "vlc_pastoral_journal_school_id_session_id_vlc_session_school_id_id_fk",
+          "tableFrom": "vlc_pastoral_journal",
+          "tableTo": "vlc_session",
+          "columnsFrom": [
+            "school_id",
+            "session_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vlc_pastoral_journal_body_len": {
+          "name": "vlc_pastoral_journal_body_len",
+          "value": "char_length(\"vlc_pastoral_journal\".\"body\") <= 4000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vlc_pastoral_note": {
+      "name": "vlc_pastoral_note",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vlc_pastoral_note_student_idx": {
+          "name": "vlc_pastoral_note_student_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vlc_pastoral_note_school_id_ref_school_id_fk": {
+          "name": "vlc_pastoral_note_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_pastoral_note",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_note_author_user_id_ref_user_id_fk": {
+          "name": "vlc_pastoral_note_author_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_pastoral_note",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_note_school_id_student_id_students_school_id_id_fk": {
+          "name": "vlc_pastoral_note_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "vlc_pastoral_note",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vlc_pastoral_note_body_len": {
+          "name": "vlc_pastoral_note_body_len",
+          "value": "char_length(\"vlc_pastoral_note\".\"body\") <= 4000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vlc_pastoral_observation": {
+      "name": "vlc_pastoral_observation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_by": {
+          "name": "observed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vlc_pastoral_observation_student_idx": {
+          "name": "vlc_pastoral_observation_student_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vlc_pastoral_observation_school_id_ref_school_id_fk": {
+          "name": "vlc_pastoral_observation_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_pastoral_observation",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_observation_recorded_by_user_id_ref_user_id_fk": {
+          "name": "vlc_pastoral_observation_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_pastoral_observation",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_observation_school_id_student_id_students_school_id_id_fk": {
+          "name": "vlc_pastoral_observation_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "vlc_pastoral_observation",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vlc_pastoral_observation_observed_by_len": {
+          "name": "vlc_pastoral_observation_observed_by_len",
+          "value": "char_length(\"vlc_pastoral_observation\".\"observed_by\") <= 80"
+        },
+        "vlc_pastoral_observation_body_len": {
+          "name": "vlc_pastoral_observation_body_len",
+          "value": "char_length(\"vlc_pastoral_observation\".\"body\") <= 4000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vlc_pastoral_paragraph": {
+      "name": "vlc_pastoral_paragraph",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_by_user_id": {
+          "name": "locked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vlc_pastoral_paragraph_school_id_ref_school_id_fk": {
+          "name": "vlc_pastoral_paragraph_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_pastoral_paragraph",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_paragraph_author_user_id_ref_user_id_fk": {
+          "name": "vlc_pastoral_paragraph_author_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_pastoral_paragraph",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_paragraph_updated_by_user_id_ref_user_id_fk": {
+          "name": "vlc_pastoral_paragraph_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_pastoral_paragraph",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_paragraph_locked_by_user_id_ref_user_id_fk": {
+          "name": "vlc_pastoral_paragraph_locked_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_pastoral_paragraph",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "locked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_paragraph_school_id_student_id_students_school_id_id_fk": {
+          "name": "vlc_pastoral_paragraph_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "vlc_pastoral_paragraph",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_vlc_pastoral_paragraph_student": {
+          "name": "uniq_vlc_pastoral_paragraph_student",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vlc_pastoral_paragraph_body_len": {
+          "name": "vlc_pastoral_paragraph_body_len",
+          "value": "char_length(\"vlc_pastoral_paragraph\".\"body\") <= 3000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vlc_peer_guide": {
+      "name": "vlc_peer_guide",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_period_id": {
+          "name": "academic_period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointed_at": {
+          "name": "appointed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "appointed_by_user_id": {
+          "name": "appointed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_vlc_peer_guide_active": {
+          "name": "uniq_vlc_peer_guide_active",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"vlc_peer_guide\".\"ended_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vlc_peer_guide_class_period_idx": {
+          "name": "vlc_peer_guide_class_period_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vlc_peer_guide_school_id_ref_school_id_fk": {
+          "name": "vlc_peer_guide_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_peer_guide",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_peer_guide_appointed_by_user_id_ref_user_id_fk": {
+          "name": "vlc_peer_guide_appointed_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_peer_guide",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "appointed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_peer_guide_school_id_student_id_students_school_id_id_fk": {
+          "name": "vlc_peer_guide_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "vlc_peer_guide",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_peer_guide_school_id_class_id_class_school_id_id_fk": {
+          "name": "vlc_peer_guide_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "vlc_peer_guide",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_peer_guide_school_id_academic_period_id_academic_period_school_id_period_id_fk": {
+          "name": "vlc_peer_guide_school_id_academic_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "vlc_peer_guide",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "academic_period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vlc_peer_guide_tenant_uk": {
+          "name": "vlc_peer_guide_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vlc_programme": {
+      "name": "vlc_programme",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_day": {
+          "name": "session_day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "session_start": {
+          "name": "session_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'14:30'"
+        },
+        "opener_min": {
+          "name": "opener_min",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "small_group_min": {
+          "name": "small_group_min",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 25
+        },
+        "plenary_min": {
+          "name": "plenary_min",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "reflection_min": {
+          "name": "reflection_min",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "close_min": {
+          "name": "close_min",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "configured_at": {
+          "name": "configured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vlc_programme_school_id_ref_school_id_fk": {
+          "name": "vlc_programme_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_programme",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vlc_programme_school_id_unique": {
+          "name": "vlc_programme_school_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vlc_programme_session_day_range": {
+          "name": "vlc_programme_session_day_range",
+          "value": "\"vlc_programme\".\"session_day\" BETWEEN 1 AND 7"
+        },
+        "vlc_programme_opener_min_positive": {
+          "name": "vlc_programme_opener_min_positive",
+          "value": "\"vlc_programme\".\"opener_min\" > 0"
+        },
+        "vlc_programme_small_group_min_positive": {
+          "name": "vlc_programme_small_group_min_positive",
+          "value": "\"vlc_programme\".\"small_group_min\" > 0"
+        },
+        "vlc_programme_plenary_min_positive": {
+          "name": "vlc_programme_plenary_min_positive",
+          "value": "\"vlc_programme\".\"plenary_min\" > 0"
+        },
+        "vlc_programme_reflection_min_positive": {
+          "name": "vlc_programme_reflection_min_positive",
+          "value": "\"vlc_programme\".\"reflection_min\" > 0"
+        },
+        "vlc_programme_close_min_positive": {
+          "name": "vlc_programme_close_min_positive",
+          "value": "\"vlc_programme\".\"close_min\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vlc_session": {
+      "name": "vlc_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_template_id": {
+          "name": "session_template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_date": {
+          "name": "session_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_by_user_id": {
+          "name": "held_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vlc_session_school_id_ref_school_id_fk": {
+          "name": "vlc_session_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_session",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_session_held_by_user_id_ref_user_id_fk": {
+          "name": "vlc_session_held_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_session",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "held_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_session_school_id_class_id_class_school_id_id_fk": {
+          "name": "vlc_session_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "vlc_session",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_session_school_id_session_template_id_vlc_session_template_school_id_id_fk": {
+          "name": "vlc_session_school_id_session_template_id_vlc_session_template_school_id_id_fk",
+          "tableFrom": "vlc_session",
+          "tableTo": "vlc_session_template",
+          "columnsFrom": [
+            "school_id",
+            "session_template_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vlc_session_tenant_uk": {
+          "name": "vlc_session_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        },
+        "uniq_vlc_session": {
+          "name": "uniq_vlc_session",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "class_id",
+            "session_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vlc_session_attendance": {
+      "name": "vlc_session_attendance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "attendance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minutes_late": {
+          "name": "minutes_late",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vlc_session_attendance_school_id_ref_school_id_fk": {
+          "name": "vlc_session_attendance_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_session_attendance",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_session_attendance_recorded_by_user_id_ref_user_id_fk": {
+          "name": "vlc_session_attendance_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_session_attendance",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_session_attendance_school_id_session_id_vlc_session_school_id_id_fk": {
+          "name": "vlc_session_attendance_school_id_session_id_vlc_session_school_id_id_fk",
+          "tableFrom": "vlc_session_attendance",
+          "tableTo": "vlc_session",
+          "columnsFrom": [
+            "school_id",
+            "session_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_session_attendance_school_id_student_id_students_school_id_id_fk": {
+          "name": "vlc_session_attendance_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "vlc_session_attendance",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_vlc_session_attendance": {
+          "name": "uniq_vlc_session_attendance",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "session_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vlc_session_attendance_minutes_late_nonneg": {
+          "name": "vlc_session_attendance_minutes_late_nonneg",
+          "value": "\"vlc_session_attendance\".\"minutes_late\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vlc_session_template": {
+      "name": "vlc_session_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_id": {
+          "name": "value_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot": {
+          "name": "slot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vlc_session_template_school_id_ref_school_id_fk": {
+          "name": "vlc_session_template_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_session_template",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_session_template_school_id_value_id_vlc_value_school_id_id_fk": {
+          "name": "vlc_session_template_school_id_value_id_vlc_value_school_id_id_fk",
+          "tableFrom": "vlc_session_template",
+          "tableTo": "vlc_value",
+          "columnsFrom": [
+            "school_id",
+            "value_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_vlc_session_template_value_slot": {
+          "name": "uniq_vlc_session_template_value_slot",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "value_id",
+            "slot"
+          ]
+        },
+        "vlc_session_template_tenant_uk": {
+          "name": "vlc_session_template_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vlc_session_template_slot_valid": {
+          "name": "vlc_session_template_slot_valid",
+          "value": "\"vlc_session_template\".\"slot\" IN ('A', 'B')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vlc_training": {
+      "name": "vlc_training",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_date": {
+          "name": "scheduled_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vlc_training_year_idx": {
+          "name": "vlc_training_year_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vlc_training_school_id_ref_school_id_fk": {
+          "name": "vlc_training_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_training",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vlc_training_tenant_uk": {
+          "name": "vlc_training_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vlc_training_duration_min_positive": {
+          "name": "vlc_training_duration_min_positive",
+          "value": "\"vlc_training\".\"duration_min\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vlc_training_absence": {
+      "name": "vlc_training_absence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "training_id": {
+          "name": "training_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peer_guide_id": {
+          "name": "peer_guide_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excused": {
+          "name": "excused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vlc_training_absence_peer_guide_idx": {
+          "name": "vlc_training_absence_peer_guide_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "peer_guide_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vlc_training_absence_school_id_ref_school_id_fk": {
+          "name": "vlc_training_absence_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_training_absence",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_training_absence_recorded_by_user_id_ref_user_id_fk": {
+          "name": "vlc_training_absence_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_training_absence",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_training_absence_school_id_training_id_vlc_training_school_id_id_fk": {
+          "name": "vlc_training_absence_school_id_training_id_vlc_training_school_id_id_fk",
+          "tableFrom": "vlc_training_absence",
+          "tableTo": "vlc_training",
+          "columnsFrom": [
+            "school_id",
+            "training_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_training_absence_school_id_peer_guide_id_vlc_peer_guide_school_id_id_fk": {
+          "name": "vlc_training_absence_school_id_peer_guide_id_vlc_peer_guide_school_id_id_fk",
+          "tableFrom": "vlc_training_absence",
+          "tableTo": "vlc_peer_guide",
+          "columnsFrom": [
+            "school_id",
+            "peer_guide_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_vlc_training_absence": {
+          "name": "uniq_vlc_training_absence",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "training_id",
+            "peer_guide_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vlc_value": {
+      "name": "vlc_value",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_twi": {
+          "name": "name_twi",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "term_group": {
+          "name": "term_group",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "descriptor": {
+          "name": "descriptor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_capstone": {
+          "name": "is_capstone",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vlc_value_school_id_ref_school_id_fk": {
+          "name": "vlc_value_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_value",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_vlc_value_ordinal": {
+          "name": "uniq_vlc_value_ordinal",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "ordinal"
+          ]
+        },
+        "vlc_value_tenant_uk": {
+          "name": "vlc_value_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vlc_value_term_group_range": {
+          "name": "vlc_value_term_group_range",
+          "value": "\"vlc_value\".\"term_group\" BETWEEN 1 AND 3"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vlc_value_change_request": {
+      "name": "vlc_value_change_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "op": {
+          "name": "op",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PROPOSED'"
+        },
+        "proposed_by_user_id": {
+          "name": "proposed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_at": {
+          "name": "proposed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_note": {
+          "name": "decision_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vlc_value_change_request_state_idx": {
+          "name": "vlc_value_change_request_state_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vlc_value_change_request_school_id_ref_school_id_fk": {
+          "name": "vlc_value_change_request_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_value_change_request",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_value_change_request_proposed_by_user_id_ref_user_id_fk": {
+          "name": "vlc_value_change_request_proposed_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_value_change_request",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "proposed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_value_change_request_decided_by_user_id_ref_user_id_fk": {
+          "name": "vlc_value_change_request_decided_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_value_change_request",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vlc_value_change_request_op_valid": {
+          "name": "vlc_value_change_request_op_valid",
+          "value": "\"vlc_value_change_request\".\"op\" IN ('ADD', 'REORDER', 'REMOVE')"
+        },
+        "vlc_value_change_request_state_valid": {
+          "name": "vlc_value_change_request_state_valid",
+          "value": "\"vlc_value_change_request\".\"state\" IN ('PROPOSED', 'APPROVED', 'REJECTED')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.plc": {
+      "name": "plc",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "facilitator_user_id": {
+          "name": "facilitator_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_frequency": {
+          "name": "override_frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_session_day": {
+          "name": "override_session_day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plc_school_id_ref_school_id_fk": {
+          "name": "plc_school_id_ref_school_id_fk",
+          "tableFrom": "plc",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plc_facilitator_user_id_ref_user_id_fk": {
+          "name": "plc_facilitator_user_id_ref_user_id_fk",
+          "tableFrom": "plc",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "facilitator_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plc_tenant_uk": {
+          "name": "plc_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "plc_type_valid": {
+          "name": "plc_type_valid",
+          "value": "\"plc\".\"type\" IN ('subject', 'cross-cutting', 'new-teacher')"
+        },
+        "plc_override_frequency_valid": {
+          "name": "plc_override_frequency_valid",
+          "value": "\"plc\".\"override_frequency\" IN ('WEEKLY', 'BIWEEKLY')"
+        },
+        "plc_override_session_day_range": {
+          "name": "plc_override_session_day_range",
+          "value": "\"plc\".\"override_session_day\" BETWEEN 1 AND 7"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.plc_cpd_ledger": {
+      "name": "plc_cpd_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attended_pts": {
+          "name": "attended_pts",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reflection_pts": {
+          "name": "reflection_pts",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plc_cpd_ledger_school_id_ref_school_id_fk": {
+          "name": "plc_cpd_ledger_school_id_ref_school_id_fk",
+          "tableFrom": "plc_cpd_ledger",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plc_cpd_ledger_user_id_ref_user_id_fk": {
+          "name": "plc_cpd_ledger_user_id_ref_user_id_fk",
+          "tableFrom": "plc_cpd_ledger",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "plc_cpd_ledger_school_id_session_id_plc_session_school_id_id_fk": {
+          "name": "plc_cpd_ledger_school_id_session_id_plc_session_school_id_id_fk",
+          "tableFrom": "plc_cpd_ledger",
+          "tableTo": "plc_session",
+          "columnsFrom": [
+            "school_id",
+            "session_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_plc_cpd_ledger": {
+          "name": "uniq_plc_cpd_ledger",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "session_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "plc_cpd_ledger_attended_pts_nonneg": {
+          "name": "plc_cpd_ledger_attended_pts_nonneg",
+          "value": "\"plc_cpd_ledger\".\"attended_pts\" >= 0"
+        },
+        "plc_cpd_ledger_reflection_pts_nonneg": {
+          "name": "plc_cpd_ledger_reflection_pts_nonneg",
+          "value": "\"plc_cpd_ledger\".\"reflection_pts\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.plc_membership": {
+      "name": "plc_membership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plc_id": {
+          "name": "plc_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plc_membership_user_idx": {
+          "name": "plc_membership_user_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plc_membership_school_id_ref_school_id_fk": {
+          "name": "plc_membership_school_id_ref_school_id_fk",
+          "tableFrom": "plc_membership",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plc_membership_user_id_ref_user_id_fk": {
+          "name": "plc_membership_user_id_ref_user_id_fk",
+          "tableFrom": "plc_membership",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "plc_membership_school_id_plc_id_plc_school_id_id_fk": {
+          "name": "plc_membership_school_id_plc_id_plc_school_id_id_fk",
+          "tableFrom": "plc_membership",
+          "tableTo": "plc",
+          "columnsFrom": [
+            "school_id",
+            "plc_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_plc_membership": {
+          "name": "uniq_plc_membership",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "plc_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plc_programme": {
+      "name": "plc_programme",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_day": {
+          "name": "session_day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "session_start": {
+          "name": "session_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'15:30'"
+        },
+        "session_length_min": {
+          "name": "session_length_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "weeks_per_semester": {
+          "name": "weeks_per_semester",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 12
+        },
+        "pts_per_attended_session": {
+          "name": "pts_per_attended_session",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.5'"
+        },
+        "pts_per_reflection": {
+          "name": "pts_per_reflection",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.5'"
+        },
+        "reflection_window_hours": {
+          "name": "reflection_window_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 48
+        },
+        "annual_plc_target": {
+          "name": "annual_plc_target",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'8'"
+        },
+        "configured_at": {
+          "name": "configured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plc_programme_school_id_ref_school_id_fk": {
+          "name": "plc_programme_school_id_ref_school_id_fk",
+          "tableFrom": "plc_programme",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plc_programme_school_id_unique": {
+          "name": "plc_programme_school_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "plc_programme_session_day_range": {
+          "name": "plc_programme_session_day_range",
+          "value": "\"plc_programme\".\"session_day\" BETWEEN 1 AND 7"
+        },
+        "plc_programme_session_length_min_positive": {
+          "name": "plc_programme_session_length_min_positive",
+          "value": "\"plc_programme\".\"session_length_min\" > 0"
+        },
+        "plc_programme_weeks_per_semester_positive": {
+          "name": "plc_programme_weeks_per_semester_positive",
+          "value": "\"plc_programme\".\"weeks_per_semester\" > 0"
+        },
+        "plc_programme_reflection_window_hours_positive": {
+          "name": "plc_programme_reflection_window_hours_positive",
+          "value": "\"plc_programme\".\"reflection_window_hours\" > 0"
+        },
+        "plc_programme_pts_per_attended_session_nonneg": {
+          "name": "plc_programme_pts_per_attended_session_nonneg",
+          "value": "\"plc_programme\".\"pts_per_attended_session\" >= 0"
+        },
+        "plc_programme_pts_per_reflection_nonneg": {
+          "name": "plc_programme_pts_per_reflection_nonneg",
+          "value": "\"plc_programme\".\"pts_per_reflection\" >= 0"
+        },
+        "plc_programme_annual_plc_target_nonneg": {
+          "name": "plc_programme_annual_plc_target_nonneg",
+          "value": "\"plc_programme\".\"annual_plc_target\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.plc_session": {
+      "name": "plc_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plc_id": {
+          "name": "plc_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_period_id": {
+          "name": "academic_period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_date": {
+          "name": "session_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agenda_json": {
+          "name": "agenda_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"items\": []}'::jsonb"
+        },
+        "opened_by_user_id": {
+          "name": "opened_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plc_session_school_id_ref_school_id_fk": {
+          "name": "plc_session_school_id_ref_school_id_fk",
+          "tableFrom": "plc_session",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plc_session_opened_by_user_id_ref_user_id_fk": {
+          "name": "plc_session_opened_by_user_id_ref_user_id_fk",
+          "tableFrom": "plc_session",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "opened_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "plc_session_school_id_plc_id_plc_school_id_id_fk": {
+          "name": "plc_session_school_id_plc_id_plc_school_id_id_fk",
+          "tableFrom": "plc_session",
+          "tableTo": "plc",
+          "columnsFrom": [
+            "school_id",
+            "plc_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plc_session_school_id_academic_period_id_academic_period_school_id_period_id_fk": {
+          "name": "plc_session_school_id_academic_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "plc_session",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "academic_period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plc_session_tenant_uk": {
+          "name": "plc_session_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        },
+        "uniq_plc_session": {
+          "name": "uniq_plc_session",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "plc_id",
+            "session_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plc_session_attendance": {
+      "name": "plc_session_attendance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "attendance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minutes_late": {
+          "name": "minutes_late",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plc_session_attendance_school_id_ref_school_id_fk": {
+          "name": "plc_session_attendance_school_id_ref_school_id_fk",
+          "tableFrom": "plc_session_attendance",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plc_session_attendance_user_id_ref_user_id_fk": {
+          "name": "plc_session_attendance_user_id_ref_user_id_fk",
+          "tableFrom": "plc_session_attendance",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "plc_session_attendance_recorded_by_user_id_ref_user_id_fk": {
+          "name": "plc_session_attendance_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "plc_session_attendance",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "plc_session_attendance_school_id_session_id_plc_session_school_id_id_fk": {
+          "name": "plc_session_attendance_school_id_session_id_plc_session_school_id_id_fk",
+          "tableFrom": "plc_session_attendance",
+          "tableTo": "plc_session",
+          "columnsFrom": [
+            "school_id",
+            "session_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_plc_session_attendance": {
+          "name": "uniq_plc_session_attendance",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "session_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "plc_session_attendance_minutes_late_nonneg": {
+          "name": "plc_session_attendance_minutes_late_nonneg",
+          "value": "\"plc_session_attendance\".\"minutes_late\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.plc_session_reflection": {
+      "name": "plc_session_reflection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "q1": {
+          "name": "q1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "q2": {
+          "name": "q2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "q3": {
+          "name": "q3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_by_user_id": {
+          "name": "confirmed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plc_session_reflection_school_id_ref_school_id_fk": {
+          "name": "plc_session_reflection_school_id_ref_school_id_fk",
+          "tableFrom": "plc_session_reflection",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plc_session_reflection_user_id_ref_user_id_fk": {
+          "name": "plc_session_reflection_user_id_ref_user_id_fk",
+          "tableFrom": "plc_session_reflection",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "plc_session_reflection_confirmed_by_user_id_ref_user_id_fk": {
+          "name": "plc_session_reflection_confirmed_by_user_id_ref_user_id_fk",
+          "tableFrom": "plc_session_reflection",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "confirmed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "plc_session_reflection_school_id_session_id_plc_session_school_id_id_fk": {
+          "name": "plc_session_reflection_school_id_session_id_plc_session_school_id_id_fk",
+          "tableFrom": "plc_session_reflection",
+          "tableTo": "plc_session",
+          "columnsFrom": [
+            "school_id",
+            "session_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_plc_session_reflection": {
+          "name": "uniq_plc_session_reflection",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "session_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plc_term_focus": {
+      "name": "plc_term_focus",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plc_id": {
+          "name": "plc_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_period_id": {
+          "name": "academic_period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "focus": {
+          "name": "focus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_by_user_id": {
+          "name": "set_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plc_term_focus_school_id_ref_school_id_fk": {
+          "name": "plc_term_focus_school_id_ref_school_id_fk",
+          "tableFrom": "plc_term_focus",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plc_term_focus_set_by_user_id_ref_user_id_fk": {
+          "name": "plc_term_focus_set_by_user_id_ref_user_id_fk",
+          "tableFrom": "plc_term_focus",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "set_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "plc_term_focus_school_id_plc_id_plc_school_id_id_fk": {
+          "name": "plc_term_focus_school_id_plc_id_plc_school_id_id_fk",
+          "tableFrom": "plc_term_focus",
+          "tableTo": "plc",
+          "columnsFrom": [
+            "school_id",
+            "plc_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plc_term_focus_school_id_academic_period_id_academic_period_school_id_period_id_fk": {
+          "name": "plc_term_focus_school_id_academic_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "plc_term_focus",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "academic_period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_plc_term_focus": {
+          "name": "uniq_plc_term_focus",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "plc_id",
+            "academic_period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "plc_term_focus_focus_len": {
+          "name": "plc_term_focus_focus_len",
+          "value": "char_length(\"plc_term_focus\".\"focus\") <= 500"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pta_action_item": {
+      "name": "pta_action_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agenda_item_id": {
+          "name": "agenda_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_user_id": {
+          "name": "person_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_name": {
+          "name": "external_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pta_action_item_agenda_item_idx": {
+          "name": "pta_action_item_agenda_item_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agenda_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pta_action_item_school_id_ref_school_id_fk": {
+          "name": "pta_action_item_school_id_ref_school_id_fk",
+          "tableFrom": "pta_action_item",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_action_item_person_user_id_ref_user_id_fk": {
+          "name": "pta_action_item_person_user_id_ref_user_id_fk",
+          "tableFrom": "pta_action_item",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "person_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pta_action_item_school_id_agenda_item_id_pta_agenda_item_school_id_id_fk": {
+          "name": "pta_action_item_school_id_agenda_item_id_pta_agenda_item_school_id_id_fk",
+          "tableFrom": "pta_action_item",
+          "tableTo": "pta_agenda_item",
+          "columnsFrom": [
+            "school_id",
+            "agenda_item_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pta_action_item_at_most_one_owner": {
+          "name": "pta_action_item_at_most_one_owner",
+          "value": "NOT (\"pta_action_item\".\"person_user_id\" IS NOT NULL AND \"pta_action_item\".\"external_name\" IS NOT NULL)"
+        },
+        "pta_action_item_status_valid": {
+          "name": "pta_action_item_status_valid",
+          "value": "\"pta_action_item\".\"status\" IN ('PENDING', 'DONE')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pta_agenda_item": {
+      "name": "pta_agenda_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minutes_id": {
+          "name": "minutes_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq_no": {
+          "name": "seq_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classification": {
+          "name": "classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "narrative": {
+          "name": "narrative",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pta_agenda_item_minutes_idx": {
+          "name": "pta_agenda_item_minutes_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "minutes_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq_no",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pta_agenda_item_school_id_ref_school_id_fk": {
+          "name": "pta_agenda_item_school_id_ref_school_id_fk",
+          "tableFrom": "pta_agenda_item",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_agenda_item_school_id_minutes_id_pta_minutes_school_id_id_fk": {
+          "name": "pta_agenda_item_school_id_minutes_id_pta_minutes_school_id_id_fk",
+          "tableFrom": "pta_agenda_item",
+          "tableTo": "pta_minutes",
+          "columnsFrom": [
+            "school_id",
+            "minutes_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pta_agenda_item_tenant_uk": {
+          "name": "pta_agenda_item_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pta_agenda_item_classification_valid": {
+          "name": "pta_agenda_item_classification_valid",
+          "value": "\"pta_agenda_item\".\"classification\" IS NULL OR \"pta_agenda_item\".\"classification\" IN ('DISCUSSION', 'ACTION', 'RESOLUTION')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pta_dues_charge": {
+      "name": "pta_dues_charge",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_item_id": {
+          "name": "line_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pta_id": {
+          "name": "pta_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_type": {
+          "name": "tier_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_period_id": {
+          "name": "academic_period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "basis": {
+          "name": "basis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cadence": {
+          "name": "cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_student_id": {
+          "name": "subject_student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_snapshot": {
+          "name": "rate_snapshot",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_pta_dues_per_student": {
+          "name": "uniq_pta_dues_per_student",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pta_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pta_dues_charge\".\"basis\" = 'PER_STUDENT'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_pta_dues_per_family": {
+          "name": "uniq_pta_dues_per_family",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pta_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "household_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pta_dues_charge\".\"basis\" = 'PER_FAMILY' AND \"pta_dues_charge\".\"household_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_pta_dues_per_family_of_one": {
+          "name": "uniq_pta_dues_per_family_of_one",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pta_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pta_dues_charge\".\"basis\" = 'PER_FAMILY' AND \"pta_dues_charge\".\"household_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pta_dues_charge_pta_idx": {
+          "name": "pta_dues_charge_pta_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pta_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pta_dues_charge_school_id_ref_school_id_fk": {
+          "name": "pta_dues_charge_school_id_ref_school_id_fk",
+          "tableFrom": "pta_dues_charge",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_dues_charge_school_id_line_item_id_invoice_line_item_school_id_id_fk": {
+          "name": "pta_dues_charge_school_id_line_item_id_invoice_line_item_school_id_id_fk",
+          "tableFrom": "pta_dues_charge",
+          "tableTo": "invoice_line_item",
+          "columnsFrom": [
+            "school_id",
+            "line_item_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_dues_charge_school_id_pta_id_ptas_school_id_id_fk": {
+          "name": "pta_dues_charge_school_id_pta_id_ptas_school_id_id_fk",
+          "tableFrom": "pta_dues_charge",
+          "tableTo": "ptas",
+          "columnsFrom": [
+            "school_id",
+            "pta_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_dues_charge_school_id_academic_period_id_academic_period_school_id_period_id_fk": {
+          "name": "pta_dues_charge_school_id_academic_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "pta_dues_charge",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "academic_period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_dues_charge_school_id_subject_student_id_students_school_id_id_fk": {
+          "name": "pta_dues_charge_school_id_subject_student_id_students_school_id_id_fk",
+          "tableFrom": "pta_dues_charge",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "subject_student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_dues_charge_school_id_household_id_household_school_id_id_fk": {
+          "name": "pta_dues_charge_school_id_household_id_household_school_id_id_fk",
+          "tableFrom": "pta_dues_charge",
+          "tableTo": "household",
+          "columnsFrom": [
+            "school_id",
+            "household_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_pta_dues_charge_line_item": {
+          "name": "uniq_pta_dues_charge_line_item",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "line_item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pta_dues_charge_tier_type_valid": {
+          "name": "pta_dues_charge_tier_type_valid",
+          "value": "\"pta_dues_charge\".\"tier_type\" IN ('FORM', 'HOUSE', 'GENERAL', 'EMERGENCY')"
+        },
+        "pta_dues_charge_basis_valid": {
+          "name": "pta_dues_charge_basis_valid",
+          "value": "\"pta_dues_charge\".\"basis\" IN ('PER_STUDENT', 'PER_FAMILY')"
+        },
+        "pta_dues_charge_cadence_valid": {
+          "name": "pta_dues_charge_cadence_valid",
+          "value": "\"pta_dues_charge\".\"cadence\" IN ('PER_TERM', 'PER_YEAR', 'ONE_OFF')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pta_dues_config_history": {
+      "name": "pta_dues_config_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_type": {
+          "name": "tier_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dues_enabled": {
+          "name": "dues_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dues_amount": {
+          "name": "dues_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dues_basis": {
+          "name": "dues_basis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dues_cadence": {
+          "name": "dues_cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pta_dues_config_history_tier_idx": {
+          "name": "pta_dues_config_history_tier_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tier_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pta_dues_config_history_school_id_ref_school_id_fk": {
+          "name": "pta_dues_config_history_school_id_ref_school_id_fk",
+          "tableFrom": "pta_dues_config_history",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_dues_config_history_changed_by_user_id_ref_user_id_fk": {
+          "name": "pta_dues_config_history_changed_by_user_id_ref_user_id_fk",
+          "tableFrom": "pta_dues_config_history",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pta_dues_config_history_school_id_tier_type_pta_tiers_config_school_id_tier_type_fk": {
+          "name": "pta_dues_config_history_school_id_tier_type_pta_tiers_config_school_id_tier_type_fk",
+          "tableFrom": "pta_dues_config_history",
+          "tableTo": "pta_tiers_config",
+          "columnsFrom": [
+            "school_id",
+            "tier_type"
+          ],
+          "columnsTo": [
+            "school_id",
+            "tier_type"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pta_meeting": {
+      "name": "pta_meeting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pta_id": {
+          "name": "pta_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_period_id": {
+          "name": "academic_period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_type": {
+          "name": "meeting_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_date": {
+          "name": "meeting_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agenda_json": {
+          "name": "agenda_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"items\": []}'::jsonb"
+        },
+        "invited_teacher_user_ids": {
+          "name": "invited_teacher_user_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "quorum_met": {
+          "name": "quorum_met",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "convened_by_user_id": {
+          "name": "convened_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parents_notified_at": {
+          "name": "parents_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pta_meeting_pta_idx": {
+          "name": "pta_meeting_pta_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pta_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "meeting_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pta_meeting_school_id_ref_school_id_fk": {
+          "name": "pta_meeting_school_id_ref_school_id_fk",
+          "tableFrom": "pta_meeting",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_meeting_convened_by_user_id_ref_user_id_fk": {
+          "name": "pta_meeting_convened_by_user_id_ref_user_id_fk",
+          "tableFrom": "pta_meeting",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "convened_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pta_meeting_school_id_pta_id_ptas_school_id_id_fk": {
+          "name": "pta_meeting_school_id_pta_id_ptas_school_id_id_fk",
+          "tableFrom": "pta_meeting",
+          "tableTo": "ptas",
+          "columnsFrom": [
+            "school_id",
+            "pta_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_meeting_school_id_academic_period_id_academic_period_school_id_period_id_fk": {
+          "name": "pta_meeting_school_id_academic_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "pta_meeting",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "academic_period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pta_meeting_tenant_uk": {
+          "name": "pta_meeting_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pta_meeting_attendance": {
+      "name": "pta_meeting_attendance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "register": {
+          "name": "register",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_guardian_id": {
+          "name": "student_guardian_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "attendance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minutes_late": {
+          "name": "minutes_late",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_pta_meeting_attendance_teacher": {
+          "name": "uniq_pta_meeting_attendance_teacher",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "meeting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pta_meeting_attendance\".\"register\" = 'TEACHER'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_pta_meeting_attendance_parent": {
+          "name": "uniq_pta_meeting_attendance_parent",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "meeting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_guardian_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pta_meeting_attendance\".\"register\" = 'PARENT'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pta_meeting_attendance_school_id_ref_school_id_fk": {
+          "name": "pta_meeting_attendance_school_id_ref_school_id_fk",
+          "tableFrom": "pta_meeting_attendance",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_meeting_attendance_user_id_ref_user_id_fk": {
+          "name": "pta_meeting_attendance_user_id_ref_user_id_fk",
+          "tableFrom": "pta_meeting_attendance",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pta_meeting_attendance_student_guardian_id_student_guardian_id_fk": {
+          "name": "pta_meeting_attendance_student_guardian_id_student_guardian_id_fk",
+          "tableFrom": "pta_meeting_attendance",
+          "tableTo": "student_guardian",
+          "columnsFrom": [
+            "student_guardian_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pta_meeting_attendance_recorded_by_user_id_ref_user_id_fk": {
+          "name": "pta_meeting_attendance_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "pta_meeting_attendance",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pta_meeting_attendance_school_id_meeting_id_pta_meeting_school_id_id_fk": {
+          "name": "pta_meeting_attendance_school_id_meeting_id_pta_meeting_school_id_id_fk",
+          "tableFrom": "pta_meeting_attendance",
+          "tableTo": "pta_meeting",
+          "columnsFrom": [
+            "school_id",
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pta_meeting_attendance_register_valid": {
+          "name": "pta_meeting_attendance_register_valid",
+          "value": "\"pta_meeting_attendance\".\"register\" IN ('TEACHER', 'PARENT')"
+        },
+        "pta_meeting_attendance_register_identity": {
+          "name": "pta_meeting_attendance_register_identity",
+          "value": "(\"pta_meeting_attendance\".\"register\" = 'TEACHER' AND \"pta_meeting_attendance\".\"user_id\" IS NOT NULL AND \"pta_meeting_attendance\".\"student_guardian_id\" IS NULL)\n        OR (\"pta_meeting_attendance\".\"register\" = 'PARENT' AND \"pta_meeting_attendance\".\"student_guardian_id\" IS NOT NULL AND \"pta_meeting_attendance\".\"user_id\" IS NULL)"
+        },
+        "pta_meeting_attendance_minutes_late_nonneg": {
+          "name": "pta_meeting_attendance_minutes_late_nonneg",
+          "value": "\"pta_meeting_attendance\".\"minutes_late\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pta_minutes": {
+      "name": "pta_minutes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "secretary_id": {
+          "name": "secretary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adopted_by_user_id": {
+          "name": "adopted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adopted_at": {
+          "name": "adopted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distributed_at": {
+          "name": "distributed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pta_minutes_school_id_ref_school_id_fk": {
+          "name": "pta_minutes_school_id_ref_school_id_fk",
+          "tableFrom": "pta_minutes",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_minutes_secretary_id_ref_user_id_fk": {
+          "name": "pta_minutes_secretary_id_ref_user_id_fk",
+          "tableFrom": "pta_minutes",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "secretary_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pta_minutes_adopted_by_user_id_ref_user_id_fk": {
+          "name": "pta_minutes_adopted_by_user_id_ref_user_id_fk",
+          "tableFrom": "pta_minutes",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "adopted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pta_minutes_school_id_meeting_id_pta_meeting_school_id_id_fk": {
+          "name": "pta_minutes_school_id_meeting_id_pta_meeting_school_id_id_fk",
+          "tableFrom": "pta_minutes",
+          "tableTo": "pta_meeting",
+          "columnsFrom": [
+            "school_id",
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_pta_minutes_meeting": {
+          "name": "uniq_pta_minutes_meeting",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "meeting_id"
+          ]
+        },
+        "pta_minutes_tenant_uk": {
+          "name": "pta_minutes_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pta_minutes_status_valid": {
+          "name": "pta_minutes_status_valid",
+          "value": "\"pta_minutes\".\"status\" IN ('DRAFT', 'CHAIR_REVIEW', 'ADOPTED')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pta_officer": {
+      "name": "pta_officer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pta_id": {
+          "name": "pta_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_user_id": {
+          "name": "person_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_name": {
+          "name": "external_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "office": {
+          "name": "office",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_basis": {
+          "name": "assignment_basis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "election_ref": {
+          "name": "election_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "term_start": {
+          "name": "term_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "term_end": {
+          "name": "term_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_pta_officer_current": {
+          "name": "uniq_pta_officer_current",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pta_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "office",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pta_officer\".\"ended_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pta_officer_person_idx": {
+          "name": "pta_officer_person_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pta_officer_school_id_ref_school_id_fk": {
+          "name": "pta_officer_school_id_ref_school_id_fk",
+          "tableFrom": "pta_officer",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_officer_person_user_id_ref_user_id_fk": {
+          "name": "pta_officer_person_user_id_ref_user_id_fk",
+          "tableFrom": "pta_officer",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "person_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pta_officer_school_id_pta_id_ptas_school_id_id_fk": {
+          "name": "pta_officer_school_id_pta_id_ptas_school_id_id_fk",
+          "tableFrom": "pta_officer",
+          "tableTo": "ptas",
+          "columnsFrom": [
+            "school_id",
+            "pta_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pta_officer_at_most_one_holder": {
+          "name": "pta_officer_at_most_one_holder",
+          "value": "NOT (\"pta_officer\".\"person_user_id\" IS NOT NULL AND \"pta_officer\".\"external_name\" IS NOT NULL)"
+        },
+        "pta_officer_assignment_basis_valid": {
+          "name": "pta_officer_assignment_basis_valid",
+          "value": "\"pta_officer\".\"assignment_basis\" IN ('ELECTED', 'APPOINTED')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pta_resolution": {
+      "name": "pta_resolution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agenda_item_id": {
+          "name": "agenda_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution_no": {
+          "name": "resolution_no",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_text": {
+          "name": "resolution_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "votes_for": {
+          "name": "votes_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "votes_against": {
+          "name": "votes_against",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "votes_abstain": {
+          "name": "votes_abstain",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding": {
+          "name": "binding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pta_resolution_agenda_item_idx": {
+          "name": "pta_resolution_agenda_item_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agenda_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pta_resolution_school_id_ref_school_id_fk": {
+          "name": "pta_resolution_school_id_ref_school_id_fk",
+          "tableFrom": "pta_resolution",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_resolution_school_id_agenda_item_id_pta_agenda_item_school_id_id_fk": {
+          "name": "pta_resolution_school_id_agenda_item_id_pta_agenda_item_school_id_id_fk",
+          "tableFrom": "pta_resolution",
+          "tableTo": "pta_agenda_item",
+          "columnsFrom": [
+            "school_id",
+            "agenda_item_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_pta_resolution_no": {
+          "name": "uniq_pta_resolution_no",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "resolution_no"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pta_resolution_votes_for_nonneg": {
+          "name": "pta_resolution_votes_for_nonneg",
+          "value": "\"pta_resolution\".\"votes_for\" >= 0"
+        },
+        "pta_resolution_votes_against_nonneg": {
+          "name": "pta_resolution_votes_against_nonneg",
+          "value": "\"pta_resolution\".\"votes_against\" >= 0"
+        },
+        "pta_resolution_votes_abstain_nonneg": {
+          "name": "pta_resolution_votes_abstain_nonneg",
+          "value": "\"pta_resolution\".\"votes_abstain\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pta_tiers_config": {
+      "name": "pta_tiers_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_type": {
+          "name": "tier_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "frequency_norm": {
+          "name": "frequency_norm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "officer_roles": {
+          "name": "officer_roles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "quorum_rule": {
+          "name": "quorum_rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dues_enabled": {
+          "name": "dues_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dues_amount": {
+          "name": "dues_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dues_basis": {
+          "name": "dues_basis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dues_cadence": {
+          "name": "dues_cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier_settings": {
+          "name": "tier_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "configured_at": {
+          "name": "configured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pta_tiers_config_school_id_ref_school_id_fk": {
+          "name": "pta_tiers_config_school_id_ref_school_id_fk",
+          "tableFrom": "pta_tiers_config",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_pta_tiers_config": {
+          "name": "uniq_pta_tiers_config",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "tier_type"
+          ]
+        },
+        "pta_tiers_config_tenant_uk": {
+          "name": "pta_tiers_config_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pta_tiers_config_tier_type_valid": {
+          "name": "pta_tiers_config_tier_type_valid",
+          "value": "\"pta_tiers_config\".\"tier_type\" IN ('FORM', 'HOUSE', 'GENERAL', 'EMERGENCY')"
+        },
+        "pta_tiers_config_dues_basis_valid": {
+          "name": "pta_tiers_config_dues_basis_valid",
+          "value": "\"pta_tiers_config\".\"dues_basis\" IN ('PER_STUDENT', 'PER_FAMILY')"
+        },
+        "pta_tiers_config_dues_cadence_valid": {
+          "name": "pta_tiers_config_dues_cadence_valid",
+          "value": "\"pta_tiers_config\".\"dues_cadence\" IN ('PER_TERM', 'PER_YEAR', 'ONE_OFF')"
+        },
+        "pta_tiers_config_emergency_no_officers_no_dues": {
+          "name": "pta_tiers_config_emergency_no_officers_no_dues",
+          "value": "\"pta_tiers_config\".\"tier_type\" <> 'EMERGENCY' OR (\"pta_tiers_config\".\"officer_roles\" = '[]'::jsonb AND \"pta_tiers_config\".\"dues_enabled\" = false)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ptas": {
+      "name": "ptas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_type": {
+          "name": "tier_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "house_id": {
+          "name": "house_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_pta_form_scope": {
+          "name": "uniq_pta_form_scope",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"ptas\".\"tier_type\" = 'FORM'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_pta_house_scope": {
+          "name": "uniq_pta_house_scope",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "house_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"ptas\".\"tier_type\" = 'HOUSE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_pta_general_singleton": {
+          "name": "uniq_pta_general_singleton",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"ptas\".\"tier_type\" = 'GENERAL'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ptas_school_id_ref_school_id_fk": {
+          "name": "ptas_school_id_ref_school_id_fk",
+          "tableFrom": "ptas",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ptas_school_id_class_id_class_school_id_id_fk": {
+          "name": "ptas_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "ptas",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "ptas_school_id_house_id_house_school_id_id_fk": {
+          "name": "ptas_school_id_house_id_house_school_id_id_fk",
+          "tableFrom": "ptas",
+          "tableTo": "house",
+          "columnsFrom": [
+            "school_id",
+            "house_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ptas_tenant_uk": {
+          "name": "ptas_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ptas_tier_type_valid": {
+          "name": "ptas_tier_type_valid",
+          "value": "\"ptas\".\"tier_type\" IN ('FORM', 'HOUSE', 'GENERAL', 'EMERGENCY')"
+        },
+        "ptas_status_valid": {
+          "name": "ptas_status_valid",
+          "value": "\"ptas\".\"status\" IN ('ACTIVE', 'CLOSED')"
+        },
+        "ptas_tier_scope_binding": {
+          "name": "ptas_tier_scope_binding",
+          "value": "(\"ptas\".\"tier_type\" = 'FORM' AND \"ptas\".\"class_id\" IS NOT NULL AND \"ptas\".\"house_id\" IS NULL)\n        OR (\"ptas\".\"tier_type\" = 'HOUSE' AND \"ptas\".\"house_id\" IS NOT NULL AND \"ptas\".\"class_id\" IS NULL)\n        OR (\"ptas\".\"tier_type\" IN ('GENERAL', 'EMERGENCY') AND \"ptas\".\"class_id\" IS NULL AND \"ptas\".\"house_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.terminal_exam_result": {
+      "name": "terminal_exam_result",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exam_type": {
+          "name": "exam_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "female_candidates": {
+          "name": "female_candidates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "male_candidates": {
+          "name": "male_candidates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "female_passed": {
+          "name": "female_passed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "male_passed": {
+          "name": "male_passed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "captured_by": {
+          "name": "captured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "terminal_exam_result_school_id_ref_school_id_fk": {
+          "name": "terminal_exam_result_school_id_ref_school_id_fk",
+          "tableFrom": "terminal_exam_result",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_exam_result_captured_by_ref_user_id_fk": {
+          "name": "terminal_exam_result_captured_by_ref_user_id_fk",
+          "tableFrom": "terminal_exam_result",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "captured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_terminal_exam_result_sitting": {
+          "name": "uniq_terminal_exam_result_sitting",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "exam_type",
+            "year"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "terminal_exam_result_exam_type_valid": {
+          "name": "terminal_exam_result_exam_type_valid",
+          "value": "\"terminal_exam_result\".\"exam_type\" IN ('BECE', 'WASSCE')"
+        },
+        "terminal_exam_result_female_candidates_nonneg": {
+          "name": "terminal_exam_result_female_candidates_nonneg",
+          "value": "\"terminal_exam_result\".\"female_candidates\" >= 0"
+        },
+        "terminal_exam_result_male_candidates_nonneg": {
+          "name": "terminal_exam_result_male_candidates_nonneg",
+          "value": "\"terminal_exam_result\".\"male_candidates\" >= 0"
+        },
+        "terminal_exam_result_female_passed_bounds": {
+          "name": "terminal_exam_result_female_passed_bounds",
+          "value": "\"terminal_exam_result\".\"female_passed\" >= 0 AND \"terminal_exam_result\".\"female_passed\" <= \"terminal_exam_result\".\"female_candidates\""
+        },
+        "terminal_exam_result_male_passed_bounds": {
+          "name": "terminal_exam_result_male_passed_bounds",
+          "value": "\"terminal_exam_result\".\"male_passed\" >= 0 AND \"terminal_exam_result\".\"male_passed\" <= \"terminal_exam_result\".\"male_candidates\""
+        },
+        "terminal_exam_result_min_one_candidate": {
+          "name": "terminal_exam_result_min_one_candidate",
+          "value": "\"terminal_exam_result\".\"female_candidates\" + \"terminal_exam_result\".\"male_candidates\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.facilities_snapshot": {
+      "name": "facilities_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classrooms_total": {
+          "name": "classrooms_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classrooms_good": {
+          "name": "classrooms_good",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classrooms_repair": {
+          "name": "classrooms_repair",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "water_source": {
+          "name": "water_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "electricity_source": {
+          "name": "electricity_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latrines_boys": {
+          "name": "latrines_boys",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latrines_girls": {
+          "name": "latrines_girls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latrines_staff": {
+          "name": "latrines_staff",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latrine_type": {
+          "name": "latrine_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handwashing": {
+          "name": "handwashing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_library": {
+          "name": "has_library",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_ict_lab": {
+          "name": "has_ict_lab",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internet": {
+          "name": "internet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_kitchen": {
+          "name": "has_kitchen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gsfp_participating": {
+          "name": "gsfp_participating",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_book_count": {
+          "name": "library_book_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "library_staff_fte": {
+          "name": "library_staff_fte",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computers_total": {
+          "name": "computers_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computers_working": {
+          "name": "computers_working",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internet_type": {
+          "name": "internet_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meals_served_last_term": {
+          "name": "meals_served_last_term",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pupils_fed_daily_avg": {
+          "name": "pupils_fed_daily_avg",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caterer_name": {
+          "name": "caterer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "textbook_availability": {
+          "name": "textbook_availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_desks_usable": {
+          "name": "student_desks_usable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_desks_broken": {
+          "name": "student_desks_broken",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teacher_desks": {
+          "name": "teacher_desks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chalkboards": {
+          "name": "chalkboards",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "whiteboards": {
+          "name": "whiteboards",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projectors": {
+          "name": "projectors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "captured_by": {
+          "name": "captured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "facilities_snapshot_school_id_ref_school_id_fk": {
+          "name": "facilities_snapshot_school_id_ref_school_id_fk",
+          "tableFrom": "facilities_snapshot",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "facilities_snapshot_captured_by_ref_user_id_fk": {
+          "name": "facilities_snapshot_captured_by_ref_user_id_fk",
+          "tableFrom": "facilities_snapshot",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "captured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "facilities_snapshot_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "facilities_snapshot_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "facilities_snapshot",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_facilities_snapshot_term": {
+          "name": "uniq_facilities_snapshot_term",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "facilities_snapshot_classrooms_nonneg": {
+          "name": "facilities_snapshot_classrooms_nonneg",
+          "value": "\"facilities_snapshot\".\"classrooms_total\" >= 0 AND \"facilities_snapshot\".\"classrooms_good\" >= 0 AND \"facilities_snapshot\".\"classrooms_repair\" >= 0"
+        },
+        "facilities_snapshot_classrooms_sum": {
+          "name": "facilities_snapshot_classrooms_sum",
+          "value": "\"facilities_snapshot\".\"classrooms_good\" + \"facilities_snapshot\".\"classrooms_repair\" <= \"facilities_snapshot\".\"classrooms_total\""
+        },
+        "facilities_snapshot_water_source_valid": {
+          "name": "facilities_snapshot_water_source_valid",
+          "value": "\"facilities_snapshot\".\"water_source\" IN ('BOREHOLE', 'PIPE', 'WELL', 'NONE')"
+        },
+        "facilities_snapshot_electricity_source_valid": {
+          "name": "facilities_snapshot_electricity_source_valid",
+          "value": "\"facilities_snapshot\".\"electricity_source\" IN ('GRID', 'SOLAR', 'GENERATOR', 'NONE')"
+        },
+        "facilities_snapshot_latrines_nonneg": {
+          "name": "facilities_snapshot_latrines_nonneg",
+          "value": "\"facilities_snapshot\".\"latrines_boys\" >= 0 AND \"facilities_snapshot\".\"latrines_girls\" >= 0 AND \"facilities_snapshot\".\"latrines_staff\" >= 0"
+        },
+        "facilities_snapshot_latrine_type_valid": {
+          "name": "facilities_snapshot_latrine_type_valid",
+          "value": "\"facilities_snapshot\".\"latrine_type\" IN ('WC', 'KVIP', 'PIT', 'NONE')"
+        },
+        "facilities_snapshot_library_nonneg": {
+          "name": "facilities_snapshot_library_nonneg",
+          "value": "\"facilities_snapshot\".\"library_book_count\" >= 0 AND \"facilities_snapshot\".\"library_staff_fte\" >= 0"
+        },
+        "facilities_snapshot_computers_nonneg": {
+          "name": "facilities_snapshot_computers_nonneg",
+          "value": "\"facilities_snapshot\".\"computers_total\" >= 0 AND \"facilities_snapshot\".\"computers_working\" >= 0"
+        },
+        "facilities_snapshot_computers_bound": {
+          "name": "facilities_snapshot_computers_bound",
+          "value": "\"facilities_snapshot\".\"computers_working\" IS NULL OR \"facilities_snapshot\".\"computers_total\" IS NULL OR \"facilities_snapshot\".\"computers_working\" <= \"facilities_snapshot\".\"computers_total\""
+        },
+        "facilities_snapshot_gsfp_nonneg": {
+          "name": "facilities_snapshot_gsfp_nonneg",
+          "value": "\"facilities_snapshot\".\"meals_served_last_term\" >= 0 AND \"facilities_snapshot\".\"pupils_fed_daily_avg\" >= 0"
+        },
+        "facilities_snapshot_furniture_nonneg": {
+          "name": "facilities_snapshot_furniture_nonneg",
+          "value": "\"facilities_snapshot\".\"student_desks_usable\" >= 0 AND \"facilities_snapshot\".\"student_desks_broken\" >= 0 AND \"facilities_snapshot\".\"teacher_desks\" >= 0 AND \"facilities_snapshot\".\"chalkboards\" >= 0 AND \"facilities_snapshot\".\"whiteboards\" >= 0 AND \"facilities_snapshot\".\"projectors\" >= 0"
+        },
+        "facilities_snapshot_textbook_availability_valid": {
+          "name": "facilities_snapshot_textbook_availability_valid",
+          "value": "\"facilities_snapshot\".\"textbook_availability\" IN ('ADEQUATE', 'INADEQUATE')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.census_return": {
+      "name": "census_return",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cadence": {
+          "name": "cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "census_date": {
+          "name": "census_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_snapshot": {
+          "name": "auto_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hand_fill": {
+          "name": "hand_fill",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_by": {
+          "name": "generated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "census_return_school_id_ref_school_id_fk": {
+          "name": "census_return_school_id_ref_school_id_fk",
+          "tableFrom": "census_return",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "census_return_generated_by_ref_user_id_fk": {
+          "name": "census_return_generated_by_ref_user_id_fk",
+          "tableFrom": "census_return",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "generated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_census_return_filing": {
+          "name": "uniq_census_return_filing",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "cadence",
+            "academic_year"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "census_return_cadence_valid": {
+          "name": "census_return_cadence_valid",
+          "value": "\"census_return\".\"cadence\" IN ('MID_YEAR', 'ANNUAL')"
+        },
+        "census_return_status_valid": {
+          "name": "census_return_status_valid",
+          "value": "\"census_return\".\"status\" IN ('DRAFT', 'COMPLETED')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sen_module_adoption": {
+      "name": "sen_module_adoption",
+      "schema": "",
+      "columns": {
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled_at": {
+          "name": "enabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "enabled_by": {
+          "name": "enabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sen_module_adoption_school_id_ref_school_id_fk": {
+          "name": "sen_module_adoption_school_id_ref_school_id_fk",
+          "tableFrom": "sen_module_adoption",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sen_module_adoption_enabled_by_ref_user_id_fk": {
+          "name": "sen_module_adoption_enabled_by_ref_user_id_fk",
+          "tableFrom": "sen_module_adoption",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "enabled_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sen_register": {
+      "name": "sen_register",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "sen_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_categories": {
+          "name": "secondary_categories",
+          "type": "sen_category[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "sen_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "support_notes": {
+          "name": "support_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodations": {
+          "name": "accommodations",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnosis_source": {
+          "name": "diagnosis_source",
+          "type": "sen_diagnosis_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnosing_clinician": {
+          "name": "diagnosing_clinician",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnosing_institution": {
+          "name": "diagnosing_institution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnosis_year": {
+          "name": "diagnosis_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent_state": {
+          "name": "consent_state",
+          "type": "sen_consent_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_on_file_at": {
+          "name": "consent_on_file_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sen_register_school_id_ref_school_id_fk": {
+          "name": "sen_register_school_id_ref_school_id_fk",
+          "tableFrom": "sen_register",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sen_register_created_by_ref_user_id_fk": {
+          "name": "sen_register_created_by_ref_user_id_fk",
+          "tableFrom": "sen_register",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sen_register_school_id_student_id_students_school_id_id_fk": {
+          "name": "sen_register_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "sen_register",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_sen_register_student": {
+          "name": "uniq_sen_register_student",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "sen_register_secondary_not_primary": {
+          "name": "sen_register_secondary_not_primary",
+          "value": "\"sen_register\".\"secondary_categories\" IS NULL OR NOT (\"sen_register\".\"category\" = ANY(\"sen_register\".\"secondary_categories\"))"
+        },
+        "sen_register_pending_no_detail": {
+          "name": "sen_register_pending_no_detail",
+          "value": "\"sen_register\".\"consent_state\" = 'GRANTED' OR (\n        \"sen_register\".\"severity\" IS NULL\n        AND \"sen_register\".\"diagnosis_source\" IS NULL\n        AND \"sen_register\".\"diagnosing_clinician\" IS NULL\n        AND \"sen_register\".\"diagnosing_institution\" IS NULL\n        AND \"sen_register\".\"diagnosis_year\" IS NULL\n        AND \"sen_register\".\"support_notes\" IS NULL\n        AND \"sen_register\".\"accommodations\" IS NULL\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sen_support_grant": {
+      "name": "sen_support_grant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_user_id": {
+          "name": "grantee_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sen_support_grant_grantee_idx": {
+          "name": "sen_support_grant_grantee_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "grantee_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sen_support_grant_student_idx": {
+          "name": "sen_support_grant_student_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sen_support_grant_school_id_ref_school_id_fk": {
+          "name": "sen_support_grant_school_id_ref_school_id_fk",
+          "tableFrom": "sen_support_grant",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sen_support_grant_grantee_user_id_ref_user_id_fk": {
+          "name": "sen_support_grant_grantee_user_id_ref_user_id_fk",
+          "tableFrom": "sen_support_grant",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "grantee_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sen_support_grant_granted_by_user_id_ref_user_id_fk": {
+          "name": "sen_support_grant_granted_by_user_id_ref_user_id_fk",
+          "tableFrom": "sen_support_grant",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "granted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sen_support_grant_revoked_by_user_id_ref_user_id_fk": {
+          "name": "sen_support_grant_revoked_by_user_id_ref_user_id_fk",
+          "tableFrom": "sen_support_grant",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sen_support_grant_school_id_student_id_students_school_id_id_fk": {
+          "name": "sen_support_grant_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "sen_support_grant",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.timetable_slot": {
+      "name": "timetable_slot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_index": {
+          "name": "period_index",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teacher_user_id": {
+          "name": "teacher_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "timetable_teacher_slot_idx": {
+          "name": "timetable_teacher_slot_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "teacher_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "timetable_slot_school_id_ref_school_id_fk": {
+          "name": "timetable_slot_school_id_ref_school_id_fk",
+          "tableFrom": "timetable_slot",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "timetable_slot_subject_id_subject_id_fk": {
+          "name": "timetable_slot_subject_id_subject_id_fk",
+          "tableFrom": "timetable_slot",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "timetable_slot_teacher_user_id_ref_user_id_fk": {
+          "name": "timetable_slot_teacher_user_id_ref_user_id_fk",
+          "tableFrom": "timetable_slot",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "teacher_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "timetable_slot_school_id_class_id_class_school_id_id_fk": {
+          "name": "timetable_slot_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "timetable_slot",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_timetable_class_slot": {
+          "name": "uniq_timetable_class_slot",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "class_id",
+            "day_of_week",
+            "period_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.announcement": {
+      "name": "announcement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "audience",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'WHOLE_SCHOOL'"
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_by_user_id": {
+          "name": "posted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "announcement_school_id_ref_school_id_fk": {
+          "name": "announcement_school_id_ref_school_id_fk",
+          "tableFrom": "announcement",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "announcement_class_id_class_id_fk": {
+          "name": "announcement_class_id_class_id_fk",
+          "tableFrom": "announcement",
+          "tableTo": "class",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "announcement_posted_by_user_id_ref_user_id_fk": {
+          "name": "announcement_posted_by_user_id_ref_user_id_fk",
+          "tableFrom": "announcement",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "posted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "notif_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'QUEUED'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_ref": {
+          "name": "provider_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_by_user_id": {
+          "name": "sent_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notif_school_time_idx": {
+          "name": "notif_school_time_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_log_school_id_ref_school_id_fk": {
+          "name": "notification_log_school_id_ref_school_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_log_student_id_students_id_fk": {
+          "name": "notification_log_student_id_students_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_log_template_id_sms_template_id_fk": {
+          "name": "notification_log_template_id_sms_template_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "sms_template",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_log_sent_by_user_id_ref_user_id_fk": {
+          "name": "notification_log_sent_by_user_id_ref_user_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "sent_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_template": {
+      "name": "sms_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sms_template_school_id_ref_school_id_fk": {
+          "name": "sms_template_school_id_ref_school_id_fk",
+          "tableFrom": "sms_template",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_template_per_school": {
+          "name": "uniq_template_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "conversation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "assigned_to_user_id": {
+          "name": "assigned_to_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SMS'"
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "routed_by_rule_id": {
+          "name": "routed_by_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "routed_by_rule_name": {
+          "name": "routed_by_rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_school_activity_idx": {
+          "name": "conversation_school_activity_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_phone_idx": {
+          "name": "conversation_phone_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_school_id_ref_school_id_fk": {
+          "name": "conversation_school_id_ref_school_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_student_id_students_id_fk": {
+          "name": "conversation_student_id_students_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "conversation_assigned_to_user_id_ref_user_id_fk": {
+          "name": "conversation_assigned_to_user_id_ref_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "assigned_to_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_tenant_uk": {
+          "name": "conversation_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbox_message": {
+      "name": "inbox_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "message_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_by_user_id": {
+          "name": "sent_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inbox_message_conversation_idx": {
+          "name": "inbox_message_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbox_message_school_id_ref_school_id_fk": {
+          "name": "inbox_message_school_id_ref_school_id_fk",
+          "tableFrom": "inbox_message",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbox_message_sent_by_user_id_ref_user_id_fk": {
+          "name": "inbox_message_sent_by_user_id_ref_user_id_fk",
+          "tableFrom": "inbox_message",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "sent_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbox_message_school_id_conversation_id_conversation_school_id_id_fk": {
+          "name": "inbox_message_school_id_conversation_id_conversation_school_id_id_fk",
+          "tableFrom": "inbox_message",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "school_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbox_routing_rule": {
+      "name": "inbox_routing_rule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_fallback": {
+          "name": "is_fallback",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "match_topic": {
+          "name": "match_topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_class": {
+          "name": "match_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_keywords": {
+          "name": "match_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assign_to_user_id": {
+          "name": "assign_to_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_all_admins": {
+          "name": "notify_all_admins",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inbox_routing_rule_school_pos_idx": {
+          "name": "inbox_routing_rule_school_pos_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbox_routing_rule_school_id_ref_school_id_fk": {
+          "name": "inbox_routing_rule_school_id_ref_school_id_fk",
+          "tableFrom": "inbox_routing_rule",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbox_routing_rule_assign_to_user_id_ref_user_id_fk": {
+          "name": "inbox_routing_rule_assign_to_user_id_ref_user_id_fk",
+          "tableFrom": "inbox_routing_rule",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "assign_to_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite": {
+      "name": "invite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignments": {
+          "name": "assignments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_user_id": {
+          "name": "accepted_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invite_school_status_idx": {
+          "name": "invite_school_status_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_school_id_ref_school_id_fk": {
+          "name": "invite_school_id_ref_school_id_fk",
+          "tableFrom": "invite",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_invited_by_user_id_ref_user_id_fk": {
+          "name": "invite_invited_by_user_id_ref_user_id_fk",
+          "tableFrom": "invite",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invite_accepted_user_id_ref_user_id_fk": {
+          "name": "invite_accepted_user_id_ref_user_id_fk",
+          "tableFrom": "invite",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "accepted_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invite_school_id_student_id_students_school_id_id_fk": {
+          "name": "invite_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "invite",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_token_unique": {
+          "name": "invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_category": {
+      "name": "book_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "book_entry_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_category_school_idx": {
+          "name": "book_category_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_category_school_id_ref_school_id_fk": {
+          "name": "book_category_school_id_ref_school_id_fk",
+          "tableFrom": "book_category",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_book_category_per_school": {
+          "name": "uniq_book_category_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "kind",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_entry": {
+      "name": "book_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "book_entry_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_date": {
+          "name": "entry_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "party": {
+          "name": "party",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_entry_school_date_idx": {
+          "name": "book_entry_school_date_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entry_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_entry_school_id_ref_school_id_fk": {
+          "name": "book_entry_school_id_ref_school_id_fk",
+          "tableFrom": "book_entry",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_entry_category_id_book_category_id_fk": {
+          "name": "book_entry_category_id_book_category_id_fk",
+          "tableFrom": "book_entry",
+          "tableTo": "book_category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "book_entry_created_by_user_id_ref_user_id_fk": {
+          "name": "book_entry_created_by_user_id_ref_user_id_fk",
+          "tableFrom": "book_entry",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fixed_asset": {
+      "name": "fixed_asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acquired_on": {
+          "name": "acquired_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_cost": {
+          "name": "original_cost",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accumulated_depreciation": {
+          "name": "accumulated_depreciation",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "useful_life_years": {
+          "name": "useful_life_years",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fixed_asset_school_idx": {
+          "name": "fixed_asset_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fixed_asset_school_id_ref_school_id_fk": {
+          "name": "fixed_asset_school_id_ref_school_id_fk",
+          "tableFrom": "fixed_asset",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.whatsapp_template": {
+      "name": "whatsapp_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTILITY'"
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en_GH'"
+        },
+        "header_type": {
+          "name": "header_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NONE'"
+        },
+        "header_text": {
+          "name": "header_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_filename": {
+          "name": "header_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footer": {
+          "name": "footer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buttons": {
+          "name": "buttons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sample_values": {
+          "name": "sample_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "whatsapp_template_school_idx": {
+          "name": "whatsapp_template_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "whatsapp_template_school_id_ref_school_id_fk": {
+          "name": "whatsapp_template_school_id_ref_school_id_fk",
+          "tableFrom": "whatsapp_template",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "whatsapp_template_created_by_user_id_ref_user_id_fk": {
+          "name": "whatsapp_template_created_by_user_id_ref_user_id_fk",
+          "tableFrom": "whatsapp_template",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_whatsapp_template_name_per_school": {
+          "name": "uniq_whatsapp_template_name_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.admission_status": {
+      "name": "admission_status",
+      "schema": "public",
+      "values": [
+        "SUBMITTED",
+        "UNDER_REVIEW",
+        "ACCEPTED",
+        "REJECTED",
+        "WAITLISTED"
+      ]
+    },
+    "public.allocation_method": {
+      "name": "allocation_method",
+      "schema": "public",
+      "values": [
+        "MANUAL",
+        "AUTO_OLDEST_FIRST",
+        "AUTO_NEWEST_FIRST"
+      ]
+    },
+    "public.allocation_type": {
+      "name": "allocation_type",
+      "schema": "public",
+      "values": [
+        "INVOICE",
+        "CREDIT",
+        "REFUND"
+      ]
+    },
+    "public.anomaly_severity": {
+      "name": "anomaly_severity",
+      "schema": "public",
+      "values": [
+        "LOW",
+        "MEDIUM",
+        "HIGH"
+      ]
+    },
+    "public.app_role": {
+      "name": "app_role",
+      "schema": "public",
+      "values": [
+        "ADMIN",
+        "HEADMASTER",
+        "VICE_HEADMASTER_ACADEMIC",
+        "TEACHER",
+        "FORM_MASTER",
+        "HOUSEMASTER",
+        "STUDENT",
+        "PARENT",
+        "BURSAR",
+        "DEAN_OF_BOARDING",
+        "MATRON"
+      ]
+    },
+    "public.assessment_category": {
+      "name": "assessment_category",
+      "schema": "public",
+      "values": [
+        "ASSIGNMENT",
+        "MID_SEM_EXAM",
+        "END_SEM_EXAM",
+        "PROJECT"
+      ]
+    },
+    "public.attendance_status": {
+      "name": "attendance_status",
+      "schema": "public",
+      "values": [
+        "PRESENT",
+        "ABSENT",
+        "LATE",
+        "EXCUSED",
+        "MEDICAL"
+      ]
+    },
+    "public.audience": {
+      "name": "audience",
+      "schema": "public",
+      "values": [
+        "WHOLE_SCHOOL",
+        "CLASS"
+      ]
+    },
+    "public.benchmark_metric": {
+      "name": "benchmark_metric",
+      "schema": "public",
+      "values": [
+        "CREDIT_RATE",
+        "DISTINCTION_RATE"
+      ]
+    },
+    "public.benchmark_quality": {
+      "name": "benchmark_quality",
+      "schema": "public",
+      "values": [
+        "STRONG",
+        "MODERATE",
+        "DIRECTIONAL"
+      ]
+    },
+    "public.benchmark_scope": {
+      "name": "benchmark_scope",
+      "schema": "public",
+      "values": [
+        "SCHOOL",
+        "REGION",
+        "NATIONAL"
+      ]
+    },
+    "public.benchmark_source": {
+      "name": "benchmark_source",
+      "schema": "public",
+      "values": [
+        "SCHOOLUP_DIRECT",
+        "WAEC_NATIONAL",
+        "WAEC_REGIONAL_SUMMARY",
+        "INTERPOLATED",
+        "MULTI_SCHOOL_POOL"
+      ]
+    },
+    "public.boarding_day_type": {
+      "name": "boarding_day_type",
+      "schema": "public",
+      "values": [
+        "WEEKDAY",
+        "SATURDAY",
+        "SUNDAY",
+        "VISITING_SUNDAY"
+      ]
+    },
+    "public.boarding_event_type": {
+      "name": "boarding_event_type",
+      "schema": "public",
+      "values": [
+        "VISITING",
+        "EXEAT_WINDOW"
+      ]
+    },
+    "public.boarding_mode": {
+      "name": "boarding_mode",
+      "schema": "public",
+      "values": [
+        "RESUMPTION",
+        "VACATION"
+      ]
+    },
+    "public.book_entry_kind": {
+      "name": "book_entry_kind",
+      "schema": "public",
+      "values": [
+        "INCOME",
+        "EXPENSE"
+      ]
+    },
+    "public.capture_path": {
+      "name": "capture_path",
+      "schema": "public",
+      "values": [
+        "AUTO_COMPILE",
+        "SCAN_EXTRACT",
+        "DIRECT_ENTRY"
+      ]
+    },
+    "public.chronic_condition": {
+      "name": "chronic_condition",
+      "schema": "public",
+      "values": [
+        "SICKLE_CELL",
+        "ASTHMA",
+        "EPILEPSY",
+        "ALLERGY",
+        "MENTAL_HEALTH",
+        "DIABETES",
+        "OTHER"
+      ]
+    },
+    "public.chronic_status": {
+      "name": "chronic_status",
+      "schema": "public",
+      "values": [
+        "STABLE",
+        "MONITOR",
+        "ACTIVE_CRISIS"
+      ]
+    },
+    "public.conversation_status": {
+      "name": "conversation_status",
+      "schema": "public",
+      "values": [
+        "OPEN",
+        "CLOSED"
+      ]
+    },
+    "public.correction_status": {
+      "name": "correction_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPROVED",
+        "REJECTED"
+      ]
+    },
+    "public.discount_kind": {
+      "name": "discount_kind",
+      "schema": "public",
+      "values": [
+        "PERCENT",
+        "FIXED"
+      ]
+    },
+    "public.exeat_notification_kind": {
+      "name": "exeat_notification_kind",
+      "schema": "public",
+      "values": [
+        "DEPARTURE",
+        "REMINDER",
+        "OVERDUE_STAGE_1",
+        "OVERDUE_STAGE_2",
+        "OVERDUE_STAGE_3"
+      ]
+    },
+    "public.exeat_status": {
+      "name": "exeat_status",
+      "schema": "public",
+      "values": [
+        "REQUESTED",
+        "HM_APPROVED",
+        "SR_HM_SIGNED",
+        "DEPARTED",
+        "RETURNED",
+        "DECLINED"
+      ]
+    },
+    "public.exeat_type": {
+      "name": "exeat_type",
+      "schema": "public",
+      "values": [
+        "SCHEDULED",
+        "SPECIAL",
+        "FEE_COLLECTION"
+      ]
+    },
+    "public.guardian_relation": {
+      "name": "guardian_relation",
+      "schema": "public",
+      "values": [
+        "MOTHER",
+        "FATHER",
+        "GUARDIAN",
+        "OTHER"
+      ]
+    },
+    "public.house_gender": {
+      "name": "house_gender",
+      "schema": "public",
+      "values": [
+        "BOYS",
+        "GIRLS",
+        "COED"
+      ]
+    },
+    "public.infraction_severity": {
+      "name": "infraction_severity",
+      "schema": "public",
+      "values": [
+        "NOTE",
+        "WARNING",
+        "BOND",
+        "SUSPENSION",
+        "DEBOARDINIZATION"
+      ]
+    },
+    "public.infraction_source": {
+      "name": "infraction_source",
+      "schema": "public",
+      "values": [
+        "MANUAL",
+        "EXEAT_OVERDUE",
+        "INSPECTION_DAILY",
+        "INSPECTION_WEEKLY",
+        "VISIT_OVERSTAY",
+        "RESUMPTION_ABSENT"
+      ]
+    },
+    "public.infraction_status": {
+      "name": "infraction_status",
+      "schema": "public",
+      "values": [
+        "OPEN",
+        "RESOLVED",
+        "SUPERSEDED"
+      ]
+    },
+    "public.inspection_result": {
+      "name": "inspection_result",
+      "schema": "public",
+      "values": [
+        "PASS",
+        "PARTIAL",
+        "FAIL"
+      ]
+    },
+    "public.inspection_type": {
+      "name": "inspection_type",
+      "schema": "public",
+      "values": [
+        "DAILY",
+        "WEEKLY"
+      ]
+    },
+    "public.invite_status": {
+      "name": "invite_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "REVOKED",
+        "EXPIRED"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "ISSUED",
+        "PARTIAL",
+        "PAID",
+        "OVERDUE",
+        "EXEMPT",
+        "VOIDED"
+      ]
+    },
+    "public.ledger_correction_reason": {
+      "name": "ledger_correction_reason",
+      "schema": "public",
+      "values": [
+        "RE_GRADED",
+        "TRANSCRIPTION_ERROR",
+        "OTHER"
+      ]
+    },
+    "public.ledger_status": {
+      "name": "ledger_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "COMPLETE",
+        "STPSHS_READY"
+      ]
+    },
+    "public.message_direction": {
+      "name": "message_direction",
+      "schema": "public",
+      "values": [
+        "INBOUND",
+        "OUTBOUND"
+      ]
+    },
+    "public.nhis_holder_kind": {
+      "name": "nhis_holder_kind",
+      "schema": "public",
+      "values": [
+        "STUDENT",
+        "GUARDIAN"
+      ]
+    },
+    "public.notif_status": {
+      "name": "notif_status",
+      "schema": "public",
+      "values": [
+        "QUEUED",
+        "SENT",
+        "FAILED"
+      ]
+    },
+    "public.ownership_type": {
+      "name": "ownership_type",
+      "schema": "public",
+      "values": [
+        "PUBLIC",
+        "PRIVATE",
+        "MISSION",
+        "INTERNATIONAL"
+      ]
+    },
+    "public.parent_ack_method": {
+      "name": "parent_ack_method",
+      "schema": "public",
+      "values": [
+        "PHONE_OTP",
+        "IN_PERSON",
+        "PDF_UPLOAD"
+      ]
+    },
+    "public.payment_actor_type": {
+      "name": "payment_actor_type",
+      "schema": "public",
+      "values": [
+        "ADMIN",
+        "SYSTEM",
+        "WEBHOOK",
+        "RECONCILIATION_JOB"
+      ]
+    },
+    "public.payment_event_type": {
+      "name": "payment_event_type",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "ALLOCATION_ADDED",
+        "ALLOCATION_VOIDED",
+        "SETTLED",
+        "VOIDED",
+        "SMS_SENT",
+        "SMS_FAILED",
+        "REFUNDED",
+        "DISCOUNT_OVERRIDDEN"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "MTN_MOMO",
+        "TELECEL_CASH",
+        "AIRTELTIGO_MONEY",
+        "BANK_TRANSFER",
+        "CASH",
+        "CHEQUE",
+        "OTHER"
+      ]
+    },
+    "public.period_source": {
+      "name": "period_source",
+      "schema": "public",
+      "values": [
+        "GES_DEFAULT",
+        "SCHOOL_OVERRIDE"
+      ]
+    },
+    "public.period_type": {
+      "name": "period_type",
+      "schema": "public",
+      "values": [
+        "TERM",
+        "SEMESTER"
+      ]
+    },
+    "public.prefect_role": {
+      "name": "prefect_role",
+      "schema": "public",
+      "values": [
+        "HEAD",
+        "DINING",
+        "SANITATION",
+        "PREP",
+        "SICKBAY"
+      ]
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "public",
+      "values": [
+        "BASIC",
+        "SENIOR",
+        "OVERSIGHT"
+      ]
+    },
+    "public.programme": {
+      "name": "programme",
+      "schema": "public",
+      "values": [
+        "GENERAL_ARTS",
+        "GENERAL_SCIENCE",
+        "BUSINESS",
+        "AGRICULTURE",
+        "VISUAL_ARTS",
+        "HOME_ECONOMICS",
+        "TECHNICAL"
+      ]
+    },
+    "public.residency": {
+      "name": "residency",
+      "schema": "public",
+      "values": [
+        "BOARDER",
+        "DAY",
+        "DEBOARDINIZED"
+      ]
+    },
+    "public.sc_form": {
+      "name": "sc_form",
+      "schema": "public",
+      "values": [
+        "SC-3",
+        "SC-7",
+        "SC-12"
+      ]
+    },
+    "public.sc_status": {
+      "name": "sc_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "FILED",
+        "ACKNOWLEDGED",
+        "APPROVED",
+        "SCHEDULED",
+        "COMPLETED",
+        "REJECTED"
+      ]
+    },
+    "public.school_type": {
+      "name": "school_type",
+      "schema": "public",
+      "values": [
+        "BASIC",
+        "SENIOR",
+        "COMBINED"
+      ]
+    },
+    "public.sen_category": {
+      "name": "sen_category",
+      "schema": "public",
+      "values": [
+        "VISUAL",
+        "HEARING",
+        "PHYSICAL",
+        "INTELLECTUAL",
+        "SPEECH",
+        "OTHER"
+      ]
+    },
+    "public.sen_consent_state": {
+      "name": "sen_consent_state",
+      "schema": "public",
+      "values": [
+        "GRANTED",
+        "PENDING"
+      ]
+    },
+    "public.sen_diagnosis_source": {
+      "name": "sen_diagnosis_source",
+      "schema": "public",
+      "values": [
+        "CLINICAL_DIAGNOSIS",
+        "SCHOOL_OBSERVED"
+      ]
+    },
+    "public.sen_severity": {
+      "name": "sen_severity",
+      "schema": "public",
+      "values": [
+        "MILD",
+        "MODERATE",
+        "SEVERE"
+      ]
+    },
+    "public.settlement_status": {
+      "name": "settlement_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "CONFIRMED",
+        "SETTLED",
+        "RECONCILED",
+        "DISPUTED"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "MALE",
+        "FEMALE"
+      ]
+    },
+    "public.shs_category": {
+      "name": "shs_category",
+      "schema": "public",
+      "values": [
+        "A",
+        "B",
+        "C",
+        "D",
+        "E",
+        "F"
+      ]
+    },
+    "public.sickbay_consult_mode": {
+      "name": "sickbay_consult_mode",
+      "schema": "public",
+      "values": [
+        "PHONE",
+        "IN_PERSON"
+      ]
+    },
+    "public.sickbay_disposition": {
+      "name": "sickbay_disposition",
+      "schema": "public",
+      "values": [
+        "DISCHARGE",
+        "ADMIT",
+        "REFER"
+      ]
+    },
+    "public.sickbay_grant_scope": {
+      "name": "sickbay_grant_scope",
+      "schema": "public",
+      "values": [
+        "FULL_PLAN",
+        "PARTIAL",
+        "DIRECTIVE"
+      ]
+    },
+    "public.sickbay_med_source": {
+      "name": "sickbay_med_source",
+      "schema": "public",
+      "values": [
+        "CHRONIC",
+        "STANDING_ORDER",
+        "DOCTOR_ORDERED",
+        "AD_HOC"
+      ]
+    },
+    "public.sickbay_med_status": {
+      "name": "sickbay_med_status",
+      "schema": "public",
+      "values": [
+        "GIVEN",
+        "REFUSED",
+        "HELD",
+        "OMITTED"
+      ]
+    },
+    "public.sickbay_mode": {
+      "name": "sickbay_mode",
+      "schema": "public",
+      "values": [
+        "FULL",
+        "FIRST_AID",
+        "REFERRAL_ONLY"
+      ]
+    },
+    "public.sickbay_notify_channel": {
+      "name": "sickbay_notify_channel",
+      "schema": "public",
+      "values": [
+        "SMS",
+        "CALL",
+        "IN_APP",
+        "SYSTEM"
+      ]
+    },
+    "public.sickbay_notify_direction": {
+      "name": "sickbay_notify_direction",
+      "schema": "public",
+      "values": [
+        "OUTBOUND",
+        "INBOUND"
+      ]
+    },
+    "public.sickbay_notify_recipient": {
+      "name": "sickbay_notify_recipient",
+      "schema": "public",
+      "values": [
+        "PARENT",
+        "HOUSEMASTER",
+        "HEADMASTER",
+        "DISTRICT_HEALTH"
+      ]
+    },
+    "public.sickbay_referral_status": {
+      "name": "sickbay_referral_status",
+      "schema": "public",
+      "values": [
+        "REFERRED",
+        "INPATIENT",
+        "RETURNING",
+        "RETURNED"
+      ]
+    },
+    "public.sickbay_slot_kind": {
+      "name": "sickbay_slot_kind",
+      "schema": "public",
+      "values": [
+        "MEDICATION_ROUND",
+        "CLINIC",
+        "DOCTOR_VISIT",
+        "ON_CALL"
+      ]
+    },
+    "public.sickbay_stock_movement_type": {
+      "name": "sickbay_stock_movement_type",
+      "schema": "public",
+      "values": [
+        "RECEIPT",
+        "WASTAGE",
+        "ADJUSTMENT"
+      ]
+    },
+    "public.sickbay_surveillance_category": {
+      "name": "sickbay_surveillance_category",
+      "schema": "public",
+      "values": [
+        "MALARIA",
+        "RESPIRATORY",
+        "DIARRHOEA",
+        "SKIN",
+        "EYE",
+        "INJURY",
+        "OTHER"
+      ]
+    },
+    "public.student_status": {
+      "name": "student_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "INACTIVE",
+        "GRADUATED",
+        "WITHDRAWN",
+        "TRANSFERRED"
+      ]
+    },
+    "public.target_rank": {
+      "name": "target_rank",
+      "schema": "public",
+      "values": [
+        "FIRST_CHOICE",
+        "SECOND_CHOICE",
+        "THIRD_CHOICE"
+      ]
+    },
+    "public.university_type": {
+      "name": "university_type",
+      "schema": "public",
+      "values": [
+        "PUBLIC_UNIVERSITY",
+        "PRIVATE_UNIVERSITY",
+        "TECHNICAL_UNIVERSITY",
+        "POLYTECHNIC",
+        "NURSING_COLLEGE",
+        "EDUCATION_COLLEGE"
+      ]
+    },
+    "public.visit_notification_kind": {
+      "name": "visit_notification_kind",
+      "schema": "public",
+      "values": [
+        "INVITATION",
+        "REMINDER_T3",
+        "REMINDER_T1",
+        "ARRIVAL_CONFIRM",
+        "OVERSTAY"
+      ]
+    },
+    "public.visit_status": {
+      "name": "visit_status",
+      "schema": "public",
+      "values": [
+        "RSVP",
+        "ARRIVED",
+        "DEPARTED"
+      ]
+    },
+    "public.visit_verification": {
+      "name": "visit_verification",
+      "schema": "public",
+      "values": [
+        "VERIFIED",
+        "FLAGGED",
+        "HM_AUTHORISED"
+      ]
+    },
+    "public.visitor_approval_status": {
+      "name": "visitor_approval_status",
+      "schema": "public",
+      "values": [
+        "PENDING_REVIEW",
+        "APPROVED"
+      ]
+    },
+    "public.wassce_candidate_status": {
+      "name": "wassce_candidate_status",
+      "schema": "public",
+      "values": [
+        "REGISTERED",
+        "ACTIVE",
+        "WITHDRAWN",
+        "COMPLETED"
+      ]
+    },
+    "public.wassce_grade": {
+      "name": "wassce_grade",
+      "schema": "public",
+      "values": [
+        "A1",
+        "B2",
+        "B3",
+        "C4",
+        "C5",
+        "C6",
+        "D7",
+        "E8",
+        "F9"
+      ]
+    },
+    "public.wassce_paper_type": {
+      "name": "wassce_paper_type",
+      "schema": "public",
+      "values": [
+        "OBJECTIVE",
+        "ESSAY",
+        "PRACTICAL",
+        "ORAL",
+        "COMBINED"
+      ]
+    },
+    "public.wassce_reg_flag": {
+      "name": "wassce_reg_flag",
+      "schema": "public",
+      "values": [
+        "ON_MEDICAL",
+        "NHIS_ISSUE",
+        "FEE"
+      ]
+    },
+    "public.wassce_subject_type": {
+      "name": "wassce_subject_type",
+      "schema": "public",
+      "values": [
+        "CORE",
+        "ELECTIVE",
+        "OPTIONAL"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/omnischools/db/migrations/meta/_journal.json
+++ b/omnischools/db/migrations/meta/_journal.json
@@ -603,6 +603,13 @@
       "when": 1787221446481,
       "tag": "0085_rainy_ironclad",
       "breakpoints": true
+    },
+    {
+      "idx": 86,
+      "version": "7",
+      "when": 1787558212035,
+      "tag": "0086_pta_meeting_parents_notified_at",
+      "breakpoints": true
     }
   ]
 }

--- a/omnischools/db/schema/pta.ts
+++ b/omnischools/db/schema/pta.ts
@@ -429,6 +429,11 @@ export const ptaMeeting = pgTable(
     convenedByUserId: uuid("convened_by_user_id").references(() => users.id, {
       onDelete: "set null",
     }),
+    // Convene-instant stamp when the convener SMS-notified the scope's parent roster (#297, State-1
+    // console-notify). NULL = not notified (notifyParents=false, or a pre-#297 meeting). App-set only —
+    // NEVER surfaced to the parent projection (the frozen parent key-set must not change); the recipient
+    // COUNT lives in the audit trail, not here.
+    parentsNotifiedAt: timestamp("parents_notified_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/omnischools/lib/actions/pta-meeting-notify.test.ts
+++ b/omnischools/lib/actions/pta-meeting-notify.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Tx } from "@/lib/db";
+
+/**
+ * #297 · State-1 console meeting-notify — BEHAVIOURAL proof of the convene → parent-SMS fence. The real
+ * derivation (loadMeetingNotifyPhones) and the real SMS path (flushSms → the console provider) run against
+ * a fake tx; ONLY the auth/db/audit/revalidate seams are mocked. This pins:
+ *   • post-commit (#253): the invite SMS goes out ONLY after the convene tx resolves — a tx that rejects
+ *     after collecting sends NOTHING (no false "meeting is on" after a rolled-back convene);
+ *   • audience == the scope's PRIMARY-guardian roster, DEDUPED by phone, non-null only (no-phone skipped);
+ *   • notifyParents=false → no intents, a NULL parents_notified_at stamp, and no notify audit row;
+ *   • the notify audit carries the recipient COUNT + meeting id ONLY — never a phone or a message body.
+ */
+
+// ── seams (only these are mocked; the derivation + SMS path are the real modules) ────────────────────
+const requireSchool = vi.fn(async () => ({
+  school: { id: "s1", name: "Asankrangwa SHS" },
+  user: { id: "u1", roles: ["ADMIN"] },
+}));
+const resolveActor = vi.fn(async () => ({ id: "u1", role: "ADMIN" }));
+vi.mock("@/lib/auth/server", () => ({
+  requireSchool: () => requireSchool(),
+  resolveActor: () => resolveActor(),
+}));
+
+const recordAudit = vi.fn(async () => {});
+vi.mock("@/lib/db/audit", () => ({ recordAudit: (...a: unknown[]) => recordAudit(...a) }));
+vi.mock("@/lib/revalidate", () => ({ safeRevalidate: vi.fn() }));
+
+// withSchool is driven per-test; isUniqueViolation is imported at module load (markAttendance) — stub it.
+const withSchool = vi.fn();
+vi.mock("@/lib/db/rls", () => ({
+  withSchool: (...a: unknown[]) => withSchool(...a),
+  isUniqueViolation: () => false,
+}));
+
+const { conveneMeeting } = await import("./pta-meeting");
+
+// ── a queue-driven fake tx: each awaited query resolves the next queued rowset; insert values captured ─
+interface Sink {
+  values: Record<string, unknown>[];
+}
+function fakeTx(queue: unknown[][], sink: Sink): Tx {
+  let i = 0;
+  const t: Record<string, unknown> = {};
+  for (const m of ["select", "from", "leftJoin", "innerJoin", "where", "orderBy", "groupBy", "limit", "insert", "returning", "update", "set", "delete"]) {
+    t[m] = () => t;
+  }
+  t.values = (v: Record<string, unknown>) => {
+    sink.values.push(v);
+    return t;
+  };
+  // thenable — the whole builder chain is evaluated synchronously, then awaited once (one queue slot).
+  (t as { then: (r: (v: unknown) => void) => void }).then = (resolve) => resolve(queue[i++] ?? []);
+  return t as unknown as Tx;
+}
+
+// The scope roster the reader returns: a duplicate phone, a NULL phone, and a whitespace-padded phone —
+// so a correct audience is exactly TWO distinct, trimmed, non-null numbers.
+const GUARDIAN_ROWS = [
+  { phone: "0244000001" },
+  { phone: "0244000001" }, // duplicate → collapses
+  { phone: null }, // no phone → skipped (no throw)
+  { phone: " 0244000002 " }, // trimmed
+];
+const PTA_ROW = [
+  {
+    id: "pta1",
+    tierType: "FORM",
+    status: "ACTIVE",
+    classId: "c1",
+    houseId: null,
+    className: "Form 2 Science",
+    houseName: null,
+    classTeacherUserId: null,
+    hmUserId: null,
+    tierSettings: {},
+  },
+];
+const PERIOD_ROW = [{ periodId: "per1", startsOn: "2000-01-01", endsOn: "2999-12-31" }];
+const INSERT_ROW = [{ id: "m1" }];
+const OFFICER_ROWS: unknown[] = []; // no stored offices — ADMIN passes via break-glass
+
+const validInput = (over: Record<string, unknown> = {}) => ({
+  ptaId: "11111111-1111-1111-1111-111111111111",
+  meetingType: "Regular PTA meeting",
+  meetingDate: "2026-06-01",
+  startTime: "10:00",
+  endTime: "12:00",
+  location: "Block C",
+  ...over,
+});
+
+const smsLogs = (spy: ReturnType<typeof vi.spyOn>) =>
+  spy.mock.calls.map((c) => String(c[0])).filter((s) => s.includes("[sms:console]"));
+
+let infoSpy: ReturnType<typeof vi.spyOn>;
+beforeEach(() => {
+  recordAudit.mockClear();
+  infoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("#297 · convene notifies the parent roster AFTER commit (default notifyParents=true)", () => {
+  it("SMSes exactly the deduped, non-null scope roster — post-commit, one message each", async () => {
+    const sink: Sink = { values: [] };
+    withSchool.mockImplementation(async (_id: string, cb: (tx: Tx) => Promise<unknown>) =>
+      cb(fakeTx([PTA_ROW, OFFICER_ROWS, PERIOD_ROW, INSERT_ROW, GUARDIAN_ROWS], sink)),
+    );
+
+    const res = await conveneMeeting(validInput());
+    expect(res.ok).toBe(true);
+
+    // audience == roster deduped/non-null: 4 rows (1 dup, 1 null) → exactly 2 sends, one body each.
+    const logs = smsLogs(infoSpy);
+    expect(logs).toHaveLength(2);
+    for (const line of logs) expect(line).toContain("Regular PTA meeting");
+
+    // the stamp is the convene instant (a Date), not null.
+    expect(sink.values[0]?.parentsNotifiedAt).toBeInstanceOf(Date);
+  });
+
+  it("writes ONE notify audit row — recipient COUNT + meeting id only, never a phone or a body", async () => {
+    const sink: Sink = { values: [] };
+    withSchool.mockImplementation(async (_id: string, cb: (tx: Tx) => Promise<unknown>) =>
+      cb(fakeTx([PTA_ROW, OFFICER_ROWS, PERIOD_ROW, INSERT_ROW, GUARDIAN_ROWS], sink)),
+    );
+
+    await conveneMeeting(validInput());
+
+    // convene audit + notify audit = 2 rows on pta_meeting.
+    const notify = recordAudit.mock.calls.find((c) => /invite SMS queued/i.test(String((c[1] as { reason?: string })?.reason)));
+    expect(notify).toBeDefined();
+    const arg = notify![1] as { entityType: string; entityId: string; after: Record<string, unknown> };
+    expect(arg.entityType).toBe("pta_meeting");
+    expect(arg.entityId).toBe("m1");
+    expect(arg.after).toEqual({ parentsNotified: 2 });
+
+    // no audit row anywhere leaks a phone number or the SMS body.
+    const serialized = JSON.stringify(recordAudit.mock.calls);
+    expect(serialized).not.toContain("0244000001");
+    expect(serialized).not.toContain("0244000002");
+    expect(serialized).not.toContain("Please attend");
+  });
+});
+
+describe("#297 · the post-commit fence — a rolled-back convene sends nothing", () => {
+  it("withSchool rejects after the callback collected → flushSms never runs, no SMS goes out", async () => {
+    const sink: Sink = { values: [] };
+    withSchool.mockImplementation(async (_id: string, cb: (tx: Tx) => Promise<unknown>) => {
+      await cb(fakeTx([PTA_ROW, OFFICER_ROWS, PERIOD_ROW, INSERT_ROW, GUARDIAN_ROWS], sink));
+      throw new Error("tx rolled back");
+    });
+
+    const res = await conveneMeeting(validInput());
+    expect(res.ok).toBe(false);
+    expect(smsLogs(infoSpy)).toHaveLength(0); // nothing sent after a rolled-back convene
+  });
+});
+
+describe("#297 · notifyParents=false — no intents, null stamp, no notify audit", () => {
+  it("sends nothing, stamps parents_notified_at NULL, and writes no notify audit row", async () => {
+    const sink: Sink = { values: [] };
+    // No guardian rowset is queued — the notify block must not run (it would consume it and send).
+    withSchool.mockImplementation(async (_id: string, cb: (tx: Tx) => Promise<unknown>) =>
+      cb(fakeTx([PTA_ROW, OFFICER_ROWS, PERIOD_ROW, INSERT_ROW], sink)),
+    );
+
+    const res = await conveneMeeting(validInput({ notifyParents: false }));
+    expect(res.ok).toBe(true);
+    expect(smsLogs(infoSpy)).toHaveLength(0);
+    expect(sink.values[0]?.parentsNotifiedAt).toBeNull();
+    expect(recordAudit.mock.calls.some((c) => /invite SMS queued/i.test(String((c[1] as { reason?: string })?.reason)))).toBe(false);
+  });
+});

--- a/omnischools/lib/actions/pta-meeting-notify.test.ts
+++ b/omnischools/lib/actions/pta-meeting-notify.test.ts
@@ -23,7 +23,7 @@ vi.mock("@/lib/auth/server", () => ({
   resolveActor: () => resolveActor(),
 }));
 
-const recordAudit = vi.fn(async () => {});
+const recordAudit = vi.fn(async (..._a: unknown[]) => {});
 vi.mock("@/lib/db/audit", () => ({ recordAudit: (...a: unknown[]) => recordAudit(...a) }));
 vi.mock("@/lib/revalidate", () => ({ safeRevalidate: vi.fn() }));
 
@@ -92,7 +92,7 @@ const validInput = (over: Record<string, unknown> = {}) => ({
 });
 
 const smsLogs = (spy: ReturnType<typeof vi.spyOn>) =>
-  spy.mock.calls.map((c) => String(c[0])).filter((s) => s.includes("[sms:console]"));
+  (spy.mock.calls as unknown[][]).map((c) => String(c[0])).filter((s) => s.includes("[sms:console]"));
 
 let infoSpy: ReturnType<typeof vi.spyOn>;
 beforeEach(() => {

--- a/omnischools/lib/actions/pta-meeting-notify.test.ts
+++ b/omnischools/lib/actions/pta-meeting-notify.test.ts
@@ -82,7 +82,9 @@ const INSERT_ROW = [{ id: "m1" }];
 const OFFICER_ROWS: unknown[] = []; // no stored offices — ADMIN passes via break-glass
 
 const validInput = (over: Record<string, unknown> = {}) => ({
-  ptaId: "11111111-1111-1111-1111-111111111111",
+  // A valid RFC-4122 UUID (version 4, variant 8): Zod's .uuid() enforces the version+variant nibbles,
+  // so an all-1s literal fails ConveneSchema and aborts the convene before any query — the earlier bug.
+  ptaId: "11111111-1111-4111-8111-111111111111",
   meetingType: "Regular PTA meeting",
   meetingDate: "2026-06-01",
   startTime: "10:00",

--- a/omnischools/lib/actions/pta-meeting.ts
+++ b/omnischools/lib/actions/pta-meeting.ts
@@ -23,10 +23,13 @@ import { safeRevalidate } from "@/lib/revalidate";
 import { canActAsPtaOfficer, hasAnyRole, PTA_MEETING_BREAKGLASS_ROLES } from "@/lib/access";
 import {
   loadMeetingScope,
+  loadMeetingNotifyPhones,
   resolvePtaWriteAccess,
   type PtaMeetingScope,
 } from "@/lib/pta/meeting-data";
 import { coalesceGraceHours, isPtaMeetingWriteLocked } from "@/lib/pta/meeting-clock";
+import { ptaMeetingInviteSms } from "@/lib/pta/meeting-invite-sms";
+import { flushSms, type SmsIntent } from "@/lib/sms";
 import { type PtaTierType } from "@/lib/pta/defaults";
 import {
   academicPeriod,
@@ -49,6 +52,83 @@ const LIST_PATH = "/senior/pta/meetings";
 const DATE = /^\d{4}-\d{2}-\d{2}$/;
 const HHMM = /^\d{2}:\d{2}$/;
 const registerPath = (meetingId: string) => `${LIST_PATH}/${meetingId}`;
+
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+/** "2026-05-14" → "14 May 2026" — ASCII/GSM-7-safe (no Intl locale surprises) for the invite SMS body. */
+function asciiMeetingDate(iso: string): string {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso);
+  if (!m) return iso;
+  return `${Number(m[3])} ${MONTHS[Number(m[2]) - 1] ?? "?"} ${m[1]}`;
+}
+
+/** The PTA display label for the invite SMS body (FORM→class, HOUSE→house, EMERGENCY, else General). */
+function convenedPtaLabel(tierType: PtaTierType, className: string | null, houseName: string | null): string {
+  return tierType === "FORM"
+    ? `${className ?? "Class"} PTA`
+    : tierType === "HOUSE"
+      ? `${houseName ?? "House"} PTA`
+      : tierType === "EMERGENCY"
+        ? "Emergency PTA"
+        : "General PTA";
+}
+
+interface ConveneDetails {
+  meetingType: string;
+  meetingDate: string;
+  startTime: string;
+  endTime: string;
+  location?: string | null;
+}
+
+/**
+ * #297 · State-1 console-notify (SHARED by both convene paths). Load the scope's PRIMARY-guardian phone
+ * roster (the SAME derivation the register renders — dedupe by phone, non-null only), pair each with the
+ * PURE invite body, and PUSH the intents onto the caller's post-commit array (delivered by `flushSms`
+ * AFTER the tx resolves; a rollback rejects before the flush line, so nothing is sent). Writes ONE SHOWN
+ * audit row — recipient COUNT + meeting id ONLY, never a phone or a body. A no-phone scope queues nothing
+ * and never throws. Staff invitees are NOT SMS'd in State-1.
+ */
+async function collectParentNotify(
+  sms: SmsIntent[],
+  tx: Tx,
+  args: {
+    schoolId: string;
+    actor: { id: string | null; role: string };
+    meetingId: string;
+    schoolName: string;
+    ptaLabel: string;
+    tierType: PtaTierType;
+    classId: string | null;
+    houseId: string | null;
+    d: ConveneDetails;
+  },
+): Promise<void> {
+  const phones = await loadMeetingNotifyPhones(tx, args.schoolId, {
+    tierType: args.tierType,
+    classId: args.classId,
+    houseId: args.houseId,
+  });
+  const body = ptaMeetingInviteSms({
+    schoolName: args.schoolName,
+    ptaLabel: args.ptaLabel,
+    meetingType: args.d.meetingType,
+    dateLabel: asciiMeetingDate(args.d.meetingDate),
+    startTime: args.d.startTime,
+    endTime: args.d.endTime,
+    location: args.d.location?.trim() || null,
+  });
+  for (const to of phones) sms.push({ to, body });
+  await recordAudit(tx, {
+    schoolId: args.schoolId,
+    actorUserId: args.actor.id ?? undefined,
+    actorRole: args.actor.role,
+    actionType: "updated",
+    entityType: "pta_meeting",
+    entityId: args.meetingId,
+    after: { parentsNotified: phones.length },
+    reason: `PTA meeting invite SMS queued to ${phones.length} parent${phones.length === 1 ? "" : "s"}`,
+  });
+}
 
 // ── shared: resolve the SENIOR academic period covering `date` (else latest begun, else last) ────────
 
@@ -149,6 +229,9 @@ const ConveneSchema = z.object({
   location: z.string().trim().max(200).nullish(),
   agendaItems: z.array(z.string().trim().min(1).max(200)).max(30).optional().default([]),
   invitedTeacherUserIds: z.array(z.string().uuid()).max(50).optional().default([]),
+  // #297 · State-1 console-notify. Default TRUE (owner-ratified): SMS the scope's parent roster on
+  // convene. The writer gate is UNCHANGED — this only toggles the post-commit notify, not who may convene.
+  notifyParents: z.boolean().optional().default(true),
 });
 
 /** Keep only the ids that are active staff of the school (drop any injected non-staff id). */
@@ -166,7 +249,11 @@ export async function conveneMeeting(input: unknown): Promise<Result> {
   const { school, user } = await requireSchool();
   const actor = await resolveActor(school.id);
   const today = new Date().toISOString().slice(0, 10);
+  const notifiedAt = new Date(); // the convene instant — the parents_notified_at stamp when notifyParents
   let newId: string | null = null;
+  // #253 post-commit fence: intents collected INSIDE the tx, flushed AFTER it resolves (rollback → the tx
+  // rejects before the flush line, so nothing is ever sent).
+  const sms: SmsIntent[] = [];
   try {
     const res = await withSchool(school.id, async (tx): Promise<Result> => {
       const [p] = await tx
@@ -174,6 +261,10 @@ export async function conveneMeeting(input: unknown): Promise<Result> {
           id: ptas.id,
           tierType: ptas.tierType,
           status: ptas.status,
+          classId: ptas.classId,
+          houseId: ptas.houseId,
+          className: classes.name,
+          houseName: houses.name,
           classTeacherUserId: classes.classTeacherUserId,
           hmUserId: houses.hmUserId,
           tierSettings: ptaTiersConfig.tierSettings,
@@ -213,6 +304,7 @@ export async function conveneMeeting(input: unknown): Promise<Result> {
           agendaJson: normaliseAgenda(d.agendaItems.map((text) => ({ text }))),
           invitedTeacherUserIds: invited,
           convenedByUserId: actor.id ?? undefined,
+          parentsNotifiedAt: d.notifyParents ? notifiedAt : null,
         })
         .returning({ id: ptaMeeting.id });
       newId = row.id;
@@ -226,9 +318,25 @@ export async function conveneMeeting(input: unknown): Promise<Result> {
         after: { ptaId: d.ptaId, meetingType: d.meetingType, meetingDate: d.meetingDate, academicPeriodId: periodId },
         reason: "PTA meeting convened",
       });
+      // #297 · State-1 console-notify: collect the parent-roster invite intents INSIDE the tx (flushed
+      // post-commit). Staff invitees are NOT SMS'd in State-1. Audience = the scope's PRIMARY guardians.
+      if (d.notifyParents) {
+        await collectParentNotify(sms, tx, {
+          schoolId: school.id,
+          actor,
+          meetingId: row.id,
+          schoolName: school.name,
+          ptaLabel: convenedPtaLabel(scope.tierType, p.className, p.houseName),
+          tierType: scope.tierType,
+          classId: p.classId,
+          houseId: p.houseId,
+          d,
+        });
+      }
       return { ok: true };
     });
     if (!res.ok) return res;
+    await flushSms(sms); // #253 — delivered ONLY after the tx committed (rollback rejects before here)
     safeRevalidate(LIST_PATH);
     if (newId) safeRevalidate(registerPath(newId));
     return { ok: true, meetingId: newId ?? undefined };
@@ -249,7 +357,9 @@ export async function conveneEmergencyMeeting(input: unknown): Promise<Result> {
   const { school, user } = await requireSchool();
   const actor = await resolveActor(school.id);
   const today = new Date().toISOString().slice(0, 10);
+  const notifiedAt = new Date(); // the convene instant — the parents_notified_at stamp when notifyParents
   let newId: string | null = null;
+  const sms: SmsIntent[] = []; // #253 post-commit fence — collected in-tx, flushed after commit
   try {
     const res = await withSchool(school.id, async (tx): Promise<Result> => {
       // Convener gate (R440): break-glass ∥ the GENERAL PTA "Chair" BY IDENTITY (a stored office).
@@ -318,6 +428,7 @@ export async function conveneEmergencyMeeting(input: unknown): Promise<Result> {
           agendaJson: normaliseAgenda(d.agendaItems.map((text) => ({ text }))),
           invitedTeacherUserIds: invited,
           convenedByUserId: actor.id ?? undefined,
+          parentsNotifiedAt: d.notifyParents ? notifiedAt : null,
         })
         .returning({ id: ptaMeeting.id });
       newId = row.id;
@@ -331,9 +442,24 @@ export async function conveneEmergencyMeeting(input: unknown): Promise<Result> {
         after: { ptaId: ptaRow.id, meetingType: d.meetingType, meetingDate: d.meetingDate, emergency: true },
         reason: "Emergency PTA meeting convened",
       });
+      // #297 · State-1 console-notify. EMERGENCY scope → all active students' primary guardians.
+      if (d.notifyParents) {
+        await collectParentNotify(sms, tx, {
+          schoolId: school.id,
+          actor,
+          meetingId: row.id,
+          schoolName: school.name,
+          ptaLabel: convenedPtaLabel("EMERGENCY", null, null),
+          tierType: "EMERGENCY",
+          classId: null,
+          houseId: null,
+          d,
+        });
+      }
       return { ok: true };
     });
     if (!res.ok) return res;
+    await flushSms(sms); // #253 — delivered ONLY after the tx committed (rollback rejects before here)
     safeRevalidate(LIST_PATH);
     if (newId) safeRevalidate(registerPath(newId));
     return { ok: true, meetingId: newId ?? undefined };

--- a/omnischools/lib/pdf/pta-officer-roster-document.tsx
+++ b/omnischools/lib/pdf/pta-officer-roster-document.tsx
@@ -1,0 +1,266 @@
+import React from "react";
+import { Document, Page, View, Text, StyleSheet } from "@react-pdf/renderer";
+import { SERIF, SANS, MONO } from "./fonts";
+import type { OfficeRow, OfficersMatrix, PtaCard } from "@/lib/pta/officers";
+
+/**
+ * The PTA OFFICER ROSTER PDF (SHS module 4.7 · #297) — a print rendering of the /senior/pta/officers
+ * matrix for a governance file. Board-pack pattern: it is fed the ALREADY-COMPOSED `OfficersMatrix`
+ * verbatim (the same shape the on-screen matrix renders), so every field the page shows the document
+ * shows — office, holder NAME, person-type, basis, term label, electionRef, vacancy markers and the
+ * multi-hat "+N" — and NOTHING else.
+ *
+ * 🔴 PII FENCE (#297 · owner-ratified: roster only, NO contact). `OfficersMatrix` carries no officer
+ * phone / email / address / studentGuardians field at all, so this presentational component structurally
+ * cannot render contact PII — a mutation that reached for one would not compile (the field is absent from
+ * the type). The pta-officer-roster.test.ts grep-guard re-asserts it at the source level.
+ *
+ * Honest absence (never fabricate a holder): a VACANT / EX_OFFICIO_VACANT / holderless-APPENDED_EX row
+ * prints a vacancy marker, never a name; a school with zero active PTAs prints a valid one-page
+ * "none configured" note (no 500). Core PDF fonts stand in for the brand faces (fonts.ts follow-up).
+ */
+
+// design tokens (hex; @react-pdf can't use CSS vars)
+const NAVY = "#1A2B47";
+const NAVY2 = "#2D3F5C";
+const NAVY3 = "#5C6675";
+const GOLD = "#C8975B";
+const GOLD_SOFT = "#E8D4B8";
+const GOLD_BG = "#F5EBDC";
+const GREEN = "#2F6B47";
+const GREEN_BG = "#E5EFE8";
+const TERRA = "#B84A39";
+const BORDER = "#E5DFD3";
+
+export interface PtaOfficerRosterData {
+  /** The composed matrix verbatim — the SAME shape the on-screen page renders (roster fields only). */
+  matrix: OfficersMatrix;
+  meta: {
+    schoolName: string;
+    schoolInitials: string;
+    generatedAtLabel: string; // route-formatted (school tz/locale never reaches the doc)
+  };
+}
+
+const s = StyleSheet.create({
+  page: { backgroundColor: "#FFFFFF", fontFamily: SANS, fontSize: 10, color: NAVY, paddingBottom: 44, paddingTop: 10 },
+  strip: { position: "absolute", top: 0, left: 0, right: 0, height: 6, backgroundColor: GOLD },
+
+  cover: {
+    backgroundColor: GOLD_BG,
+    borderBottomWidth: 1,
+    borderColor: GOLD_SOFT,
+    alignItems: "center",
+    paddingHorizontal: 40,
+    paddingTop: 20,
+    paddingBottom: 18,
+  },
+  mark: { width: 46, height: 46, backgroundColor: NAVY, borderRadius: 8, alignItems: "center", justifyContent: "center", marginBottom: 10 },
+  markText: { fontFamily: SERIF, fontWeight: "bold", fontSize: 18, color: GOLD },
+  coverSchool: { fontFamily: SERIF, fontWeight: "bold", fontSize: 22, color: NAVY, textAlign: "center" },
+  coverTitle: { fontFamily: SERIF, fontSize: 13, color: NAVY, marginTop: 6, textAlign: "center" },
+  coverGold: { color: GOLD },
+  coverGen: { fontSize: 8.5, color: NAVY3, marginTop: 6 },
+  coverFraming: { fontSize: 9, color: NAVY3, marginTop: 6, textAlign: "center" },
+
+  body: { paddingHorizontal: 40, paddingTop: 14 },
+
+  sectionHead: { flexDirection: "row", justifyContent: "space-between", alignItems: "flex-end", marginTop: 12, marginBottom: 6 },
+  sectionTitle: { fontFamily: SERIF, fontSize: 14, color: NAVY },
+  sectionMeta: { fontSize: 8.5, color: NAVY3 },
+
+  // one PTA card
+  card: { borderWidth: 1, borderColor: BORDER, borderRadius: 6, marginBottom: 8 },
+  cardHead: { flexDirection: "row", justifyContent: "space-between", alignItems: "center", backgroundColor: GREEN_BG, borderBottomWidth: 1, borderColor: BORDER, paddingHorizontal: 10, paddingVertical: 6 },
+  cardLabel: { fontFamily: SERIF, fontSize: 11, fontWeight: "bold", color: NAVY },
+  cardScope: { fontSize: 8, color: NAVY3 },
+  cardCount: { fontFamily: MONO, fontSize: 8.5, color: NAVY2 },
+
+  row: { flexDirection: "row", borderBottomWidth: 0.5, borderColor: BORDER, paddingHorizontal: 10, paddingVertical: 5 },
+  rowLast: { borderBottomWidth: 0 },
+  cOffice: { width: "22%", paddingRight: 6 },
+  cHolder: { width: "34%", paddingRight: 6 },
+  cBasis: { width: "18%", paddingRight: 6 },
+  cTerm: { width: "26%" },
+
+  office: { fontSize: 9.5, fontWeight: "bold", color: NAVY },
+  exTag: { fontSize: 7.5, color: GOLD },
+  holder: { fontSize: 9.5, color: NAVY2 },
+  vacant: { fontSize: 9.5, color: TERRA, fontStyle: "italic" },
+  meta: { fontSize: 7.5, color: NAVY3 },
+  mono: { fontFamily: MONO, fontSize: 8, color: NAVY3 },
+
+  emptyPanel: { borderWidth: 1, borderColor: BORDER, borderRadius: 6, padding: 16, marginTop: 16 },
+  emptyText: { fontSize: 10, color: NAVY3, lineHeight: 1.5 },
+
+  footer: {
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    right: 0,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    paddingHorizontal: 40,
+    paddingVertical: 12,
+    borderTopWidth: 1,
+    borderTopColor: BORDER,
+  },
+  footerText: { fontSize: 7.5, color: NAVY3, letterSpacing: 0.4 },
+  goldEm: { color: GOLD, fontWeight: "bold" },
+});
+
+/** The holder cell: an honest vacancy marker or the composed holder name + display tags (roster only). */
+function HolderCell({ row }: { row: OfficeRow }) {
+  const isVacant = row.kind === "VACANT";
+  const isExVacant = row.kind === "EX_OFFICIO_VACANT" || (row.kind === "APPENDED_EX" && !row.holderName);
+  if (isVacant) {
+    return (
+      <View style={s.cHolder}>
+        <Text style={s.vacant}>Vacant</Text>
+        {row.previousHolder ? (
+          <Text style={s.meta}>
+            previously {row.previousHolder}
+            {row.vacantSince ? ` · since ${row.vacantSince}` : ""}
+          </Text>
+        ) : null}
+      </View>
+    );
+  }
+  if (isExVacant) {
+    return (
+      <View style={s.cHolder}>
+        <Text style={s.vacant}>Not yet in post</Text>
+        <Text style={s.meta}>derives automatically once set</Text>
+      </View>
+    );
+  }
+  return (
+    <View style={s.cHolder}>
+      <Text style={s.holder}>{row.holderName}</Text>
+      <Text style={s.meta}>
+        {row.personType ? row.personType : "—"}
+        {row.otherHatCount > 0 ? ` · +${row.otherHatCount} other PTA role${row.otherHatCount === 1 ? "" : "s"}` : ""}
+      </Text>
+    </View>
+  );
+}
+
+function OfficeLine({ row, last }: { row: OfficeRow; last: boolean }) {
+  const exOfficio = row.kind === "EX_OFFICIO" || row.kind === "APPENDED_EX";
+  return (
+    <View style={[s.row, last ? s.rowLast : {}]} wrap={false}>
+      <View style={s.cOffice}>
+        <Text style={s.office}>{row.office}</Text>
+        {exOfficio ? <Text style={s.exTag}>ex-officio</Text> : null}
+      </View>
+      <HolderCell row={row} />
+      <View style={s.cBasis}>
+        <Text style={s.meta}>{row.basisLabel ?? (exOfficio ? "Derived" : "—")}</Text>
+        {row.electionRef ? <Text style={s.mono}>{row.electionRef}</Text> : null}
+      </View>
+      <View style={s.cTerm}>
+        <Text style={s.meta}>{row.termLabel ?? "—"}</Text>
+      </View>
+    </View>
+  );
+}
+
+function OfficerCard({ card }: { card: PtaCard }) {
+  return (
+    <View style={s.card} wrap={false}>
+      <View style={s.cardHead}>
+        <View>
+          <Text style={s.cardLabel}>{card.label}</Text>
+          {card.scopeBadge ? <Text style={s.cardScope}>{card.scopeBadge}</Text> : null}
+        </View>
+        <Text style={s.cardCount}>
+          {card.filled}/{card.total} filled
+        </Text>
+      </View>
+      {card.rows.map((row, i) => (
+        <OfficeLine key={`${row.office}-${i}`} row={row} last={i === card.rows.length - 1} />
+      ))}
+    </View>
+  );
+}
+
+function Section({ title, meta, cards }: { title: string; meta: string; cards: PtaCard[] }) {
+  if (cards.length === 0) return null;
+  return (
+    <View>
+      <View style={s.sectionHead}>
+        <Text style={s.sectionTitle}>{title}</Text>
+        <Text style={s.sectionMeta}>{meta}</Text>
+      </View>
+      {cards.map((c) => (
+        <OfficerCard key={c.id} card={c} />
+      ))}
+    </View>
+  );
+}
+
+export function PtaOfficerRosterDocument({ data }: { data: PtaOfficerRosterData }) {
+  const { matrix, meta } = data;
+  const empty = matrix.general === null && matrix.houses.length === 0 && matrix.forms.length === 0;
+  return (
+    <Document
+      title={`PTA Officer Roster — ${meta.schoolName}`}
+      author="Omnischools"
+      subject="PTA officer roster"
+    >
+      <Page size="A4" style={s.page}>
+        <View style={s.strip} fixed />
+
+        <View style={s.cover}>
+          <View style={s.mark}>
+            <Text style={s.markText}>{meta.schoolInitials}</Text>
+          </View>
+          <Text style={s.coverSchool}>{meta.schoolName}</Text>
+          <Text style={s.coverTitle}>
+            PTA Officer <Text style={s.coverGold}>Roster</Text>
+          </Text>
+          <Text style={s.coverGen}>Generated {meta.generatedAtLabel}</Text>
+          <Text style={s.coverFraming}>
+            Governance roster · offices, holders and terms only. No contact details.
+          </Text>
+        </View>
+
+        <View style={s.body}>
+          {empty ? (
+            <View style={s.emptyPanel}>
+              <Text style={s.emptyText}>
+                No active PTAs are configured for this school yet. Configure the tiers and run Generate on
+                the PTA Setup tab, then assign officers — the roster will populate here.
+              </Text>
+            </View>
+          ) : (
+            <>
+              {matrix.general ? <Section title="General PTA" meta="Executive" cards={[matrix.general]} /> : null}
+              <Section
+                title="House PTAs"
+                meta={`${matrix.totals.houses.filled}/${matrix.totals.houses.total} filled`}
+                cards={matrix.houses}
+              />
+              <Section
+                title="Form PTAs"
+                meta={`${matrix.totals.forms.filled}/${matrix.totals.forms.total} filled`}
+                cards={matrix.forms}
+              />
+            </>
+          )}
+        </View>
+
+        <View style={s.footer} fixed>
+          <Text style={s.footerText}>
+            Prepared on <Text style={s.goldEm}>Omnischools</Text> · the school management platform
+          </Text>
+          <Text
+            style={s.footerText}
+            render={({ pageNumber, totalPages }) => `${meta.schoolName} · PTA officers · ${pageNumber}/${totalPages}`}
+            fixed
+          />
+        </View>
+      </Page>
+    </Document>
+  );
+}

--- a/omnischools/lib/pdf/pta-officer-roster.test.ts
+++ b/omnischools/lib/pdf/pta-officer-roster.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import { readCode } from "@/lib/test-utils/source-shape";
+import { renderPtaOfficerRosterPdf } from "./render-pta-officer-roster";
+import { PtaOfficerRosterDocument } from "./pta-officer-roster-document";
+import type { PtaOfficerRosterData } from "./pta-officer-roster-document";
+import {
+  composeMatrix,
+  type OfficersMatrix,
+  type PtaComposeInput,
+  type StoredOfficer,
+} from "@/lib/pta/officers";
+
+/**
+ * #297 · Capability A — the PTA officer-roster PDF. The route + document are the OFFICER-CONTACT fence:
+ * the ONLY data source is the composed `OfficersMatrix` (no phone/email/address field exists on it), so
+ * this suite grep-guards both source files for a contact-PII reach AND renders the empty / all-vacant /
+ * populated matrices to prove the document never throws and never fabricates a holder. The @react-pdf
+ * render runs in Node here (the fuller build guarantee is `next build` compiling the route).
+ */
+
+const ROUTE = "app/api/senior/pta/officers/route.ts";
+const DOC = "lib/pdf/pta-officer-roster-document.tsx";
+
+const meta = { schoolName: "Asankrangwa SHS", schoolInitials: "AS", generatedAtLabel: "19 Aug 2026 · 12:00" };
+const EMPTY: OfficersMatrix = {
+  general: null,
+  houses: [],
+  forms: [],
+  multiHat: [],
+  totals: { houses: { filled: 0, total: 0 }, forms: { filled: 0, total: 0 } },
+};
+
+const generalInput: PtaComposeInput = {
+  id: "gen",
+  tierType: "GENERAL",
+  label: "General PTA",
+  scopeBadge: null,
+  officerRoles: ["Chair", "Secretary", "Treasurer"],
+  tierSettings: {},
+  exOfficioSecretaryName: null,
+  headmasterNames: ["Dr Ama Head"],
+};
+const formInput: PtaComposeInput = {
+  id: "form1",
+  tierType: "FORM",
+  label: "Form 2 Science PTA",
+  scopeBadge: "32 students",
+  officerRoles: ["Chair", "Secretary", "Treasurer"],
+  tierSettings: {},
+  exOfficioSecretaryName: "Mr Kwesi Teacher", // ex-officio class teacher
+  headmasterNames: [],
+};
+const stored: StoredOfficer[] = [
+  {
+    id: "o1",
+    ptaId: "gen",
+    office: "Chair",
+    personUserId: "u1",
+    holderName: "Ama Aidoo",
+    personType: "parent",
+    assignmentBasis: "ELECTED",
+    electionRef: "AGM 2025 · minute 3.2",
+    termStart: "2025-01-01",
+    termEnd: "2027-01-01",
+  },
+];
+// General has one filled (Chair), rest vacant; Form has ex-officio Secretary + two vacancies.
+const POPULATED = composeMatrix([generalInput, formInput], stored, [], "2026-01-01");
+// Same inputs, NO stored officers → every electable office vacant, ex-officio still derived.
+const ALL_VACANT = composeMatrix([generalInput, formInput], [], [], "2026-01-01");
+
+// ── PII fence (owner-ratified: roster only, NO contact) ───────────────────────────────────────────
+describe("🔴 #297-A · the officer-roster PDF never reaches for officer contact PII", () => {
+  const CONTACT = [/\.phone\b/, /\.email\b/, /studentGuardians/, /\.address\b/];
+  it.each([ROUTE, DOC])("%s selects/renders no phone/email/address/studentGuardians", (rel) => {
+    const code = readCode(rel);
+    for (const pat of CONTACT) {
+      expect(code, `${rel} must not reach ${pat}`).not.toMatch(pat);
+    }
+  });
+
+  it("the ONLY data source is getPtaOfficerMatrix — no meeting/guardian reader is imported", () => {
+    const route = readCode(ROUTE);
+    expect(route).toContain("getPtaOfficerMatrix");
+    expect(route).not.toContain("getPtaMeeting");
+    expect(route).not.toContain("studentGuardians");
+  });
+});
+
+// ── the route gate + session-scoping ──────────────────────────────────────────────────────────────
+describe("🔴 #297-A · the route is ADMIN-gated (read == manage) and session-scoped", () => {
+  const route = readCode(ROUTE);
+
+  it("gates on requireSchoolRole(PTA_CONFIG_WRITE_ROLES) — the SAME gate as the officers page", () => {
+    expect(route).toMatch(/requireSchoolRole\(\s*PTA_CONFIG_WRITE_ROLES\s*\)/);
+  });
+
+  it("keys on the SESSION school id — never a query/body school id (no cross-tenant export)", () => {
+    expect(route).toMatch(/getPtaOfficerMatrix\(\s*school\.id\s*\)/);
+    expect(route).not.toMatch(/searchParams/);
+    expect(route).not.toMatch(/schoolId/);
+  });
+
+  it("returns an inline PDF with private, no-store caching, on the Node runtime", () => {
+    expect(route).toMatch(/application\/pdf/);
+    expect(route).toMatch(/inline; filename=/);
+    expect(route).toMatch(/private, no-store/);
+    expect(route).toMatch(/runtime\s*=\s*["'`]nodejs["'`]/);
+  });
+
+  it("is a GET-only download — no POST/PUT/PATCH", () => {
+    expect(route).toMatch(/export async function GET/);
+    expect(route).not.toMatch(/export async function (POST|PUT|PATCH)/);
+  });
+});
+
+// ── render: empty / all-vacant / populated all produce a valid one-page PDF, no throw ───────────────
+describe("🔴 #297-A · the document renders every roster state without throwing", () => {
+  const data = (matrix: OfficersMatrix): PtaOfficerRosterData => ({ matrix, meta });
+
+  it("zero active PTAs → a valid one-page 'none configured' PDF (never a 500)", async () => {
+    const pdf = await renderPtaOfficerRosterPdf(data(EMPTY));
+    expect(pdf.length).toBeGreaterThan(1000);
+  });
+
+  it("an all-vacant matrix renders vacant slots (ex-officio still derived), no fabricated holder", async () => {
+    const pdf = await renderPtaOfficerRosterPdf(data(ALL_VACANT));
+    expect(pdf.length).toBeGreaterThan(1000);
+  });
+
+  it("a populated matrix renders — and differs in bytes from empty (the doc reflects the data)", async () => {
+    const populated = await renderPtaOfficerRosterPdf(data(POPULATED));
+    const empty = await renderPtaOfficerRosterPdf(data(EMPTY));
+    expect(populated.length).toBeGreaterThan(1000);
+    expect(populated.toString("latin1")).not.toEqual(empty.toString("latin1"));
+  }, 20_000);
+
+  it("the composed matrix carries a real holder for the filled office and no holder for a vacancy", () => {
+    // sanity on the fixture: Chair is STORED with the parent holder; Secretary/Treasurer are VACANT.
+    const chair = POPULATED.general!.rows.find((r) => r.office === "Chair")!;
+    expect(chair.kind).toBe("STORED");
+    expect(chair.holderName).toBe("Ama Aidoo");
+    const treasurer = POPULATED.general!.rows.find((r) => r.office === "Treasurer")!;
+    expect(treasurer.kind).toBe("VACANT");
+    expect(treasurer.holderName).toBeNull();
+  });
+
+  it("the document element carries NO contact prop path — it renders only roster fields", () => {
+    // Rendering the tree with a contact-bearing matrix cannot leak: the shape has no such field. This
+    // exercises the branch structure (empty flag + sections) without asserting compressed byte content.
+    const el = PtaOfficerRosterDocument({ data: data(POPULATED) });
+    expect(el).toBeTruthy();
+  });
+});

--- a/omnischools/lib/pdf/render-pta-officer-roster.tsx
+++ b/omnischools/lib/pdf/render-pta-officer-roster.tsx
@@ -1,0 +1,9 @@
+import "server-only";
+import React from "react";
+import { renderToBuffer } from "@react-pdf/renderer";
+import { PtaOfficerRosterDocument, type PtaOfficerRosterData } from "./pta-officer-roster-document";
+
+/** Render the PTA officer roster to a PDF Buffer (Node runtime only). Mirrors render-board-pack. */
+export function renderPtaOfficerRosterPdf(data: PtaOfficerRosterData): Promise<Buffer> {
+  return renderToBuffer(<PtaOfficerRosterDocument data={data} />);
+}

--- a/omnischools/lib/pta/meeting-data.ts
+++ b/omnischools/lib/pta/meeting-data.ts
@@ -292,6 +292,39 @@ export async function loadMeetingScope(
   };
 }
 
+/**
+ * The PARENT-notify audience for a meeting scope (#297 · State-1 console-notify): the SAME primary-
+ * guardian roster the register's PARENT column derives (R436), reduced to DEDUPED, non-null phone
+ * numbers. FORM→class, HOUSE→house, GENERAL/EMERGENCY→all active students' primary guardians (no scope
+ * filter). Runs inside the caller's convene tx; the convener collects each phone as a post-commit
+ * SmsIntent (a rollback discards them). One SMS per distinct number (dedupe by phone); a guardian with no
+ * phone is silently skipped.
+ */
+export async function loadMeetingNotifyPhones(
+  tx: Tx,
+  schoolId: string,
+  scope: { tierType: PtaTierType; classId: string | null; houseId: string | null },
+): Promise<string[]> {
+  const conds = [
+    eq(students.schoolId, schoolId),
+    eq(students.status, "ACTIVE"),
+    eq(studentGuardians.isPrimary, true),
+  ];
+  if (scope.tierType === "FORM" && scope.classId) conds.push(eq(students.classId, scope.classId));
+  else if (scope.tierType === "HOUSE" && scope.houseId) conds.push(eq(students.houseId, scope.houseId));
+  const rows = await tx
+    .select({ phone: studentGuardians.phone })
+    .from(studentGuardians)
+    .innerJoin(students, and(eq(students.schoolId, studentGuardians.schoolId), eq(students.id, studentGuardians.studentId)))
+    .where(and(...conds));
+  const phones = new Set<string>();
+  for (const r of rows) {
+    const p = r.phone?.trim();
+    if (p) phones.add(p);
+  }
+  return [...phones];
+}
+
 const tierLabelOf = (t: PtaTierType): string =>
   t === "FORM" ? "Form PTA" : t === "HOUSE" ? "House PTA" : t === "EMERGENCY" ? "Emergency PTA" : "General PTA";
 const iconInitialsOf = (t: PtaTierType): string =>

--- a/omnischools/lib/pta/meeting-invite-sms.test.ts
+++ b/omnischools/lib/pta/meeting-invite-sms.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { ptaMeetingInviteSms, type PtaMeetingInviteInput } from "./meeting-invite-sms";
+import { smsSegments } from "@/lib/sms";
+
+/**
+ * #297 · the PURE PTA meeting-invite SMS body. Meeting-details-only, GSM-7, ≤2 segments — proven here so
+ * the console notify path can never smuggle a payment link / dues figure / RSVP instruction into the body.
+ */
+
+const base: PtaMeetingInviteInput = {
+  schoolName: "Asankrangwa SHS",
+  ptaLabel: "Form 2 Science PTA",
+  meetingType: "Regular PTA meeting",
+  dateLabel: "Thu 14 May 2026",
+  startTime: "10:00",
+  endTime: "12:00",
+  location: "Block C, room 4",
+};
+
+const isGsm7 = (s: string) => [...s].every((c) => c.charCodeAt(0) < 128);
+
+describe("#297 · ptaMeetingInviteSms — meeting details only", () => {
+  it("carries the school, PTA, type, date, time and location", () => {
+    const body = ptaMeetingInviteSms(base);
+    expect(body).toContain("Asankrangwa SHS");
+    expect(body).toContain("Form 2 Science PTA");
+    expect(body).toContain("Regular PTA meeting");
+    expect(body).toContain("Thu 14 May 2026");
+    expect(body).toContain("10:00-12:00");
+    expect(body).toContain("Block C, room 4");
+  });
+
+  it("omits the location clause when there is no location", () => {
+    const body = ptaMeetingInviteSms({ ...base, location: null });
+    expect(body).not.toContain(" at ");
+    expect(body).toContain("Please attend.");
+  });
+
+  it("is GSM-7 (plain ASCII — no em-dash / smart quotes)", () => {
+    expect(isGsm7(ptaMeetingInviteSms(base))).toBe(true);
+    expect(ptaMeetingInviteSms(base)).not.toMatch(/[—“”‘’]/);
+  });
+
+  it("is at most TWO GSM-7 segments (bounded cost)", () => {
+    expect(smsSegments(ptaMeetingInviteSms(base))).toBeLessThanOrEqual(2);
+    expect(smsSegments(ptaMeetingInviteSms({ ...base, location: null }))).toBeLessThanOrEqual(2);
+  });
+
+  it("stays ≤2 segments even with a maximal type + location (drops location, then hard-caps)", () => {
+    const body = ptaMeetingInviteSms({
+      ...base,
+      schoolName: "A".repeat(120),
+      meetingType: "T".repeat(120),
+      location: "L".repeat(200),
+    });
+    expect(smsSegments(body)).toBeLessThanOrEqual(2);
+    expect(body.length).toBeLessThanOrEqual(306);
+  });
+
+  it("carries NO payment link, dues figure or RSVP instruction (scope fence)", () => {
+    const body = ptaMeetingInviteSms(base);
+    for (const banned of [/GHS/i, /https?:\/\//, /\bRSVP\b/i, /\breply\b/i, /\bdues\b/i, /\bpay\b/i]) {
+      expect(body, `must not contain ${banned}`).not.toMatch(banned);
+    }
+  });
+});

--- a/omnischools/lib/pta/meeting-invite-sms.ts
+++ b/omnischools/lib/pta/meeting-invite-sms.ts
@@ -1,0 +1,34 @@
+/**
+ * PTA meeting-invite SMS body — PURE, DB-free, unit-tested (meeting-invite-sms.test.ts). The #297
+ * State-1 console-notify counterpart to boarding's arrivalSms: `lib/actions/pta-meeting.ts` collects
+ * the parent-roster phones INSIDE its convene tx and, AFTER commit, pairs each with THIS body.
+ *
+ * 🔴 SCOPE FENCE (owner-ratified: send-only, no RSVP). Meeting details ONLY — NO payment link, NO dues
+ * figure, NO RSVP / reply-to instruction. GSM-7 (plain ASCII — no em-dash / smart quotes), capped at
+ * two segments so a bulk run's cost is bounded regardless of a long meeting type / location.
+ */
+
+/** Two GSM-7 segments = 153 × 2 chars (a single segment is 160; concatenation drops to 153 each). */
+const TWO_SEGMENT_CAP = 306;
+
+export interface PtaMeetingInviteInput {
+  schoolName: string;
+  ptaLabel: string; // "Form 2 Science PTA" / "General PTA" / "Emergency PTA"
+  meetingType: string; // the free-text display label
+  dateLabel: string; // pre-formatted ASCII date, e.g. "Thu 14 May 2026"
+  startTime: string; // "HH:MM"
+  endTime: string; // "HH:MM"
+  location: string | null;
+}
+
+export function ptaMeetingInviteSms(i: PtaMeetingInviteInput): string {
+  const build = (loc: string | null): string => {
+    const where = loc && loc.trim() ? ` at ${loc.trim()}` : "";
+    return `${i.schoolName}: ${i.ptaLabel} - ${i.meetingType} on ${i.dateLabel}, ${i.startTime}-${i.endTime}${where}. Please attend.`;
+  };
+  let body = build(i.location);
+  // Keep the two-segment invariant: drop the optional location first, then hard-cap (bounded inputs).
+  if (body.length > TWO_SEGMENT_CAP) body = build(null);
+  // ponytail: hard 2-seg slice as a last resort; representative Ghanaian labels never reach it.
+  return body.length > TWO_SEGMENT_CAP ? body.slice(0, TWO_SEGMENT_CAP) : body;
+}

--- a/omnischools/lib/sms/after-commit-253.test.ts
+++ b/omnischools/lib/sms/after-commit-253.test.ts
@@ -35,6 +35,7 @@ const SMS_CALLERS = [
   "lib/actions/invites.ts",
   "lib/actions/onboarding.ts",
   "lib/actions/inbox.ts",
+  "lib/actions/pta-meeting.ts",
   "lib/actions/staff.ts",
   "lib/actions/users.ts",
   "lib/actions/wassce-readiness.ts",


### PR DESCRIPTION
Closes #297.

**Officer roster PDF** — a new admin-gated download (`GET /api/senior/pta/officers`, `PTA_CONFIG_WRITE_ROLES` = Admin/Headmaster) rendering the PTA officer matrix (office, holder, person-type, basis, term, election ref, vacancies, multi-hat). **No contact PII** — the fence is structural: the officer-matrix type carries no phone/email/address field, so the document cannot render one. Board-pack pattern; the page's "Export" is a real `<a href="/api/*">`.

**State-1 console meeting-notify** — `conveneMeeting`/`conveneEmergencyMeeting` gain `notifyParents` (default on): the scope's primary guardians (deduped, non-null) get an invite SMS, **collected in-tx and flushed post-commit** (#253 — a rolled-back convene sends nothing), **console-only** (no live gateway), body carries meeting details only (no payment/RSVP). One SHOWN audit row records the recipient **count** + meeting id (no phone, no body). One nullable column `pta_meeting.parents_notified_at` (migration 0086) — on the already-RLS'd table, so **no new RLS / no prod-paste**.

**Gates (all green):** Quinn GREEN (2205 tests; post-commit fence mutation-proven). Dex APPROVE (faithful board-pack + #253 reuse; structural PII fence). Sarah CLEAN (PII fence, distinct gate, tenant isolation, console-only, no prod-paste).

Non-blocking note: the notify audience dedupes by phone and (unlike the on-screen register's teacher-wins exclusion) may SMS a staff member who is also a scope guardian — harmless for a send-only invite, no AC violation.