### PR TITLE
feat(auth): require-2FA-for-admins enforcement (default-off, fail-safe) — closes #254

### DIFF
--- a/omnischools/components/settings/security-form.tsx
+++ b/omnischools/components/settings/security-form.tsx
@@ -57,8 +57,9 @@ export function SecurityForm({
               Require two-factor for administrators
             </span>
             <span className="mt-0.5 block text-[12px] leading-relaxed text-navy-3">
-              Admins must confirm an SMS code on sign-in, in addition to their password. The
-              enrolment flow ships with the auth release; this records the requirement now.
+              Admins must confirm an SMS code on sign-in, in addition to their password. Takes
+              effect once phone-OTP sign-in is live — until then it stays recorded but inert, so
+              no admin is locked out.
             </span>
           </span>
         </label>

--- a/omnischools/lib/access.ts
+++ b/omnischools/lib/access.ts
@@ -94,6 +94,26 @@ export const INSIGHTS_READ_ROLES = [
 ] as const satisfies readonly KnownAppRole[];
 
 /**
+ * 🔴 INCR-254 (deferred half) — the "administrators" the school's "Require two-factor for
+ * administrators" security setting (ref_school.require_2fa) applies to: when that setting is ON, a
+ * member of this set must complete a phone-OTP factor in their session (not password-only) or be sent
+ * to step-up. The school's leadership/admin tier — ADMIN + HEADMASTER + PROPRIETOR — matching the
+ * setting copy ("administrators").
+ *
+ * A DISTINCT, purpose-named gate whose membership happens to match STAFF_ADMIN_ROLES / USER_ADMIN_ROLES
+ * / INSIGHTS_READ_ROLES today but is SEMANTICALLY SEPARATE ("who must 2FA when required", not "who mints
+ * administrators" / "who runs login-lifecycle verbs" / "who reads director analytics"). Naming it apart
+ * is the standing discipline that keeps widening one gate from silently widening another
+ * ([[builds-widen-ratified-authz-and-self-bless]]) — do NOT collapse it into a sibling. `as const
+ * satisfies` makes a typo'd code a compile error.
+ */
+export const TWO_FACTOR_ADMIN_ROLES = [
+  "ADMIN",
+  "HEADMASTER",
+  "PROPRIETOR",
+] as const satisfies readonly KnownAppRole[];
+
+/**
  * Senior (SHS) tier role groups. The score ledger is a teaching surface (teachers + form
  * masters + academic leadership); the Vice Headmaster progress view is management-only
  * (Admin, Headmaster, Vice Headmaster Academic). STUDENT / PARENT never reach either.

--- a/omnischools/lib/auth/enforce-two-factor.test.ts
+++ b/omnischools/lib/auth/enforce-two-factor.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * INCR-254 (deferred half) — end-to-end proof that `requireSchool()` enforces the "Require two-factor
+ * for administrators" setting (ref_school.require_2fa): a password-only ADMIN is bounced to
+ * `/login?stepup=1` ONLY when OTP is deliverable; otherwise (the NO-LOCKOUT case) it is admitted. Mocks
+ * mirror enforce-session-age.test.ts — identity/redirect/headers/school-read stubbed, redirect asserted
+ * from a thrown `REDIRECT:<url>` sentinel. session_hours is null throughout so session-age never fires.
+ */
+
+vi.mock("@/lib/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/auth")>();
+  return {
+    ...actual,
+    getCurrentUser: vi.fn(),
+    authIsLive: vi.fn(() => true),
+    sessionLoginAtMs: vi.fn(async () => Date.now()), // fresh — session-age inert (sessionHours null anyway)
+    sessionAuthMethods: vi.fn(),
+    otpLoginRequired: vi.fn(),
+  };
+});
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  }),
+}));
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => new Map([["x-pathname", "/dashboard"]])),
+}));
+
+const schoolRow = {
+  id: "sch-1",
+  name: "Test SHS",
+  shortName: null,
+  gesCode: "WR-X-001",
+  schoolType: "SENIOR",
+  sessionHours: null as number | null,
+  require2fa: true as boolean | null,
+  districtName: null,
+  regionName: null,
+};
+vi.mock("@/lib/db/rls", () => ({
+  withoutTenantScope: vi.fn(async () => schoolRow),
+  withSchool: vi.fn(),
+}));
+
+import {
+  getCurrentUser,
+  sessionAuthMethods,
+  otpLoginRequired,
+  type AppUser,
+} from "@/lib/auth";
+import { requireSchool } from "@/lib/auth/server";
+
+const admin: AppUser = { id: "u-1", phone: "+233200000000", roles: ["ADMIN"], schoolId: "sch-1" };
+const teacher: AppUser = { id: "u-2", phone: "+233200000001", roles: ["TEACHER"], schoolId: "sch-1" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  schoolRow.require2fa = true;
+  schoolRow.sessionHours = null;
+  vi.mocked(getCurrentUser).mockResolvedValue(admin);
+  vi.mocked(otpLoginRequired).mockReturnValue(true);
+  vi.mocked(sessionAuthMethods).mockResolvedValue(["password"]);
+});
+
+describe("requireSchool enforces require-2FA-for-admins", () => {
+  it("redirects a password-only admin to step-up when OTP is deliverable", async () => {
+    await expect(requireSchool()).rejects.toThrow("REDIRECT:/login?stepup=1");
+  });
+
+  it("passes an admin whose session already completed OTP", async () => {
+    vi.mocked(sessionAuthMethods).mockResolvedValue(["otp"]);
+    const { school } = await requireSchool();
+    expect(school.id).toBe("sch-1");
+  });
+
+  it("🔴 NO-LOCKOUT: a password-only admin is NOT blocked when OTP is undeliverable", async () => {
+    vi.mocked(otpLoginRequired).mockReturnValue(false);
+    const { school } = await requireSchool();
+    expect(school.id).toBe("sch-1");
+    // fail-safe won BEFORE touching the session (short-circuit is fine, but the point is: no redirect)
+  });
+
+  it("never enforces a non-admin (teacher passes even password-only) — and skips the amr read", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(teacher);
+    const { school } = await requireSchool();
+    expect(school.id).toBe("sch-1");
+    expect(sessionAuthMethods).not.toHaveBeenCalled();
+  });
+
+  it("no enforcement when the setting is off — never reads the session amr", async () => {
+    schoolRow.require2fa = false;
+    const { school } = await requireSchool();
+    expect(school.id).toBe("sch-1");
+    expect(sessionAuthMethods).not.toHaveBeenCalled();
+  });
+});

--- a/omnischools/lib/auth/server.ts
+++ b/omnischools/lib/auth/server.ts
@@ -4,8 +4,17 @@ import { eq, and } from "drizzle-orm";
 import { env } from "@/lib/env";
 import { withoutTenantScope } from "@/lib/db/rls";
 import { schools, roleAssignments, roles, users, districts, regions } from "@/db/schema";
-import { getCurrentUser, authIsLive, sessionLoginAtMs, type AppUser, type AppRole } from "@/lib/auth";
+import {
+  getCurrentUser,
+  authIsLive,
+  sessionLoginAtMs,
+  sessionAuthMethods,
+  otpLoginRequired,
+  type AppUser,
+  type AppRole,
+} from "@/lib/auth";
 import { sessionAgeExceeded } from "@/lib/auth/session-age";
+import { twoFactorStepUpRequired } from "@/lib/auth/two-factor";
 import {
   isFinanceOnly,
   pathAllowedForFinance,
@@ -15,6 +24,7 @@ import {
   BOARD_HOME,
   hasAnyRole,
   isStaff,
+  TWO_FACTOR_ADMIN_ROLES,
 } from "@/lib/access";
 
 export interface ActiveSchool {
@@ -27,6 +37,8 @@ export interface ActiveSchool {
   location: string | null;
   /** "Session length" security setting (hours); null = the school never configured a limit. */
   sessionHours: number | null;
+  /** "Require two-factor for administrators" security setting; null/false = off (the default). */
+  require2fa: boolean | null;
 }
 
 /**
@@ -52,6 +64,7 @@ export async function getActiveSchool(forUser?: AppUser): Promise<ActiveSchool |
     gesCode: schools.gesCode,
     schoolType: schools.schoolType,
     sessionHours: schools.sessionHours,
+    require2fa: schools.require2fa,
     districtName: districts.name,
     regionName: regions.name,
   };
@@ -117,6 +130,40 @@ async function enforceSessionAge(school: ActiveSchool): Promise<void> {
   }
 }
 
+/**
+ * INCR-254 (deferred half) — enforce the school's "Require two-factor for administrators" setting
+ * (ref_school.require_2fa). When ON, a signed-in admin-tier user (TWO_FACTOR_ADMIN_ROLES) whose session
+ * completed only a password factor (no OTP in its `amr`) is sent to `/login?stepup=1` to re-authenticate
+ * through the EXISTING phone-OTP path (the login form defaults to its Phone-OTP tab; no new flow). The
+ * decision lives in the pure `twoFactorStepUpRequired`; this only reads the setting/roles/amr and redirects.
+ *
+ * 🔴 FAIL-SAFE (Sarah), the deliberate inverse of enforceSessionAge: enforcement fires ONLY when OTP is
+ * genuinely DELIVERABLE (`otpLoginRequired()` — the same gate that decides whether OTP is required at
+ * login). If OTP can't be delivered yet (pre-#260, SMS console-only), forcing it would permanently lock
+ * out the school's ONLY admins — so no-deliverable-OTP ⇒ do NOT block. Also inert under dev-bypass /
+ * `!authIsLive()` (both fold into `otpLoginRequired()` being false) and whenever the setting is off. The
+ * full reasoning + the amr-readability asymmetry are on `twoFactorStepUpRequired`.
+ *
+ * The cheap `!school.require2fa` short-circuit (default OFF for ~every school) skips the getSession()
+ * round-trip on the hot path; the pure fn re-checks it and remains the tested authority.
+ */
+async function enforceRequireTwoFactor(school: ActiveSchool, user: AppUser): Promise<void> {
+  if (!school.require2fa) return;
+  const isAdmin = hasAnyRole(user.roles, TWO_FACTOR_ADMIN_ROLES);
+  if (!isAdmin) return;
+  const amr = await sessionAuthMethods();
+  if (
+    twoFactorStepUpRequired({
+      require2fa: school.require2fa,
+      isAdmin,
+      otpDeliverable: otpLoginRequired(),
+      amr,
+    })
+  ) {
+    redirect("/login?stepup=1");
+  }
+}
+
 /** For app pages: ensure a signed-in user, else send to login. */
 export async function requireUser(): Promise<AppUser> {
   const user = await getCurrentUser();
@@ -168,6 +215,10 @@ export async function requireSchool(
   const school = await getActiveSchool(user);
   if (!school) redirect("/start");
   await enforceSessionAge(school);
+  // AFTER school-resolve, alongside session-age: an admin the school requires to 2FA but who is
+  // password-only is bounced to step-up. Fail-SAFE (never blocks when OTP is undeliverable) — see
+  // enforceRequireTwoFactor. Placed here so it covers every (app) page's own render, like the staff gate.
+  await enforceRequireTwoFactor(school, user);
   if (!opts?.allowNonStaff && !isStaff(user.roles)) {
     // A board-only session hitting a staff URL lands on its own read-only overview FIRST (GOV-2 / R334);
     // a parent has somewhere to be; a student-only session has no portal yet, and `/start` is the honest

--- a/omnischools/lib/auth/two-factor.test.ts
+++ b/omnischools/lib/auth/two-factor.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { twoFactorStepUpRequired, hasOtpFactor } from "./two-factor";
+
+/**
+ * INCR-254 (deferred half) — the pure decision surface for the "Require two-factor for administrators"
+ * setting (ref_school.require_2fa). The guard wiring is proven end-to-end in enforce-two-factor.test.ts.
+ * The load-bearing case is the NO-LOCKOUT / FAIL-SAFE one: an admin with no OTP is NOT blocked when OTP
+ * can't be delivered.
+ */
+
+describe("hasOtpFactor", () => {
+  it("true when the session completed a phone-OTP factor", () => {
+    expect(hasOtpFactor(["otp"])).toBe(true);
+    expect(hasOtpFactor(["password", "otp"])).toBe(true);
+    expect(hasOtpFactor(["OTP"])).toBe(true); // case-insensitive
+    expect(hasOtpFactor(["totp"])).toBe(true); // tolerant of a future MFA factor
+  });
+  it("false for a password-only session", () => {
+    expect(hasOtpFactor(["password"])).toBe(false);
+    expect(hasOtpFactor([])).toBe(false);
+  });
+});
+
+describe("twoFactorStepUpRequired — fail-SAFE 2FA gate", () => {
+  const base = { require2fa: true, isAdmin: true, otpDeliverable: true, amr: ["password"] };
+
+  it("no-op when the setting is off (off / null / undefined) — any user", () => {
+    expect(twoFactorStepUpRequired({ ...base, require2fa: false })).toBe(false);
+    expect(twoFactorStepUpRequired({ ...base, require2fa: null })).toBe(false);
+    expect(twoFactorStepUpRequired({ ...base, require2fa: undefined })).toBe(false);
+  });
+
+  it("no-op for a non-admin, even with the setting on and no OTP", () => {
+    expect(twoFactorStepUpRequired({ ...base, isAdmin: false })).toBe(false);
+  });
+
+  it("🔴 NO-LOCKOUT: an admin with no OTP is NOT blocked when OTP is undeliverable", () => {
+    // The whole safety mechanism — forcing an OTP that can't arrive would brick the school.
+    expect(twoFactorStepUpRequired({ ...base, otpDeliverable: false })).toBe(false);
+  });
+
+  it("blocks: setting on + admin + OTP deliverable + password-only session", () => {
+    expect(twoFactorStepUpRequired(base)).toBe(true);
+  });
+
+  it("passes: setting on + admin + OTP deliverable + session already did OTP", () => {
+    expect(twoFactorStepUpRequired({ ...base, amr: ["otp"] })).toBe(false);
+    expect(twoFactorStepUpRequired({ ...base, amr: ["password", "otp"] })).toBe(false);
+  });
+
+  it("blocks an unreadable amr when OTP is deliverable (safe — recoverable via the very step-up)", () => {
+    expect(twoFactorStepUpRequired({ ...base, amr: [] })).toBe(true);
+  });
+});

--- a/omnischools/lib/auth/two-factor.ts
+++ b/omnischools/lib/auth/two-factor.ts
@@ -1,0 +1,55 @@
+/**
+ * INCR-254 (deferred half) — the pure decision for a school's "Require two-factor for administrators"
+ * security setting (ref_school.require_2fa). Kept free of next/navigation + Supabase so the decision
+ * matrix (and the critical NO-LOCKOUT / fail-safe call) is unit-testable without a live session. The
+ * wiring (read the amr, read the setting, redirect) lives in lib/auth/server.ts::enforceRequireTwoFactor.
+ */
+
+/**
+ * The `amr` (Authentication Methods References) methods that count as a completed OTP factor. Our live
+ * login path is Supabase phone-OTP (`verifyOtp({ type: "sms" })`), which GoTrue records as method
+ * `"otp"`; the rest are tolerated so a future MFA/TOTP enrolment (or a GoTrue label change) still
+ * satisfies the requirement rather than silently forcing a redundant step-up.
+ * ponytail: small allow-list, widen only if a new second factor ships with a different amr label.
+ */
+export const OTP_AMR_METHODS = ["otp", "sms", "mfa", "totp"] as const;
+
+/** Did the session complete a phone-OTP (or MFA) factor, as opposed to password-only? */
+export function hasOtpFactor(amr: readonly string[]): boolean {
+  return amr.some((m) => (OTP_AMR_METHODS as readonly string[]).includes(m.toLowerCase()));
+}
+
+/**
+ * `true` ⇒ this signed-in session must be sent to complete phone-OTP (step-up) before it may use an
+ * admin surface. Fires ONLY when every condition holds:
+ *
+ *  - `require2fa` falsey (off / null / undefined) ⇒ false — the school never opted in (DEFAULT OFF).
+ *  - `!isAdmin`                                    ⇒ false — the setting only covers the admin tier.
+ *  - `!otpDeliverable`                             ⇒ false — 🔴 THE NO-LOCKOUT / FAIL-SAFE GATE.
+ *  - otherwise                                     ⇒ block unless the session already did OTP.
+ *
+ * 🔴 FAIL-SAFE, the deliberate INVERSE of `sessionAgeExceeded` (which fails CLOSED). `otpDeliverable`
+ * is `otpLoginRequired()` — the SAME gate that decides whether OTP is even required at login (auth live
+ * AND the SMS provider switched on). If OTP cannot actually be delivered (pre-#260: SMS/OTP still
+ * console-only), forcing an OTP that will never arrive would permanently LOCK OUT the school's only
+ * admins — a bricked school. A password-only admin session is a strictly better outcome than that, so
+ * here AVAILABILITY WINS: no deliverable OTP ⇒ do not block. (session-age can fail closed because its
+ * worst case is a harmless re-login; this must fail safe because its worst case is a lockout with no
+ * recovery path.) Default-OFF plus this gate is why shipping now is inert until the phone-OTP go-live.
+ *
+ * NOTE the asymmetry with amr-readability: when OTP *is* deliverable, an unreadable/absent amr (`[]`)
+ * DOES block — but that is safe, not a lockout, because the user can complete the very OTP we redirect
+ * them to. Deliverability, not amr-readability, is the lockout gate; so everything downstream of it
+ * stays strict.
+ */
+export function twoFactorStepUpRequired(a: {
+  require2fa: boolean | null | undefined;
+  isAdmin: boolean;
+  otpDeliverable: boolean;
+  amr: readonly string[];
+}): boolean {
+  if (!a.require2fa) return false;
+  if (!a.isAdmin) return false;
+  if (!a.otpDeliverable) return false; // no-lockout: never force an undeliverable OTP
+  return !hasOtpFactor(a.amr);
+}


### PR DESCRIPTION
**Closes #254** (the session-hours half merged in #330; this is the require-2FA half).

Enforces the previously-stored-but-inert "Require two-factor for administrators" setting (`ref_school.require_2fa`, default OFF). When a school turns it ON, an admin-tier user (`TWO_FACTOR_ADMIN_ROLES` = Admin/Headmaster/Proprietor — a distinct purpose-named gate) whose session hasn't completed an OTP factor is redirected to `/login?stepup=1` to complete it. Wired into `requireSchool` beside `enforceSessionAge`; pure decision in `lib/auth/two-factor.ts`, reusing the session-age `amr` infra.

### The load-bearing decision — fail-SAFE (no lockout)
Enforcement fires only when OTP is **actually deliverable** (`otpLoginRequired()` = auth-live AND `AUTH_OTP_LIVE`). If OTP can't be delivered (pre-#260, SMS console-only), it **does not block** — forcing an undeliverable OTP would permanently lock out a school's only admins. This is the deliberate inverse of session-age's fail-*closed* (session-age's worst case is a re-login; this one's is a bricked school). Default-off + this deliverability gate means it's **inert until the phone-OTP go-live (#260)** — safe to ship now.

**Gates (all green):** Sarah CLEAN (fail-safe is a correct posture, not a bypass — `otpDeliverable` is a server flag, not attacker-controllable; `amr` is signature-validated by `getUser()` before the guard). Quinn GREEN (7-point matrix; mutation-proven the fail-safe reds both no-lockout tests). Dex APPROVE (clean pure/impure seam mirroring session-age; total admin coverage, no double-enforce). **No schema, no prod-paste.**

Non-blocking: `stepup=1` (like the existing `expired=1`) isn't yet surfaced as a "complete 2FA" message on `/login` — a copy pass for the #260 go-live.