### PR TITLE
feat(boarding): prefect appointment workflow (#298 part A)

### DIFF
--- a/omnischools/components/boarding/roster-board.tsx
+++ b/omnischools/components/boarding/roster-board.tsx
@@ -1,10 +1,12 @@
 "use client";
 import { useMemo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { reassignBunk } from "@/lib/actions/boarding";
+import { reassignBunk, appointPrefect, revokePrefect } from "@/lib/actions/boarding";
 import {
   PREFECT_LABEL,
+  PREFECT_ORDER,
   type BunkState,
+  type PrefectRole,
   type PrefectSlot,
   type RosterDorm,
   type RosterOccupant,
@@ -49,15 +51,23 @@ export function RosterBoard({
   const [target, setTarget] = useState<{ bunkId: string; address: string } | null>(null);
   const [reason, setReason] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [apptError, setApptError] = useState<string | null>(null);
 
   const bunkById = useMemo(() => {
-    const m = new Map<string, { occupant: RosterOccupant | null; address: string }>();
+    const m = new Map<
+      string,
+      { occupant: RosterOccupant | null; address: string; prefectRole: PrefectRole | null }
+    >();
     for (const d of dorms)
-      for (const b of d.bunks) m.set(b.id, { occupant: b.occupant, address: b.address });
+      for (const b of d.bunks)
+        m.set(b.id, { occupant: b.occupant, address: b.address, prefectRole: b.prefectRole });
     return m;
   }, [dorms]);
 
   const selected = selectedBunkId ? bunkById.get(selectedBunkId)?.occupant ?? null : null;
+  const selectedPrefectRole = selectedBunkId
+    ? bunkById.get(selectedBunkId)?.prefectRole ?? null
+    : null;
 
   function onBunkClick(bunkId: string, state: BunkState) {
     setError(null);
@@ -100,13 +110,43 @@ export function RosterBoard({
     });
   }
 
+  function appoint(role: PrefectRole) {
+    if (!selected) return;
+    setApptError(null);
+    startTransition(async () => {
+      const res = await appointPrefect({ studentId: selected.studentId, role });
+      if (!res.ok) {
+        setApptError(res.error ?? "Could not appoint this prefect.");
+        return;
+      }
+      setSelectedBunkId(null);
+      router.refresh();
+    });
+  }
+
+  function revoke() {
+    if (!selected) return;
+    setApptError(null);
+    startTransition(async () => {
+      const res = await revokePrefect({ studentId: selected.studentId });
+      if (!res.ok) {
+        setApptError(res.error ?? "Could not revoke this prefect.");
+        return;
+      }
+      setSelectedBunkId(null);
+      router.refresh();
+    });
+  }
+
   return (
     <div className="space-y-6">
-      {/* Prefect strip — display-only (appointment workflow is a later increment). */}
+      {/* Prefect strip — appointment via a selected boarder's card (INCR #298). */}
       <div className="rounded-xl border border-gold-soft bg-gold-bg p-5">
         <div className="mb-3.5 text-[10px] font-bold uppercase tracking-[0.14em] text-gold">
           House prefects ·{" "}
-          <em className="font-medium not-italic text-navy">five roles, display-only</em>
+          <em className="font-medium not-italic text-navy">
+            {canReassign ? "select a boarder to appoint" : "five roles"}
+          </em>
         </div>
         <div className="grid grid-cols-2 gap-3 md:grid-cols-5">
           {prefects.map((p) => (
@@ -262,9 +302,18 @@ export function RosterBoard({
         <DetailCard
           occupant={selected}
           houseName={house.name}
+          prefectRole={selectedPrefectRole}
           canReassign={canReassign}
+          canAppoint={canReassign}
+          pending={pending}
+          apptError={apptError}
           onMove={() => beginMove(selected)}
-          onClose={() => setSelectedBunkId(null)}
+          onAppoint={appoint}
+          onRevoke={revoke}
+          onClose={() => {
+            setSelectedBunkId(null);
+            setApptError(null);
+          }}
         />
       )}
 
@@ -318,17 +367,30 @@ export function RosterBoard({
 function DetailCard({
   occupant,
   houseName,
+  prefectRole,
   canReassign,
+  canAppoint,
+  pending,
+  apptError,
   onMove,
+  onAppoint,
+  onRevoke,
   onClose,
 }: {
   occupant: RosterOccupant;
   houseName: string;
+  prefectRole: PrefectRole | null;
   canReassign: boolean;
+  canAppoint: boolean;
+  pending: boolean;
+  apptError: string | null;
   onMove: () => void;
+  onAppoint: (role: PrefectRole) => void;
+  onRevoke: () => void;
   onClose: () => void;
 }) {
   const flagged = occupant.flagged;
+  const [pickRole, setPickRole] = useState<PrefectRole>("HEAD");
   return (
     <div
       className={`overflow-hidden rounded-xl border bg-surface ${
@@ -398,6 +460,49 @@ function DetailCard({
           </button>
         )}
       </div>
+
+      {/* Prefect appointment (INCR #298) — same authority as a bunk move. */}
+      {canAppoint && (
+        <div className="border-t border-border px-5 py-4">
+          {prefectRole ? (
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="text-[12px] text-navy-2">
+                Prefect · <b className="text-navy">{PREFECT_LABEL[prefectRole]}</b>
+              </div>
+              <button
+                onClick={onRevoke}
+                disabled={pending}
+                className="rounded-md border border-terra bg-terra-bg px-3 py-1.5 text-xs font-semibold text-terra disabled:opacity-50"
+              >
+                {pending ? "Working…" : "Revoke prefect"}
+              </button>
+            </div>
+          ) : (
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-[12px] text-navy-3">Appoint as prefect:</span>
+              <select
+                value={pickRole}
+                onChange={(e) => setPickRole(e.target.value as PrefectRole)}
+                className="rounded-md border border-border-2 bg-bg px-2 py-1 text-xs font-semibold text-navy outline-none focus:border-gold"
+              >
+                {PREFECT_ORDER.map((r) => (
+                  <option key={r} value={r}>
+                    {PREFECT_LABEL[r]}
+                  </option>
+                ))}
+              </select>
+              <button
+                onClick={() => onAppoint(pickRole)}
+                disabled={pending}
+                className="rounded-md bg-gold px-3 py-1.5 text-xs font-semibold text-navy disabled:opacity-50"
+              >
+                {pending ? "Working…" : "Appoint"}
+              </button>
+            </div>
+          )}
+          {apptError && <p className="mt-2 text-xs font-semibold text-terra">{apptError}</p>}
+        </div>
+      )}
     </div>
   );
 }

--- a/omnischools/components/boarding/roster-board.tsx
+++ b/omnischools/components/boarding/roster-board.tsx
@@ -300,6 +300,7 @@ export function RosterBoard({
       {/* Student detail card — neutral default, terra when pastorally flagged. */}
       {selected && (
         <DetailCard
+          key={selected.studentId}
           occupant={selected}
           houseName={house.name}
           prefectRole={selectedPrefectRole}

--- a/omnischools/lib/actions/boarding-discipline.ts
+++ b/omnischools/lib/actions/boarding-discipline.ts
@@ -16,6 +16,7 @@ import {
   students,
   houses,
   bunkAllocation,
+  boardingBunk,
   schools,
 } from "@/db/schema";
 import { insertInfraction } from "@/lib/boarding/discipline-core";
@@ -416,6 +417,34 @@ export async function commitDeboardinization(input: unknown): Promise<ActionResu
       .update(students)
       .set({ residency: "DEBOARDINIZED", currentBunkId: null })
       .where(and(eq(students.schoolId, school.id), eq(students.id, rec.studentId)));
+
+    // 4) a released bunk must not keep a prefect tag (INCR #298). Otherwise the title strands on the
+    // now-vacant bunk and the next occupant — placed by a reassign that isn't itself carrying a tag —
+    // is silently mis-attributed the role, and the SICKBAY derived read follows the ghost. Clear it in
+    // the same tx (mirrors reassignBunk's clear-source), auditing a revoke iff a role was actually held.
+    if (stu.currentBunkId) {
+      const [rel] = await tx
+        .select({ role: boardingBunk.prefectRole })
+        .from(boardingBunk)
+        .where(and(eq(boardingBunk.schoolId, school.id), eq(boardingBunk.id, stu.currentBunkId)));
+      if (rel?.role) {
+        await tx
+          .update(boardingBunk)
+          .set({ prefectRole: null })
+          .where(and(eq(boardingBunk.schoolId, school.id), eq(boardingBunk.id, stu.currentBunkId)));
+        await recordAudit(tx, {
+          schoolId: school.id,
+          actorUserId: actor.id ?? undefined,
+          actorRole: actor.role,
+          actionType: "BOARDING_PREFECT_REVOKED",
+          entityType: "student",
+          entityId: rec.studentId,
+          before: { prefectRole: rel.role },
+          after: { prefectRole: null },
+          reason: "Prefect role released on deboardinization",
+        });
+      }
+    }
 
     await recordAudit(tx, {
       schoolId: school.id,

--- a/omnischools/lib/actions/boarding-prefect.test.ts
+++ b/omnischools/lib/actions/boarding-prefect.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { readCode } from "@/lib/test-utils/source-shape";
+
+/**
+ * INCR #298 (A) — prefect appointment workflow. The appoint/revoke/carry logic is imperative DB
+ * mutation (clear-prior, set-tag, move-tag) a pure suite cannot stage two concurrent transactions to
+ * prove behaviourally, so this pins the STRUCTURE the correctness rests on (the expression, not the
+ * name): every mutation happens inside the withSchool tx; the appointment SETS the existing
+ * boarding_bunk.prefect_role tag (Kofi's zero-schema ruling) so the two existing readers stay the sole
+ * source of truth; and the sickbay-prefect derived read + the strip builder keep reading that tag.
+ */
+
+/** Slice a named `export async function` body out to the next top-level export/const. */
+function fnBody(src: string, name: string): string {
+  const start = src.indexOf(`export async function ${name}`);
+  if (start === -1) throw new Error(`fn ${name} not found`);
+  const rest = src.slice(start + 1);
+  const next = rest.search(/\nexport (?:async function|const|default)/);
+  return rest.slice(0, next === -1 ? undefined : next);
+}
+/** Slice an internal (non-exported) `async function` body. */
+function helperBody(src: string, name: string): string {
+  const start = src.indexOf(`async function ${name}`);
+  if (start === -1) throw new Error(`helper ${name} not found`);
+  const rest = src.slice(start + 1);
+  const next = rest.search(/\n(?:export )?(?:async function|function|const) /);
+  return rest.slice(0, next === -1 ? undefined : next);
+}
+
+const boarding = () => readCode("lib/actions/boarding.ts");
+
+describe("appointPrefect · gate is identical to a bunk move (AC-A5, no widening)", () => {
+  it("checks BOARDING_ROLES on the caller and defers house scope to the shared gate", () => {
+    const b = fnBody(boarding(), "appointPrefect");
+    expect(b).toMatch(/hasAnyRole\(user\.roles,\s*BOARDING_ROLES\)/);
+    expect(b, "delegates the own-house check to the shared loader").toContain("loadGatedBoarder(");
+  });
+  it("the shared loader enforces canAccessHouse (so a plain HOUSEMASTER stays in their House)", () => {
+    expect(helperBody(boarding(), "loadGatedBoarder")).toContain("canAccessHouse(");
+  });
+});
+
+describe("appointPrefect · eligibility + one-holder-per-role (AC-A2/A3/A7)", () => {
+  const b = () => fnBody(boarding(), "appointPrefect");
+  it("rejects a non-ACTIVE, non-BOARDER, or un-allocated boarder before any write", () => {
+    const s = b();
+    expect(s).toContain('stu.status !== "ACTIVE"');
+    expect(s).toContain('stu.residency !== "BOARDER"');
+    expect(s).toMatch(/if\s*\(!bunkId\)/);
+  });
+  it("clears the prior holder of the role in-tx BEFORE tagging the appointee (AC-A2)", () => {
+    const s = b();
+    const tx = s.indexOf("withSchool(");
+    const clear = s.indexOf("prefectRole: null"); // the prior-holder clear
+    const set = s.indexOf("prefectRole: role"); // the appointee's new tag
+    expect(tx, "mutations run inside the tenant tx").toBeGreaterThan(-1);
+    expect(clear, "clears a prior holder").toBeGreaterThan(tx);
+    expect(set, "then sets the appointee's tag").toBeGreaterThan(clear);
+    // the clear is scoped to the role within the House (never a blanket wipe).
+    expect(s).toMatch(/eq\(boardingDormitory\.houseId/);
+    expect(s).toMatch(/eq\(boardingBunk\.prefectRole,\s*role\)/);
+  });
+});
+
+describe("appoint/revoke audit dodges the GOV-10 classify-at-creation trap (entityType student)", () => {
+  it("both audit writes use the already-SHOWN 'student' entityType, not a new unclassified one", () => {
+    const s = boarding();
+    expect(s).toContain('actionType: "BOARDING_PREFECT_APPOINTED"');
+    expect(s).toContain('actionType: "BOARDING_PREFECT_REVOKED"');
+    // no BOARDING_PREFECT_* audit may carry an entityType other than "student" (else next build fails
+    // the audit-classification guard — an unclassified entity is REDACTED-or-SHOWN by omission).
+    for (const m of s.matchAll(/actionType:\s*"BOARDING_PREFECT_[A-Z]+"[\s\S]{0,120}?entityType:\s*"([a-z_]+)"/g)) {
+      expect(m[1], "prefect audit entityType").toBe("student");
+    }
+  });
+});
+
+describe("reassignBunk · carries the prefect tag with its holder (AC-A8)", () => {
+  it("moves the tag from source to target bunk inside the same move tx (never strands it)", () => {
+    const s = fnBody(boarding(), "reassignBunk");
+    const move = s.indexOf("currentBunkId: targetBunkId"); // the student move
+    const readSrc = s.indexOf("src?.role"); // read the source bunk's tag
+    const carry = s.indexOf("prefectRole: src.role"); // stamp it onto the target
+    expect(move).toBeGreaterThan(-1);
+    expect(readSrc, "reads the source bunk's tag after the move").toBeGreaterThan(move);
+    expect(carry, "stamps the tag onto the target bunk").toBeGreaterThan(readSrc);
+    // and clears the vacated source bunk so the title is not duplicated.
+    expect(s.slice(carry)).toContain("prefectRole: null");
+  });
+});
+
+describe("the two readers my zero-schema model depends on still read the bunk tag (AC-A9/A10)", () => {
+  it("getHealthPrefects still derives the sickbay roster from boarding_bunk.prefect_role='SICKBAY'", () => {
+    const s = readCode("lib/sickbay/config.ts");
+    const body = s.slice(s.indexOf("function getHealthPrefects"));
+    expect(body).toMatch(/eq\(boardingBunk\.prefectRole,\s*"SICKBAY"\)/);
+  });
+  it("buildPrefectStrip still keys the strip off the bunk's prefectRole tag", () => {
+    const s = readCode("lib/boarding/roster.ts");
+    const body = s.slice(s.indexOf("function buildPrefectStrip"));
+    expect(body).toMatch(/b\.prefectRole/);
+  });
+});

--- a/omnischools/lib/actions/boarding-prefect.test.ts
+++ b/omnischools/lib/actions/boarding-prefect.test.ts
@@ -89,6 +89,20 @@ describe("reassignBunk · carries the prefect tag with its holder (AC-A8)", () =
   });
 });
 
+describe("deboardinization releases the prefect tag too (AC-A9 strand — #298 fast-follow)", () => {
+  it("commitDeboardinization clears the released bunk's prefect_role + audits a revoke, same tx", () => {
+    const s = readCode("lib/actions/boarding-discipline.ts");
+    // the vacate: residency flip nulls the bunk; the tag must be cleared right after so it never strands.
+    const nulled = s.indexOf("currentBunkId: null");
+    expect(nulled, "the deboard vacate path exists").toBeGreaterThan(-1);
+    const after = s.slice(nulled);
+    const clear = after.indexOf("prefectRole: null");
+    const audit = after.indexOf('actionType: "BOARDING_PREFECT_REVOKED"');
+    expect(clear, "clears the released bunk's tag after the vacate").toBeGreaterThan(-1);
+    expect(audit, "and audits a revoke").toBeGreaterThan(-1);
+  });
+});
+
 describe("the two readers my zero-schema model depends on still read the bunk tag (AC-A9/A10)", () => {
   it("getHealthPrefects still derives the sickbay roster from boarding_bunk.prefect_role='SICKBAY'", () => {
     const s = readCode("lib/sickbay/config.ts");

--- a/omnischools/lib/actions/boarding.ts
+++ b/omnischools/lib/actions/boarding.ts
@@ -1,7 +1,8 @@
 "use server";
-import { and, eq, isNull, ne } from "drizzle-orm";
+import { and, eq, inArray, isNull, ne } from "drizzle-orm";
 import { z } from "zod";
 import { withSchool, isUniqueViolation } from "@/lib/db/rls";
+import type { Tx } from "@/lib/db";
 import { recordAudit } from "@/lib/db/audit";
 import { requireSchool, resolveActor } from "@/lib/auth/server";
 import { getCurrentUser } from "@/lib/auth";
@@ -155,6 +156,26 @@ export async function reassignBunk(input: unknown): Promise<Result> {
         .set({ currentBunkId: targetBunkId })
         .where(and(eq(students.schoolId, school.id), eq(students.id, studentId)));
 
+      // AC-A8 — a prefect tag lives on the BUNK, so carry it with its holder. Without this the
+      // title strands on the vacated bunk (silently re-attributed to whoever fills it next, and
+      // the SICKBAY derived read would follow the wrong occupant). Same tx as the move.
+      if (stu.currentBunkId) {
+        const [src] = await tx
+          .select({ role: boardingBunk.prefectRole })
+          .from(boardingBunk)
+          .where(and(eq(boardingBunk.schoolId, school.id), eq(boardingBunk.id, stu.currentBunkId)));
+        if (src?.role) {
+          await tx
+            .update(boardingBunk)
+            .set({ prefectRole: src.role })
+            .where(and(eq(boardingBunk.schoolId, school.id), eq(boardingBunk.id, targetBunkId)));
+          await tx
+            .update(boardingBunk)
+            .set({ prefectRole: null })
+            .where(and(eq(boardingBunk.schoolId, school.id), eq(boardingBunk.id, stu.currentBunkId)));
+        }
+      }
+
       await recordAudit(tx, {
         schoolId: school.id,
         actorUserId: actor.id ?? undefined,
@@ -172,7 +193,7 @@ export async function reassignBunk(input: unknown): Promise<Result> {
       return { ok: true as const, houseId: stu.houseId };
     });
 
-    if ("error" in outcome) return { ok: false, error: outcome.error };
+    if (!outcome.ok) return { ok: false, error: outcome.error };
     safeRevalidate(`/senior/boarding/houses/${outcome.houseId}/roster`);
     return { ok: true };
   } catch (err) {
@@ -188,4 +209,203 @@ export async function reassignBunk(input: unknown): Promise<Result> {
     }
     throw err;
   }
+}
+
+const PrefectRoleSchema = z.enum(["HEAD", "DINING", "SANITATION", "PREP", "SICKBAY"]);
+const AppointSchema = z.object({
+  studentId: z.string().uuid(),
+  role: PrefectRoleSchema,
+});
+const RevokeSchema = z.object({ studentId: z.string().uuid() });
+
+/**
+ * Load a boarder + their House's HM pointer and run the shared appoint/revoke gate: BOARDING_ROLES,
+ * and a plain HOUSEMASTER only for their own House (AC-A5 — identical to reassignBunk, no widening).
+ * Returns the student row on success, or an error string. Keeps both actions honest to one gate.
+ */
+async function loadGatedBoarder(
+  tx: Tx,
+  schoolId: string,
+  studentId: string,
+  user: { roles: string[]; id: string },
+) {
+  const [stu] = await tx
+    .select({
+      id: students.id,
+      houseId: students.houseId,
+      status: students.status,
+      residency: students.residency,
+      currentBunkId: students.currentBunkId,
+    })
+    .from(students)
+    .where(and(eq(students.schoolId, schoolId), eq(students.id, studentId)));
+  if (!stu || !stu.houseId) {
+    return { ok: false as const, error: "That boarder is not in a House." };
+  }
+  const [house] = await tx
+    .select({ hmUserId: houses.hmUserId })
+    .from(houses)
+    .where(and(eq(houses.schoolId, schoolId), eq(houses.id, stu.houseId)));
+  if (!canAccessHouse(user.roles, user.id, house?.hmUserId)) {
+    return { ok: false as const, error: "You can only manage the House you are assigned to." };
+  }
+  return { ok: true as const, stu };
+}
+
+/**
+ * Appoint a boarder to a prefect role (INCR #298 part A). The prefect tag is a nullable enum on the
+ * occupant's CURRENT bunk (Kofi's zero-schema ruling): appointing SETS it, so both existing readers
+ * (buildPrefectStrip, the SICKBAY-prefect derived read in lib/sickbay) stay byte-unchanged. One holder
+ * per (House × role): the prior holder in this House is cleared in the SAME transaction (AC-A2). A
+ * student holds at most one role — a single column can only carry one (AC-A4). Requires the boarder be
+ * ACTIVE, resident, and already allocated a bunk (AC-A3/A7). Gated to BOARDING_ROLES + own-House.
+ */
+export async function appointPrefect(input: unknown): Promise<Result> {
+  const { school } = await requireSchool();
+  const user = await getCurrentUser();
+  if (!user || !hasAnyRole(user.roles, BOARDING_ROLES)) {
+    return { ok: false, error: "Your role cannot appoint prefects." };
+  }
+  const parsed = AppointSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };
+  }
+  const { studentId, role } = parsed.data;
+  const actor = await resolveActor(school.id);
+
+  const outcome = await withSchool(school.id, async (tx) => {
+    const gated = await loadGatedBoarder(tx, school.id, studentId, user);
+    if (!gated.ok) return gated;
+    const { stu } = gated;
+    if (stu.status !== "ACTIVE") return { ok: false as const, error: "That boarder is not active." };
+    if (stu.residency !== "BOARDER") {
+      return { ok: false as const, error: "Only a resident boarder can be a prefect." };
+    }
+    const bunkId = stu.currentBunkId;
+    if (!bunkId) {
+      return { ok: false as const, error: "Allocate this boarder a bunk before appointing them." };
+    }
+
+    // AC-A2 — clear the current holder of this role in this House (bunk tag lives via dorm→house).
+    const priorBunks = await tx
+      .select({ id: boardingBunk.id })
+      .from(boardingBunk)
+      .innerJoin(
+        boardingDormitory,
+        and(
+          eq(boardingDormitory.schoolId, boardingBunk.schoolId),
+          eq(boardingDormitory.id, boardingBunk.dormitoryId),
+        ),
+      )
+      .where(
+        and(
+          eq(boardingBunk.schoolId, school.id),
+          eq(boardingDormitory.houseId, stu.houseId!),
+          eq(boardingBunk.prefectRole, role),
+          ne(boardingBunk.id, bunkId),
+        ),
+      );
+    if (priorBunks.length > 0) {
+      const priorBunkIds = priorBunks.map((b) => b.id);
+      const priorHolders = await tx
+        .select({ id: students.id })
+        .from(students)
+        .where(and(eq(students.schoolId, school.id), inArray(students.currentBunkId, priorBunkIds)));
+      await tx
+        .update(boardingBunk)
+        .set({ prefectRole: null })
+        .where(and(eq(boardingBunk.schoolId, school.id), inArray(boardingBunk.id, priorBunkIds)));
+      for (const h of priorHolders) {
+        await recordAudit(tx, {
+          schoolId: school.id,
+          actorUserId: actor.id ?? undefined,
+          actorRole: actor.role,
+          actionType: "BOARDING_PREFECT_REVOKED",
+          entityType: "student",
+          entityId: h.id,
+          before: { prefectRole: role },
+          after: { prefectRole: null },
+          reason: "Prefect role reassigned",
+        });
+      }
+    }
+
+    // AC-A1/A4 — set the tag on the appointee's own bunk (a single column carries exactly one role).
+    const [before] = await tx
+      .select({ role: boardingBunk.prefectRole })
+      .from(boardingBunk)
+      .where(and(eq(boardingBunk.schoolId, school.id), eq(boardingBunk.id, bunkId)));
+    await tx
+      .update(boardingBunk)
+      .set({ prefectRole: role })
+      .where(and(eq(boardingBunk.schoolId, school.id), eq(boardingBunk.id, bunkId)));
+    await recordAudit(tx, {
+      schoolId: school.id,
+      actorUserId: actor.id ?? undefined,
+      actorRole: actor.role,
+      actionType: "BOARDING_PREFECT_APPOINTED",
+      entityType: "student",
+      entityId: studentId,
+      before: { prefectRole: before?.role ?? null },
+      after: { prefectRole: role },
+      reason: "Prefect appointed",
+    });
+    return { ok: true as const, houseId: stu.houseId! };
+  });
+
+  if (!outcome.ok) return { ok: false, error: outcome.error };
+  safeRevalidate(`/senior/boarding/houses/${outcome.houseId}/roster`);
+  return { ok: true };
+}
+
+/**
+ * Revoke a boarder's prefect role (AC-A6): clear the tag on their current bunk. Idempotent — clearing
+ * a boarder who holds no role is a no-op success. Gated to BOARDING_ROLES + own-House.
+ */
+export async function revokePrefect(input: unknown): Promise<Result> {
+  const { school } = await requireSchool();
+  const user = await getCurrentUser();
+  if (!user || !hasAnyRole(user.roles, BOARDING_ROLES)) {
+    return { ok: false, error: "Your role cannot revoke prefects." };
+  }
+  const parsed = RevokeSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };
+  }
+  const { studentId } = parsed.data;
+  const actor = await resolveActor(school.id);
+
+  const outcome = await withSchool(school.id, async (tx) => {
+    const gated = await loadGatedBoarder(tx, school.id, studentId, user);
+    if (!gated.ok) return gated;
+    const { stu } = gated;
+    const bunkId = stu.currentBunkId;
+    if (!bunkId) return { ok: true as const, houseId: stu.houseId! };
+    const [bunk] = await tx
+      .select({ role: boardingBunk.prefectRole })
+      .from(boardingBunk)
+      .where(and(eq(boardingBunk.schoolId, school.id), eq(boardingBunk.id, bunkId)));
+    if (bunk?.role) {
+      await tx
+        .update(boardingBunk)
+        .set({ prefectRole: null })
+        .where(and(eq(boardingBunk.schoolId, school.id), eq(boardingBunk.id, bunkId)));
+      await recordAudit(tx, {
+        schoolId: school.id,
+        actorUserId: actor.id ?? undefined,
+        actorRole: actor.role,
+        actionType: "BOARDING_PREFECT_REVOKED",
+        entityType: "student",
+        entityId: studentId,
+        before: { prefectRole: bunk.role },
+        after: { prefectRole: null },
+        reason: "Prefect revoked",
+      });
+    }
+    return { ok: true as const, houseId: stu.houseId! };
+  });
+
+  if (!outcome.ok) return { ok: false, error: outcome.error };
+  safeRevalidate(`/senior/boarding/houses/${outcome.houseId}/roster`);
+  return { ok: true };
 }

--- a/omnischools/lib/actions/boarding.ts
+++ b/omnischools/lib/actions/boarding.ts
@@ -287,6 +287,12 @@ export async function appointPrefect(input: unknown): Promise<Result> {
     }
 
     // AC-A2 — clear the current holder of this role in this House (bunk tag lives via dorm→house).
+    // ponytail: the one-holder-per-(House×role) rule is app-enforced (clear-prior then set) with no DB
+    // backstop — Kofi's zero-schema ruling forbids the partial-unique that would close it, because
+    // `boarding_bunk` has no house_id (house is via the dorm join). Two concurrent same-role appoints at
+    // READ COMMITTED can transiently double-tag; readers tolerate it (buildPrefectStrip is first-wins,
+    // getHealthPrefects would list two, the next appoint self-heals). Low contention, self-healing.
+    // Upgrade path: add house_id to boarding_bunk + a partial-unique on (school_id, house_id, prefect_role).
     const priorBunks = await tx
       .select({ id: boardingBunk.id })
       .from(boardingBunk)

--- a/omnischools/lib/boarding/roster.test.ts
+++ b/omnischools/lib/boarding/roster.test.ts
@@ -113,6 +113,35 @@ describe("assembleDorms — data-driven N×M, ordered (AC A5/B1/J5)", () => {
     expect(strip[1].occupant).toBeNull(); // DINING not tagged → empty slot
   });
 
+  it("buildPrefectStrip is the ≤1-per-role backstop: two bunks tagged the SAME role → one slot, first wins (AC-A10)", () => {
+    // The DB invariant (one holder per House×role, appointPrefect AC-A2) can slip via a path the
+    // carry does not cover — e.g. a deboardinized prefect strands their tag on the vacated bunk
+    // (boarding-discipline commitDeboardinization nulls current_bunk_id but leaves prefect_role set).
+    // The strip must still render ≤1 slot per role and never fabricate an occupant onto a stranded tag.
+    const dorms: RawDorm[] = [{ id: "dA", name: "A", sectionLabel: null }];
+    const bunks: RawBunk[] = [
+      { id: "a1", dormId: "dA", position: 1, prefectRole: "HEAD" }, // occupied HEAD
+      { id: "a2", dormId: "dA", position: 2, prefectRole: "HEAD" }, // duplicate HEAD (invariant slip)
+      { id: "a3", dormId: "dA", position: 3, prefectRole: "SICKBAY" }, // tagged but VACANT (stranded)
+    ];
+    const occupants = new Map<string, RosterOccupant>([
+      ["a1", occ({ studentId: "head1" })],
+      ["a2", occ({ studentId: "head2" })],
+      // a3 deliberately has NO occupant — the stranded-tag case.
+    ]);
+    const strip = buildPrefectStrip(assembleDorms(dorms, bunks, occupants));
+
+    expect(strip).toHaveLength(5); // never more than the 5 canonical roles, even with a duplicate tag
+    const head = strip.filter((s) => s.role === "HEAD");
+    expect(head).toHaveLength(1); // ≤1 per role at the render layer
+    expect(head[0].occupant?.studentId).toBe("head1"); // first tagged bunk (A-01) wins, not A-02
+    expect(head[0].addressShort).toBe("A-01");
+
+    const sickbay = strip.find((s) => s.role === "SICKBAY")!;
+    expect(sickbay.occupant).toBeNull(); // a stranded tag is NEVER given a fabricated occupant
+    expect(sickbay.addressShort).toBe("A-03"); // it does surface the stranded bunk's address (ghost slot)
+  });
+
   it("summarize derives totals (vacant = total − filled) and unallocated tray count", () => {
     const s = summarize(result, /*boarderCount*/ 4, /*unallocatedCount*/ 1);
     expect(s.totalBunks).toBe(5);


### PR DESCRIPTION
Part A of #298 — turns the display-only House-prefect strip into a real appoint/revoke workflow. **Part B (public tokenised parent RSVP link) follows as a separate PR** pending the owner's DPA/consent-notice sign-off, so this PR does not close #298.

## What it does
- **Appoint / revoke prefects** from a boarder's card on the House roster. Zero new schema (Kofi's ruling): appoint/revoke set/clear the existing nullable `boarding_bunk.prefect_role` tag on the appointee's current bunk, so both existing readers — `buildPrefectStrip` and the SICKBAY-prefect derived read in `lib/sickbay` — stay the single source of truth and cannot break.
- **One holder per (House × role):** the prior holder in the House is cleared in the same transaction. A student holds at most one role (single column).
- **Gate:** `BOARDING_ROLES` + `canAccessHouse` — identical to `reassignBunk`, server-enforced, no widening. A plain HOUSEMASTER is fenced to their own House. ACTIVE + resident + allocated-bunk required.
- **`reassignBunk` now carries the prefect tag** with its holder, so a move never strands the title on the vacated bunk (which would mis-attribute it and corrupt the sickbay roster).
- **`commitDeboardinization` now releases the tag** on the vacated bunk (root-cause fix for the same strand class, surfaced by QA).
- Audits under the already-classified `entityType:"student"` (no GOV-10 classify-at-creation trap).

## Gates
- **Quinn (QA): GREEN** — all AC-A1..A11 verified; added an AC-A10 render test; found the deboardinization strand (fixed here).
- **Dex (arch): APPROVE** — pattern-faithful, portable, zero lock-in; two low notes addressed.
- **Sarah (security): SECURITY-CLEAN** — no authz widening, no cross-house/tenant leakage, crafted-POST rejected server-side, audit diffs carry no PII.
- `tsc` clean · full vitest green (2259) · `next build` exit 0.

## Deploy
**No SQL to run** — zero-schema change; `prefect_role` is a pre-existing column on the already-tenant-scoped `boarding_bunk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)