### PR TITLE
feat(insights): board pack exports the director drill-downs + shared builder (#309)

### DIFF
--- a/omnischools/app/(board)/board/board-pack/route.ts
+++ b/omnischools/app/(board)/board/board-pack/route.ts
@@ -1,69 +1,22 @@
 import { requireBoard } from "@/lib/auth/server";
-import { getSchoolRollup } from "@/lib/rollup/school-rollup";
-import { renderBoardPackPdf } from "@/lib/pdf/render-board-pack";
-import type { BoardPackData } from "@/lib/pdf/board-pack-document";
+import { buildBoardPackResponse } from "@/lib/pdf/board-pack-response";
 
 // @react-pdf/renderer is Node-only (fontkit); never run this on the edge.
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 /**
- * GET /board/board-pack — the board/director downloadable governance-overview PDF (GOV-5).
+ * GET /board/board-pack — the board's downloadable governance-overview PDF (GOV-5).
  *
- * Gated by `requireBoard()` (BOARD_MEMBER only; a non-board session is redirected before it reaches
- * this handler). The school id is SESSION-derived (never a URL school id — R339); `?periodId` only
- * picks the term. It lives UNDER the `/board` prefix on purpose: `requireBoard()`'s x-pathname
- * confinement admits only `/board*` paths, so an `/api/...` location would 307-redirect a legitimate
- * board member. Reads the rollup arms VERBATIM and streams the pack inline (clone of the receipt route).
+ * Gated by `requireBoard()` (BOARD_MEMBER only; a non-board session is redirected before it reaches this
+ * handler). It lives UNDER the `/board` prefix on purpose: `requireBoard()`'s x-pathname confinement admits
+ * only `/board*` paths, so an `/api/...` location would 307-redirect a legitimate board member. School id is
+ * SESSION-derived (never a URL id — R339); `?periodId` only picks the term. The document + data assembly is
+ * the SHARED `buildBoardPackResponse` (#309) — this route and `/api/insights/board-pack` differ ONLY in the
+ * gate, and both now carry the full aggregate drill-downs the two synced surfaces show.
  */
 export async function GET(req: Request) {
   const { school } = await requireBoard();
   const periodId = new URL(req.url).searchParams.get("periodId") ?? undefined;
-
-  const rollup = await getSchoolRollup(school.id, { periodId });
-
-  const termLabel = rollup.period
-    ? `${rollup.period.label} · ${rollup.period.academicYear}`
-    : "No academic period configured";
-
-  const data: BoardPackData = {
-    rollup,
-    meta: {
-      schoolName: school.name,
-      schoolInitials: initialsOf(school.name),
-      termLabel,
-      generatedAtLabel: fmtDateTime(rollup.generatedAt),
-    },
-  };
-
-  const pdf = await renderBoardPackPdf(data);
-  const term = termLabel.replace(/[^A-Za-z0-9]+/g, "-").replace(/^-|-$/g, "");
-  return new Response(new Uint8Array(pdf), {
-    headers: {
-      "Content-Type": "application/pdf",
-      "Content-Disposition": `inline; filename="Board-pack-${term}.pdf"`,
-      "Cache-Control": "private, no-store",
-    },
-  });
+  return buildBoardPackResponse(school, periodId);
 }
-
-// 2-letter school-crest initials (matches the shipped PDF loaders' one-liner: "Aggrey Memorial" → "AM").
-const initialsOf = (name: string) =>
-  name
-    .trim()
-    .split(/\s+/)
-    .slice(0, 2)
-    .map((w) => w[0]?.toUpperCase() ?? "")
-    .join("") || "S";
-
-// Documents take pre-formatted dates (house style) — format in the route, in the school tz/locale.
-const fmtDateTime = (d: Date) =>
-  d
-    .toLocaleString("en-GB", {
-      day: "numeric",
-      month: "short",
-      year: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    })
-    .replace(",", " ·");

--- a/omnischools/app/api/insights/board-pack/route.ts
+++ b/omnischools/app/api/insights/board-pack/route.ts
@@ -1,73 +1,24 @@
 import { requireSchoolRole } from "@/lib/auth/server";
 import { INSIGHTS_READ_ROLES } from "@/lib/access";
-import { getSchoolRollup } from "@/lib/rollup/school-rollup";
-import { renderBoardPackPdf } from "@/lib/pdf/render-board-pack";
-import type { BoardPackData } from "@/lib/pdf/board-pack-document";
+import { buildBoardPackResponse } from "@/lib/pdf/board-pack-response";
 
 // @react-pdf/renderer is Node-only (fontkit); never run this on the edge.
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 /**
- * GET /api/insights/board-pack — the DIRECTORS' downloadable governance-overview PDF (INS §17-F follow-up).
+ * GET /api/insights/board-pack — the DIRECTORS' downloadable governance-overview PDF (INS §17-F).
  *
- * The SAME aggregate board pack the board sees (GOV-5), re-gated for the director tier: `INSIGHTS_READ_ROLES`
+ * The SAME aggregate board pack the board gets (GOV-5), re-gated for the director tier: `INSIGHTS_READ_ROLES`
  * (ADMIN/HEADMASTER/PROPRIETOR), the same gate as the `/insights` page. It lives under `app/api/*` — the
  * repo's authenticated-download convention (receipts / report-cards / sen census-export) — NOT under the
  * page tree (which `no-html-link-for-pages` would flag); and unlike `requireBoard()`, `requireSchoolRole`
- * carries no `/board*` x-pathname confinement, so `/api` is the correct home (a director hitting `/board/*`
- * would be bounced). School id is SESSION-derived (never a URL id — R339); `?periodId` only picks the term.
- * Content is the PII-stripped rollup arms directors already see on `/insights` — no new exposure. Clone of
- * the `/board/board-pack` route (same data, same document), differing only in the gate + location.
+ * carries no `/board*` x-pathname confinement, so `/api` is the correct home. School id is SESSION-derived
+ * (never a URL id — R339); `?periodId` only picks the term. The document + data assembly is now the SHARED
+ * `buildBoardPackResponse` (#309) — this route and `/board/board-pack` differ ONLY in the gate.
  */
 export async function GET(req: Request) {
   const { school } = await requireSchoolRole(INSIGHTS_READ_ROLES);
   const periodId = new URL(req.url).searchParams.get("periodId") ?? undefined;
-
-  const rollup = await getSchoolRollup(school.id, { periodId });
-
-  const termLabel = rollup.period
-    ? `${rollup.period.label} · ${rollup.period.academicYear}`
-    : "No academic period configured";
-
-  const data: BoardPackData = {
-    rollup,
-    meta: {
-      schoolName: school.name,
-      schoolInitials: initialsOf(school.name),
-      termLabel,
-      generatedAtLabel: fmtDateTime(rollup.generatedAt),
-    },
-  };
-
-  const pdf = await renderBoardPackPdf(data);
-  const term = termLabel.replace(/[^A-Za-z0-9]+/g, "-").replace(/^-|-$/g, "");
-  return new Response(new Uint8Array(pdf), {
-    headers: {
-      "Content-Type": "application/pdf",
-      "Content-Disposition": `inline; filename="Board-pack-${term}.pdf"`,
-      "Cache-Control": "private, no-store",
-    },
-  });
+  return buildBoardPackResponse(school, periodId);
 }
-
-// 2-letter school-crest initials (matches the shipped PDF loaders' one-liner: "Aggrey Memorial" → "AM").
-const initialsOf = (name: string) =>
-  name
-    .trim()
-    .split(/\s+/)
-    .slice(0, 2)
-    .map((w) => w[0]?.toUpperCase() ?? "")
-    .join("") || "S";
-
-// Documents take pre-formatted dates (house style) — format in the route, in the school tz/locale.
-const fmtDateTime = (d: Date) =>
-  d
-    .toLocaleString("en-GB", {
-      day: "numeric",
-      month: "short",
-      year: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    })
-    .replace(",", " ·");

--- a/omnischools/lib/pdf/board-pack-document.tsx
+++ b/omnischools/lib/pdf/board-pack-document.tsx
@@ -34,6 +34,11 @@ import type { CensusEnrolment } from "@/lib/reports/census-enrolment-data";
  * dashboard branches — reading `arm.data` on a non-CAPTURED arm is a COMPILE ERROR (the boardTile
  * guarantee, now enforced in print). The route pre-formats only the date + initials + term label
  * (tz/locale/session data the doc must not reach for). Core PDF fonts stand in for the brand faces.
+ *
+ * #309 · it ALSO carries the director drill-down aggregates the `/insights` (and synced `/board`)
+ * surfaces show — year-group performance, attendance-by-level, census age/gender/approved-age, and the
+ * "needs attention" rows. Unlike the rollup arms these are PRE-DERIVED aggregates (not honest-absence
+ * arms), each guarded by its own empty-check (omit-not-fake). All aggregate-only — no per-student row.
  */
 
 // --- design tokens (hex; @react-pdf can't use CSS vars) ---

--- a/omnischools/lib/pdf/board-pack-document.tsx
+++ b/omnischools/lib/pdf/board-pack-document.tsx
@@ -23,6 +23,9 @@ import type {
   TerminalResultSummary,
   InfrastructureSummary,
 } from "@/lib/rollup/school-rollup";
+import type { ActionItem, InsightsAttendanceLevelRow } from "@/lib/insights/insights-data";
+import type { LevelPerformance } from "@/lib/reports/class-performance-data";
+import type { CensusEnrolment } from "@/lib/reports/census-enrolment-data";
 
 /**
  * GOV-5 · the board-pack PDF (A4 portrait) — a print rendering of the GOV-4 board dashboard for a
@@ -65,6 +68,13 @@ const STATUS_HEX: Record<AttendanceStatus, string> = {
 export type BoardPackData = {
   /** The rollup arms verbatim — the document branches on each `arm.status` (§0.1 compile-fence). */
   rollup: SchoolRollup;
+  // Director drill-downs (INS §17-F / #309) — the aggregate arms the /insights page adds beyond the
+  // board rollup. All aggregate-only (year-group / age-band), never a per-student row. Both the board
+  // and directors' packs carry them (the two surfaces are synced), so the document is shared, not cloned.
+  attention: ActionItem[];
+  levelPerf: LevelPerformance;
+  attendanceByLevel: InsightsAttendanceLevelRow[];
+  census: CensusEnrolment;
   meta: {
     schoolName: string;
     schoolInitials: string;
@@ -212,7 +222,26 @@ const s = StyleSheet.create({
   },
   footerText: { fontSize: 7.5, color: NAVY3, letterSpacing: 0.4 },
   goldEm: { color: GOLD, fontWeight: "bold" },
+
+  // director drill-down tables + attention rows (#309)
+  tr: {
+    flexDirection: "row",
+    borderBottomWidth: 1,
+    borderColor: BORDER,
+    paddingVertical: 3,
+  },
+  trHead: { backgroundColor: BG, borderBottomWidth: 1, borderColor: GOLD_SOFT },
+  thText: { fontSize: 7.5, fontWeight: "bold", color: NAVY3, letterSpacing: 0.4, paddingHorizontal: 3 },
+  tdText: { fontFamily: MONO, fontSize: 9, color: NAVY2, paddingHorizontal: 3 },
+  tdLabel: { fontSize: 9, color: NAVY, paddingHorizontal: 3 },
+  attnRow: { flexDirection: "row", alignItems: "flex-start", gap: 7, paddingVertical: 4 },
+  dot: { width: 7, height: 7, borderRadius: 4, marginTop: 2 },
+  attnLabel: { fontSize: 10, fontWeight: "bold", color: NAVY },
+  attnValue: { fontSize: 9, color: NAVY3, marginTop: 1 },
 });
+
+// ActionItem severity → hex (greyscale-safe order terra → warn → navy-2, as on the dashboard).
+const ATTN_HEX: Record<ActionItem["dot"], string> = { terra: TERRA, warn: WARN, "navy-2": NAVY2 };
 
 /* ─────────────────────────── small presentational bits ─────────────────────────── */
 
@@ -659,10 +688,134 @@ function InfrastructureBody({ d }: { d: InfrastructureSummary }) {
   );
 }
 
+/* ─────────────────────────── director drill-downs (#309) ─────────────────────────── */
+
+/** A flex-weighted table row. First cell left-aligns (the label), the rest right-align (figures). */
+function Tr({ cells, widths, head }: { cells: string[]; widths: number[]; head?: boolean }) {
+  return (
+    <View style={[s.tr, head ? s.trHead : {}]}>
+      {cells.map((c, i) => (
+        <Text
+          key={i}
+          style={[
+            head ? s.thText : i === 0 ? s.tdLabel : s.tdText,
+            { flexGrow: widths[i], flexBasis: 0, textAlign: i === 0 ? "left" : "right" },
+          ]}
+        >
+          {c}
+        </Text>
+      ))}
+    </View>
+  );
+}
+
+/** "Needs your attention" — the conditional action rows (omit-not-fake: no rows ⇒ the section is absent). */
+function AttentionSection({ items }: { items: ActionItem[] }) {
+  if (items.length === 0) return null;
+  return (
+    <View style={s.section} wrap={false}>
+      <SectionHead lead="Needs your" accent="attention" meta={`${items.length} ${items.length === 1 ? "item" : "items"}`} />
+      {items.map((it) => (
+        <View key={it.key} style={s.attnRow}>
+          <View style={[s.dot, { backgroundColor: ATTN_HEX[it.dot] }]} />
+          <View style={{ flex: 1 }}>
+            <Text style={s.attnLabel}>{it.label}</Text>
+            <Text style={s.attnValue}>{it.value}</Text>
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+/** Performance by year-group — the aggregate LevelPerformance rows (omitted when nothing is graded). */
+function YearGroupPerformanceSection({ perf }: { perf: LevelPerformance }) {
+  if (!perf.hasAnyScores || perf.rows.length === 0) return null;
+  return (
+    <View style={s.section} wrap={false}>
+      <SectionHead lead="Performance" accent="by year-group" meta="aggregate · this term" />
+      <Tr head widths={[3, 1.4, 1.2, 1.2, 2]} cells={["Year group", "Average", "Grade", "Pass", "Graded"]} />
+      {perf.rows.map((r) => (
+        <Tr
+          key={r.level}
+          widths={[3, 1.4, 1.2, 1.2, 2]}
+          cells={[
+            r.level,
+            pct(r.average),
+            r.grade ?? "—",
+            pct(r.passRate),
+            `${num(r.studentsGraded)} · ${r.classesGraded}/${r.classes} cls`,
+          ]}
+        />
+      ))}
+    </View>
+  );
+}
+
+/** Attendance by year-group — the lossless P/L/E/M/A fold (omitted when the attendance arm isn't captured). */
+function AttendanceByLevelSection({ rows }: { rows: InsightsAttendanceLevelRow[] }) {
+  if (rows.length === 0) return null;
+  return (
+    <View style={s.section} wrap={false}>
+      <SectionHead lead="Attendance" accent="by year-group" meta="(present + late) ÷ marks" />
+      <Tr head widths={[3, 1.3, 1, 1, 1, 1, 1]} cells={["Year group", "Rate", "P", "L", "E", "M", "A"]} />
+      {rows.map((r) => (
+        <Tr
+          key={r.level}
+          widths={[3, 1.3, 1, 1, 1, 1, 1]}
+          cells={[
+            r.level,
+            pct(r.rate),
+            num(r.counts.present),
+            num(r.counts.late),
+            num(r.counts.excused),
+            num(r.counts.medical),
+            num(r.counts.absent),
+          ]}
+        />
+      ))}
+    </View>
+  );
+}
+
+/** Census · age & gender — roll + gender split + the GES "enrolment by approved age" (under/on/over). */
+function CensusSection({ census }: { census: CensusEnrolment }) {
+  return (
+    <View style={s.section} wrap={false}>
+      <SectionHead lead="Census" accent="age & gender" meta={`as of ${census.censusDate}`} />
+      <View style={s.headRow}>
+        <Text style={s.headline}>{num(census.roll)}</Text>
+        <Text style={s.caption}>
+          on roll · {census.gender.female}F · {census.gender.male}M
+        </Text>
+      </View>
+      <GenderBar female={census.gender.female} male={census.gender.male} />
+      {census.approvedAge.length > 0 ? (
+        <View style={{ marginTop: 10 }}>
+          <Text style={s.eyebrow}>ENROLMENT BY APPROVED AGE · VS GES OFFICIAL AGE</Text>
+          <Tr head widths={[3, 1.4, 1.2, 1.2, 1.2]} cells={["Year group", "Official age", "Under", "On-age", "Over"]} />
+          {census.approvedAge.map((a) => (
+            <Tr
+              key={a.level}
+              widths={[3, 1.4, 1.2, 1.2, 1.2]}
+              cells={[a.level, String(a.officialAge), num(a.under), num(a.on), num(a.over)]}
+            />
+          ))}
+        </View>
+      ) : null}
+      {census.dobUnknown > 0 ? (
+        <Text style={s.small}>
+          {num(census.dobUnknown)} pupils have no date of birth on file — excluded from the age bands.
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
 /* ─────────────────────────── document ─────────────────────────── */
 
 export function BoardPackDocument({ data }: { data: BoardPackData }) {
-  const { rollup, meta } = data;
+  const { rollup, attention, levelPerf, attendanceByLevel, census, meta } = data;
   return (
     <Document
       title={`Board & Governance Overview — ${meta.schoolName}`}
@@ -688,8 +841,9 @@ export function BoardPackDocument({ data }: { data: BoardPackData }) {
           </Text>
         </View>
 
-        {/* Sections — board order */}
+        {/* Sections — board order, then the director drill-downs (#309) */}
         <View style={s.body}>
+          <AttentionSection items={attention} />
           <EnrolmentSection arm={rollup.enrolment} />
           <AttendanceSection arm={rollup.attendance} />
           <FinanceSection arm={rollup.netPositionFinance} />
@@ -698,6 +852,11 @@ export function BoardPackDocument({ data }: { data: BoardPackData }) {
           <TerminalSection arm={rollup.terminalResults} />
 
           <InfrastructureSection arm={rollup.infrastructure} />
+
+          {/* Director drill-downs — aggregate detail the /insights + synced /board surfaces show. */}
+          <YearGroupPerformanceSection perf={levelPerf} />
+          <AttendanceByLevelSection rows={attendanceByLevel} />
+          <CensusSection census={census} />
         </View>
 
         {/* Fixed footer + pagination */}

--- a/omnischools/lib/pdf/board-pack-parts.test.ts
+++ b/omnischools/lib/pdf/board-pack-parts.test.ts
@@ -97,26 +97,39 @@ describe("GOV-5 · board-grain formatters", () => {
   });
 });
 
-// ── route gate (source-level, airtight) ────────────────────────────────────────────────────────
-describe("GOV-5 · /board/board-pack route is board-gated + session-scoped", () => {
-  const route = readFileSync(
-    resolve(cwd(), "app/(board)/board/board-pack/route.ts"),
-    "utf8",
-  );
+// ── route gates + shared builder (source-level, airtight) ────────────────────────────────────────
+// #309 de-cloned the two board-pack routes: both now GATE and delegate to the shared
+// `buildBoardPackResponse`, which holds the (session-scoped) data assembly + the pdf response.
+const src = (p: string) => readFileSync(resolve(cwd(), p), "utf8");
 
-  it("gates on requireBoard() (a non-board session is redirected before the handler runs)", () => {
-    expect(route).toMatch(/requireBoard\s*\(\s*\)/);
+describe("GOV-5/§17-F · board-pack routes are gated, session-scoped, and share ONE builder (#309)", () => {
+  const boardRoute = src("app/(board)/board/board-pack/route.ts");
+  const insightsRoute = src("app/api/insights/board-pack/route.ts");
+  const shared = src("lib/pdf/board-pack-response.ts");
+
+  it("the /board route gates on requireBoard() and runs on the node runtime", () => {
+    expect(boardRoute).toMatch(/requireBoard\s*\(\s*\)/);
+    expect(boardRoute).toMatch(/runtime\s*=\s*["'`]nodejs["'`]/);
   });
 
-  it("derives the rollup from the SESSION school id, never a URL school id (R339)", () => {
-    expect(route).toMatch(/getSchoolRollup\s*\(\s*school\.id/);
-    // no client-supplied school id: the only searchParams read is periodId (the term).
-    expect(route).not.toMatch(/searchParams\.get\(\s*["'`]schoolId/);
+  it("the /api/insights route gates on INSIGHTS_READ_ROLES and runs on the node runtime", () => {
+    expect(insightsRoute).toMatch(/requireSchoolRole\s*\(\s*INSIGHTS_READ_ROLES/);
+    expect(insightsRoute).toMatch(/runtime\s*=\s*["'`]nodejs["'`]/);
   });
 
-  it("runs on the node runtime and streams application/pdf inline", () => {
-    expect(route).toMatch(/runtime\s*=\s*["'`]nodejs["'`]/);
-    expect(route).toMatch(/application\/pdf/);
-    expect(route).toMatch(/inline; filename=/);
+  it("both routes delegate to the SHARED buildBoardPackResponse — the clone is gone", () => {
+    expect(boardRoute).toMatch(/buildBoardPackResponse\s*\(\s*school/);
+    expect(insightsRoute).toMatch(/buildBoardPackResponse\s*\(\s*school/);
+  });
+
+  it("neither route trusts a URL school id — only periodId is read (R339)", () => {
+    expect(boardRoute).not.toMatch(/searchParams\.get\(\s*["'`]schoolId/);
+    expect(insightsRoute).not.toMatch(/searchParams\.get\(\s*["'`]schoolId/);
+  });
+
+  it("the shared builder is session-scoped (getDirectorsInsights on school.id) and streams pdf inline", () => {
+    expect(shared).toMatch(/getDirectorsInsights\s*\(\s*school\.id/);
+    expect(shared).toMatch(/application\/pdf/);
+    expect(shared).toMatch(/inline; filename=/);
   });
 });

--- a/omnischools/lib/pdf/board-pack-render.test.ts
+++ b/omnischools/lib/pdf/board-pack-render.test.ts
@@ -80,3 +80,35 @@ describe("#309 · the enriched board pack renders to a valid PDF", () => {
     expect(pdf.length).toBeGreaterThan(1500); // a real multi-section document, not an empty page
   });
 });
+
+/**
+ * #309 AC-3 honest-absence — the brand-new-school path (the most common real state). Empty attention
+ * ⇒ no AttentionSection; `!hasAnyScores` ⇒ no year-group perf table; empty attendanceByLevel ⇒ no
+ * attendance-by-level table; a zero census still renders its (empty) frame. The document must render
+ * without throwing AND must be strictly SMALLER than the enriched pack — proving the three guarded
+ * sections were truly DROPPED (omit-not-fake), not silently rendered as empty tables/headers.
+ */
+const emptyData: BoardPackData = {
+  ...data,
+  attention: [],
+  levelPerf: { terms: [], term: null, priorTerm: null, hasAnyScores: false, rows: [] },
+  attendanceByLevel: [],
+  census: {
+    censusDate: "2026-01-15",
+    roll: 0,
+    gender: { female: 0, male: 0, total: 0 },
+    byClass: [],
+    byLevel: [],
+    ageByLevel: [],
+    approvedAge: [],
+    dobUnknown: 0,
+  },
+};
+
+describe("#309 AC-3 · honest-absence drops the guarded director sections", () => {
+  it("renders a valid PDF that is strictly smaller than the populated pack (sections omitted, not empty)", async () => {
+    const [full, empty] = await Promise.all([renderBoardPackPdf(data), renderBoardPackPdf(emptyData)]);
+    expect(empty.subarray(0, 5).toString("latin1")).toBe("%PDF-");
+    expect(empty.length).toBeLessThan(full.length);
+  });
+});

--- a/omnischools/lib/pdf/board-pack-render.test.ts
+++ b/omnischools/lib/pdf/board-pack-render.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { renderBoardPackPdf } from "./render-board-pack";
+import type { BoardPackData } from "./board-pack-document";
+
+/**
+ * #309 render smoke — the four director drill-down sections (attention, year-group performance,
+ * attendance-by-level, census age/gender/approved-age) must actually RENDER, not just typecheck. A
+ * tsc-clean @react-pdf tree can still throw at renderToBuffer (a bad style value, an undefined access),
+ * so this feeds a realistic pack through the real renderer and asserts a valid PDF comes out. The rollup
+ * arms are all NOT_CAPTURED (reason panels) — the point is to exercise the NEW sections end to end.
+ */
+
+const uncaptured = { status: "NOT_CAPTURED", reason: "Nothing captured yet." } as const;
+const notApplicable = { status: "NOT_APPLICABLE", reason: "Not applicable." } as const;
+
+const data: BoardPackData = {
+  rollup: {
+    schoolId: "s1",
+    period: null,
+    generatedAt: new Date(0),
+    enrolment: uncaptured,
+    attendance: uncaptured,
+    feeCollections: uncaptured,
+    netPositionFinance: uncaptured,
+    performance: { basic: uncaptured, senior: notApplicable },
+    terminalResults: { bece: uncaptured, wassce: notApplicable },
+    infrastructure: uncaptured,
+    terms: [],
+  },
+  attention: [
+    { key: "fees", href: "/billing", dot: "terra", label: "Outstanding fees", value: "GHS 5,000 outstanding · 40% collected" },
+    { key: "census", href: "/reports/census", dot: "navy-2", label: "GES annual census", value: "Not started for 2025/26." },
+  ],
+  levelPerf: {
+    terms: [],
+    term: null,
+    priorTerm: null,
+    hasAnyScores: true,
+    rows: [
+      {
+        level: "JHS 1",
+        average: 72.5,
+        grade: "B",
+        tone: "green",
+        passRate: 80,
+        studentsGraded: 120,
+        classesGraded: 2,
+        classes: 2,
+        priorAverage: null,
+        delta: null,
+      },
+    ],
+  },
+  attendanceByLevel: [
+    { level: "JHS 1", rate: 81, marked: 160, counts: { present: 120, late: 10, excused: 2, medical: 4, absent: 24 } },
+    { level: "JHS 2", rate: null, marked: 0, counts: { present: 0, late: 0, excused: 0, medical: 0, absent: 0 } },
+  ],
+  census: {
+    censusDate: "2026-01-15",
+    roll: 250,
+    gender: { female: 130, male: 120, total: 250 },
+    byClass: [],
+    byLevel: [],
+    ageByLevel: [],
+    approvedAge: [{ level: "JHS 1", officialAge: 12, under: 5, on: 100, over: 15, unknown: 0 }],
+    dobUnknown: 3,
+  },
+  meta: {
+    schoolName: "Test Memorial SHS",
+    schoolInitials: "TM",
+    termLabel: "Term 2 · 2025/26",
+    generatedAtLabel: "15 Jan 2026 · 09:00",
+  },
+};
+
+describe("#309 · the enriched board pack renders to a valid PDF", () => {
+  it("produces a non-trivial %PDF buffer with the director sections included", async () => {
+    const pdf = await renderBoardPackPdf(data);
+    expect(pdf.subarray(0, 5).toString("latin1")).toBe("%PDF-");
+    expect(pdf.length).toBeGreaterThan(1500); // a real multi-section document, not an empty page
+  });
+});

--- a/omnischools/lib/pdf/board-pack-response.ts
+++ b/omnischools/lib/pdf/board-pack-response.ts
@@ -1,0 +1,70 @@
+import "server-only";
+import { getDirectorsInsights, buildAttention } from "@/lib/insights/insights-data";
+import { renderBoardPackPdf } from "@/lib/pdf/render-board-pack";
+import type { BoardPackData } from "@/lib/pdf/board-pack-document";
+
+/**
+ * The SHARED board-pack builder (#309). ONE document + data assembly behind BOTH routes — the board's
+ * `/board/board-pack` (requireBoard) and the directors' `/api/insights/board-pack`
+ * (INSIGHTS_READ_ROLES) — which now differ ONLY in their gate, killing the maintenance clone. The pack
+ * carries the full aggregate set the two synced surfaces show: the rollup arms + year-group performance
+ * + attendance-by-level + census age/gender/approved-age + the "needs attention" rows — all
+ * aggregate-only, no per-student row. The caller resolves `school` from the SESSION (never a URL id);
+ * `periodId` only picks the term.
+ */
+export async function buildBoardPackResponse(
+  school: { id: string; name: string },
+  periodId: string | undefined,
+): Promise<Response> {
+  const insights = await getDirectorsInsights(school.id, { periodId });
+  const { rollup, levelPerf, attendanceByLevel, census } = insights;
+
+  const termLabel = rollup.period
+    ? `${rollup.period.label} · ${rollup.period.academicYear}`
+    : "No academic period configured";
+
+  const data: BoardPackData = {
+    rollup,
+    attention: buildAttention(insights, termLabel),
+    levelPerf,
+    attendanceByLevel,
+    census,
+    meta: {
+      schoolName: school.name,
+      schoolInitials: initialsOf(school.name),
+      termLabel,
+      generatedAtLabel: fmtDateTime(rollup.generatedAt),
+    },
+  };
+
+  const pdf = await renderBoardPackPdf(data);
+  const term = termLabel.replace(/[^A-Za-z0-9]+/g, "-").replace(/^-|-$/g, "");
+  return new Response(new Uint8Array(pdf), {
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": `inline; filename="Board-pack-${term}.pdf"`,
+      "Cache-Control": "private, no-store",
+    },
+  });
+}
+
+// 2-letter school-crest initials (matches the shipped PDF loaders' one-liner: "Aggrey Memorial" → "AM").
+const initialsOf = (name: string) =>
+  name
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? "")
+    .join("") || "S";
+
+// Documents take pre-formatted dates (house style) — format here, in the school tz/locale.
+const fmtDateTime = (d: Date) =>
+  d
+    .toLocaleString("en-GB", {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    })
+    .replace(",", " ·");


### PR DESCRIPTION
**Closes #309.** The `/api/insights` board-pack was a clone of `/board/board-pack` carrying only `{rollup, meta}`, so the directors' export omitted everything #249/#250 added to the page — and it was a maintenance duplicate.

## What it does
- **Enriches the board-pack PDF** with the four aggregate director sections the `/insights` (and synced `/board`) surfaces show: **needs-attention rows, performance by year-group, attendance by year-group, and census age/gender/approved-age**.
- **Kills the clone**: one shared `buildBoardPackResponse(school, periodId)` behind both routes; they now differ ONLY in their gate (`requireBoard` vs `INSIGHTS_READ_ROLES`).

## Aggregate-only, no new exposure
- Every new section carries only year-group / age-band / school-wide rows — **no student id/name/code/DOB** reaches `BoardPackData`. Attendance is sourced from the PII-stripped `rollup.attendance` fold, never `getAttendanceSummary`.
- Both routes keep their existing gate; `school` is session-derived (never a URL id). Not a widening — the board dashboard already renders these same drill-ins on screen, so the pack matches what the board member already sees.

## Gates
- **Quinn: GREEN** — both ACs; added an honest-absence render test (empty sections dropped, not emitted).
- **Dex: APPROVE** — clean de-clone, right seam; two non-blocking nits addressed.
- **Sarah: SECURITY-CLEAN** — no per-student data, no gate change, no widening, no token/PII in URL/filename.
- tsc clean · vitest 2274 green · `next build` exit 0 · render smoke proves the enriched PDF renders.

## Deploy
**No SQL to run** — presentational/aggregate only, no schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)