### PR TITLE
fix(wassce): delete the fabricated topic heatmap + intervention plan (#268)

### DIFF
--- a/omnischools/app/(app)/senior/wassce/cohort/page.tsx
+++ b/omnischools/app/(app)/senior/wassce/cohort/page.tsx
@@ -718,8 +718,8 @@ function Chip({ grade, dim }: { grade: string; dim?: boolean }) {
 
 /**
  * One heatmap row. The fill of every cell is `GRADE_COLORS[column]` — CONSTANT down each column,
- * independent of the count. This is a grade gradient table, not a magnitude heatmap: `HEAT_COLORS`
- * (INCR-16's count-driven scale) would be a category error here. A genuine zero renders "0", the
+ * independent of the count. This is a grade gradient table, not a magnitude heatmap: a count-driven
+ * magnitude scale would be a category error here. A genuine zero renders "0", the
  * documented exception to the em-dash rule — the coloured cell carries the meaning.
  */
 function Row({

--- a/omnischools/app/(app)/senior/wassce/subject/page.tsx
+++ b/omnischools/app/(app)/senior/wassce/subject/page.tsx
@@ -288,7 +288,7 @@ export default async function WassceSubjectTeacherPage(props: {
       <section id="plan" className="space-y-3">
         <div className="flex flex-wrap items-baseline justify-between gap-2">
           <h2 className="font-display text-2xl font-medium text-navy">
-            The <em className="italic text-gold">final</em> 24 days
+            The <em className="italic text-gold">final</em> stretch
           </h2>
           <span className="rounded-full bg-bg px-2 py-0.5 text-[10px] uppercase tracking-wide text-navy-3">
             not yet built

--- a/omnischools/app/(app)/senior/wassce/subject/page.tsx
+++ b/omnischools/app/(app)/senior/wassce/subject/page.tsx
@@ -5,7 +5,7 @@ import { SENIOR_LEDGER_ROLES, WASSCE_SETUP_ROLES, hasAnyRole } from "@/lib/acces
 import { withSchool } from "@/lib/db/rls";
 import { loadSubjectTeacherSurface } from "@/lib/wassce/mock-data";
 import { WassceMockEntryGrid } from "@/components/senior/wassce-mock-entry-grid";
-import { GRADE_COLORS, HEAT_COLORS } from "@/lib/wassce/grade-colors";
+import { GRADE_COLORS } from "@/lib/wassce/grade-colors";
 import { benchmarkDot } from "@/lib/wassce/mock-grades";
 import type { BenchCell } from "@/lib/wassce/mock-view";
 
@@ -273,37 +273,14 @@ export default async function WassceSubjectTeacherPage(props: {
             Where the <em className="italic text-gold">cohort</em> is weak
           </h2>
           <span className="rounded-full bg-bg px-2 py-0.5 text-[10px] uppercase tracking-wide text-navy-3">
-            static · needs a per-topic table (deferred)
+            not yet captured
           </span>
         </div>
-        <div className="overflow-x-auto rounded-lg border border-border bg-surface p-4">
-          <table className="w-full min-w-[720px] border-collapse text-[11px]">
-            <thead className="text-[10px] font-bold uppercase tracking-wide text-navy-3">
-              <tr className="border-b border-border">
-                <th className="px-2 py-2 text-left">Topic</th>
-                <th className="px-2 py-2 text-center">A1</th>
-                <th className="px-2 py-2 text-center">B2–B3</th>
-                <th className="px-2 py-2 text-center">C4–C6</th>
-                <th className="px-2 py-2 text-center">D7–E8</th>
-                <th className="px-2 py-2 text-center">F9</th>
-                <th className="px-2 py-2 text-center">Cohort avg</th>
-              </tr>
-            </thead>
-            <tbody>
-              {TOPIC_HEATMAP.map((t) => (
-                <tr key={t.topic} className="border-b border-border">
-                  <td className="px-2 py-2">
-                    <div className="font-semibold text-navy">{t.topic}</div>
-                    <div className="text-[10px] text-navy-3">{t.meta}</div>
-                  </td>
-                  {t.cells.map((c, i) => (
-                    <HeatCell key={i} count={c.n} level={c.h} />
-                  ))}
-                  <HeatCell label={t.avg.g} level={t.avg.h} />
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <div className="rounded-lg border border-dashed border-border bg-bg p-6 text-[12px] leading-relaxed text-navy-3">
+          A per-topic diagnostic needs question-level marks against the syllabus — which the mock ledger
+          does not capture (it records one grade per paper, not per topic). Rather than show invented
+          figures, this stays empty until per-topic mark capture is built. The cohort&apos;s
+          predicted-grade distribution is in the mock standings above.
         </div>
       </section>
 
@@ -314,30 +291,13 @@ export default async function WassceSubjectTeacherPage(props: {
             The <em className="italic text-gold">final</em> 24 days
           </h2>
           <span className="rounded-full bg-bg px-2 py-0.5 text-[10px] uppercase tracking-wide text-navy-3">
-            static · plan text + co-sign deferred
+            not yet built
           </span>
         </div>
-        <div className="grid gap-3.5 md:grid-cols-3">
-          {INTERVENTION_TIERS.map((t) => (
-            <div
-              key={t.eyebrow}
-              className="rounded-lg border border-border bg-surface p-4"
-              style={{ borderTop: `3px solid ${t.color}` }}
-            >
-              <div className="text-[10px] font-bold uppercase" style={{ color: t.color }}>
-                {t.eyebrow}
-              </div>
-              <div className="mt-1 font-display text-[15px] font-medium text-navy">{t.title}</div>
-              <div className="mt-2 border-b border-border pb-2 text-[12px] text-navy-2">{t.students}</div>
-              <ul className="mt-2 space-y-1.5 text-[11.5px] text-navy-2">
-                {t.plan.map((p) => (
-                  <li key={p} className="before:mr-1 before:text-gold before:content-['·']">
-                    {p}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ))}
+        <div className="rounded-lg border border-dashed border-border bg-bg p-6 text-[12px] leading-relaxed text-navy-3">
+          A structured, co-signed intervention plan isn&apos;t built yet — so rather than show a
+          fabricated schedule, this stays empty. The bands it would target (credit-borderline, and those
+          within a one-grade lift) are visible in the mock standings above.
         </div>
       </section>
 
@@ -409,20 +369,6 @@ function SumCell({ accent, lead, body }: { accent?: "green"; lead: string; body:
   );
 }
 
-function HeatCell({ count, label, level }: { count?: number; label?: string; level: keyof typeof HEAT_COLORS }) {
-  const c = HEAT_COLORS[level];
-  return (
-    <td className="px-1 py-1 text-center">
-      <span
-        className="inline-flex h-7 w-full min-w-[34px] items-center justify-center rounded font-display text-[11px] font-semibold"
-        style={{ background: c.bg, color: c.text }}
-      >
-        {label ?? (count === 0 ? "" : count)}
-      </span>
-    </td>
-  );
-}
-
 function Dot({ cls }: { cls: string }) {
   return <span className={`inline-block h-2 w-2 rounded-full align-middle ${cls}`} />;
 }
@@ -460,66 +406,3 @@ function BenchCellView({ cell }: { cell: BenchCell }) {
     </div>
   );
 }
-
-/* ------------------------------- seeded/static section content (Lucy map §3/§4) ------------------------------- */
-
-type Heat = keyof typeof HEAT_COLORS;
-const TOPIC_HEATMAP: {
-  topic: string;
-  meta: string;
-  cells: { n: number; h: Heat }[];
-  avg: { g: string; h: Heat };
-}[] = [
-  { topic: "Organic chemistry", meta: "12 questions · 24% of paper", cells: [{ n: 12, h: "h5" }, { n: 11, h: "h4" }, { n: 5, h: "h2" }, { n: 0, h: "h0" }, { n: 0, h: "h0" }], avg: { g: "B2", h: "h4" } },
-  { topic: "Inorganic · transition metals", meta: "8 questions · 16% of paper", cells: [{ n: 9, h: "h5" }, { n: 10, h: "h4" }, { n: 7, h: "h3" }, { n: 2, h: "h1" }, { n: 0, h: "h0" }], avg: { g: "B3", h: "h3" } },
-  { topic: "Stoichiometry & mole concept", meta: "6 questions · 12% of paper", cells: [{ n: 10, h: "h5" }, { n: 12, h: "h4" }, { n: 6, h: "h2" }, { n: 0, h: "h0" }, { n: 0, h: "h0" }], avg: { g: "B2", h: "h4" } },
-  { topic: "Atomic structure & bonding", meta: "5 questions · 10% of paper", cells: [{ n: 8, h: "h5" }, { n: 13, h: "h4" }, { n: 7, h: "h3" }, { n: 0, h: "h0" }, { n: 0, h: "h0" }], avg: { g: "B3", h: "h3" } },
-  { topic: "Acids · bases · salts", meta: "5 questions · 10% of paper", cells: [{ n: 11, h: "h5" }, { n: 10, h: "h4" }, { n: 6, h: "h2" }, { n: 1, h: "h0" }, { n: 0, h: "h0" }], avg: { g: "B2", h: "h4" } },
-  { topic: "Equilibria · Le Chatelier", meta: "5 questions · 10% of paper", cells: [{ n: 4, h: "h3" }, { n: 9, h: "h3" }, { n: 12, h: "h2" }, { n: 3, h: "h1" }, { n: 0, h: "h0" }], avg: { g: "C4", h: "h2" } },
-  { topic: "Electrochemistry", meta: "4 questions · 8% of paper", cells: [{ n: 3, h: "h2" }, { n: 8, h: "h3" }, { n: 12, h: "h2" }, { n: 4, h: "h1" }, { n: 1, h: "h0" }], avg: { g: "C5", h: "h1" } },
-  { topic: "Reaction kinetics", meta: "3 questions · 6% of paper", cells: [{ n: 7, h: "h4" }, { n: 11, h: "h4" }, { n: 9, h: "h3" }, { n: 1, h: "h1" }, { n: 0, h: "h0" }], avg: { g: "B3", h: "h3" } },
-  { topic: "Energetics & thermochemistry", meta: "3 questions · 6% of paper", cells: [{ n: 6, h: "h4" }, { n: 9, h: "h3" }, { n: 10, h: "h2" }, { n: 3, h: "h1" }, { n: 0, h: "h0" }], avg: { g: "C4", h: "h2" } },
-  { topic: "Industrial chemistry · contemporary", meta: "2 questions · 4% of paper", cells: [{ n: 7, h: "h4" }, { n: 12, h: "h4" }, { n: 8, h: "h3" }, { n: 1, h: "h0" }, { n: 0, h: "h0" }], avg: { g: "B3", h: "h3" } },
-];
-
-// Frame 04 renders SEEDED/STATIC (AC16) — there is no intervention table to derive from. The dates
-// keep their day + month and DROP the weekday: the surface wrote `Sat 24 May`, and 24 May 2026 is a
-// SUNDAY. A weekday nothing computed is a claim the page cannot stand behind (R90).
-const INTERVENTION_TIERS = [
-  {
-    eyebrow: "Tier 1 · urgent intervention",
-    title: "Borderline credit",
-    color: "#B84A39",
-    students: "The C5–C6 band — the FOCUS candidates (derived from Mock-2 bands).",
-    plan: [
-      "8 hrs after-school tutoring (Mon + Wed, weeks 1–4)",
-      "Pair-tutor with a top-3 student for inorganic — Saturday mornings",
-      "Daily 20-min question set on the weakest topic (equilibria + electrochem)",
-      "Weekly parent SMS update · pre-paper boost session 5 Jun",
-    ],
-  },
-  {
-    eyebrow: "Tier 2 · focused improvement",
-    title: "Move B3 → B2 or B2 → A1",
-    color: "#C8975B",
-    students: "The B3 / newly-B2 band · all within reach of a one-grade lift in 24 days.",
-    plan: [
-      "Whole-class focus on equilibria + electrochem (2 lessons each)",
-      "WAEC past-paper practice · weekly · marked by Mr Asiedu",
-      "Topic-specific resource pack per weak topic",
-      "Mid-cycle check-in · 24 May",
-    ],
-  },
-  {
-    eyebrow: "Tier 3 · consolidate strengths",
-    title: "A1 / B2 band · hold the line",
-    color: "#2F6B47",
-    students: "The A1/B2 band · low risk of slipping if confidence is maintained.",
-    plan: [
-      "Self-directed past-paper drills · weekly check-in only",
-      "Peer-tutor assignments (top 3 paired with Tier 1 students)",
-      "Stretch material on industrial chem + contemporary issues",
-      "Pre-paper boost session optional · 5 Jun",
-    ],
-  },
-];

--- a/omnischools/lib/wassce/grade-colors.ts
+++ b/omnischools/lib/wassce/grade-colors.ts
@@ -22,13 +22,3 @@ export const GRADE_COLORS: Record<WassceGrade, string> = {
 
 /** Chip text colour — the light bg token hex (readable on every palette-A fill). */
 export const GRADE_CHIP_TEXT = "#FAF7F2";
-
-/** Palette B (§0.2B) — heatmap 6-step scale, count-driven. h0 is the light bg (navy-3 text). */
-export const HEAT_COLORS: Record<"h0" | "h1" | "h2" | "h3" | "h4" | "h5", { bg: string; text: string }> = {
-  h5: { bg: "#1E5A35", text: "#FAF7F2" }, // strong · 14+
-  h4: { bg: "#3D8059", text: "#FAF7F2" }, // good · 10–13
-  h3: { bg: "#B59B3D", text: "#FAF7F2" }, // mixed · 6–9
-  h2: { bg: "#C58A2E", text: "#FAF7F2" }, // focus area · 3–5
-  h1: { bg: "#B84A39", text: "#FAF7F2" }, // critical gap · 0–2
-  h0: { bg: "#FAF7F2", text: "#8A93A6" }, // zero
-};

--- a/omnischools/lib/wassce/subject-defab-268.test.ts
+++ b/omnischools/lib/wassce/subject-defab-268.test.ts
@@ -31,6 +31,8 @@ describe("#268 · the WASSCE subject-teacher fabrications are gone", () => {
     for (const fake of ["after-school tutoring", "parent SMS", "past-paper", "5 Jun", "24 May", "boost session"]) {
       expect(src, `fabricated plan string "${fake}" must be gone`).not.toContain(fake);
     }
+    // the §04 heading no longer asserts an invented day-count ("The final 24 days" — days-to-paper is "—").
+    expect(src).not.toMatch(/final<\/em>\s*\d+\s*days/);
   });
 
   it("the §03 and §04 shells survive with an honest, zero-number placeholder (AC-268-03)", () => {

--- a/omnischools/lib/wassce/subject-defab-268.test.ts
+++ b/omnischools/lib/wassce/subject-defab-268.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { cwd } from "node:process";
+
+/**
+ * INCR #268 — the WASSCE subject-teacher page rendered two FABRICATIONS every teacher saw as their own
+ * cohort: §03's hardcoded `TOPIC_HEATMAP` (fake per-topic grade counts) and §04's `INTERVENTION_TIERS`
+ * (invented tutoring schedule + dates + parent SMS). No per-topic data exists in the schema, so Kofi
+ * ruled omit-not-fake: delete both, keep an honest zero-number shell. This locks that — a reintroduced
+ * constant or any fabricated figure fails here.
+ */
+
+const src = readFileSync(resolve(cwd(), "app/(app)/senior/wassce/subject/page.tsx"), "utf8");
+
+describe("#268 · the WASSCE subject-teacher fabrications are gone", () => {
+  it("the fabricated constants + their render helper no longer exist (AC-268-02)", () => {
+    expect(src).not.toMatch(/TOPIC_HEATMAP/);
+    expect(src).not.toMatch(/INTERVENTION_TIERS/);
+    expect(src).not.toMatch(/\bHeatCell\b/);
+    expect(src).not.toMatch(/HEAT_COLORS/); // the import is dropped too
+  });
+
+  it("no fabricated per-topic content survives (AC-268-01)", () => {
+    for (const fake of ["Organic chemistry", "transition metals", "Stoichiometry", "Le Chatelier", "% of paper"]) {
+      expect(src, `fabricated topic string "${fake}" must be gone`).not.toContain(fake);
+    }
+  });
+
+  it("no fabricated intervention content survives (AC-268-04)", () => {
+    for (const fake of ["after-school tutoring", "parent SMS", "past-paper", "5 Jun", "24 May", "boost session"]) {
+      expect(src, `fabricated plan string "${fake}" must be gone`).not.toContain(fake);
+    }
+  });
+
+  it("the §03 and §04 shells survive with an honest, zero-number placeholder (AC-268-03)", () => {
+    expect(src).toMatch(/id="heatmap"/); // shell kept (OC-268-A)
+    expect(src).toMatch(/id="plan"/);
+    expect(src).toMatch(/not yet captured/);
+    expect(src).toMatch(/not yet built/);
+    expect(src).toMatch(/stays empty/);
+  });
+});

--- a/omnischools/lib/wassce/subject-defab-268.test.ts
+++ b/omnischools/lib/wassce/subject-defab-268.test.ts
@@ -28,7 +28,7 @@ describe("#268 · the WASSCE subject-teacher fabrications are gone", () => {
   });
 
   it("no fabricated intervention content survives (AC-268-04)", () => {
-    for (const fake of ["after-school tutoring", "parent SMS", "past-paper", "5 Jun", "24 May", "boost session"]) {
+    for (const fake of ["after-school tutoring", "parent SMS", "WAEC past-paper practice", "5 Jun", "24 May", "boost session"]) {
       expect(src, `fabricated plan string "${fake}" must be gone`).not.toContain(fake);
     }
     // the §04 heading no longer asserts an invented day-count ("The final 24 days" — days-to-paper is "—").


### PR DESCRIPTION
**Closes #268.** The WASSCE subject-teacher page rendered two fabrications every teacher saw as their own cohort — §03's hardcoded `TOPIC_HEATMAP` (fake per-topic A1..F9 counts) and §04's `INTERVENTION_TIERS` (invented tutoring schedule, dates, parent SMS). A "static/deferred" badge does not cure a fabricated number (R90).

## Resolution (Kofi's ruling: omit-not-fake, not reframe)
No per-topic data exists in the schema (`mock_results` is keyed per subject, never per topic), so a real per-topic table is impossible — and a grade *distribution* would only duplicate §01's real histogram under a misleading "where the cohort is weak" heading. So both sections are **deleted**, each keeping an honest **zero-number shell** (heading + a one-line "not yet captured / not yet built" placeholder) so the page's IA and `#heatmap`/`#plan` anchors survive.
- Removed the dead `HeatCell` helper, both constants, the `HEAT_COLORS` import, and (once orphaned) the `HEAT_COLORS` export itself.
- Dropped the invented "24 days" from the §04 heading (days-to-paper is uncomputed, shown as "—").

## Gates
- **Quinn: GREEN** — all ACs; caught the "24 days" residual (fixed).
- **Dex: APPROVE** — clean deletion, IA intact, honest placeholders on-token; orphaned-export cleanup done.
- **Sarah: not engaged** — this change touches no auth, data, schema, query, or PII (pure static-content honesty), so there is no security surface to review.
- tsc clean · vitest 2275 green · `next build` exit 0 · regression-locked (`subject-defab-268.test.ts`).

## Note
The same page carries OTHER fabrications Kofi scoped to a **separate follow-up bit** — a hardcoded fake teacher name ("Mr S. Asiedu") + invented NTC/PLC/CPD figures. Not touched here; tracked separately. The page is honest about §03/§04 after this, not yet fabrication-free.

## Deploy
No SQL, no schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)