### PR TITLE
fix(wassce): de-fabricate the teacher persona + CPD record (#268 follow-up)

### DIFF
--- a/omnischools/app/(app)/senior/wassce/subject/page.tsx
+++ b/omnischools/app/(app)/senior/wassce/subject/page.tsx
@@ -19,8 +19,9 @@ export const dynamic = "force-dynamic";
  * subject. `?subjectId` / `?cohortId` are tenant-scoped view selectors (never a teacher id).
  *
  * Frames 01 (histogram + credit/distinction/mean), 02 (mark-entry grid) and 05 (benchmark "my cohort")
- * DERIVE from real `mock_results` (AC7/8/9). Frames 03 (topic heatmap) + 04 (intervention plan) + the
- * CPD/NTC/practical fields render SEEDED/STATIC — no per-topic table, no aggregate, no projection (AC16).
+ * DERIVE from real `mock_results` (AC7/8/9). The §01 persona is the SESSION user (real name + initials);
+ * NTC licence / PLC / CPD are OMITTED — dropped, not faked (R404-deferred). Frames 03 (per-topic) + 04
+ * (intervention plan) are honest empty shells (#268) — the backing data does not exist yet.
  */
 export default async function WassceSubjectTeacherPage(props: {
   searchParams: Promise<{ subjectId?: string; cohortId?: string }>;
@@ -128,33 +129,23 @@ export default async function WassceSubjectTeacherPage(props: {
 
       {/* ================= §01 — My cohort ================= */}
       <section id="cohort" className="space-y-4">
-        {/* teacher identity — persona is static (cross-module HR/NTC); the assignment count derives */}
+        {/* teacher identity — the SESSION user (real name/initials). NTC/PLC/CPD are omitted (dropped,
+            not faked — R404-deferred); only the derived subject + candidate count are shown. */}
         <div className="grid grid-cols-[auto_1fr_auto] items-center gap-4 rounded-xl border border-border bg-surface p-4">
           <span
             className="flex h-[60px] w-[60px] items-center justify-center rounded-xl font-display text-[22px] text-gold"
             style={{ background: "linear-gradient(135deg, var(--navy), var(--navy-2))" }}
           >
-            SA
+            {initialsOf(user.name)}
           </span>
           <div>
-            <div className="font-display text-[22px] font-medium text-navy">
-              Mr S. <em className="italic text-gold">Asiedu</em>
-            </div>
+            <div className="font-display text-[22px] font-medium text-navy">{user.name ?? "—"}</div>
             <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[12px] text-navy-3">
               <span>
-                <b className="text-navy">Subject</b> · {subjectName} · F3
+                <b className="text-navy">Subject</b> · {subjectName}
               </span>
               <span>
-                <b className="text-navy">Form Master</b> · F3 Slessor
-              </span>
-              <span>
-                <b className="text-navy">HOD Science</b>
-              </span>
-              <span>
-                <b className="text-navy">NTC Licence</b> · GA-TL-78423 · valid to 2028
-              </span>
-              <span>
-                <b className="text-navy">PLC</b> · Science HOD PLC · 12 sessions YTD
+                <b className="text-navy">Cohort</b> · WASSCE {data.cohort.examYear}
               </span>
             </div>
           </div>
@@ -163,13 +154,13 @@ export default async function WassceSubjectTeacherPage(props: {
           </span>
         </div>
 
-        {/* countdown strip — cells 2/3/4 derive; cells 1/5 seeded (subject clock / practical attendance) */}
+        {/* countdown strip — cells 2/3/4 derive from mock_results; cells 1/5 are honest-empty (no source yet) */}
         <div className="grid gap-3 md:grid-cols-5">
           <StripCell
             accent="terra"
             label="Days to Chemistry paper"
             value="—"
-            meta="Subject clock · wassce_paper_sittings (seeded)"
+            meta="Not yet captured"
           />
           <StripCell
             accent="green"
@@ -316,18 +307,6 @@ export default async function WassceSubjectTeacherPage(props: {
             <b>Strong</b> direct measurement · <Dot cls="bg-gold" /> <b>Moderate</b> annual snapshot ·{" "}
             <Dot cls="bg-warn" /> <b>Directional</b> interpolated from coarser data.
           </div>
-          <div className="rounded-lg border border-gold-soft bg-gold-bg p-4 text-[12px] text-navy-2">
-            <div className="font-display text-[14px] font-medium text-navy">
-              Mr Asiedu&apos;s CPD record on this cohort
-            </div>
-            <p className="mt-1">
-              Three-year teaching cycle · joined them in F1 (Sep 2023) · 142 lessons taught · 18 mock
-              assessments marked · 12 Science HOD PLC sessions attended · 1 CPD-credited equilibria
-              pedagogy session led at the Western Region NTC convention (+15 CPD points). NTC licence
-              renewal eligible at end of cycle.{" "}
-              <span className="text-navy-3">(cross-module HR/NTC — static)</span>
-            </p>
-          </div>
         </section>
       )}
     </div>
@@ -335,6 +314,14 @@ export default async function WassceSubjectTeacherPage(props: {
 }
 
 /* ------------------------------- derived-frame helpers ------------------------------- */
+
+/** Avatar initials from a full name (first + last initial); "—" when the name is null/blank. */
+const initialsOf = (full: string | null | undefined) => {
+  const parts = (full ?? "").trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "—";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+};
 
 function StripCell({
   accent,

--- a/omnischools/lib/wassce/persona-defab.test.ts
+++ b/omnischools/lib/wassce/persona-defab.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { cwd } from "node:process";
+
+/**
+ * WASSCE subject-teacher page · persona/CPD de-fabrication (follow-up to #268). The §01 block hardcoded a
+ * fake teacher "Mr S. Asiedu" + NTC licence + PLC count + invented role chips, and §05 an invented CPD
+ * record — all shown to every teacher as their own (R90). Kofi ruled: replace the name/initials with the
+ * SESSION user (the only field with a real source); omit-not-fake everything else (NTC/PLC/CPD are
+ * R404-deferred, "dropped not faked"). This locks that.
+ */
+const src = readFileSync(resolve(cwd(), "app/(app)/senior/wassce/subject/page.tsx"), "utf8");
+
+describe("WASSCE persona/CPD de-fabrication", () => {
+  it("the fabricated identity + NTC/PLC/CPD strings are gone (AC-PERSONA-1/4/5/6/8)", () => {
+    for (const fake of [
+      "Asiedu",
+      "GA-TL-78423",
+      "valid to 2028",
+      "Form Master",
+      "HOD Science",
+      "12 sessions YTD",
+      "142 lessons",
+      "18 mock",
+      "CPD record",
+      "+15 CPD",
+      "renewal eligible",
+      "Slessor",
+    ]) {
+      expect(src, `fabricated string "${fake}" must be gone`).not.toContain(fake);
+    }
+  });
+
+  it("the persona renders the REAL session user's name + initials (AC-PERSONA-1/2/3)", () => {
+    expect(src).toMatch(/\{initialsOf\(user\.name\)\}/); // real avatar initials
+    expect(src).toMatch(/\{user\.name \?\? "—"\}/); // real name, honest em-dash fallback (no invented person)
+    expect(src).toMatch(/const initialsOf = /); // the helper exists
+  });
+
+  it("the honest derived fields survive (AC-PERSONA-7)", () => {
+    expect(src).toMatch(/Subject<\/b> · \{subjectName\}/);
+    expect(src).toMatch(/WASSCE \{data\.cohort\.examYear\}/); // derived cohort year, not a hardcoded form
+    expect(src).toMatch(/\{s\.candidates\} candidates assigned/);
+  });
+
+  it("no cell claims a '(seeded)' source that feeds no value (AC-PERSONA-9)", () => {
+    expect(src).not.toMatch(/\(seeded\)/);
+  });
+
+  it("the docblock no longer endorses the fabrication as SEEDED/STATIC (AC-PERSONA-10)", () => {
+    expect(src).not.toMatch(/CPD\/NTC\/practical fields render SEEDED\/STATIC/);
+    expect(src).toMatch(/persona is the SESSION user/);
+  });
+});


### PR DESCRIPTION
Follow-up to #268 (which deleted the §03 topic-heatmap + §04 intervention-plan fabrications). This kills the **remaining** fabrications on the same page — the higher-severity ones Kofi scoped out of #268 because they misrepresent **identity**: a hardcoded fake teacher "Mr S. Asiedu" + "SA" avatar, a fake NTC licence (`GA-TL-78423`), "PLC · 12 sessions YTD", invented role chips (Form Master / HOD), and a §05 invented CPD record (142 lessons / 18 mocks / +15 CPD points). Every teacher saw all of it as their own record (R90).

## Resolution (Kofi's ruling)
- **Name + avatar → the REAL session user** (`user.name` + a local `initialsOf`) — the only field with a first-class source. Honest `—` fallback when the name is null (never an invented person).
- **NTC licence / PLC count / role chips / the entire §05 CPD box → omit-not-fake, deleted.** No source is loaded on this surface, and the CPD ledger / 3-yr licence cycle / NTC-sync are explicitly **R404-deferred** ("dropped, not faked").
- Kept every derived field (subject, cohort exam-year, candidate count, all mock stats + benchmark). Fixed strip cell 1's false "(seeded)" source claim. Rewrote the stale docblock that endorsed the fabrication.

## Gates
- **Quinn: GREEN** — all AC-PERSONA-1..11; `initialsOf` 10/10 edge cases; lock mutation-probed.
- **Dex: APPROVE** — real-user wiring sound (nullable-safe, no assertion), clean deletion, `examYear` is a real DTO field.
- **Sarah: not engaged** — the only new render is the session user's *own* name; no cross-user exposure, no query/schema/auth/PII change.
- tsc clean · `lib/wassce` 167 green · `next build` exit 0 · regression-locked (`persona-defab.test.ts`).

## Follow-ups (out of scope here)
- The page header still hardcodes `F3`/`F3 Science`, stale for an in-flight **F2** cohort — a candidate for the next honesty pass on this surface (flagged by both gates).
- Whether to surface the teacher's **real** NTC licence / PLC CPD is an owner call (`OC-WASSCE-NTC-CHIP` / `OC-WASSCE-CPD-LINK`) — default omit.

No schema, no deploy SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)