### PR TITLE
fix(wassce): derive the cohort form label (F3/F2), drop the hardcoded stream

### DIFF
--- a/omnischools/app/(app)/senior/wassce/subject/page.tsx
+++ b/omnischools/app/(app)/senior/wassce/subject/page.tsx
@@ -62,6 +62,9 @@ export default async function WassceSubjectTeacherPage(props: {
 
   const s = data.stats;
   const subjectName = data.subject.name;
+  // The cohort's form derives from `frozen` (exam-year cohort = F3, in-flight = F2) — the same rule the
+  // cohort switcher uses. Never hardcode "F3": an in-flight F2 cohort would then be mislabelled.
+  const cohortForm = data.cohort.frozen ? "F3" : "F2";
   const qs = (patch: Record<string, string>) => {
     const p = new URLSearchParams();
     if (searchParams.cohortId) p.set("cohortId", searchParams.cohortId);
@@ -75,11 +78,11 @@ export default async function WassceSubjectTeacherPage(props: {
       {/* ---- page head ---- */}
       <div className="border-b border-border pb-4">
         <div className="text-[11px] uppercase tracking-[0.12em] text-navy-3">
-          WASSCE {data.cohort.examYear} › {subjectName} · F3 Science
+          WASSCE {data.cohort.examYear} › {subjectName} · {cohortForm}
         </div>
         <div className="mt-2 flex flex-wrap items-start justify-between gap-3">
           <h1 className="font-display text-2xl font-medium text-navy">
-            {subjectName} · <em className="italic text-gold">F3</em> · my cohort
+            {subjectName} · <em className="italic text-gold">{cohortForm}</em> · my cohort
           </h1>
           <div className="flex flex-col items-end gap-1.5">
             {data.subjectOptions.length > 1 && (

--- a/omnischools/lib/wassce/persona-defab.test.ts
+++ b/omnischools/lib/wassce/persona-defab.test.ts
@@ -52,4 +52,11 @@ describe("WASSCE persona/CPD de-fabrication", () => {
     expect(src).not.toMatch(/CPD\/NTC\/practical fields render SEEDED\/STATIC/);
     expect(src).toMatch(/persona is the SESSION user/);
   });
+
+  it("the cohort form in the header is DERIVED (F3/F2 by frozen), not hardcoded", () => {
+    expect(src).toMatch(/const cohortForm = data\.cohort\.frozen \? "F3" : "F2"/);
+    expect(src).not.toContain("· F3 Science"); // the hardcoded breadcrumb stream is gone
+    expect(src).not.toMatch(/text-gold">F3<\/em>/); // the hardcoded form label is gone
+    expect(src).toMatch(/\{cohortForm\}/); // both header spots use the derived value
+  });
 });


### PR DESCRIPTION
Completes the WASSCE subject-page honesty pass. Both Quinn and Dex flagged this exact item in the #338 review as out-of-scope-then but a clean follow-up: the page header hardcoded `F3` / `F3 Science`, which is **stale for an in-flight F2 cohort** (the cohort switcher on the same page already renders `F2` for a non-frozen cohort).

## Fix
- The form now **derives** from `data.cohort.frozen` (`F3` for the exam-year cohort, `F2` for an in-flight one) — reusing the exact rule the cohort switcher uses. Both header spots use the derived value.
- The unsourced **"Science" stream is dropped** (omit-not-fake): a WASSCE cohort spans Science/Arts/Business, and there is no stream field on the surface data — so labelling it "Science" was a fabrication for any non-Science cohort.

## Verification
- Locked in `persona-defab.test.ts` (the form is derived; no hardcoded `F3`/`F3 Science` remains).
- tsc clean · `next build` exit 0. No schema, no deploy SQL, no security surface.

This is the 4-line implementation of the fix both gates pre-vetted in #338; the test lock is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)