### PR TITLE
fix(wassce): de-fabricate the setup page (personas, amounts, counts, dates)

### DIFF
--- a/omnischools/app/(app)/senior/wassce/setup/page.tsx
+++ b/omnischools/app/(app)/senior/wassce/setup/page.tsx
@@ -119,7 +119,7 @@ export default async function WassceSetupPage() {
         )}
 
         {/* §1.3 Stat strip — all counts derive from the reader. */}
-        <div className="mb-5 grid gap-3.5 md:grid-cols-4">
+        <div className="mb-5 grid gap-3.5 md:grid-cols-3">
           <StatTile
             live
             label="F3 cohort"
@@ -442,8 +442,8 @@ export default async function WassceSetupPage() {
               <b className="text-navy-2">{counts.candidates} candidates registered</b> with WAEC.
               Centre code <span className="font-mono font-bold text-navy">{data.centreCode}</span>.
               Index numbers issued. {counts.flagged} students flagged today — {counts.medicalFlags} on a
-              medical special-consideration (SC-12) process, {counts.nhisFlags} with NHIS-card issues
-              affecting the WAEC fee reconciliation.
+              medical special-consideration (SC-12) process, {counts.nhisFlags} with NHIS-card issues, and
+              {counts.feeFlags} with WAEC-fee reconciliation to resolve.
             </>
           }
           actions={[
@@ -509,7 +509,7 @@ export default async function WassceSetupPage() {
             flag
             label="Flagged today"
             value={String(counts.flagged)}
-            trend={`${counts.medicalFlags} medical · ${counts.nhisFlags} NHIS / fee admin`}
+            trend={`${counts.medicalFlags} medical · ${counts.nhisFlags} NHIS · ${counts.feeFlags} fee`}
           />
           <RosterTile
             label="Accommodations"

--- a/omnischools/app/(app)/senior/wassce/setup/page.tsx
+++ b/omnischools/app/(app)/senior/wassce/setup/page.tsx
@@ -28,7 +28,8 @@ export const dynamic = "force-dynamic";
  * READ-ONLY (Kofi AC-B): the surface exposes NO mutating server action and every write-looking
  * control (Edit · F2 cohort, + Late registration, freeze toggle, nav-out to unbuilt targets) is
  * rendered INERT. Export/Print/Audit are read stubs (disabled in INCR-15). No projection anywhere
- * (AC-G): Mock-2 aggregate is seeded/display-only, no tier is computed, the mock tile is static.
+ * (AC-G): no WASSCE tier/prediction is computed here. Every count/rate/amount on the page DERIVES from
+ * a reader field or a documented policy constant — no hardcoded persona, count, amount, or date.
  */
 export default async function WassceSetupPage() {
   const { school } = await requireSchoolRole(WASSCE_SETUP_ROLES);
@@ -50,6 +51,9 @@ export default async function WassceSetupPage() {
 
   const { counts, cohort, targets: t, examWindow: ew } = data;
   const examYear = cohort.examYear;
+  // Confirmed rate derives from the real counts — never a hardcoded percentage.
+  const confirmedPct =
+    counts.candidates > 0 ? Math.round((counts.confirmed / counts.candidates) * 1000) / 10 : 0;
 
   return (
     <div className="mx-auto max-w-page space-y-10">
@@ -114,7 +118,7 @@ export default async function WassceSetupPage() {
           </div>
         )}
 
-        {/* §1.3 Stat strip — counts derive; mock tile is static (INCR-16). */}
+        {/* §1.3 Stat strip — all counts derive from the reader. */}
         <div className="mb-5 grid gap-3.5 md:grid-cols-4">
           <StatTile
             live
@@ -142,17 +146,6 @@ export default async function WassceSetupPage() {
               <>
                 <b className="text-navy-2">{counts.subjectsCore} core</b> · {counts.subjectsElective}{" "}
                 electives
-              </>
-            }
-          />
-          <StatTile
-            label="Mocks completed"
-            value="2"
-            unit="of 2"
-            trend={
-              <>
-                Mock 1 <b className="text-navy-2">Nov 2025</b> · Mock 2{" "}
-                <b className="text-navy-2">Mar 2026</b>
               </>
             }
           />
@@ -199,7 +192,7 @@ export default async function WassceSetupPage() {
           </div>
         </div>
 
-        {/* §1.6 Cross-module strip — static commitments, wire nothing. */}
+        {/* §1.6 Cross-module strip — GENERIC feature explainers (no per-cohort persona/data wired). */}
         <div className="grid gap-3.5 md:grid-cols-3">
           <XmodCard
             label="Cross-module · Classes"
@@ -208,8 +201,7 @@ export default async function WassceSetupPage() {
             titlePost=" mapping"
             body={
               <>
-                Each F3 student belongs to one programme via their class assignment.{" "}
-                <b className="text-bg">F3 SCI 1, F3 SCI 2, F3 BUS 1, F3 BUS 2</b>, etc. Class →
+                Each F3 student belongs to one programme via their class assignment. That class →
                 programme join carries forward into WASSCE registration.
               </>
             }
@@ -221,9 +213,8 @@ export default async function WassceSetupPage() {
             titlePost=" locked"
             body={
               <>
-                Each subject has one or more F3 teachers. <b className="text-bg">Mr S. Asiedu</b> takes
-                Chemistry across all F3 SCI classes. Subject-view surface keys off this roster —
-                readiness data flows back to each teacher.
+                Each subject has one or more F3 teachers. The subject-view surface keys off this
+                roster — readiness data flows back to each teacher.
               </>
             }
           />
@@ -234,9 +225,10 @@ export default async function WassceSetupPage() {
             titlePost=" reconciliation"
             body={
               <>
-                WAEC charges per student per paper. <b className="text-bg">GHS 1,400 per candidate</b>{" "}
-                for {examYear}. Free SHS covers core fees; private add-ons (re-sits, extra electives)
-                flow into billing as individual line items. {counts.flagged} students flagged below.
+                WAEC charges per student per paper.{" "}
+                <b className="text-bg">{formatGhs(WAEC_FEE_PER_CANDIDATE)} per candidate</b> for{" "}
+                {examYear}. Free SHS covers core fees; private add-ons (re-sits, extra electives) flow
+                into billing as individual line items. {counts.flagged} students flagged below.
               </>
             }
           />
@@ -430,10 +422,9 @@ export default async function WassceSetupPage() {
               </table>
             </div>
             <div className="mt-3 rounded-lg bg-bg px-3 py-2.5 text-[10px] leading-relaxed text-navy-3">
-              Each figure is a <b>published snapshot stamped with its reference year</b>, re-verified from
-              every university&apos;s admissions portal each admission cycle — not a live feed. Universities
-              sometimes adjust cut-offs after WASSCE results come in if the applicant pool changes. The
-              figures here are <b>indicative, not guarantees</b>. Cut-off colour is difficulty-coded and
+              Each figure is a <b>published snapshot stamped with its reference year</b> — a recorded
+              reference, not a live feed. Universities sometimes adjust cut-offs after WASSCE results come
+              in if the applicant pool changes. The figures here are <b>indicative, not guarantees</b>. Cut-off colour is difficulty-coded and
               deliberately inverted: terra = the hardest (lowest) cut-offs, green = the easiest.
             </div>
           </div>
@@ -450,9 +441,9 @@ export default async function WassceSetupPage() {
             <>
               <b className="text-navy-2">{counts.candidates} candidates registered</b> with WAEC.
               Centre code <span className="font-mono font-bold text-navy">{data.centreCode}</span>.
-              Index numbers issued Feb 2026. {counts.flagged} students flagged today — one on a medical
-              special-consideration (SC-12) process, two with NHIS-card issues affecting the WAEC fee
-              reconciliation.
+              Index numbers issued. {counts.flagged} students flagged today — {counts.medicalFlags} on a
+              medical special-consideration (SC-12) process, {counts.nhisFlags} with NHIS-card issues
+              affecting the WAEC fee reconciliation.
             </>
           }
           actions={[
@@ -512,13 +503,13 @@ export default async function WassceSetupPage() {
             label="Confirmed"
             value={String(counts.confirmed)}
             sub={`of ${counts.candidates}`}
-            trend="98.8% · all papers paid · index numbers issued"
+            trend={`${confirmedPct}% of the cohort · index numbers issued`}
           />
           <RosterTile
             flag
             label="Flagged today"
             value={String(counts.flagged)}
-            trend="1 medical · 2 NHIS / fee admin"
+            trend={`${counts.medicalFlags} medical · ${counts.nhisFlags} NHIS / fee admin`}
           />
           <RosterTile
             label="Accommodations"
@@ -529,14 +520,14 @@ export default async function WassceSetupPage() {
             mono
             label="Total fees"
             value={data.totalFeesLabel}
-            trend="Free SHS covers 100% · 0 outstanding"
+            trend="Free SHS covers core registration fees"
           />
         </div>
 
         {/* §4.4 + §4.5 filter/sort strip + roster table (client view-state; no writes). */}
         <WassceRosterTable rows={data.roster} />
 
-        {/* §4.6 Cross-module strip — static; target modules unbuilt. */}
+        {/* §4.6 Cross-module strip — GENERIC explainers for cross-module integrations (target modules unbuilt). */}
         <div className="mt-5 grid gap-3.5 md:grid-cols-3">
           <XmodCard
             label="Cross-module · Sickbay"
@@ -554,28 +545,27 @@ export default async function WassceSetupPage() {
           />
           <XmodCard
             label="Cross-module · VLC"
-            titlePre="A. Quartey "
-            titleEm="pastoral"
+            titlePre="Pastoral "
+            titleEm="flag"
             titlePost=" cross-reference"
             body={
               <>
-                Pastoral flag visible to Dean only · no exam exemption granted (VLC pastoral case is
-                about the support, not the standards). She sits the same papers as everyone else; the
-                Dean checks in privately.
+                A candidate&apos;s pastoral flag is visible to the Dean only · no exam exemption granted
+                (a VLC pastoral case is about the support, not the standards). They sit the same papers
+                as everyone else; the Dean checks in privately.
               </>
             }
           />
           <XmodCard
             label="Cross-module · Billing"
             titlePre=""
-            titleEm={`${counts.flagged} fee flags`}
+            titleEm={`${counts.flagged} flags`}
             titlePost=" resolved or active"
             body={
               <>
-                P. Donkor&apos;s <b className="text-bg">GHS 240</b> is the only fee-blocking issue.
-                Bursar is working with the GES district office. Per Free SHS policy, no candidate can
-                be denied WASSCE for fee reasons — the school carries the gap if the district
-                doesn&apos;t reconcile.
+                Per Free SHS policy, no candidate can be denied WASSCE for fee reasons — where a fee gap
+                arises the bursar reconciles with the GES district office, and the school carries the gap
+                if the district doesn&apos;t.
               </>
             }
           />
@@ -625,7 +615,7 @@ export default async function WassceSetupPage() {
             </div>
             <div className="mt-1 text-[12px] text-navy-3">
               {counts.candidates} candidates registered with WAEC · {counts.programmes} programmes
-              locked · Mock 2 results posted · 11 cross-module integrations active.{" "}
+              locked.{" "}
               <b className="text-navy">WASSCE {examYear} is in progress.</b> No further setup changes
               possible until WAEC results arrive in August.
             </div>

--- a/omnischools/lib/wassce/setup-data.ts
+++ b/omnischools/lib/wassce/setup-data.ts
@@ -135,6 +135,8 @@ export type WassceSetupData = {
     subjectsElective: number;
     confirmed: number;
     flagged: number;
+    medicalFlags: number;
+    nhisFlags: number;
     accommodations: number;
   };
   accommodationBreakdown: string; // "2 chronic · 1 sight · 1 hearing"
@@ -326,6 +328,8 @@ export async function loadWassceSetup(
         subjectsElective: 0,
         confirmed: 0,
         flagged: 0,
+        medicalFlags: 0,
+        nhisFlags: 0,
         accommodations: 0,
       },
       accommodationBreakdown: "—",
@@ -423,6 +427,8 @@ export async function loadWassceSetup(
 
   // --- derived counts (all off real rows) ---
   const flagged = roster.filter((r) => r.isFlagged).length;
+  const medicalFlags = candRows.filter((c) => c.regFlag === "ON_MEDICAL").length;
+  const nhisFlags = candRows.filter((c) => c.regFlag === "NHIS_ISSUE").length;
   const accommodations = roster.filter((r) => r.hasAccommodation).length;
   const accByType = { chronic: 0, sight: 0, hearing: 0 };
   for (const c of candRows) {
@@ -542,6 +548,8 @@ export async function loadWassceSetup(
       subjectsElective: elecNames.size,
       confirmed: candRows.length - flagged,
       flagged,
+      medicalFlags,
+      nhisFlags,
       accommodations,
     },
     accommodationBreakdown,

--- a/omnischools/lib/wassce/setup-data.ts
+++ b/omnischools/lib/wassce/setup-data.ts
@@ -137,6 +137,7 @@ export type WassceSetupData = {
     flagged: number;
     medicalFlags: number;
     nhisFlags: number;
+    feeFlags: number;
     accommodations: number;
   };
   accommodationBreakdown: string; // "2 chronic · 1 sight · 1 hearing"
@@ -330,6 +331,7 @@ export async function loadWassceSetup(
         flagged: 0,
         medicalFlags: 0,
         nhisFlags: 0,
+        feeFlags: 0,
         accommodations: 0,
       },
       accommodationBreakdown: "—",
@@ -429,6 +431,7 @@ export async function loadWassceSetup(
   const flagged = roster.filter((r) => r.isFlagged).length;
   const medicalFlags = candRows.filter((c) => c.regFlag === "ON_MEDICAL").length;
   const nhisFlags = candRows.filter((c) => c.regFlag === "NHIS_ISSUE").length;
+  const feeFlags = candRows.filter((c) => c.regFlag === "FEE").length;
   const accommodations = roster.filter((r) => r.hasAccommodation).length;
   const accByType = { chronic: 0, sight: 0, hearing: 0 };
   for (const c of candRows) {
@@ -550,6 +553,7 @@ export async function loadWassceSetup(
       flagged,
       medicalFlags,
       nhisFlags,
+      feeFlags,
       accommodations,
     },
     accommodationBreakdown,

--- a/omnischools/lib/wassce/setup-defab.test.ts
+++ b/omnischools/lib/wassce/setup-defab.test.ts
@@ -42,14 +42,17 @@ describe("WASSCE setup · fabrications gone (AC-SETUP-*)", () => {
     expect(page).toMatch(/formatGhs\(WAEC_FEE_PER_CANDIDATE\)/); // WAEC fee from the single constant
     expect(page).toMatch(/const confirmedPct =/); // confirmed % derived, not "98.8"
     expect(page).toMatch(/\{confirmedPct\}%/);
-    expect(page).toMatch(/\{counts\.medicalFlags\}/); // flag split derived, not "1 medical · 2 NHIS"
+    // flag split derived + COMPLETE (medical + NHIS + fee = flagged), never a hardcoded "1 medical · 2 NHIS".
+    expect(page).toMatch(/\{counts\.medicalFlags\}/);
     expect(page).toMatch(/\{counts\.nhisFlags\}/);
+    expect(page).toMatch(/\{counts\.feeFlags\}/);
   });
 
-  it("the reader exposes the derived flag split (AC-SETUP-13a)", () => {
+  it("the reader exposes the full derived flag split — all 3 regFlag values (AC-SETUP-13a)", () => {
     expect(reader).toMatch(/medicalFlags = candRows\.filter\(\(c\) => c\.regFlag === "ON_MEDICAL"\)/);
     expect(reader).toMatch(/nhisFlags = candRows\.filter\(\(c\) => c\.regFlag === "NHIS_ISSUE"\)/);
-    expect(reader).toMatch(/medicalFlags: number/);
+    expect(reader).toMatch(/feeFlags = candRows\.filter\(\(c\) => c\.regFlag === "FEE"\)/);
+    expect(reader).toMatch(/feeFlags: number/);
   });
 
   it("the generic explainers survive (regression — don't over-delete; AC-SETUP-03/07)", () => {

--- a/omnischools/lib/wassce/setup-defab.test.ts
+++ b/omnischools/lib/wassce/setup-defab.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { cwd } from "node:process";
+
+/**
+ * WASSCE setup-page honesty sweep (Kofi's AC-SETUP-*). The page showed every teacher a mix of fabricated
+ * data as this cohort's own: fake personas (Mr S. Asiedu, A. Quartey, P. Donkor), hardcoded amounts
+ * (GHS 1,400 / GHS 240), a hardcoded "11 cross-module integrations active" count, a static mock tile
+ * (2 / Nov 2025 / Mar 2026), a hardcoded 98.8%/Feb-2026, and an unperformed cut-off "re-verified" claim.
+ * Fixed: real personas/counts genericised or derived from the reader (medicalFlags/nhisFlags/confirmedPct,
+ * formatGhs(WAEC_FEE_PER_CANDIDATE)); unsourced specifics omitted. This locks it.
+ */
+const page = readFileSync(resolve(cwd(), "app/(app)/senior/wassce/setup/page.tsx"), "utf8");
+const reader = readFileSync(resolve(cwd(), "lib/wassce/setup-data.ts"), "utf8");
+
+describe("WASSCE setup · fabrications gone (AC-SETUP-*)", () => {
+  it("no fabricated persona / amount / count / date is rendered as this cohort's fact", () => {
+    for (const fake of [
+      "Asiedu",
+      "Quartey",
+      "Donkor",
+      "GHS 1,400",
+      "GHS 240",
+      "11 cross-module",
+      "Mock 2 results posted",
+      "98.8",
+      "Feb 2026",
+      "Nov 2025",
+      "Mar 2026",
+      "F3 SCI 1",
+      "0 outstanding",
+      "fee flags",
+    ]) {
+      expect(page, `fabricated "${fake}" must be gone`).not.toContain(fake);
+    }
+    // the cut-off note no longer asserts an unperformed portal re-verification.
+    expect(page).not.toMatch(/re-verified from\s*\n?\s*every university/);
+  });
+
+  it("counts/amounts DERIVE from the reader or a policy constant (AC-SETUP-04/13)", () => {
+    expect(page).toMatch(/formatGhs\(WAEC_FEE_PER_CANDIDATE\)/); // WAEC fee from the single constant
+    expect(page).toMatch(/const confirmedPct =/); // confirmed % derived, not "98.8"
+    expect(page).toMatch(/\{confirmedPct\}%/);
+    expect(page).toMatch(/\{counts\.medicalFlags\}/); // flag split derived, not "1 medical · 2 NHIS"
+    expect(page).toMatch(/\{counts\.nhisFlags\}/);
+  });
+
+  it("the reader exposes the derived flag split (AC-SETUP-13a)", () => {
+    expect(reader).toMatch(/medicalFlags = candRows\.filter\(\(c\) => c\.regFlag === "ON_MEDICAL"\)/);
+    expect(reader).toMatch(/nhisFlags = candRows\.filter\(\(c\) => c\.regFlag === "NHIS_ISSUE"\)/);
+    expect(reader).toMatch(/medicalFlags: number/);
+  });
+
+  it("the generic explainers survive (regression — don't over-delete; AC-SETUP-03/07)", () => {
+    expect(page).toContain("subject-view surface keys off this"); // §1.6 teachers generic copy
+    expect(page).toContain("DRAFT WAEC SC-12"); // §4.6 Sickbay card generic explainer kept
+    expect(page).toContain("no candidate can be denied WASSCE for fee reasons"); // §4.6 billing generic
+  });
+});


### PR DESCRIPTION
Continues the WASSCE honesty sweep — the setup page after the subject page (#337/#338/#339 merged). It showed every teacher a mix of fabricated data as this cohort's own (R90). Per Kofi's 14-AC ruling:

## Removed the fake personas
- **"Mr S. Asiedu"** (§1.6 teachers — the same fake teacher deleted from the subject page), **"A. Quartey"** (§4.6 VLC — also a *named-student pastoral-flag* pattern on an admin-visible surface), **"P. Donkor"** (§4.6 billing). The cards keep their **generic feature-explainer** copy.

## Derived what has a real source
- WAEC fee → `formatGhs(WAEC_FEE_PER_CANDIDATE)` (single constant); the medical/NHIS/**fee** flag split → new reader counts (`medicalFlags`/`nhisFlags`/`feeFlags` off `candRows.regFlag`, a complete enumeration); confirmed % → `confirmed/candidates`. No more hardcoded "GHS 1,400", "1 medical · 2 NHIS", "98.8%".

## Omitted the unsourced
- The static mock tile (2 / Nov 2025 / Mar 2026 — no mock data in the reader), "11 cross-module integrations active", "Mock 2 results posted", the "Feb 2026" index date, the "0 outstanding" fee claim. Softened the §3.5 cut-off note's unperformed "re-verified from every university's portal" claim (#274).

## Gates
- **Quinn: GREEN** — all 14 ACs; reader change verified (correct `regFlag` enum values, both returns); test mutation-proven.
- **Dex: APPROVE** — after two minors, both fixed here (`feeFlags` completes the split; `grid-cols-3` after the mock tile's removal). Note: Dex's initially-flagged "working-tree drift" was a false alarm — Quinn's mutation-probe and Dex's read raced on the shared worktree; the committed state is clean.
- **Sarah: not engaged** — pure content honesty; removing a fake-named-student pastoral pattern is a net confidentiality *improvement*, and no real PII/query/auth/schema is touched.
- tsc clean · `lib/wassce` green · `next build` exit 0 · regression-locked (`setup-defab.test.ts`).

## Owner OCs
- **OC-SETUP-WAEC-FEE** — confirm the real WAEC/Free-SHS per-candidate fee (one constant `WAEC_FEE_PER_CANDIDATE` drives it everywhere).
- **#274** — cut-off dataset provenance (the note is softened in the interim).

No schema, no deploy SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)