### PR TITLE
feat(parent): consume the guardian email — deliver the parent invite by email too (#307)

### DIFF
--- a/omnischools/lib/actions/invites-guardian-email.test.ts
+++ b/omnischools/lib/actions/invites-guardian-email.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { readCode } from "@/lib/test-utils/source-shape";
+
+/**
+ * #307 — guardian email was captured on 3 surfaces but consumed by nothing. Now the parent-portal invite
+ * ALSO delivers to the guardian's STORED email (student_guardian.email). The security invariant is
+ * preserved: the email is resolved server-side from the guardian row (never caller free-text), and it is
+ * DELIVERY ONLY — the OTP/claim destination + the phone-keyed claim stamping (AC C2/C4) stay the stored
+ * phone, so email never becomes an alternate claim key (the #307 decision, default omit).
+ */
+const invites = () => readCode("lib/actions/invites.ts");
+const parentData = () => readCode("lib/parent/parent-data.ts");
+
+describe("#307 · guardian email is consumed by the parent invite", () => {
+  it("resolveParentInviteTargetTx now selects + returns the stored guardian email", () => {
+    const s = parentData();
+    expect(s).toMatch(/email: studentGuardians\.email/); // selected from the stored row
+    expect(s).toMatch(/email: g\.email/); // returned
+    expect(s).toMatch(/email: string \| null/); // on the ParentInviteTarget type
+  });
+
+  it("the parent invite delivers to the STORED email, never a caller-supplied one", () => {
+    const s = invites();
+    // the parent branch sets the delivery email from the resolved target (stored), not from request input.
+    expect(s).toMatch(/inviteEmail = target\.email/);
+    expect(s).toMatch(/email: inviteEmail/); // the invite row stores that resolved email
+    expect(s).toMatch(/to: inviteEmail/); // sendEmail delivers to it
+    expect(s).toMatch(/if \(inviteEmail\)/); // guarded — no email, no send (console-degrades like SMS)
+  });
+
+  it("email is DELIVERY ONLY — the OTP/claim destination stays the stored phone (no claim-key change)", () => {
+    const s = invites();
+    // the SMS OTP/claim link still goes to the stored `phone`; the claim keying is untouched by this change.
+    expect(s).toMatch(/phone = target\.phone/);
+    expect(s).toMatch(/sendSms\(\s*\n?\s*phone,/);
+    // no email-keyed claim: the accept/stamp path keys on phone (AC C4) — this file never stamps on email.
+    expect(s).not.toMatch(/stamp.*email|email.*claim key/i);
+  });
+});

--- a/omnischools/lib/actions/invites.ts
+++ b/omnischools/lib/actions/invites.ts
@@ -63,7 +63,7 @@ export async function createInvite(input: unknown): Promise<Result & { token?: s
   let assignments = d.assignments ?? null;
   // The invite EMAIL delivery target. Staff: the caller-supplied email. Parent: the STORED guardian email
   // (#307 — consumes student_guardian.email), resolved server-side, never caller free-text; delivery only.
-  let inviteEmail: string | null = d.email ?? null;
+  let inviteEmail: string | null = d.email || null; // `||` keeps the pre-#307 staff behaviour ("" → null)
 
   if (isParentRole(d.role)) {
     role = { code: "PARENT", label: "Parent" };

--- a/omnischools/lib/actions/invites.ts
+++ b/omnischools/lib/actions/invites.ts
@@ -61,6 +61,9 @@ export async function createInvite(input: unknown): Promise<Result & { token?: s
   let fullName: string;
   let studentId: string | null = null;
   let assignments = d.assignments ?? null;
+  // The invite EMAIL delivery target. Staff: the caller-supplied email. Parent: the STORED guardian email
+  // (#307 — consumes student_guardian.email), resolved server-side, never caller free-text; delivery only.
+  let inviteEmail: string | null = d.email ?? null;
 
   if (isParentRole(d.role)) {
     role = { code: "PARENT", label: "Parent" };
@@ -74,6 +77,7 @@ export async function createInvite(input: unknown): Promise<Result & { token?: s
     fullName = target.fullName;
     studentId = target.studentId;
     assignments = null; // a parent invite carries no class grants
+    inviteEmail = target.email; // #307 — deliver to the STORED guardian email (not caller-supplied)
   } else {
     role = resolveRole(d.role);
     if (!d.fullName || d.fullName.trim().length < 2) return { ok: false, error: "Enter a name" };
@@ -122,7 +126,7 @@ export async function createInvite(input: unknown): Promise<Result & { token?: s
         token,
         role: role.code,
         fullName,
-        email: d.email || null,
+        email: inviteEmail,
         phone,
         studentId,
         assignments,
@@ -150,11 +154,17 @@ export async function createInvite(input: unknown): Promise<Result & { token?: s
         ? `${sender}: Follow your child's WASSCE readiness on Omnischools. Set up your parent access: ${link}`
         : `${sender}: You've been added as ${role.label}. Set up your account: ${link}`,
     );
-    if (d.email) {
+    // Email delivery — parent: the STORED guardian email (#307); staff: the caller-supplied email. The
+    // link is the SAME token as the SMS; email only DELIVERS it. The OTP/claim destination stays the
+    // stored phone, so email is never a claim credential. Console-degrades with no Resend key (like SMS).
+    if (inviteEmail) {
       await sendEmail({
-        to: d.email,
+        to: inviteEmail,
         subject: `You're invited to ${school.name} on Omnischools`,
-        html: `<p>You've been added as <b>${role.label}</b> at ${school.name}.</p><p><a href="${link}">Accept the invite & set your password</a>.</p>`,
+        html:
+          role.code === "PARENT"
+            ? `<p>Follow your child's progress at ${school.name} on Omnischools.</p><p><a href="${link}">Set up your parent access</a> — you'll confirm with a code sent to your phone.</p>`
+            : `<p>You've been added as <b>${role.label}</b> at ${school.name}.</p><p><a href="${link}">Accept the invite & set your password</a>.</p>`,
       });
     }
     safeRevalidate(role.code === "PARENT" && studentId ? `/students/${studentId}` : "/staff");

--- a/omnischools/lib/parent/parent-data.ts
+++ b/omnischools/lib/parent/parent-data.ts
@@ -29,7 +29,7 @@ import {
 // Claiming-flow seam (used by lib/actions/invites.ts) — the destination is always the STORED number.
 // ─────────────────────────────────────────────────────────────────────────────────────────────────
 
-export type ParentInviteTarget = { phone: string; fullName: string; studentId: string };
+export type ParentInviteTarget = { phone: string; fullName: string; studentId: string; email: string | null };
 
 /**
  * AC C1/C2 — resolve the invite DESTINATION from the stored guardian row, never from caller input.
@@ -43,7 +43,7 @@ export async function resolveParentInviteTargetTx(
   guardianId: string,
 ): Promise<ParentInviteTarget | null> {
   const [g] = await tx
-    .select({ phone: studentGuardians.phone, name: studentGuardians.name })
+    .select({ phone: studentGuardians.phone, name: studentGuardians.name, email: studentGuardians.email })
     .from(studentGuardians)
     .where(
       and(
@@ -54,7 +54,9 @@ export async function resolveParentInviteTargetTx(
     )
     .limit(1);
   if (!g) return null;
-  return { phone: g.phone, fullName: g.name, studentId };
+  // `email` is the STORED guardian email — a delivery channel for the invite link ONLY. The claim/OTP
+  // destination and the phone-keyed claim stamping (AC C2/C4) are unchanged: email is never a claim key.
+  return { phone: g.phone, fullName: g.name, studentId, email: g.email };
 }
 
 /**


### PR DESCRIPTION
**Closes #307.** `student_guardian.email` was captured on 3 surfaces (create/update/import) and shown on the profile, but **read by nothing** — parent linking is phone-only, comms SMS-only. Schools were collecting data that did nothing.

## What it does
The school-issued per-child **parent invite now emails the claim link to the guardian's stored email**, alongside the existing SMS to the stored phone. `resolveParentInviteTargetTx` resolves `student_guardian.email` from the guardian row (like the stored phone); the invite delivers to it with a parent-appropriate body.

## The security decision (email as an alternate claim key → **NO**)
Ruled to the safe default: **email is delivery-only, never a claim key.**
- The parent email is **server-resolved from the guardian row, never caller free-text** (the parent branch unconditionally overwrites from `target.email`; the resolver is fenced by `schoolId AND guardianId AND studentId` + tenant RLS) — a caller can't redirect a parent's claim link to an attacker address.
- The OTP/claim destination and the phone-keyed claim stamping (AC C2/C4) are **unchanged**: the email carries the *same* invite token as the SMS; the claim still confirms via the code sent to the stored phone. `inv.email` lands only in the nullable `ref_user.email` contact column — never read for auth.

## Gates
- **Quinn: GREEN** — all ACs; one MINOR (`??`→`||` staff-persisted-value delta) fixed.
- **Dex: APPROVE** — clean, additive, invariant guaranteed by control flow; no over-coupling.
- **Sarah: SECURITY-CLEAN** — delivery-only confirmed, stored-not-supplied, no gate widening, no PII leak, no prod SQL.
- tsc clean · vitest 2292 green · `next build` exit 0 · regression-locked (`invites-guardian-email.test.ts`).

## Notes
- **Goes live automatically when Resend (#261) is provisioned** — with no key, `sendEmail` console-degrades exactly like SMS without Hubtel. No code change needed then.
- Pre-existing (not introduced here, flagged by both gates): the email body interpolates `${school.name}` / `${role.label}` unescaped — a low-severity defense-in-depth item worth an HTML-escape pass across `sendEmail` bodies someday.

No schema, no deploy SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)