### PR TITLE
feat(parent): School Calendar tab + parent_scope on calendar tables (#278)

### DIFF
--- a/omnischools/app/(parent)/calendar/page.tsx
+++ b/omnischools/app/(parent)/calendar/page.tsx
@@ -1,0 +1,212 @@
+import { requireParent } from "@/lib/auth/server";
+import { loadParentPortal } from "@/lib/parent/parent-portal-data";
+import {
+  loadParentCalendar,
+  type ParentCalendarHoliday,
+  type ParentCalendarTerm,
+} from "@/lib/parent/parent-calendar-data";
+import { relationshipLabel, parentLongDate } from "@/lib/wassce/parent-copy";
+import { ParentHeader, ParentNav } from "../parent-chrome";
+
+/**
+ * INCR-278 · the parent-portal SCHOOL CALENDAR tab — the school's term/semester dates + holidays, read
+ * from `academic_period` + `school_holiday` (school-wide, no per-child data; reader is parent-calendar-data).
+ * Same PARENT session gate as the other (parent) routes. UNLIKE the WASSCE/Sickbay/PTA tabs this one does
+ * NOT gate on a linked child — the calendar is school-wide; a no-child (or pre-paste) session simply
+ * fail-closes to the honest empty via RLS. Read-only by construction. Every date is derived, never invented
+ * (R90): no "current" term unless today is inside one, no "next" term unless one is actually upcoming.
+ */
+export const dynamic = "force-dynamic";
+
+const KIND_LABEL: Record<string, string> = {
+  PUBLIC: "Public holiday",
+  BREAK: "Break",
+  EVENT: "Event",
+  EXAM: "Exam",
+};
+const KIND_CHIP: Record<string, string> = {
+  PUBLIC: "bg-terra-bg text-terra",
+  BREAK: "bg-gold-bg text-navy",
+  EVENT: "bg-navy text-bg",
+  EXAM: "bg-warn-bg text-warn",
+};
+
+/** A 'YYYY-MM-DD' column → "28 March 2026" (UTC, no time — the parent-copy idiom). */
+const longDay = (iso: string): string => parentLongDate(new Date(`${iso}T00:00:00Z`));
+const dateRange = (startsOn: string, endsOn: string): string =>
+  startsOn === endsOn ? longDay(startsOn) : `${longDay(startsOn)} – ${longDay(endsOn)}`;
+
+export default async function ParentCalendarPage() {
+  const { user, school } = await requireParent();
+  const [data, calendar] = await Promise.all([
+    loadParentPortal(school.id, user.id),
+    loadParentCalendar(school.id, user.id),
+  ]);
+  const child = data.children[0] ?? null;
+
+  const guardianDisplay = data.guardianName ?? user.name ?? "Parent";
+  const relation = data.guardianRelationship ? relationshipLabel(data.guardianRelationship) : "Parent";
+
+  return (
+    <div className="mx-auto max-w-[980px]">
+      <ParentHeader
+        schoolName={school.name}
+        childName={child?.fullName ?? null}
+        guardianDisplay={guardianDisplay}
+        relation={relation}
+      />
+      <ParentNav active="School calendar" />
+
+      <div className="px-7 pb-9 pt-6">
+        {calendar.terms.length === 0 ? (
+          <Empty />
+        ) : (
+          <div className="space-y-6">
+            {calendar.current && <CurrentTerm current={calendar.current} />}
+            <Terms
+              terms={calendar.terms}
+              nextTerm={calendar.nextTerm}
+              academicYear={calendar.academicYear}
+            />
+            <Holidays holidays={calendar.holidays} academicYear={calendar.academicYear} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** No term configured (or pre-paste fail-closed) — one honest empty, never an invented date (AC-CAL-16). */
+function Empty() {
+  return (
+    <div className="rounded-xl border border-border bg-surface px-6 py-8 text-center text-[13px] leading-relaxed text-navy-2">
+      Your school hasn&apos;t published its calendar yet. Term dates and holidays will show here once the
+      school sets them up.
+    </div>
+  );
+}
+
+/* ─────────────────────────────────────────────────────── This term (progress) ── */
+
+function CurrentTerm({ current }: { current: { label: string; dayOf: number; total: number } }) {
+  const pct = current.total > 0 ? Math.min(100, Math.round((current.dayOf / current.total) * 100)) : 0;
+  return (
+    <section
+      className="rounded-xl border border-gold-soft px-6 py-[22px]"
+      style={{ background: "linear-gradient(135deg,#F5EBDC 0%,#FAF7F2 100%)" }}
+    >
+      <div className="mb-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-navy-3">
+        This term
+      </div>
+      <div className="flex items-baseline justify-between gap-3">
+        <div className="font-display text-[20px] font-medium leading-tight text-navy">{current.label}</div>
+        <div className="font-mono text-[13px] font-semibold text-navy-2">
+          Day {current.dayOf} of {current.total}
+        </div>
+      </div>
+      <div className="mt-3.5 h-2 overflow-hidden rounded-pill bg-surface">
+        <div className="h-full rounded-pill bg-gold" style={{ width: `${pct}%` }} />
+      </div>
+      <div className="mt-2 text-[11px] text-navy-3">School days so far, weekends and holidays excluded.</div>
+    </section>
+  );
+}
+
+/* ───────────────────────────────────────────────────────────────── Term dates ── */
+
+function Terms({
+  terms,
+  nextTerm,
+  academicYear,
+}: {
+  terms: ParentCalendarTerm[];
+  nextTerm: ParentCalendarTerm | null;
+  academicYear: string | null;
+}) {
+  const nextKey = nextTerm ? nextTerm.startsOn + nextTerm.label : null;
+  return (
+    <section className="overflow-hidden rounded-xl border border-border bg-surface">
+      <div className="border-b border-border bg-bg px-6 py-[18px]">
+        <h3 className="font-display text-base font-medium text-navy">Term dates</h3>
+        <div className="text-[11px] text-navy-3">
+          {academicYear ? `Academic year ${academicYear}` : "All published terms"}
+        </div>
+      </div>
+      {terms.map((t) => {
+        const isNext = nextKey != null && t.startsOn + t.label === nextKey;
+        return (
+          <div
+            key={t.startsOn + t.label}
+            className="grid grid-cols-[1fr_auto] items-center gap-4 border-b border-border px-6 py-4 last:border-b-0"
+          >
+            <div>
+              <div className="flex items-center gap-2">
+                <span className="font-display text-[15px] font-medium text-navy">{t.label}</span>
+                {t.isCurrent && (
+                  <span className="inline-flex items-center rounded-pill bg-gold px-2.5 py-[3px] text-[11px] font-semibold text-navy">
+                    Now
+                  </span>
+                )}
+                {isNext && !t.isCurrent && (
+                  <span className="inline-flex items-center rounded-pill bg-navy px-2.5 py-[3px] text-[11px] font-semibold text-bg">
+                    Up next
+                  </span>
+                )}
+              </div>
+              <div className="text-xs text-navy-3">{t.academicYear}</div>
+            </div>
+            <div className="text-right font-mono text-[13px] text-navy-2">
+              {dateRange(t.startsOn, t.endsOn)}
+            </div>
+          </div>
+        );
+      })}
+    </section>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────── Holidays & breaks ── */
+
+function Holidays({
+  holidays,
+  academicYear,
+}: {
+  holidays: ParentCalendarHoliday[];
+  academicYear: string | null;
+}) {
+  return (
+    <section className="overflow-hidden rounded-xl border border-border bg-surface">
+      <div className="border-b border-border bg-bg px-6 py-[18px]">
+        <h3 className="font-display text-base font-medium text-navy">Holidays &amp; breaks</h3>
+        <div className="text-[11px] text-navy-3">
+          {academicYear ? `Non-teaching days in ${academicYear}` : "Non-teaching days"}
+        </div>
+      </div>
+      {holidays.length === 0 ? (
+        <div className="px-6 py-6 text-[13px] leading-relaxed text-navy-2">
+          No holidays or breaks have been published for this year yet.
+        </div>
+      ) : (
+        holidays.map((h, i) => (
+          <div
+            key={i}
+            className="grid grid-cols-[1fr_auto] items-center gap-4 border-b border-border px-6 py-4 last:border-b-0"
+          >
+            <div>
+              <div className="font-display text-[15px] font-medium text-navy">{h.name}</div>
+              <div className="font-mono text-xs text-navy-3">{dateRange(h.startsOn, h.endsOn)}</div>
+            </div>
+            <span
+              className={
+                "inline-flex items-center rounded-pill px-2.5 py-[3px] text-[11px] font-semibold " +
+                (KIND_CHIP[h.kind] ?? "bg-bg text-navy-3")
+              }
+            >
+              {KIND_LABEL[h.kind] ?? h.kind}
+            </span>
+          </div>
+        ))
+      )}
+    </section>
+  );
+}

--- a/omnischools/app/(parent)/parent-chrome.tsx
+++ b/omnischools/app/(parent)/parent-chrome.tsx
@@ -2,10 +2,12 @@ import Link from "next/link";
 import { avatarInitials, initialSurname } from "@/lib/wassce/parent-copy";
 
 /**
- * The shared parent-portal chrome (SHS module 4.3) — header + flat seven-tab nav, extracted from the
- * wassce page so the tab-flip lives in ONE place (INCR-29 R234: activate the inert "Sickbay" tab as a
- * live link). One child, resolved from the session (never a URL param); labels verbatim; NO faked
- * unread dot (R234). WASSCE, Sickbay, and PTA are live routes today; the other four stay inert spans.
+ * The shared parent-portal chrome (SHS module 4.3) — header + flat nav, extracted from the wassce page so
+ * the tab set lives in ONE place. One child, resolved from the session (never a URL param); labels
+ * verbatim; NO faked unread dot (R234). INCR-278: the nav is now EVERY tab a live route — WASSCE, Sickbay,
+ * PTA, School calendar — with NO inert "coming soon" spans (R234 honest-absence: a disabled tab is a faked
+ * affordance). Communications / Billing / Boarding return here each behind its own increment when it ships
+ * (Billing needs a safe scoped projection — invoice deliberately stays parent_deny, R476 tuition-leak).
  */
 
 export function ParentHeader({
@@ -50,22 +52,22 @@ export function ParentHeader({
   );
 }
 
-/** The tab whose route is built today. WASSCE + Sickbay + PTA are live links; the rest stay inert. */
-export type ParentTab = "WASSCE" | "Sickbay" | "PTA";
+/** Every tab is a live route today. */
+export type ParentTab = "WASSCE" | "Sickbay" | "PTA" | "School calendar";
 
-// INCR-55a — PTA is the 7th flat tab, placed after Billing (participation slice; 55b appends Officers +
-// Adopted minutes on the same page).
-const TABS = ["WASSCE", "Sickbay", "Communications", "Billing", "PTA", "Boarding", "School calendar"] as const;
-const HREF: Partial<Record<(typeof TABS)[number], string>> = {
+// INCR-278 — four flat tabs, ALL live routes (the inert Communications / Billing / Boarding spans are gone;
+// each returns behind its own increment). Every entry below has an HREF.
+const TABS = ["WASSCE", "Sickbay", "PTA", "School calendar"] as const;
+const HREF: Record<(typeof TABS)[number], string> = {
   WASSCE: "/wassce",
   Sickbay: "/sickbay",
   PTA: "/pta",
+  "School calendar": "/calendar",
 };
 
 /**
- * Seven flat tabs; `active` is the current one. A non-active tab with a route becomes a real <Link>; the
- * unbuilt tabs remain inert spans. NO unread dot — it would be faked with no open-episode source on this
- * render path (R234).
+ * The flat parent nav; `active` is the current one. Every non-active tab is a real <Link> (all four are live
+ * routes — no inert spans, R234). NO unread dot — it would be faked with no open-episode source (R234).
  */
 export function ParentNav({ active }: { active: ParentTab }) {
   return (
@@ -76,7 +78,8 @@ export function ParentNav({ active }: { active: ParentTab }) {
           ? "whitespace-nowrap border-b-2 border-gold px-4 py-3.5 text-[13px] font-semibold text-navy"
           : "whitespace-nowrap border-b-2 border-transparent px-4 py-3.5 text-[13px] font-medium text-navy-3";
         const href = HREF[t];
-        return href && !isActive ? (
+        // HREF is total → every tab has a route; the ONLY <span> is the active tab (no inert spans, R234).
+        return !isActive ? (
           <Link key={t} href={href} className={cls}>
             {t}
           </Link>

--- a/omnischools/db/sql/policies.sql
+++ b/omnischools/db/sql/policies.sql
@@ -943,6 +943,44 @@ AS $$
     )
 $$;
 
+-- ---- INCR-278: the SEVENTH widening of the 19a parent boundary (22 → 24 parent_scope tables) — the
+-- parent SCHOOL CALENDAR tab (owner-authorised). A parent gains ROW access to the term/semester dates
+-- (academic_period) and the holidays/breaks/events/exam weeks (school_holiday) of their LINKED school, so
+-- the read-only parent portal can render the school calendar. Kept in sync with
+-- db/sql/prod-paste-0092-parent-calendar-scope.sql — this block is DEV; that file is the hand-paste on PROD
+-- (⚠ RLS is NOT auto-applied on prod; without the paste both tables keep parent_deny and the parent
+-- Calendar tab is an honest empty state — fail-closed, never a leak).
+--
+-- 🔴 THE SAFEST PARENT GRANT IN THE MODULE: NO PER-CHILD JOIN. Every other parent_scope policy reaches a
+-- SPECIFIC child (parent_student_ids / parent_pta_ids). These two tables are SCHOOL-WIDE — the calendar is
+-- identical for every child in the school and carries ZERO per-student data (academic_period: year / term
+-- label / dates / product_line / closed_at; school_holiday: name / dates / kind). So there is NO cross-child
+-- leak surface to fence: any parent linked to the school may read the whole school's calendar. The scope is
+-- therefore the SCHOOL itself, keyed on the SAME app.current_school GUC that withParentScope already sets
+-- (and that the PERMISSIVE tenant_isolation policy at the top of this file already enforces on every row).
+-- The restrictive predicate `pu IS NULL OR school_id = current_school` is thus a true no-op tightening — its
+-- only job is to EXIST so the catalog parent_deny loop below excludes these two tables — while re-affirming
+-- the school boundary EXPLICITLY (defence in depth; never a bare `OR TRUE` a reader could misread as "open to
+-- everyone"). USING doubles as WITH CHECK; there is no parent write path anywhere (Kofi R4).
+
+-- academic_period — the school's term/semester dates (school-wide; no per-child data).
+DROP POLICY IF EXISTS parent_deny ON academic_period;
+DROP POLICY IF EXISTS parent_scope ON academic_period;
+CREATE POLICY parent_scope ON academic_period AS RESTRICTIVE FOR ALL TO public
+  USING (
+    NULLIF(current_setting('app.current_parent_user', true), '') IS NULL
+    OR school_id = NULLIF(current_setting('app.current_school', true), '')::uuid
+  );
+
+-- school_holiday — the school's holidays / breaks / events / exam weeks (school-wide; no per-child data).
+DROP POLICY IF EXISTS parent_deny ON school_holiday;
+DROP POLICY IF EXISTS parent_scope ON school_holiday;
+CREATE POLICY parent_scope ON school_holiday AS RESTRICTIVE FOR ALL TO public
+  USING (
+    NULLIF(current_setting('app.current_parent_user', true), '') IS NULL
+    OR school_id = NULLIF(current_setting('app.current_school', true), '')::uuid
+  );
+
 -- ---- layer 1: parent_deny on every tenant table EXCEPT the parent-readable set (CATALOG-DRIVEN) ----
 -- This USED to be a hand-maintained 77-name array; a new tenant table that got tenant_isolation but was
 -- forgotten here escaped the parent boundary silently (Dex BLOCK; student_health_record was the leak).

--- a/omnischools/db/sql/prod-paste-0092-parent-calendar-scope.sql
+++ b/omnischools/db/sql/prod-paste-0092-parent-calendar-scope.sql
@@ -1,0 +1,110 @@
+-- Omnischools — PROD paste 0092: PARENT SCHOOL-CALENDAR SCOPE (INCR-278). POLICY-ONLY — ZERO new tables,
+-- ZERO enums, ZERO altered columns, ZERO backfills. It adds a narrow `parent_scope` policy to EXACTLY TWO
+-- existing tables (academic_period, school_holiday) and re-runs the catalog-driven parent_deny loop.
+-- Idempotent — safe to run more than once. Paste into the Supabase SQL editor on PROD after merging.
+-- Byte-identical in effect to the INCR-278 block in db/sql/policies.sql (dev, db:policies).
+--
+-- WHAT IT SHIPS. A parent SCHOOL CALENDAR tab in the read-only parent portal. To render it, a parent linked
+-- to a school must READ that school's term/semester dates (academic_period) and its holidays/breaks/events/
+-- exam weeks (school_holiday). This is the SEVENTH widening of the INCR-19a parent boundary (22 → 24
+-- parent_scope tables).
+--
+-- 🔴 THE SAFEST PARENT GRANT IN THE MODULE — NO PER-CHILD JOIN, NO CROSS-CHILD LEAK SURFACE. Every prior
+-- parent_scope policy reaches a SPECIFIC child (parent_student_ids / parent_pta_ids) because the row carries
+-- per-student data. These two tables are SCHOOL-WIDE: the calendar is identical for every child in the school
+-- and carries ZERO per-student data —
+--   • academic_period : academic_year / period_label / starts_on / ends_on / product_line / closed_at
+--   • school_holiday  : name / starts_on / ends_on / kind
+-- — so there is nothing to fence per-child. The scope is the SCHOOL itself, keyed on the SAME app.current_school
+-- GUC that lib/db/rls.ts → withParentScope(schoolId, userId) already sets, and that the PERMISSIVE
+-- tenant_isolation policy on both tables already enforces on every row a parent session can see. The parent's
+-- active-school membership is therefore ALREADY established in the session GUC — this paste adds no new
+-- membership check, it simply stops denying the school's own calendar rows to a parent of that school.
+-- The restrictive predicate `pu IS NULL OR school_id = current_school` is a true no-op tightening: its only
+-- structural job is to EXIST so the catalog parent_deny loop below EXCLUDES these two tables, while
+-- re-affirming the school boundary EXPLICITLY (defence in depth — never a bare `OR TRUE` that reads as "open
+-- to everyone"). There is no confidential column here and no per-child column, so unlike the sickbay/PTA
+-- widenings there is NO reader-projection column-guard obligation — every column on both tables is
+-- school-public calendar data.
+--
+-- ⚠ WHAT HAPPENS IF THIS IS NOT RUN — FAIL-CLOSED, NEVER A LEAK. db:policies configures LOCAL DEV ONLY.
+-- Without this paste, academic_period + school_holiday keep their existing parent_deny on prod, so a parent
+-- session (app.current_parent_user set) reads ZERO rows from both → the parent Calendar tab is an honest
+-- empty state, never a cross-tenant or cross-child leak. The cost of skipping is a blank tab, not exposure.
+-- Run it to actually ship the feature.
+--
+-- SCOPE — EXACTLY TWO TABLES CHANGE. Only academic_period and school_holiday gain parent_scope (their old
+-- parent_deny is dropped). Tenant isolation is untouched on every table. Billing (invoice / invoice_line_item
+-- / payment / payment_allocation / receipt) DELIBERATELY keeps parent_deny (R476 tuition-leak) and is out of
+-- scope: a parent-billing view would need a safe bridge/projection, never a raw invoice grant. The catalog
+-- parent_deny loop at the tail re-affirms parent_deny on every other tenant table (auto-EXCLUDING the two
+-- tables that now carry parent_scope), so a future tenant table stays auto-denied with zero edits.
+--
+-- Verify afterwards:
+--   -- these two tables carry parent_scope; billing tables still carry parent_deny:
+--   select c.relname, p.polname from pg_policy p join pg_class c on c.oid = p.polrelid
+--   where c.relname in ('academic_period','school_holiday','invoice','payment','receipt') order by 1, 2;
+--   -- and db/sql/verify-prod-rls.sql: Query 1 must return ZERO ROWS; tenant_tables unchanged;
+--   -- parent_readable up by 2 (24) and parent_denied down by 2.
+
+-- ---- layer 2: the two new parent_scope policies (byte-identical to db/sql/policies.sql INCR-278 block) ----
+-- School-wide, no per-child join. `pu IS NULL` → staff/bypass session → total no-op. `pu` set → the row must
+-- belong to the parent's active school (which tenant_isolation already required) → the parent reads the whole
+-- school calendar and nothing else. USING doubles as WITH CHECK; there is no parent write path (Kofi R4).
+
+-- academic_period — the school's term/semester dates (school-wide; no per-child data).
+DROP POLICY IF EXISTS parent_deny ON academic_period;
+DROP POLICY IF EXISTS parent_scope ON academic_period;
+CREATE POLICY parent_scope ON academic_period AS RESTRICTIVE FOR ALL TO public
+  USING (
+    NULLIF(current_setting('app.current_parent_user', true), '') IS NULL
+    OR school_id = NULLIF(current_setting('app.current_school', true), '')::uuid
+  );
+
+-- school_holiday — the school's holidays / breaks / events / exam weeks (school-wide; no per-child data).
+DROP POLICY IF EXISTS parent_deny ON school_holiday;
+DROP POLICY IF EXISTS parent_scope ON school_holiday;
+CREATE POLICY parent_scope ON school_holiday AS RESTRICTIVE FOR ALL TO public
+  USING (
+    NULLIF(current_setting('app.current_parent_user', true), '') IS NULL
+    OR school_id = NULLIF(current_setting('app.current_school', true), '')::uuid
+  );
+
+-- ---- layer 1: parent_deny — the CATALOG-DRIVEN loop, verbatim from db/sql/policies.sql ----
+-- 🔴 RUN THIS. It is NOT a hand-list: it applies RESTRICTIVE parent_deny to every FORCE-RLS + school_id table
+-- that does NOT already carry a parent_scope policy — which, after the block above, is every tenant table
+-- EXCEPT the 24 parent-readable ones (the 22 shipped + the 2 added here). It re-creates identical policies on
+-- the already-covered tables (hence idempotent) and, crucially, KEEPS the two INCR-278 tables EXCLUDED (they
+-- now carry parent_scope) while re-affirming parent_deny on billing and every other tenant table. It is what
+-- keeps a FUTURE tenant table auto-denied with zero code change.
+DO $$
+DECLARE
+  tbl text;
+BEGIN
+  FOR tbl IN
+    SELECT c.relname
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = 'public'
+    WHERE c.relkind = 'r'
+      AND c.relforcerowsecurity
+      AND EXISTS (
+        SELECT 1 FROM information_schema.columns col
+        WHERE col.table_schema = 'public'
+          AND col.table_name = c.relname
+          AND col.column_name = 'school_id'
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_policy p
+        WHERE p.polrelid = c.oid AND p.polname = 'parent_scope'
+      )
+    ORDER BY c.relname
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS parent_deny ON %I;', tbl);
+    EXECUTE format(
+      'CREATE POLICY parent_deny ON %I AS RESTRICTIVE FOR ALL TO public '
+      'USING (NULLIF(current_setting(''app.current_parent_user'', true), '''') IS NULL);',
+      tbl
+    );
+  END LOOP;
+END
+$$;

--- a/omnischools/lib/parent/parent-calendar-data.ts
+++ b/omnischools/lib/parent/parent-calendar-data.ts
@@ -1,0 +1,139 @@
+import "server-only";
+import { and, asc, eq, ne } from "drizzle-orm";
+import { withParentScope } from "@/lib/db/rls";
+import type { Tx } from "@/lib/db";
+import { academicPeriod, schoolHolidays } from "@/db/schema";
+import { termDayProgress, type HolidayRange } from "@/lib/school-calendar";
+
+/**
+ * INCR-278 · the PARENT-facing SCHOOL CALENDAR reader (SHS module 4.3) — the SEVENTH widening of the 19a
+ * parent boundary (22 → 24 parent_scope tables; Wells's prod-paste-0092). SERVER-ONLY — imports the db
+ * driver, so a client component must never import it (only `pnpm build` catches that leak; the
+ * parent-portal-data / reports-data precedent).
+ *
+ * 🔴 THE SAFEST PARENT READ IN THE PORTAL — NO PER-CHILD DATA. `academic_period` + `school_holiday` are
+ * SCHOOL-WIDE: the calendar is identical for every child and carries ZERO per-student columns, so the
+ * parent_scope grant needs (and this reader selects) NO per-child filter — there is nothing child-shaped to
+ * leak. Runs under `withParentScope` ONLY (the D10 parent-loader rule — never `withSchool` /
+ * `withoutTenantScope`, both of which bypass the parent boundary). Read-only by construction.
+ *
+ * Column guard: `academic_period.closed_by_user_id` (staff PII) and `product_line` are NEVER returned —
+ * product_line is read ONLY (in the WHERE) to exclude the SENIOR_F3 boarding pseudo-period (migration 0048).
+ *
+ * Honesty (R90 omit-not-fake) lives in the PURE `buildParentCalendar` below (unit-tested): the "current"
+ * term is the one CONTAINING today and ONLY that (no force-mark in an out-of-term gap); `nextTerm` is
+ * omitted when none is upcoming; holidays are windowed to the reference academic year so old breaks don't
+ * accumulate.
+ */
+
+export type ParentCalendarTerm = {
+  label: string; // periodLabel — "Term 2" / "Semester 1"
+  academicYear: string;
+  startsOn: string; // "YYYY-MM-DD"
+  endsOn: string;
+  isCurrent: boolean;
+};
+
+export type ParentCalendarHoliday = {
+  name: string;
+  startsOn: string;
+  endsOn: string;
+  kind: string; // PUBLIC | BREAK | EVENT | EXAM
+};
+
+export type ParentCalendar = {
+  academicYear: string | null; // the reference year (current term's, else the most recent) — heading label
+  terms: ParentCalendarTerm[]; // chronological (ascending)
+  current: { label: string; dayOf: number; total: number } | null; // only when today is inside a term
+  nextTerm: ParentCalendarTerm | null; // earliest term starting after today, else null
+  holidays: ParentCalendarHoliday[]; // within the reference academic year, ascending
+};
+
+/** A term row as read from `academic_period` (ascending by start). */
+export type CalendarTermRow = { label: string; academicYear: string; startsOn: string; endsOn: string };
+
+/**
+ * PURE — the honest calendar derivation (no db, client/server safe, unit-tested). `termRows` MUST be
+ * ascending by start (SENIOR_F3 already excluded by the caller's WHERE). Marks the term containing `today`
+ * as current and ONLY that (AC-CAL-07); picks the first future term as `nextTerm` else null (AC-CAL-08);
+ * windows holidays to the reference year (AC-CAL-10); day-progress only for the current term (AC-CAL-09).
+ */
+export function buildParentCalendar(
+  termRows: CalendarTermRow[],
+  holidayRows: ParentCalendarHoliday[],
+  today: string,
+): ParentCalendar {
+  const currentIdx = termRows.findIndex((t) => t.startsOn <= today && today <= t.endsOn);
+  const current = currentIdx >= 0 ? termRows[currentIdx] : null;
+  const terms: ParentCalendarTerm[] = termRows.map((t, i) => ({
+    label: t.label,
+    academicYear: t.academicYear,
+    startsOn: t.startsOn,
+    endsOn: t.endsOn,
+    isCurrent: i === currentIdx,
+  }));
+
+  const nextTerm = terms.find((t) => t.startsOn > today) ?? null; // ascending → first future term
+
+  // Reference academic year (OC-CAL-HOLIDAY-WINDOW): current term's year, else the most recent term's.
+  const refYear = current?.academicYear ?? termRows[termRows.length - 1]?.academicYear ?? null;
+  const yearTerms = refYear ? termRows.filter((t) => t.academicYear === refYear) : [];
+  const yearStart = yearTerms[0]?.startsOn ?? null;
+  const yearEnd = yearTerms[yearTerms.length - 1]?.endsOn ?? null;
+
+  const holidays =
+    yearStart && yearEnd
+      ? holidayRows.filter((h) => h.startsOn <= yearEnd && h.endsOn >= yearStart)
+      : [];
+
+  const progress = current
+    ? termDayProgress(current.startsOn, current.endsOn, today, holidays as HolidayRange[])
+    : null;
+
+  return {
+    academicYear: refYear,
+    terms,
+    current:
+      current && progress ? { label: current.label, dayOf: progress.dayOf, total: progress.total } : null,
+    nextTerm,
+    holidays,
+  };
+}
+
+/** MUST run on a `tx` already scoped by `withParentScope` (see `loadParentCalendar`). */
+export async function loadParentCalendarTx(
+  tx: Tx,
+  schoolId: string,
+  today: string = new Date().toISOString().slice(0, 10),
+): Promise<ParentCalendar> {
+  // Real terms only — SENIOR_F3 is a boarding pseudo-period, not a calendar term (AC-CAL-06). Ascending so
+  // "current"/"next"/the year window read straight off order. product_line filters in the WHERE, never shown.
+  const termRows = await tx
+    .select({
+      label: academicPeriod.periodLabel,
+      academicYear: academicPeriod.academicYear,
+      startsOn: academicPeriod.startsOn,
+      endsOn: academicPeriod.endsOn,
+    })
+    .from(academicPeriod)
+    .where(and(eq(academicPeriod.schoolId, schoolId), ne(academicPeriod.productLine, "SENIOR_F3")))
+    .orderBy(asc(academicPeriod.startsOn), asc(academicPeriod.periodNumber));
+
+  const holidayRows = await tx
+    .select({
+      name: schoolHolidays.name,
+      startsOn: schoolHolidays.startsOn,
+      endsOn: schoolHolidays.endsOn,
+      kind: schoolHolidays.kind,
+    })
+    .from(schoolHolidays)
+    .where(eq(schoolHolidays.schoolId, schoolId))
+    .orderBy(asc(schoolHolidays.startsOn));
+
+  return buildParentCalendar(termRows, holidayRows, today);
+}
+
+/** Entry point — the parent's school calendar under `withParentScope` (never `withSchool`). */
+export async function loadParentCalendar(schoolId: string, userId: string): Promise<ParentCalendar> {
+  return withParentScope(schoolId, userId, (tx) => loadParentCalendarTx(tx, schoolId));
+}

--- a/omnischools/lib/parent/parent-calendar.test.ts
+++ b/omnischools/lib/parent/parent-calendar.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { readCode } from "@/lib/test-utils/source-shape";
+import { buildParentCalendar, type CalendarTermRow, type ParentCalendarHoliday } from "./parent-calendar-data";
+
+/**
+ * INCR-278 · the parent-portal School Calendar tab. Two guards:
+ *  1. the PURE honest derivation (buildParentCalendar) — Kofi AC-CAL-06..10/16/17: current = today-in-term
+ *     and ONLY that (no force-mark in a gap), next = first future term or none, holidays windowed to the
+ *     reference year, progress only for the current term.
+ *  2. source-shape — the reader stays inside withParentScope with no per-child / staff-PII column, and the
+ *     nav is FOUR live routes with no inert "coming soon" spans (R234).
+ */
+
+// 2025/26: three ascending terms with a Christmas gap and an Easter gap.
+const TERMS: CalendarTermRow[] = [
+  { label: "Term 1", academicYear: "2025/26", startsOn: "2025-09-01", endsOn: "2025-12-19" },
+  { label: "Term 2", academicYear: "2025/26", startsOn: "2026-01-06", endsOn: "2026-04-10" },
+  { label: "Term 3", academicYear: "2025/26", startsOn: "2026-05-04", endsOn: "2026-08-07" },
+];
+const HOLIDAYS: ParentCalendarHoliday[] = [
+  { name: "Old-year break", startsOn: "2024-12-20", endsOn: "2025-01-03", kind: "BREAK" }, // out of 2025/26
+  { name: "Independence Day", startsOn: "2026-03-06", endsOn: "2026-03-06", kind: "PUBLIC" }, // in Term 2
+];
+
+describe("buildParentCalendar · honest derivation (AC-CAL-*)", () => {
+  it("marks ONLY the term containing today as current, and gives day-progress for it", () => {
+    const c = buildParentCalendar(TERMS, HOLIDAYS, "2026-02-15"); // inside Term 2
+    expect(c.terms.map((t) => t.isCurrent)).toEqual([false, true, false]);
+    expect(c.current?.label).toBe("Term 2");
+    expect(c.current!.total).toBeGreaterThan(0);
+    expect(c.current!.dayOf).toBeGreaterThan(0);
+    expect(c.current!.dayOf).toBeLessThanOrEqual(c.current!.total);
+    expect(c.academicYear).toBe("2025/26");
+  });
+
+  it("force-marks NO term current in an out-of-term gap (R90 — never snap to the nearest)", () => {
+    const c = buildParentCalendar(TERMS, HOLIDAYS, "2025-12-25"); // Christmas gap, between Term 1 and 2
+    expect(c.current).toBeNull();
+    expect(c.terms.some((t) => t.isCurrent)).toBe(false);
+    expect(c.nextTerm?.label).toBe("Term 2"); // the gap still points at the upcoming term
+  });
+
+  it("nextTerm is the first future term, and null once none remain", () => {
+    expect(buildParentCalendar(TERMS, HOLIDAYS, "2026-02-15").nextTerm?.label).toBe("Term 3");
+    const after = buildParentCalendar(TERMS, HOLIDAYS, "2026-09-01"); // past every term
+    expect(after.nextTerm).toBeNull();
+    expect(after.current).toBeNull();
+    expect(after.academicYear).toBe("2025/26"); // most-recent term's year is the reference
+  });
+
+  it("windows holidays to the reference academic year (drops other years)", () => {
+    const c = buildParentCalendar(TERMS, HOLIDAYS, "2026-02-15");
+    expect(c.holidays.map((h) => h.name)).toEqual(["Independence Day"]); // the 2024 break is dropped
+  });
+
+  it("no terms → an all-empty calendar (AC-CAL-16), never an invented date", () => {
+    const c = buildParentCalendar([], HOLIDAYS, "2026-02-15");
+    expect(c.terms).toEqual([]);
+    expect(c.current).toBeNull();
+    expect(c.nextTerm).toBeNull();
+    expect(c.academicYear).toBeNull();
+    expect(c.holidays).toEqual([]); // no year window → no holidays surfaced
+  });
+
+  it("terms but no holidays → terms/progress stand, holidays empty (AC-CAL-17)", () => {
+    const c = buildParentCalendar(TERMS, [], "2026-02-15");
+    expect(c.current?.label).toBe("Term 2");
+    expect(c.holidays).toEqual([]);
+  });
+});
+
+describe("parent-calendar-data · reader stays in the parent boundary (source-shape)", () => {
+  const reader = () => readCode("lib/parent/parent-calendar-data.ts");
+
+  it("runs under withParentScope only — never withSchool / withoutTenantScope", () => {
+    const s = reader();
+    expect(s).toMatch(/withParentScope/);
+    expect(s).not.toMatch(/withSchool|withoutTenantScope/);
+  });
+
+  it("excludes the SENIOR_F3 pseudo-period and never returns staff-PII / per-child columns", () => {
+    const s = reader();
+    expect(s).toMatch(/ne\(academicPeriod\.productLine, "SENIOR_F3"\)/); // AC-CAL-06
+    expect(s).not.toMatch(/closedBy/i); // closed_by_user_id (staff PII) never selected — AC-CAL-11
+    expect(s).not.toMatch(/productLine:/); // product_line filters in WHERE, never projected — AC-CAL-06
+    expect(s).not.toMatch(/\bstudents\b/); // no per-child table at all — AC-CAL-11/12
+    expect(s).not.toMatch(/boarding_calendar_event|boardingCalendar/i); // visiting days deferred — AC-CAL-12
+  });
+});
+
+describe("parent-chrome · four live tabs, no inert spans (AC-CAL-01..04)", () => {
+  const nav = () => readCode("app/(parent)/parent-chrome.tsx");
+  const page = () => readCode("app/(parent)/calendar/page.tsx");
+
+  it("TABS is exactly the four live routes; the three inert tabs are gone", () => {
+    const s = nav();
+    expect(s).toMatch(/const TABS = \["WASSCE", "Sickbay", "PTA", "School calendar"\] as const;/); // AC-CAL-01
+    expect(s).toMatch(/ParentTab = "WASSCE" \| "Sickbay" \| "PTA" \| "School calendar"/); // AC-CAL-03
+    expect(s).toMatch(/"School calendar": "\/calendar"/); // AC-CAL-03 route
+    expect(s).not.toMatch(/Partial<Record/); // HREF is total → no tab can be an inert span — AC-CAL-02
+    expect(s).not.toMatch(/coming soon|disabled|greyed/i); // AC-CAL-04
+    expect((s.match(/<span/g) ?? []).length).toBe(1); // the ONLY span is the active tab — AC-CAL-02
+  });
+
+  it("the calendar route is school-wide — active nav, no child gate", () => {
+    const s = page();
+    expect(s).toMatch(/ParentNav active="School calendar"/); // AC-CAL-03
+    expect(s).not.toMatch(/NoChild/); // school-wide → no linked-child gate (fail-closes to Empty via RLS)
+    expect(s).toMatch(/calendar\.terms\.length === 0/); // the one honest empty — AC-CAL-16
+  });
+});


### PR DESCRIPTION
## What this ships

The **fourth live tab** in the read-only parent portal — the school's **term/semester dates + holidays** — and removes the three inert "coming soon" nav spans (Communications / Billing / Boarding). The parent nav is now four tabs that are **all live routes** (R234: a disabled tab is a faked affordance).

Scoping note: the "first live tab" was pivoted from **Billing** (deliberately hard — see below) to **School Calendar**, which is the *cleanest and safest* widening in the module: `academic_period` + `school_holiday` are **school-wide** (zero per-child columns), so the parent_scope grant carries no per-child join and no cross-child leak surface.

## Changes
- **`lib/parent/parent-calendar-data.ts`** — parent-scoped reader (`withParentScope` only, never `withSchool`/`withoutTenantScope`) over `academic_period` + `school_holiday`. No per-child column, no staff PII (`closed_by_user_id` / `product_line` never projected; `product_line` filters `SENIOR_F3` in the WHERE only). The honest derivation is the pure, unit-tested `buildParentCalendar`: **current** term = the one containing today and *only* that (no force-mark in an out-of-term gap), **next** term omitted when none is upcoming, **holidays** windowed to the reference academic year, day-progress only for the current term.
- **`app/(parent)/calendar/page.tsx`** — the tab. School-wide, so **not** child-gated; fail-closes to a single honest empty via RLS.
- **`app/(parent)/parent-chrome.tsx`** — `TABS` → the four live routes; `HREF` is a total `Record` (no inert span can exist).
- **`db/sql/policies.sql` + `db/sql/prod-paste-0092-parent-calendar-scope.sql`** — the **7th widening of the 19a parent boundary (22 → 24 parent_scope tables)**. Policy-only, idempotent; the catalog `parent_deny` loop re-affirms deny on every other tenant table.
- **`lib/parent/parent-calendar.test.ts`** — pure-logic honesty fixtures + source-shape guards (nav + column-guard). 10/10 green.

## Gates
- **Quinn (QA): GREEN** — 10/10 tests; all 8 mutation probes red a test (every honesty/column-guard invariant genuinely protected); `tsc` exit 0; 134/134 broader parent+access tests green.
- **Dex (architecture/portability): APPROVE** — honours the parent-loader seam + `server-only`; mirrors the sibling parent routes; reuses `termDayProgress`/`SENIOR_F3` exclusion; zero new Vercel/Supabase lock-in.
- **Sarah (security + merge-readiness): CLEAR-TO-MERGE** — all 8 attacker-viewpoint checks pass (cross-tenant isolation, fail-closed cast, PII/column guard, billing stays `parent_deny` per R476, idempotency, no parent write path, dev/prod parity).

## ⚠️ Owner action at deploy
- **Hand-paste `db/sql/prod-paste-0092-parent-calendar-scope.sql`** into the Supabase SQL editor on **prod** after merge (`db:policies` configures local dev only). It is the **only** new prod-paste this PR introduces relative to `origin/main`. Until it runs, the tab fail-closes to an honest empty — never a leak.
- Diff vs `origin/main` is exactly **1 commit / 6 files** (the earlier "25 commits ahead" was a stale *local* `main`; the sibling PRs #298/#307/#309/#268 and migration 0088 / prod-paste-0091 are already on `origin/main`).

## Deferred (out of scope)
- **Billing** stays `parent_deny` on purpose (R476 tuition-leak) — a parent-billing view needs a safe scoped projection (which invoices belong to *this* parent's children, sibling/household lines redacted), i.e. its own security-design increment.
- **Communications / Boarding** tabs return each behind its own increment.
- COMBINED-school dual-calendar interleaving (BASIC terms + SENIOR semesters) is honest today (all real rows); whether such a parent should see two interleaved calendars is a later product call (Kofi), not a defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)