### PR TITLE
feat(parent): Attendance tab + own-child parent_scope on attendance_record

### DIFF
--- a/omnischools/app/(parent)/attendance-summary/page.tsx
+++ b/omnischools/app/(parent)/attendance-summary/page.tsx
@@ -1,0 +1,266 @@
+import { requireParent } from "@/lib/auth/server";
+import { loadParentPortal } from "@/lib/parent/parent-portal-data";
+import {
+  loadParentAttendance,
+  type AttendanceBucket,
+  type ParentAttendance,
+  type ParentAttendanceTerm,
+  type ParentAttendanceWeekDay,
+} from "@/lib/parent/parent-attendance-data";
+import { relationshipLabel, parentLongDate } from "@/lib/wassce/parent-copy";
+import { ParentHeader, ParentNav } from "../parent-chrome";
+
+/**
+ * INCR · the parent-portal ATTENDANCE tab — a parent's read of their OWN child's attendance (reader is
+ * parent-attendance-data, the frozen-key-set column guard). Same PARENT session gate as the other (parent)
+ * routes; the child is resolved from the SESSION (never a URL id). Read-only by construction. Every figure
+ * is derived from real `attendance_record` rows (R90): no fabricated rate/day/streak; an unmarked term shows
+ * an honest "not recorded yet", never 0% or 100%. MEDICAL is folded → Excused in the reader (never shown as
+ * a distinct health-inflected marker); reason/note/teacher-name/clock never reach this surface.
+ */
+export const dynamic = "force-dynamic";
+
+const BUCKET: Record<AttendanceBucket, { label: string; tile: string; pill: string; seg: string }> = {
+  PRESENT: { label: "Present", tile: "bg-green text-white", pill: "bg-green-bg text-green", seg: "bg-green" },
+  LATE: { label: "Late", tile: "bg-gold text-navy", pill: "bg-gold-bg text-navy", seg: "bg-gold" },
+  EXCUSED: { label: "Excused", tile: "bg-warn text-white", pill: "bg-warn-bg text-warn", seg: "bg-warn" },
+  ABSENT: { label: "Absent", tile: "bg-terra text-white", pill: "bg-terra-bg text-terra", seg: "bg-terra" },
+};
+const DAY_LETTER = ["Su", "M", "T", "W", "T", "F", "Sa"]; // getUTCDay index; Mon–Fri only are rendered
+const longDay = (iso: string): string => parentLongDate(new Date(`${iso}T00:00:00Z`));
+
+export default async function ParentAttendancePage() {
+  const { user, school } = await requireParent();
+  const data = await loadParentPortal(school.id, user.id);
+  const child = data.children[0] ?? null;
+  const attendance = child ? await loadParentAttendance(school.id, user.id, child.studentId) : null;
+
+  const guardianDisplay = data.guardianName ?? user.name ?? "Parent";
+  const relation = data.guardianRelationship ? relationshipLabel(data.guardianRelationship) : "Parent";
+
+  return (
+    <div className="mx-auto max-w-[980px]">
+      <ParentHeader
+        schoolName={school.name}
+        childName={child?.fullName ?? null}
+        guardianDisplay={guardianDisplay}
+        relation={relation}
+      />
+      <ParentNav active="Attendance" />
+
+      <div className="px-7 pb-9 pt-6">
+        {!child ? (
+          <NoChild />
+        ) : (
+          <div className="space-y-6">
+            <TodayHero firstName={child.firstName} attendance={attendance!} />
+            <WeekStrip week={attendance!.week} />
+            <TermSummary firstName={child.firstName} attendance={attendance!} />
+            <RecentAbsences absences={attendance!.recentAbsences} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** No portal-linked child — a linking issue, not an attendance fact (mirrors the Sickbay/WASSCE tabs). */
+function NoChild() {
+  return (
+    <div className="rounded-xl border border-border bg-surface px-6 py-8 text-center text-[13px] leading-relaxed text-navy-2">
+      No student is linked to this portal yet. Please contact the school office.
+    </div>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────── Today (hero) ── */
+
+function TodayHero({ firstName, attendance }: { firstName: string; attendance: ParentAttendance }) {
+  const today = attendance.today;
+  if (!today) return null; // no mark today / weekend / holiday → omit the hero (the week + term carry it)
+
+  const absent = today.bucket === "ABSENT";
+  const headline =
+    today.bucket === "PRESENT" ? (
+      <>
+        {firstName} was <em className="text-gold">at school</em> today.
+      </>
+    ) : today.bucket === "LATE" ? (
+      <>
+        {firstName} was <em className="text-gold">at school</em> today, marked a little late.
+      </>
+    ) : today.bucket === "EXCUSED" ? (
+      <>
+        {firstName} was <em className="text-gold">away with the school&apos;s knowledge</em> today.
+      </>
+    ) : (
+      <>
+        {firstName} was <em className="text-terra">not at school</em> today.
+      </>
+    );
+
+  return (
+    <section
+      className={"rounded-xl border px-[26px] py-[22px] " + (absent ? "border-terra-soft" : "border-gold-soft")}
+      style={{
+        background: absent
+          ? "linear-gradient(135deg,#F7E8E5 0%,#FAF7F2 100%)"
+          : "linear-gradient(135deg,#E5EFE8 0%,#FAF7F2 100%)",
+      }}
+    >
+      <div className="mb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-navy-3">Today</div>
+      <h2 className="font-display text-[22px] font-medium leading-snug text-navy">{headline}</h2>
+      <p className="mt-2 text-xs leading-relaxed text-navy-3">
+        {absent
+          ? `If ${firstName} should have been in school, please contact the school office.`
+          : "Marked by the school today."}
+      </p>
+    </section>
+  );
+}
+
+/* ───────────────────────────────────────────────────────────────── This week ── */
+
+function WeekStrip({ week }: { week: ParentAttendanceWeekDay[] }) {
+  return (
+    <section className="overflow-hidden rounded-xl border border-border bg-surface">
+      <div className="border-b border-border bg-bg px-6 py-[18px]">
+        <h3 className="font-display text-base font-medium text-navy">This week</h3>
+        <div className="text-[11px] text-navy-3">Monday to Friday</div>
+      </div>
+      <div className="grid grid-cols-5 gap-2.5 px-6 py-5">
+        {week.map((d) => {
+          const num = Number(d.date.slice(8, 10));
+          const meta = d.bucket ? BUCKET[d.bucket] : null;
+          return (
+            <div
+              key={d.date}
+              className={
+                "flex flex-col items-center gap-1 rounded-lg border py-3 text-center " +
+                (d.isToday ? "border-gold ring-1 ring-gold " : "border-border ") +
+                (meta ? "" : d.isSchoolDay ? "bg-bg" : "bg-bg opacity-60")
+              }
+            >
+              <div className="font-display text-[11px] font-semibold text-navy-3">
+                {DAY_LETTER[new Date(`${d.date}T00:00:00Z`).getUTCDay()]}
+              </div>
+              <div className="font-display text-lg font-medium text-navy">{num}</div>
+              {meta ? (
+                <span className={"rounded-pill px-2 py-[2px] text-[10px] font-semibold " + meta.pill}>
+                  {meta.label}
+                </span>
+              ) : (
+                <span className="text-[10px] text-navy-3">{d.isToday ? "Today" : d.isSchoolDay ? "—" : "No school"}</span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+/* ───────────────────────────────────────────────────────────────── This term ── */
+
+const ORDER: AttendanceBucket[] = ["PRESENT", "LATE", "EXCUSED", "ABSENT"];
+
+function TermSummary({ firstName, attendance }: { firstName: string; attendance: ParentAttendance }) {
+  const term = attendance.term;
+  if (!term) {
+    return (
+      <section className="rounded-xl border border-border bg-surface px-6 py-8 text-center text-[13px] leading-relaxed text-navy-2">
+        Your school hasn&apos;t set up this term&apos;s calendar yet. {firstName}&apos;s attendance summary
+        will show here once it does.
+      </section>
+    );
+  }
+  if (term.markedDays === 0) {
+    return (
+      <section className="rounded-xl border border-border bg-surface px-6 py-8 text-center">
+        <div className="font-display text-base font-medium text-navy">
+          No attendance recorded for {firstName} this term yet.
+        </div>
+        <div className="mt-1.5 text-[13px] leading-relaxed text-navy-2">
+          Once the school starts marking the register for {term.label.split(" · ")[0]}, {firstName}&apos;s
+          summary will appear here.
+        </div>
+      </section>
+    );
+  }
+
+  const pct = term.atSchoolPct;
+  const band = pct == null ? "text-navy" : pct >= 90 ? "text-green" : pct >= 75 ? "text-warn" : "text-terra";
+  return (
+    <section className="overflow-hidden rounded-xl border border-border bg-surface">
+      <div className="border-b border-border bg-bg px-6 py-[18px]">
+        <h3 className="font-display text-base font-medium text-navy">This term</h3>
+        <div className="text-[11px] text-navy-3">{term.label}</div>
+      </div>
+      <div className="px-6 py-5">
+        <div className="flex items-baseline gap-3">
+          <div className={"font-display text-[36px] font-semibold leading-none " + band}>{pct}%</div>
+          <div className="font-mono text-[13px] text-navy-2">
+            at school <span className="font-semibold">{term.atSchoolDays}</span> of {term.markedDays} days
+          </div>
+        </div>
+
+        {/* breakdown bar — only buckets with a count, proportional to marked days */}
+        <div className="mt-4 flex h-2.5 overflow-hidden rounded-pill">
+          {ORDER.filter((b) => term.counts[bucketKey(b)] > 0).map((b) => (
+            <div
+              key={b}
+              className={"h-full " + BUCKET[b].seg}
+              style={{ width: `${(term.counts[bucketKey(b)] / term.markedDays) * 100}%` }}
+            />
+          ))}
+        </div>
+        <div className="mt-2.5 flex flex-wrap gap-x-4 gap-y-1">
+          {ORDER.filter((b) => term.counts[bucketKey(b)] > 0).map((b) => (
+            <span key={b} className="inline-flex items-center gap-1.5 text-[11px] text-navy-3">
+              <span className={"h-2 w-2 rounded-full " + BUCKET[b].seg} />
+              {BUCKET[b].label} <span className="font-mono text-navy-2">{term.counts[bucketKey(b)]}</span>
+            </span>
+          ))}
+        </div>
+
+        {attendance.priorTerm && (
+          <div className="mt-4 border-t border-border pt-3 font-mono text-xs text-navy-3">
+            Last term{" "}
+            <span className="text-navy-2">
+              {attendance.priorTerm.atSchoolPct == null ? "—" : `${attendance.priorTerm.atSchoolPct}%`}
+            </span>{" "}
+            · {attendance.priorTerm.atSchoolDays} of {attendance.priorTerm.markedDays} days
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+const bucketKey = (b: AttendanceBucket): "present" | "late" | "excused" | "absent" =>
+  b === "PRESENT" ? "present" : b === "LATE" ? "late" : b === "EXCUSED" ? "excused" : "absent";
+
+/* ─────────────────────────────────────────────────────────── Recent absences ── */
+
+function RecentAbsences({ absences }: { absences: ParentAttendance["recentAbsences"] }) {
+  if (absences.length === 0) return null; // no absences → omit the section (nothing to note is good news)
+  return (
+    <section className="overflow-hidden rounded-xl border border-border bg-surface">
+      <div className="border-b border-border bg-bg px-6 py-[18px]">
+        <h3 className="font-display text-base font-medium text-navy">Days away this term</h3>
+        <div className="text-[11px] text-navy-3">Absent and excused days, most recent first</div>
+      </div>
+      {absences.map((a) => (
+        <div
+          key={a.date}
+          className="flex items-center justify-between gap-4 border-b border-border px-6 py-3.5 last:border-b-0"
+        >
+          <span className="font-mono text-[13px] text-navy-2">{longDay(a.date)}</span>
+          <span className={"rounded-pill px-2.5 py-[3px] text-[11px] font-semibold " + BUCKET[a.bucket].pill}>
+            {BUCKET[a.bucket].label}
+          </span>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/omnischools/app/(parent)/parent-chrome.tsx
+++ b/omnischools/app/(parent)/parent-chrome.tsx
@@ -53,13 +53,17 @@ export function ParentHeader({
 }
 
 /** Every tab is a live route today. */
-export type ParentTab = "WASSCE" | "Sickbay" | "PTA" | "School calendar";
+export type ParentTab = "WASSCE" | "Attendance" | "Sickbay" | "PTA" | "School calendar";
 
-// INCR-278 — four flat tabs, ALL live routes (the inert Communications / Billing / Boarding spans are gone;
-// each returns behind its own increment). Every entry below has an HREF.
-const TABS = ["WASSCE", "Sickbay", "PTA", "School calendar"] as const;
+// INCR-278 → +Attendance — flat tabs, ALL live routes (the inert Communications / Billing / Boarding spans
+// are gone; each returns behind its own increment). Attendance sits second — the most-checked daily fact
+// ("is my child in school?"). Every entry below has an HREF.
+const TABS = ["WASSCE", "Attendance", "Sickbay", "PTA", "School calendar"] as const;
 const HREF: Record<(typeof TABS)[number], string> = {
   WASSCE: "/wassce",
+  // URL is /attendance-summary (the /attendance path is the STAFF marking route — parent routes share the
+  // (app) route namespace, so the parent tab needs a unique segment); the tab LABEL stays "Attendance".
+  Attendance: "/attendance-summary",
   Sickbay: "/sickbay",
   PTA: "/pta",
   "School calendar": "/calendar",

--- a/omnischools/db/sql/policies.sql
+++ b/omnischools/db/sql/policies.sql
@@ -981,6 +981,40 @@ CREATE POLICY parent_scope ON school_holiday AS RESTRICTIVE FOR ALL TO public
     OR school_id = NULLIF(current_setting('app.current_school', true), '')::uuid
   );
 
+-- ---- INCR — PARENT ATTENDANCE: the EIGHTH widening of the 19a parent boundary (24 → 25 parent_scope
+-- tables) — the parent-portal ATTENDANCE tab (read-only, owner-authorised). A parent gains ROW access to
+-- the per-day attendance marks (attendance_record) of their OWN CHILD, so the read-only parent portal can
+-- render the child's today / this-week / this-term attendance. Kept in sync with
+-- db/sql/prod-paste-0093-parent-attendance-scope.sql — this block is DEV; that file is the hand-paste on
+-- PROD (⚠ RLS is NOT auto-applied on prod; without the paste attendance_record keeps parent_deny and the
+-- parent Attendance tab is an honest empty state — fail-closed, never a leak).
+--
+-- 🔴 PER-CHILD JOIN — NOT school-wide. Unlike the INCR-278 calendar (school-wide, keyed on current_school),
+-- attendance_record carries PER-STUDENT data, so the predicate reaches a SPECIFIC child via the SECURITY
+-- DEFINER helper parent_student_ids(school_id, pu) — byte-shaped like wassce_candidates above. A parent of
+-- school A reads ONLY their own child's rows; another child of the SAME school → 0 rows; cross-tenant → 0.
+-- `pu IS NULL` → staff/bypass session → total no-op (the permissive tenant_isolation still governs). USING
+-- doubles as WITH CHECK; there is no parent write path (Kofi R4).
+--
+-- 🔴 RLS IS ROW-LEVEL — IT CANNOT MASK COLUMNS. This policy opens the child's ROW; the reader's frozen
+-- key-set (lib/parent/parent-attendance-data.ts, under withParentScope ONLY) is the column guard and MUST
+-- omit reason_code / note / marked_by_user_id / marked_at, and fold MEDICAL→EXCUSED so "MEDICAL" never
+-- crosses the wire (OC-PARENT-ATT-KEYSET). attendance_correction (staff decision_note / requested_by_user_id
+-- / decided_by_user_id) and attendance_settings (school config) are DELIBERATELY NOT widened — they carry no
+-- parent_scope policy, so the catalog loop below re-affirms parent_deny on both, and billing stays denied too.
+
+-- attendance_record — the child's per-day attendance marks (own-child only, via parent_student_ids).
+DROP POLICY IF EXISTS parent_deny ON attendance_record;
+DROP POLICY IF EXISTS parent_scope ON attendance_record;
+CREATE POLICY parent_scope ON attendance_record AS RESTRICTIVE FOR ALL TO public
+  USING (
+    NULLIF(current_setting('app.current_parent_user', true), '') IS NULL
+    OR student_id IN (
+      SELECT parent_student_ids(
+        school_id, NULLIF(current_setting('app.current_parent_user', true), '')::uuid)
+    )
+  );
+
 -- ---- layer 1: parent_deny on every tenant table EXCEPT the parent-readable set (CATALOG-DRIVEN) ----
 -- This USED to be a hand-maintained 77-name array; a new tenant table that got tenant_isolation but was
 -- forgotten here escaped the parent boundary silently (Dex BLOCK; student_health_record was the leak).

--- a/omnischools/db/sql/prod-paste-0093-parent-attendance-scope.sql
+++ b/omnischools/db/sql/prod-paste-0093-parent-attendance-scope.sql
@@ -1,0 +1,105 @@
+-- Omnischools — PROD paste 0093: PARENT ATTENDANCE SCOPE (INCR — parent-portal Attendance tab). POLICY-ONLY —
+-- ZERO new tables, ZERO enums, ZERO altered columns, ZERO backfills. It adds ONE narrow `parent_scope` policy
+-- to EXACTLY ONE existing table (attendance_record) and re-runs the catalog-driven parent_deny loop.
+-- Idempotent — safe to run more than once. Paste into the Supabase SQL editor on PROD after merging.
+-- Byte-identical in effect to the "INCR — PARENT ATTENDANCE" block in db/sql/policies.sql (dev, db:policies).
+--
+-- WHAT IT SHIPS. A read-only parent ATTENDANCE tab in the parent portal. To render it, a parent linked to a
+-- school must READ their OWN CHILD's per-day attendance marks (attendance_record: date + status). This is the
+-- EIGHTH widening of the INCR-19a parent boundary (24 → 25 parent_scope tables).
+--
+-- 🔴 OWN-CHILD ONLY — PER-CHILD JOIN, NOT school-wide. Unlike the INCR-278 calendar tables (school-wide, keyed
+-- on current_school), attendance_record carries PER-STUDENT data, so the restrictive predicate reaches a
+-- SPECIFIC child through the SECURITY DEFINER helper parent_student_ids(school_id, pu) — byte-shaped like the
+-- wassce_candidates policy (INCR-19a). The predicate is:
+--   pu IS NULL  OR  student_id IN (SELECT parent_student_ids(school_id, pu))
+-- where pu = NULLIF(current_setting('app.current_parent_user', true), ''). A parent of school A reads ONLY
+-- their own child's rows; ANOTHER child of the SAME school → 0 rows; CROSS-TENANT → 0 rows. `pu IS NULL` →
+-- staff/bypass session → total no-op (the permissive tenant_isolation still governs the row). USING doubles as
+-- WITH CHECK; there is no parent write path anywhere (Kofi R4). Depends on parent_student_ids()
+-- (prod-paste-0055), which already ships on prod.
+--
+-- 🔴 RLS IS ROW-LEVEL — IT CANNOT MASK COLUMNS. This policy opens the child's ROW. The reader's frozen key-set
+-- (lib/parent/parent-attendance-data.ts, under withParentScope ONLY) is the column guard and MUST omit
+-- reason_code / note / marked_by_user_id / marked_at, and fold MEDICAL→EXCUSED so the string "MEDICAL" never
+-- crosses the wire (OC-PARENT-ATT-KEYSET). This paste does NOT and CANNOT enforce that projection — it only
+-- decides which ROWS a parent may reach (their own child's).
+--
+-- ⚠ WHAT HAPPENS IF THIS IS NOT RUN — FAIL-CLOSED, NEVER A LEAK. db:policies configures LOCAL DEV ONLY.
+-- Without this paste, attendance_record keeps its existing parent_deny on prod, so a parent session
+-- (app.current_parent_user set) reads ZERO rows → the parent Attendance tab is an honest empty state, never a
+-- cross-tenant or cross-child leak. The cost of skipping is a blank tab, not exposure. Run it to ship the tab.
+--
+-- SCOPE — EXACTLY ONE TABLE CHANGES. Only attendance_record gains parent_scope (its old parent_deny is
+-- dropped). attendance_correction (staff decision_note / requested_by_user_id / decided_by_user_id — the
+-- correction workflow's staff PII) and attendance_settings (per-school marking config) are DELIBERATELY NOT
+-- widened: the reader never touches them, so they keep parent_deny (re-affirmed by the catalog loop below,
+-- which still covers them — no parent_scope policy exists on either, so the NOT EXISTS(parent_scope) filter
+-- includes them). Billing (invoice / invoice_line_item / payment / payment_allocation / receipt) likewise
+-- keeps parent_deny (R476 tuition-leak). Tenant isolation is untouched on every table. The catalog parent_deny
+-- loop at the tail re-affirms parent_deny on every other tenant table (auto-EXCLUDING the tables that carry
+-- parent_scope), so a future tenant table stays auto-denied with zero edits.
+--
+-- Verify afterwards:
+--   -- attendance_record carries parent_scope; correction/settings/billing still carry parent_deny:
+--   select c.relname, p.polname from pg_policy p join pg_class c on c.oid = p.polrelid
+--   where c.relname in ('attendance_record','attendance_correction','attendance_settings','invoice','receipt')
+--   order by 1, 2;
+--   -- and db/sql/verify-prod-rls.sql: Query 1 must return ZERO ROWS; tenant_tables unchanged;
+--   -- parent_readable up by 1 (25) and parent_denied down by 1.
+
+-- ---- layer 2: the new parent_scope policy (byte-identical to db/sql/policies.sql "INCR — PARENT ATTENDANCE"
+-- block) ---- `pu IS NULL` → staff/bypass session → total no-op. `pu` set → student_id must resolve to one of
+-- the parent's OWN children via parent_student_ids() (SECURITY DEFINER). USING doubles as WITH CHECK; there is
+-- no parent write path (Kofi R4).
+
+-- attendance_record — the child's per-day attendance marks (own-child only, via parent_student_ids).
+DROP POLICY IF EXISTS parent_deny ON attendance_record;
+DROP POLICY IF EXISTS parent_scope ON attendance_record;
+CREATE POLICY parent_scope ON attendance_record AS RESTRICTIVE FOR ALL TO public
+  USING (
+    NULLIF(current_setting('app.current_parent_user', true), '') IS NULL
+    OR student_id IN (
+      SELECT parent_student_ids(
+        school_id, NULLIF(current_setting('app.current_parent_user', true), '')::uuid)
+    )
+  );
+
+-- ---- layer 1: parent_deny — the CATALOG-DRIVEN loop, verbatim from db/sql/policies.sql ----
+-- 🔴 RUN THIS. It is NOT a hand-list: it applies RESTRICTIVE parent_deny to every FORCE-RLS + school_id table
+-- that does NOT already carry a parent_scope policy — which, after the block above, is every tenant table
+-- EXCEPT the 25 parent-readable ones (the 24 shipped + attendance_record added here). It re-creates identical
+-- policies on the already-covered tables (hence idempotent) and, crucially, KEEPS attendance_record EXCLUDED
+-- (it now carries parent_scope) while re-affirming parent_deny on attendance_correction, attendance_settings,
+-- billing and every other tenant table. It is what keeps a FUTURE tenant table auto-denied with zero change.
+DO $$
+DECLARE
+  tbl text;
+BEGIN
+  FOR tbl IN
+    SELECT c.relname
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = 'public'
+    WHERE c.relkind = 'r'
+      AND c.relforcerowsecurity
+      AND EXISTS (
+        SELECT 1 FROM information_schema.columns col
+        WHERE col.table_schema = 'public'
+          AND col.table_name = c.relname
+          AND col.column_name = 'school_id'
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_policy p
+        WHERE p.polrelid = c.oid AND p.polname = 'parent_scope'
+      )
+    ORDER BY c.relname
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS parent_deny ON %I;', tbl);
+    EXECUTE format(
+      'CREATE POLICY parent_deny ON %I AS RESTRICTIVE FOR ALL TO public '
+      'USING (NULLIF(current_setting(''app.current_parent_user'', true), '''') IS NULL);',
+      tbl
+    );
+  END LOOP;
+END
+$$;

--- a/omnischools/docs/senior/incr-parent-attendance-surface-map.md
+++ b/omnischools/docs/senior/incr-parent-attendance-surface-map.md
@@ -1,0 +1,60 @@
+# INCR — Parent-portal Attendance tab (read-only) · build-ready spec
+
+**Status:** spec-complete, front-half done (Kofi ACs + Lucy surface map). **BUILD BLOCKED on PR #342 (INCR #278) merging** — the nav wiring collides with `app/(parent)/parent-chrome.tsx` and the route can't compile without it, so the whole increment lands as ONE unit off the post-#342 main. Also awaiting owner **OC-PARENT-ATT-KEYSET** (conservative defaults below are shippable as-is).
+
+Clone the shipped sibling: `app/(parent)/sickbay/page.tsx` + `lib/parent/parent-sickbay-data.ts` (frozen-key-set reader under `withParentScope`, projection = the only column guard, honest-empty). Surface source (goofy-poitras primary wd, absent from senior-live): `Surfaces/schoolup-attendance-parent.html`.
+
+## The RLS widening (mandatory prod-paste)
+`attendance_record` is in the `parent_deny` catalog today (`db/sql/policies.sql`) → parent reads 0 rows (fail-closed). This is the **8th widening of the 19a parent boundary (24 → 25 parent_scope tables)**. Add ONE policy, byte-shaped like the `wassce_candidates` policy (`policies.sql` ~L359):
+```sql
+CREATE POLICY parent_scope ON attendance_record AS RESTRICTIVE FOR ALL TO public
+  USING (
+    NULLIF(current_setting('app.current_parent_user', true), '') IS NULL
+    OR student_id IN (SELECT parent_student_ids(school_id, NULLIF(current_setting('app.current_parent_user', true),'')::uuid))
+  );
+```
+Add the INCR block to `policies.sql` (dev) AND author **`prod-paste-0093`** (owner hand-runs on prod — RLS is not auto-applied). `attendance_correction` + `attendance_settings` STAY `parent_deny` (correction rows carry staff `decisionNote`/`requestedByUserId`/`decidedByUserId`).
+
+## OC-PARENT-ATT-KEYSET — ruling (owner-confirmable; conservative defaults)
+1. **Medical (M) → FOLD into Excused** in the SQL projection (`CASE status WHEN 'MEDICAL' THEN 'EXCUSED' ELSE status END`). The string `"MEDICAL"` never crosses the wire. Kofi proved the fold costs **zero rate accuracy** (Medical & Excused both out of numerator, both in denominator). Owner-widenable to distinct Medical (one-line projection change).
+2. **`reasonCode` OMITTED** by default (owner-widenable to structured category only — never free-text). **`note` (free-text) PERMANENT omit** (DPA hazard — third-party/health/disciplinary text). 
+3. **`markedByUserId` / `markedAt` clock OMITTED** (staff PII / surveillance-shaped); the only temporal field is the date-only `date`.
+
+## Frozen key-set (final — reconciled Kofi + Lucy; the enforcement point)
+Reader `loadParentAttendanceStatus(schoolId, userId, studentId)` under `withParentScope` ONLY. `studentId` = server-resolved input filter, NEVER a URL param, NEVER returned. Reads ONLY `attendance_record` (+ `academic_period`/`school_holiday` — already parent_scoped — for term bounds + school-day/holiday classification). Joins NOTHING to `users`/`attendance_correction`/comms.
+```
+Day    = { date:'YYYY-MM-DD', bucket:'PRESENT'|'LATE'|'EXCUSED'|'ABSENT' }   // MEDICAL folded→EXCUSED
+Status = {
+  today:   Day | null                                   // null = no mark / weekend / holiday
+  week:    { date, bucket, isToday, isSchoolDay }[]      // Mon–Fri current school week
+  term:    { label, startsOn, asOf, atSchoolDays, markedDays, atSchoolPct,
+             counts:{ present, late, excused, absent } } | null   // NO `medical` key
+  priorTerm: { label, atSchoolPct, atSchoolDays, markedDays } | null
+  recentAbsences: { date, bucket:'ABSENT'|'EXCUSED' }[] // dates + bucket ONLY
+}
+```
+**NEVER selected/returned:** `reason_code`, `note`, `marked_by_user_id` (+ any `users` join), `marked_at` clock, `attendance_correction.*`, the value `"MEDICAL"`, `studentId`/ids/free-text.
+
+## OMIT from the surface (write affordances / cross-module PII — R234 / omit-not-fake)
+- Teacher name in hero ("Mr. Mensah") → "Marked present today." (no name, no clock).
+- State B **school-contact card** (named HM + WhatsApp/call = comms `parent_deny` + staff PII) → OMIT whole card; at most a static un-named "contact the school office" line.
+- **Planned-absence CTA + "tell the school / correction" links** → write affordances, OMIT (read-only v1).
+- **State C (planned-absence form)** → a parent WRITE surface (new mutation + SMS-suppression + reason taxonomy) → DEFER to its own increment.
+- No at-risk/threshold/pattern/predictive labels (parent surface is information, not coaching).
+
+## Two open reconciliations (flag to owner; default per note)
+1. **"At school %" numerator — present-only vs present+late.** Surface demo = **present-only** (State B 29/47 = 61%); staff canonical (`attendance-summary-data.ts`) = `(present+late)/marked`. Exact-surface-replication → **default present-only** (`atSchoolPct = round(present/markedDays*100)`, `null` when markedDays=0), matching the surface. Confirm with Kofi/owner. Kofi's AC-PATT-12 assumed present+late — reconcile to present-only unless owner rules otherwise. Either way: `present+late+excused+absent === markedDays`.
+2. **Multi-child switcher** — surface implies multi-child; shipped portal is single-child (`data.children[0]`). Build single-child (like sickbay) for v1.
+
+## Acceptance criteria
+Kofi's **AC-PATT-01..21** govern (scope/plumbing, own-child + cross-tenant isolation, frozen-key-set projection guard, honest rollup incl. `ratePct=null` when markedDays=0, fold-costs-no-accuracy, honest-empty states, per-day `{date,status}` only). Test as source-shape (reader projection / withParentScope-only / no PII columns) + pure rollup fixtures (mirror the #278 `buildParentCalendar` split — extract a pure `buildParentAttendance(rows, termWindow, today)`).
+
+## Build order (after #342 merges)
+1. `prod-paste-0093` + `policies.sql` INCR block (Wells).
+2. `lib/parent/parent-attendance-data.ts` (reader + pure rollup) + `lib/parent/parent-attendance-copy.ts` (jargon-guarded copy, mirror `wassce/parent-copy.ts`).
+3. `app/(parent)/attendance-summary/page.tsx` (States A+B card bodies 1:1; NoChild + honest-empty from sickbay). URL is `/attendance-summary` — `/attendance` is the STAFF marking route (parent routes share the `(app)` namespace), so the tab needs a unique segment; the tab LABEL stays "Attendance".
+4. `app/(parent)/parent-chrome.tsx` — add `Attendance → /attendance-summary` as the 5th tab.
+5. `lib/parent/parent-attendance.test.ts`.
+6. Gates: Quinn ALONE (mutation-probe), then Dex + Sarah (Sarah verifies the parent_scope grant is own-child leak-safe + billing/correction stay denied).
+
+Sources: full Kofi ruling (AC-PATT + OC reasoning) and Lucy surface map (3 states, token table, §8 SHOW/OMIT table) in the session transcript.

--- a/omnischools/lib/parent/parent-attendance-data.ts
+++ b/omnischools/lib/parent/parent-attendance-data.ts
@@ -1,0 +1,257 @@
+import "server-only";
+import { and, asc, desc, eq, gte, lte, sql } from "drizzle-orm";
+import { withParentScope } from "@/lib/db/rls";
+import type { Tx } from "@/lib/db";
+import { academicPeriod, attendanceRecords, schoolHolidays, students } from "@/db/schema";
+import { isHoliday, type HolidayRange } from "@/lib/school-calendar";
+
+/**
+ * 🔴 INCR — the PARENT-facing ATTENDANCE reader (SHS module 4.4 × parent portal 4.3 · Kofi AC-PATT-*).
+ * The 8th widening of the 19a parent boundary (24 → 25 parent_scope tables; Wells's prod-paste-0093 opens
+ * the ROW on `attendance_record` scoped to the parent's OWN children). SERVER-ONLY — imports the db driver,
+ * so a client component must never import it (only `pnpm build` catches that leak).
+ *
+ * RLS is ROW-level and CANNOT mask a column, so THIS PROJECTION is the ONLY column guard (the Sickbay R229
+ * precedent). The reader reads `attendance_record` (+ `academic_period`/`school_holiday`, already
+ * parent_scoped by INCR-278, for the term window and school-day classification, and one own-child
+ * `students.programme` read to pick the CHILD's product line in a COMBINED school) — and joins NOTHING to
+ * `users`, `attendance_correction`, or any comms table.
+ *
+ * OC-PARENT-ATT-KEYSET (Kofi, owner-confirmable — conservative defaults):
+ *   • MEDICAL is FOLDED → EXCUSED in the SQL projection; the string "MEDICAL" NEVER leaves the DB. The fold
+ *     costs zero rate accuracy (Medical and Excused both sit out of the numerator, both in the denominator).
+ *   • `reason_code` / `note` (free-text — a DPA hazard) / `marked_by_user_id` / the `marked_at` CLOCK are
+ *     NEVER selected. The only temporal field is the date-only `date`.
+ * `studentId` is an INPUT filter resolved server-side from the session (never a URL param), NEVER returned;
+ * the `parent_scope` RLS predicate independently restricts it to THIS parent's own children, so a forged id
+ * yields zero rows (fail-closed). Read-only by construction — no write, no notify/SMS.
+ *
+ * "At school" = PRESENT + LATE (the canonical `rateOf` formula in lib/reports/attendance-summary-data.ts;
+ * Kofi AC-PATT-12). A late student was at school. (The design surface's illustrative 61% counts present-only;
+ * the domain ruling is present+late. Owner-widenable.)
+ */
+
+export type AttendanceBucket = "PRESENT" | "LATE" | "EXCUSED" | "ABSENT"; // MEDICAL folded → EXCUSED
+
+export type ParentAttendanceDay = { date: string; bucket: AttendanceBucket };
+export type ParentAttendanceWeekDay = {
+  date: string;
+  bucket: AttendanceBucket | null; // null = no mark (future/holiday/not marked)
+  isToday: boolean;
+  isSchoolDay: boolean; // Mon–Fri and not a school holiday
+};
+export type ParentAttendanceCounts = { present: number; late: number; excused: number; absent: number };
+export type ParentAttendanceTerm = {
+  label: string; // "Term 2 · 2025/26"
+  startsOn: string;
+  asOf: string; // min(today, term end)
+  atSchoolDays: number; // present + late
+  markedDays: number; // present + late + excused + absent
+  atSchoolPct: number | null; // round(atSchoolDays / markedDays * 100); null when markedDays === 0
+  counts: ParentAttendanceCounts;
+};
+export type ParentAttendancePriorTerm = {
+  label: string;
+  atSchoolPct: number | null;
+  atSchoolDays: number;
+  markedDays: number;
+};
+
+/** FROZEN KEY-SET (AC-PATT-07). No studentId/ids/reason/note/staff/clock ever crosses the wire. */
+export type ParentAttendance = {
+  today: ParentAttendanceDay | null; // null = no mark today / weekend / holiday
+  week: ParentAttendanceWeekDay[]; // Mon–Fri of the current school week
+  term: ParentAttendanceTerm | null; // null = no academic period configured
+  priorTerm: ParentAttendancePriorTerm | null;
+  recentAbsences: { date: string; bucket: "ABSENT" | "EXCUSED" }[]; // dates + bucket ONLY, most recent first
+};
+
+/** A term row as read from `academic_period` (newest-first, SENIOR_F3 excluded). */
+export type PatTermRow = { label: string; academicYear: string; startsOn: string; endsOn: string };
+
+const termLabel = (t: PatTermRow): string => `${t.label} · ${t.academicYear}`;
+
+/** Newest-first term containing today, else the most recent started, else the newest (the report default). */
+function pickTerm(terms: PatTermRow[], today: string): PatTermRow | null {
+  if (terms.length === 0) return null;
+  return (
+    terms.find((t) => t.startsOn <= today && today <= t.endsOn) ??
+    terms.find((t) => t.startsOn <= today) ??
+    terms[0]
+  );
+}
+
+/** The chronologically-previous term to `term` (terms newest-first), else null. */
+function priorOf(terms: PatTermRow[], term: PatTermRow): PatTermRow | null {
+  // terms are single-product-line here (the reader filters academic_period to the child's line), so a strict
+  // startsOn comparison is a clean key — no two terms share a start.
+  const older = terms.filter((t) => t.startsOn < term.startsOn);
+  return older[0] ?? null; // newest-first → first older entry is the closest previous term
+}
+
+function tally(rows: ParentAttendanceDay[]): ParentAttendanceCounts {
+  const c: ParentAttendanceCounts = { present: 0, late: 0, excused: 0, absent: 0 };
+  for (const r of rows) {
+    if (r.bucket === "PRESENT") c.present += 1;
+    else if (r.bucket === "LATE") c.late += 1;
+    else if (r.bucket === "EXCUSED") c.excused += 1;
+    else if (r.bucket === "ABSENT") c.absent += 1;
+  }
+  return c;
+}
+const markedOf = (c: ParentAttendanceCounts) => c.present + c.late + c.excused + c.absent;
+const atSchoolOf = (c: ParentAttendanceCounts) => c.present + c.late; // Kofi AC-PATT-12
+const pctOf = (c: ParentAttendanceCounts): number | null =>
+  markedOf(c) > 0 ? Math.round((atSchoolOf(c) / markedOf(c)) * 100) : null;
+
+/** Monday-based Mon–Fri ISO dates of the week containing `today` (UTC). */
+function schoolWeek(today: string): string[] {
+  const t = new Date(`${today}T00:00:00Z`);
+  const dow = t.getUTCDay(); // 0=Sun … 6=Sat
+  const mondayOffset = dow === 0 ? -6 : 1 - dow;
+  const monday = new Date(t);
+  monday.setUTCDate(t.getUTCDate() + mondayOffset);
+  return Array.from({ length: 5 }, (_, i) => {
+    const d = new Date(monday);
+    d.setUTCDate(monday.getUTCDate() + i);
+    return d.toISOString().slice(0, 10);
+  });
+}
+
+/**
+ * PURE — the honest attendance derivation (no db, unit-tested). `termRows` newest-first (SENIOR_F3 already
+ * excluded); `dayRows` are the child's records across the current + prior term window, each already folded
+ * (MEDICAL→EXCUSED) and date-only. Everything the surface shows is derived here from real rows only (R90):
+ * no fabricated rate/day/streak; `atSchoolPct` is null (not 0/100) when nothing is marked.
+ */
+export function buildParentAttendance(
+  termRows: PatTermRow[],
+  dayRows: ParentAttendanceDay[],
+  holidays: HolidayRange[],
+  today: string,
+): ParentAttendance {
+  const byDate = new Map<string, AttendanceBucket>();
+  for (const r of dayRows) byDate.set(r.date, r.bucket);
+
+  const week: ParentAttendanceWeekDay[] = schoolWeek(today).map((date) => ({
+    date,
+    bucket: byDate.get(date) ?? null,
+    isToday: date === today,
+    isSchoolDay: !isHoliday(date, holidays), // Mon–Fri by construction; a holiday makes it a non-school day
+  }));
+
+  const todayBucket = byDate.get(today);
+  const todayDay: ParentAttendanceDay | null = todayBucket ? { date: today, bucket: todayBucket } : null;
+
+  const current = pickTerm(termRows, today);
+  if (!current) {
+    return { today: todayDay, week, term: null, priorTerm: null, recentAbsences: [] };
+  }
+
+  const inTerm = (t: PatTermRow) => dayRows.filter((r) => r.date >= t.startsOn && r.date <= t.endsOn);
+  const termDaysRows = inTerm(current);
+  const counts = tally(termDaysRows);
+  const term: ParentAttendanceTerm = {
+    label: termLabel(current),
+    startsOn: current.startsOn,
+    asOf: today < current.endsOn ? today : current.endsOn,
+    atSchoolDays: atSchoolOf(counts),
+    markedDays: markedOf(counts),
+    atSchoolPct: pctOf(counts),
+    counts,
+  };
+
+  const prior = priorOf(termRows, current);
+  let priorTerm: ParentAttendancePriorTerm | null = null;
+  if (prior) {
+    const pc = tally(inTerm(prior));
+    // Only show a prior-term summary when it actually has marks (an empty prior term is not a "0%").
+    if (markedOf(pc) > 0) {
+      priorTerm = { label: termLabel(prior), atSchoolPct: pctOf(pc), atSchoolDays: atSchoolOf(pc), markedDays: markedOf(pc) };
+    }
+  }
+
+  const recentAbsences = termDaysRows
+    .filter((r) => r.bucket === "ABSENT" || r.bucket === "EXCUSED")
+    .sort((a, b) => b.date.localeCompare(a.date))
+    .map((r) => ({ date: r.date, bucket: r.bucket as "ABSENT" | "EXCUSED" }));
+
+  return { today: todayDay, week, term, priorTerm, recentAbsences };
+}
+
+/** MUST run on a `tx` already scoped by `withParentScope`. `studentId` is an input filter, never returned. */
+export async function loadParentAttendanceTx(
+  tx: Tx,
+  schoolId: string,
+  studentId: string,
+  today: string = new Date().toISOString().slice(0, 10),
+): Promise<ParentAttendance> {
+  // The CHILD's product line: SHS students carry a `programme`; Basic students don't (own-child read under
+  // parent_scope). Filtering academic_period to this line makes a COMBINED school's term pick land on the
+  // child's OWN terms — for a per-child surface the window sets the counts, not just a label (Dex MED-1).
+  // It also excludes the SENIOR_F3 boarding pseudo-period (its product_line is neither SENIOR nor BASIC).
+  const [stu] = await tx
+    .select({ programme: students.programme })
+    .from(students)
+    .where(and(eq(students.schoolId, schoolId), eq(students.id, studentId)))
+    .limit(1);
+  const childLine = stu?.programme ? "SENIOR" : "BASIC";
+
+  // Real terms for the child's line, newest-first.
+  const termRows: PatTermRow[] = await tx
+    .select({
+      label: academicPeriod.periodLabel,
+      academicYear: academicPeriod.academicYear,
+      startsOn: academicPeriod.startsOn,
+      endsOn: academicPeriod.endsOn,
+    })
+    .from(academicPeriod)
+    .where(and(eq(academicPeriod.schoolId, schoolId), eq(academicPeriod.productLine, childLine)))
+    .orderBy(desc(academicPeriod.academicYear), desc(academicPeriod.periodNumber));
+
+  // Window = the current + prior term (so the prior-term summary has its rows); fall back to all if unknown.
+  const current = pickTerm(termRows, today);
+  const prior = current ? priorOf(termRows, current) : null;
+  const windowStart = prior?.startsOn ?? current?.startsOn ?? null;
+  const windowEnd = current?.endsOn ?? null;
+
+  // The child's records, MEDICAL folded → EXCUSED IN SQL so "MEDICAL" never leaves the DB. reason_code /
+  // note / marked_by_user_id / the marked_at clock are NEVER selected (the projection is the column guard).
+  const dayRows: ParentAttendanceDay[] = await tx
+    .select({
+      date: attendanceRecords.date,
+      bucket: sql<AttendanceBucket>`case ${attendanceRecords.status} when 'MEDICAL' then 'EXCUSED' else ${attendanceRecords.status} end`,
+    })
+    .from(attendanceRecords)
+    .where(
+      and(
+        eq(attendanceRecords.schoolId, schoolId),
+        eq(attendanceRecords.studentId, studentId),
+        windowStart ? gte(attendanceRecords.date, windowStart) : undefined,
+        windowEnd ? lte(attendanceRecords.date, windowEnd) : undefined,
+      ),
+    );
+
+  // Holidays for the week-strip school-day classification (school_holiday is parent_scoped since INCR-278).
+  const holidays: HolidayRange[] = await tx
+    .select({
+      name: schoolHolidays.name,
+      startsOn: schoolHolidays.startsOn,
+      endsOn: schoolHolidays.endsOn,
+      kind: schoolHolidays.kind,
+    })
+    .from(schoolHolidays)
+    .where(eq(schoolHolidays.schoolId, schoolId))
+    .orderBy(asc(schoolHolidays.startsOn));
+
+  return buildParentAttendance(termRows, dayRows, holidays, today);
+}
+
+/** Entry point — ONE child's attendance under `withParentScope` (never `withSchool`). */
+export async function loadParentAttendance(
+  schoolId: string,
+  userId: string,
+  studentId: string,
+): Promise<ParentAttendance> {
+  return withParentScope(schoolId, userId, (tx) => loadParentAttendanceTx(tx, schoolId, studentId));
+}

--- a/omnischools/lib/parent/parent-attendance.test.ts
+++ b/omnischools/lib/parent/parent-attendance.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from "vitest";
+import { readCode } from "@/lib/test-utils/source-shape";
+import {
+  buildParentAttendance,
+  type PatTermRow,
+  type ParentAttendanceDay,
+} from "./parent-attendance-data";
+import type { HolidayRange } from "@/lib/school-calendar";
+
+/**
+ * INCR · parent-portal Attendance tab (Kofi AC-PATT-*). Two guards:
+ *  1. the PURE honesty derivation (buildParentAttendance) — current-term rollup, present+late numerator,
+ *     excused/(folded medical) out of the numerator, ratePct null (not 0/100) when nothing is marked, honest
+ *     recent-absences, prior-term only when it has marks.
+ *  2. source-shape — the reader stays inside withParentScope, folds MEDICAL→EXCUSED in SQL, and never selects
+ *     reason/note/staff/clock or joins users/corrections; the nav is FIVE live tabs with no inert spans.
+ */
+
+// 2025/26, newest-first (as the reader orders academic_period): Term 2 current, Term 1 prior.
+const T2: PatTermRow = { label: "Term 2", academicYear: "2025/26", startsOn: "2026-01-06", endsOn: "2026-04-10" };
+const T1: PatTermRow = { label: "Term 1", academicYear: "2025/26", startsOn: "2025-09-01", endsOn: "2025-12-19" };
+const TERMS = [T2, T1];
+const TODAY = "2026-02-11"; // a Wednesday; its Mon–Fri week is 2026-02-09 … 2026-02-13
+
+// buckets are already folded (MEDICAL→EXCUSED happens in SQL before the builder sees a row).
+const ROWS: ParentAttendanceDay[] = [
+  { date: "2026-01-15", bucket: "PRESENT" },
+  { date: "2026-01-16", bucket: "ABSENT" },
+  { date: "2026-02-09", bucket: "PRESENT" },
+  { date: "2026-02-10", bucket: "LATE" },
+  { date: "2026-02-11", bucket: "PRESENT" }, // today
+  { date: "2026-02-12", bucket: "EXCUSED" },
+  { date: "2026-02-13", bucket: "ABSENT" },
+  // prior term
+  { date: "2025-09-05", bucket: "PRESENT" },
+  { date: "2025-09-06", bucket: "PRESENT" },
+];
+const HOLIDAYS: HolidayRange[] = [
+  { name: "Mid-term", startsOn: "2026-02-12", endsOn: "2026-02-12", kind: "BREAK" },
+];
+
+describe("buildParentAttendance · honest derivation (AC-PATT-*)", () => {
+  it("rolls up the current term: present+late numerator, excused+medical out of it (AC-PATT-12/14)", () => {
+    const a = buildParentAttendance(TERMS, ROWS, HOLIDAYS, TODAY);
+    expect(a.term).not.toBeNull();
+    expect(a.term!.counts).toEqual({ present: 3, late: 1, excused: 1, absent: 2 });
+    expect(a.term!.markedDays).toBe(7); // present+late+excused+absent
+    expect(a.term!.atSchoolDays).toBe(4); // present+late ONLY — excused (incl folded medical) excluded
+    expect(a.term!.atSchoolPct).toBe(57); // round(4/7*100)
+    expect(a.term!.label).toBe("Term 2 · 2025/26");
+    // the identity that proves the numerator choice + that excused sits in the denominator only:
+    expect(a.term!.atSchoolDays).toBe(a.term!.counts.present + a.term!.counts.late);
+    expect(a.term!.markedDays).toBe(
+      a.term!.counts.present + a.term!.counts.late + a.term!.counts.excused + a.term!.counts.absent,
+    );
+  });
+
+  it("ratePct is null (not 0/100) when nothing is marked (AC-PATT-13)", () => {
+    const a = buildParentAttendance(TERMS, [], [], TODAY);
+    expect(a.term).not.toBeNull(); // the term still resolves (by date) — it just has no marks
+    expect(a.term!.markedDays).toBe(0);
+    expect(a.term!.atSchoolPct).toBeNull();
+    expect(a.recentAbsences).toEqual([]);
+    expect(a.priorTerm).toBeNull(); // no prior-term marks → no fabricated 0%
+  });
+
+  it("no academic term → term null, never an invented rate (AC-PATT-20)", () => {
+    const a = buildParentAttendance([], ROWS, [], TODAY);
+    expect(a.term).toBeNull();
+    expect(a.priorTerm).toBeNull();
+  });
+
+  it("today = the child's mark for today, else null; the hero fold never emits MEDICAL", () => {
+    expect(buildParentAttendance(TERMS, ROWS, HOLIDAYS, TODAY).today).toEqual({
+      date: "2026-02-11",
+      bucket: "PRESENT",
+    });
+    // a today with no row → null (weekend/holiday/not-marked); the hero is omitted.
+    const noMark = buildParentAttendance(TERMS, ROWS, HOLIDAYS, "2026-02-14");
+    expect(noMark.today).toBeNull();
+  });
+
+  it("week strip is Mon–Fri, flags today, and marks a holiday as a non-school day", () => {
+    const a = buildParentAttendance(TERMS, ROWS, HOLIDAYS, TODAY);
+    expect(a.week).toHaveLength(5);
+    expect(a.week.map((d) => d.date)).toEqual([
+      "2026-02-09", "2026-02-10", "2026-02-11", "2026-02-12", "2026-02-13",
+    ]);
+    expect(a.week.filter((d) => d.isToday)).toHaveLength(1);
+    expect(a.week.find((d) => d.isToday)!.date).toBe("2026-02-11");
+    expect(a.week.find((d) => d.date === "2026-02-12")!.isSchoolDay).toBe(false); // holiday
+    expect(a.week.find((d) => d.date === "2026-02-09")!.isSchoolDay).toBe(true);
+  });
+
+  it("recentAbsences = absent+excused of the current term, most recent first, dates+bucket only", () => {
+    const a = buildParentAttendance(TERMS, ROWS, HOLIDAYS, TODAY);
+    expect(a.recentAbsences).toEqual([
+      { date: "2026-02-13", bucket: "ABSENT" },
+      { date: "2026-02-12", bucket: "EXCUSED" },
+      { date: "2026-01-16", bucket: "ABSENT" },
+    ]);
+  });
+
+  it("priorTerm shows ONLY when it has marks (AC-PATT-17 honesty)", () => {
+    const a = buildParentAttendance(TERMS, ROWS, HOLIDAYS, TODAY);
+    expect(a.priorTerm).toEqual({ label: "Term 1 · 2025/26", atSchoolPct: 100, atSchoolDays: 2, markedDays: 2 });
+  });
+
+  it("the term window is inclusive of both the start and end dates (AC-PATT-16)", () => {
+    const boundary: ParentAttendanceDay[] = [
+      { date: T2.startsOn, bucket: "PRESENT" }, // exactly on term start
+      { date: T2.endsOn, bucket: "ABSENT" }, // exactly on term end
+    ];
+    const a = buildParentAttendance(TERMS, boundary, [], TODAY);
+    expect(a.term!.markedDays).toBe(2); // both boundary days fall inside the window
+    expect(a.term!.counts).toEqual({ present: 1, late: 0, excused: 0, absent: 1 });
+  });
+});
+
+describe("parent-attendance-data · reader stays in the parent boundary (source-shape)", () => {
+  const reader = () => readCode("lib/parent/parent-attendance-data.ts");
+
+  it("runs under withParentScope only — never withSchool / withoutTenantScope", () => {
+    const s = reader();
+    expect(s).toMatch(/withParentScope/);
+    expect(s).not.toMatch(/withSchool|withoutTenantScope/);
+  });
+
+  it("folds MEDICAL→EXCUSED in SQL; the bucket type never carries MEDICAL", () => {
+    const s = reader();
+    expect(s).toMatch(/when 'MEDICAL' then 'EXCUSED'/); // the fold happens in the projection
+    expect(s).toMatch(/AttendanceBucket = "PRESENT" \| "LATE" \| "EXCUSED" \| "ABSENT"/); // no MEDICAL bucket
+  });
+
+  it("never selects reason/note/staff/clock, and joins nothing (column guard)", () => {
+    const s = reader();
+    // target actual Drizzle column access (comments legitimately name these columns as the deny-list).
+    expect(s).not.toMatch(/attendanceRecords\.reasonCode/);
+    expect(s).not.toMatch(/attendanceRecords\.note/);
+    expect(s).not.toMatch(/attendanceRecords\.markedByUserId/);
+    expect(s).not.toMatch(/attendanceRecords\.markedAt/);
+    expect(s).not.toMatch(/attendanceCorrections/); // the corrections table is never imported/used
+    expect(s).not.toMatch(/Join\(/); // no join at all → no users/staff-name reaches the wire
+  });
+});
+
+describe("parent-chrome · Attendance is the 5th live tab (source-shape)", () => {
+  const nav = () => readCode("app/(parent)/parent-chrome.tsx");
+  const page = () => readCode("app/(parent)/attendance-summary/page.tsx");
+
+  it("TABS/HREF/ParentTab carry Attendance → /attendance, still no inert span", () => {
+    const s = nav();
+    expect(s).toMatch(/const TABS = \["WASSCE", "Attendance", "Sickbay", "PTA", "School calendar"\] as const;/);
+    expect(s).toMatch(/ParentTab = "WASSCE" \| "Attendance" \| "Sickbay" \| "PTA" \| "School calendar"/);
+    expect(s).toMatch(/Attendance: "\/attendance-summary"/); // unique parent URL (/attendance is the staff route)
+    expect(s).not.toMatch(/Partial<Record/);
+    expect((s.match(/<span/g) ?? []).length).toBe(1); // only the active tab is a span
+  });
+
+  it("the attendance route is child-gated and renders its own active nav", () => {
+    const s = page();
+    expect(s).toMatch(/ParentNav active="Attendance"/);
+    expect(s).toMatch(/NoChild/); // per-child surface → linked-child gate (unlike the school-wide calendar)
+    expect(s).toMatch(/child\.studentId/); // studentId resolved server-side, passed to the reader
+  });
+});

--- a/omnischools/lib/parent/parent-calendar.test.ts
+++ b/omnischools/lib/parent/parent-calendar.test.ts
@@ -88,15 +88,19 @@ describe("parent-calendar-data · reader stays in the parent boundary (source-sh
   });
 });
 
-describe("parent-chrome · four live tabs, no inert spans (AC-CAL-01..04)", () => {
+describe("parent-chrome · no inert tabs, calendar live (AC-CAL-01..04)", () => {
   const nav = () => readCode("app/(parent)/parent-chrome.tsx");
   const page = () => readCode("app/(parent)/calendar/page.tsx");
 
-  it("TABS is exactly the four live routes; the three inert tabs are gone", () => {
+  // Count-robust: assert the #278 INTENT (the three inert tabs stay gone, calendar is a live route, no inert
+  // spans) rather than pinning the whole TABS literal — so adding a later live tab can't red this test.
+  it("the three inert tabs are gone and School calendar is a live route (no inert spans)", () => {
     const s = nav();
-    expect(s).toMatch(/const TABS = \["WASSCE", "Sickbay", "PTA", "School calendar"\] as const;/); // AC-CAL-01
-    expect(s).toMatch(/ParentTab = "WASSCE" \| "Sickbay" \| "PTA" \| "School calendar"/); // AC-CAL-03
-    expect(s).toMatch(/"School calendar": "\/calendar"/); // AC-CAL-03 route
+    // quoted → only TABS/HREF/the ParentTab union carry these, never the prose comment.
+    expect(s).not.toMatch(/"Communications"/); // AC-CAL-01
+    expect(s).not.toMatch(/"Billing"/);
+    expect(s).not.toMatch(/"Boarding"/);
+    expect(s).toMatch(/"School calendar": "\/calendar"/); // still a live route — AC-CAL-03
     expect(s).not.toMatch(/Partial<Record/); // HREF is total → no tab can be an inert span — AC-CAL-02
     expect(s).not.toMatch(/coming soon|disabled|greyed/i); // AC-CAL-04
     expect((s.match(/<span/g) ?? []).length).toBe(1); // the ONLY span is the active tab — AC-CAL-02


### PR DESCRIPTION
## What this ships

The **fifth live parent-portal tab** — a parent's read-only view of their **own child's attendance**: today's status, this week (Mon–Fri strip), this term's summary, and days away. Tab label is "Attendance"; its URL is `/attendance-summary` (see the route note below).

## Changes
- **`lib/parent/parent-attendance-data.ts`** — parent-scoped reader (`withParentScope` only) over `attendance_record`. RLS is row-level, so the SELECT projection is the **only** column guard: **MEDICAL is folded → EXCUSED in SQL** (the health-inflected marker never crosses the wire), and `reason_code` / `note` (free-text DPA hazard) / `marked_by_user_id` / the `marked_at` clock are never selected; no `users`/`attendance_correction` join. The honest derivation is the pure, unit-tested `buildParentAttendance`: **present+late** numerator (the canonical `rateOf` formula), excused (incl. folded medical) denominator-only, `ratePct` **null** (not 0/100) when nothing is marked, holiday-aware week strip, prior-term only when it has marks, boundary-inclusive term window. It also reads the child's own `students.programme` to scope terms to the child's product line (COMBINED-school correctness).
- **`app/(parent)/attendance-summary/page.tsx`** — the tab (today hero / week strip / term summary / days-away). Child-gated; honest empties throughout.
- **`app/(parent)/parent-chrome.tsx`** — Attendance added as the 2nd tab (most-checked daily fact).
- **`db/sql/{policies.sql, prod-paste-0093-parent-attendance-scope.sql}`** — the **8th widening of the 19a parent boundary (24 → 25 parent_scope tables)**: own-child `parent_scope` on `attendance_record` (`parent_student_ids` join, the audited `wassce_candidates` shape). `attendance_correction` / `attendance_settings` / all billing tables stay `parent_deny`. Fail-closed to an honest empty until the paste lands.
- **`docs/senior/incr-parent-attendance-surface-map.md`** — the build spec (Kofi ACs + Lucy surface map).
- **`lib/parent/parent-calendar.test.ts`** — its nav assertions were made count-robust (assert the intent, not the full TABS literal) so adding this tab — and future tabs — can't red it.

## Gates
- **Quinn (QA): GREEN** — all AC-PATT satisfied; 7/7 honesty/column-guard mutation probes red a test; `pnpm build` exit 0; 122/122 `lib/parent` tests; `tsc` clean.
- **Dex (architecture/portability): APPROVE after fixes** — caught a **build-breaking route collision** (`app/(parent)/attendance` vs the staff `app/(app)/attendance`, both `/attendance`) that vitest can't see; fixed by the `/attendance-summary` rename. Also flagged the COMBINED-school term pick → fixed with the product-line filter. Zero new lock-in.
- **Sarah (security + merge-readiness): CLEAR-TO-MERGE** — own-child IDOR is leak-safe by construction (`parent_student_ids` re-filters every row, fail-closed); the new `students.programme` read is own-child + programme-only; correction/settings/billing stay denied; fail-closed before the paste.

## Route note (why `/attendance-summary`)
Parent `(parent)` routes share the `(app)` URL namespace (no `/parent/*` prefix), so a parent tab name must be unique against the staff routes too. `/attendance` is the staff marking route, so the parent tab uses `/attendance-summary` (label stays "Attendance"). **Process note:** this class of collision is only caught by `next build`, not vitest — the gate now runs `pnpm build`.

## ⚠️ Owner action at deploy
**Hand-paste `db/sql/prod-paste-0093-parent-attendance-scope.sql`** on prod after merge (`db:policies` is dev-only). Until then the tab is a fail-closed honest empty — never a leak. Verify: `attendance_record` shows `parent_scope`; correction/settings/billing still `parent_deny`; `verify-prod-rls.sql` Query 1 = 0 rows; parent_readable = 25.

## Owner-confirmable decisions (conservative defaults shipped)
- **OC-PARENT-ATT-KEYSET** — Medical folded into Excused (widenable to distinct); reason category omitted (widenable to structured category only); free-text note + staff id are permanent omits.
- **OC-PARENT-ATT-ATSCHOOL** — "at school %" counts **present+late** (Kofi's domain ruling / canonical formula); the design mock showed present-only. One-line flip if you prefer present-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)