### PR TITLE
feat(parent): Communications tab — 2-way in-app messages (first parent write)

### DIFF
--- a/omnischools/app/(parent)/messages/compose.tsx
+++ b/omnischools/app/(parent)/messages/compose.tsx
@@ -1,0 +1,71 @@
+"use client";
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { sendParentMessage } from "@/lib/actions/parent-comms";
+
+/**
+ * INCR-COMM · the parent's compose box — the FIRST interactive parent-portal control. Calls the
+ * `sendParentMessage` server action ONLY (no server-only import, so it can be a client component). In-app
+ * framing, never "via SMS" (Lucy §6 guardrail). On success it clears + `router.refresh()` so the server
+ * component re-reads the thread; on error it shows the action's message inline.
+ */
+const MAX = 1000;
+
+export function Compose({ childFirstName }: { childFirstName: string }) {
+  const [body, setBody] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+  const router = useRouter();
+
+  const trimmed = body.trim();
+  const tooLong = body.length > MAX;
+  const canSend = trimmed.length > 0 && !tooLong && !pending;
+
+  function submit() {
+    if (!canSend) return;
+    setError(null);
+    startTransition(async () => {
+      const res = await sendParentMessage({ body });
+      if (res.ok) {
+        setBody("");
+        router.refresh();
+      } else {
+        setError(res.error ?? "Couldn't send your message. Please try again.");
+      }
+    });
+  }
+
+  return (
+    <section className="rounded-xl border border-border bg-surface px-4 py-3.5">
+      <label htmlFor="parent-message" className="text-[11px] font-semibold text-navy-3">
+        Message the school about {childFirstName}
+      </label>
+      <textarea
+        id="parent-message"
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        disabled={pending}
+        rows={3}
+        placeholder="Write a message to the school…"
+        className="mt-2 w-full resize-none rounded-md border border-border-2 bg-bg px-3 py-2 text-[13px] text-navy outline-none focus:border-gold disabled:opacity-60"
+      />
+      <div className="mt-1 flex items-center justify-between gap-3">
+        <span className={"font-mono text-[10px] " + (tooLong ? "text-terra" : "text-navy-3")}>
+          {body.length} / {MAX}
+        </span>
+        <button
+          type="button"
+          onClick={submit}
+          disabled={!canSend}
+          className="rounded-md bg-navy px-5 py-2 text-[13px] font-semibold text-bg transition-opacity hover:opacity-90 disabled:opacity-60"
+        >
+          {pending ? "Sending…" : "Send"}
+        </button>
+      </div>
+      {error && <p className="mt-1.5 text-[12px] text-terra">{error}</p>}
+      <p className="mt-1.5 text-[10px] text-navy-3">
+        This goes to the school office in the app. They&apos;ll reply here.
+      </p>
+    </section>
+  );
+}

--- a/omnischools/app/(parent)/messages/page.tsx
+++ b/omnischools/app/(parent)/messages/page.tsx
@@ -1,0 +1,170 @@
+import { requireParent } from "@/lib/auth/server";
+import { loadParentPortal } from "@/lib/parent/parent-portal-data";
+import { loadParentComms, type ParentCommsMessage } from "@/lib/parent/parent-comms-data";
+import { relationshipLabel } from "@/lib/wassce/parent-copy";
+import { ParentHeader, ParentNav } from "../parent-chrome";
+import { Compose } from "./compose";
+
+/**
+ * INCR-COMM · the parent-portal Communications ("Messages") tab — a 2-way in-app thread between a parent
+ * and their school (reader is parent-comms-data — the safe key-set; write is the sendParentMessage action).
+ * Same PARENT session gate as the other (parent) routes; the thread is resolved from the SESSION (child +
+ * the parent's own stored phone), never a URL id. The parent reads staff replies here and can send a
+ * message — in-app only, NO SMS. Every message is real (R90): no fabricated thread / staff name / delivery
+ * state / unread dot. URL is /messages (the staff route is /communication).
+ */
+export const dynamic = "force-dynamic";
+
+const STAMP = new Intl.DateTimeFormat("en-GB", {
+  day: "numeric", month: "short", year: "numeric", hour: "numeric", minute: "2-digit", timeZone: "UTC",
+});
+const stamp = (d: Date) => STAMP.format(d);
+
+export default async function ParentMessagesPage() {
+  const { user, school } = await requireParent();
+  const data = await loadParentPortal(school.id, user.id);
+  const child = data.children[0] ?? null;
+  const comms = child ? await loadParentComms(school.id, user.id, data.guardianPhone) : null;
+
+  const guardianDisplay = data.guardianName ?? user.name ?? "Parent";
+  const relation = data.guardianRelationship ? relationshipLabel(data.guardianRelationship) : "Parent";
+
+  return (
+    <div className="mx-auto max-w-[980px]">
+      <ParentHeader
+        schoolName={school.name}
+        childName={child?.fullName ?? null}
+        guardianDisplay={guardianDisplay}
+        relation={relation}
+      />
+      <ParentNav active="Messages" />
+
+      <div className="px-7 pb-9 pt-6">
+        {!child ? (
+          <NoChild />
+        ) : (
+          <div className="space-y-5">
+            <Greeting schoolName={school.name} childFirstName={child.firstName} />
+            <Tone total={comms!.total} repliedByYou={comms!.repliedByYou} lastMessageAt={comms!.lastMessageAt} />
+            <Thread messages={comms!.messages} schoolName={school.name} />
+            <Compose childFirstName={child.firstName} />
+            <PrivacyFooter />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** No portal-linked child — a linking issue, not a message fact (mirrors the sibling tabs). Compose hidden. */
+function NoChild() {
+  return (
+    <div className="rounded-xl border border-border bg-surface px-6 py-8 text-center text-[13px] leading-relaxed text-navy-2">
+      No student is linked to this portal yet. Please contact the school office.
+    </div>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────────── greeting ── */
+
+function Greeting({ schoolName, childFirstName }: { schoolName: string; childFirstName: string }) {
+  return (
+    <div>
+      <div className="text-[9px] font-bold uppercase tracking-[0.16em] text-gold">
+        Messages from {schoolName}
+      </div>
+      <h2 className="mt-1 font-display text-2xl font-medium tracking-[-0.018em] text-navy">
+        Your <em className="text-gold">conversation</em> with the school
+      </h2>
+      <p className="mt-1 text-[13px] text-navy-3">
+        Everything the school has sent you about <b className="text-navy-2">{childFirstName}</b>, and what
+        you&apos;ve replied.
+      </p>
+    </div>
+  );
+}
+
+/* ───────────────────────────────────────────────────────────────────── tone ── */
+
+function Tone({
+  total,
+  repliedByYou,
+  lastMessageAt,
+}: {
+  total: number;
+  repliedByYou: number;
+  lastMessageAt: Date | null;
+}) {
+  return (
+    <section className="rounded-[14px] border border-border bg-surface px-[18px] py-4">
+      <div className="text-[9px] font-bold uppercase tracking-[0.14em] text-gold">This term</div>
+      {total === 0 ? (
+        <p className="mt-1 font-display text-[15px] text-navy">You have no messages with the school yet.</p>
+      ) : (
+        <>
+          <p className="mt-1 font-display text-[15px] text-navy">
+            You and the school have exchanged <em className="text-gold">{msgs(total)}</em>. You replied to{" "}
+            <b>{repliedByYou} of them</b>.
+          </p>
+          {lastMessageAt && (
+            <p className="mt-2 border-t border-dashed border-border pt-2 text-[11px] text-navy-3">
+              Last message: <span className="font-mono">{stamp(lastMessageAt)}</span>
+            </p>
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+const msgs = (n: number) => `${n} message${n === 1 ? "" : "s"}`;
+
+/* ─────────────────────────────────────────────────────────────────── thread ── */
+
+function Thread({ messages, schoolName }: { messages: ParentCommsMessage[]; schoolName: string }) {
+  if (messages.length === 0) {
+    return (
+      <div className="rounded-xl border border-border bg-surface px-6 py-6 text-center text-[13px] leading-relaxed text-navy-2">
+        You haven&apos;t exchanged any messages with the school yet. Send one below and the school will reply
+        here.
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-2">
+      {messages.map((m, i) => (
+        <Bubble key={i} m={m} schoolName={schoolName} />
+      ))}
+    </div>
+  );
+}
+
+function Bubble({ m, schoolName }: { m: ParentCommsMessage; schoolName: string }) {
+  const you = m.sender === "you";
+  return (
+    <div
+      className={
+        "rounded-xl px-4 py-3.5 " +
+        (you ? "border border-gold-soft bg-gold-bg" : "border border-border border-l-[3px] border-l-gold bg-surface")
+      }
+    >
+      <div className="mb-1.5 flex items-start justify-between gap-2.5">
+        <span className="text-[11px] font-semibold text-navy">{you ? "You" : schoolName}</span>
+        <span className="font-mono text-[10px] text-navy-3">{stamp(m.createdAt)}</span>
+      </div>
+      <p className="whitespace-pre-wrap text-[13px] leading-normal text-navy-2">{m.body}</p>
+    </div>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────── privacy footer ── */
+
+function PrivacyFooter() {
+  return (
+    <div className="rounded-[10px] border border-dashed border-border-2 bg-bg px-[14px] py-3 text-[11px] leading-relaxed text-navy-3">
+      <b className="text-navy-2">What you see here:</b> messages the school sent you and your replies.{" "}
+      <b className="text-navy-2">What you don&apos;t see:</b> internal staff notes about your account and
+      the school&apos;s operational data — <em className="font-display text-gold">those are private to the
+      school</em>. For anything else, contact the school office.
+    </div>
+  );
+}

--- a/omnischools/app/(parent)/parent-chrome.tsx
+++ b/omnischools/app/(parent)/parent-chrome.tsx
@@ -53,17 +53,19 @@ export function ParentHeader({
 }
 
 /** Every tab is a live route today. */
-export type ParentTab = "WASSCE" | "Attendance" | "Sickbay" | "PTA" | "School calendar";
+export type ParentTab = "WASSCE" | "Attendance" | "Messages" | "Sickbay" | "PTA" | "School calendar";
 
-// INCR-278 → +Attendance — flat tabs, ALL live routes (the inert Communications / Billing / Boarding spans
-// are gone; each returns behind its own increment). Attendance sits second — the most-checked daily fact
-// ("is my child in school?"). Every entry below has an HREF.
-const TABS = ["WASSCE", "Attendance", "Sickbay", "PTA", "School calendar"] as const;
+// INCR-278 → +Attendance → +Messages — flat tabs, ALL live routes (Billing / Boarding return behind their
+// own increments). Attendance is second (the most-checked daily fact); "Messages" is the 2-way parent↔school
+// thread. Every entry below has an HREF.
+const TABS = ["WASSCE", "Attendance", "Messages", "Sickbay", "PTA", "School calendar"] as const;
 const HREF: Record<(typeof TABS)[number], string> = {
   WASSCE: "/wassce",
   // URL is /attendance-summary (the /attendance path is the STAFF marking route — parent routes share the
   // (app) route namespace, so the parent tab needs a unique segment); the tab LABEL stays "Attendance".
   Attendance: "/attendance-summary",
+  // URL is /messages — the STAFF route is /communication (parent routes share the (app) namespace).
+  Messages: "/messages",
   Sickbay: "/sickbay",
   PTA: "/pta",
   "School calendar": "/calendar",

--- a/omnischools/db/sql/policies.sql
+++ b/omnischools/db/sql/policies.sql
@@ -439,10 +439,41 @@ CREATE POLICY parent_scope ON readiness_statements AS RESTRICTIVE FOR ALL TO pub
     )
   );
 
+-- ============================================================================================
+-- INCR — PARENT COMMUNICATIONS: the FIRST parent WRITE path (kept in sync with
+-- db/sql/prod-paste-0094-parent-inbox-write.sql — this block is DEV; that file is the hand-paste
+-- on PROD; ⚠ RLS is NOT auto-applied on prod). Until now the parent boundary was READ-ONLY by
+-- contract (Kofi R4) and every parent_scope policy left WITH CHECK = USING because "no app writes
+-- ever run inside withParentScope". That is no longer true: a parent posts an in-app INBOUND
+-- message to a thread about their own child, on their own stored phone (lib/parent/* under
+-- withParentScope). FOR ALL with USING-as-WITH-CHECK would over-grant that write three ways —
+-- (1) a parent could INSERT direction=OUTBOUND, forging a "from the school" message staff also
+-- see; (2) a parent could set any sent_by_user_id (impersonation / anon); (3) FOR ALL authorises
+-- UPDATE/DELETE, so a parent could edit or delete history (their own OR staff OUTBOUND) in scope.
+-- So conversation + inbox_message get a TIGHTENED write shape while their READ stays identical:
+--   • inbox_message.parent_scope keeps its read USING but gains a CONSTRAINED WITH CHECK —
+--     a parent INSERT must be direction='INBOUND' AND sent_by_user_id = the parent GUC AND land
+--     in one of the parent's own scoped threads (same reach predicate as the read).
+--   • conversation.parent_scope is UNCHANGED — its existing WITH CHECK = USING already constrains
+--     a parent INSERT to own-child (NULL student excluded) + own-phone, which is exactly the
+--     intended "start a new thread about my child" write.
+--   • Both tables gain per-command parent_no_update / parent_no_delete DENY policies so a parent
+--     can only INSERT + SELECT, never mutate or delete a row (no tampering, no reassignment, no
+--     status/topic/read_at flip on conversation).
+-- STAFF ARE UNAFFECTED (the load-bearing regression check): every new predicate is guarded
+-- `pu IS NULL OR <rule>` / `pu IS NULL` and staff (withSchool) + the inbound webhook (withSchool)
+-- + escalated (withoutTenantScope) sessions NEVER set app.current_parent_user, so `pu IS NULL` is
+-- TRUE for them → every added clause is a total no-op → the staff inbox (OUTBOUND replies, status
+-- changes, deletes) behaves byte-for-byte as before. parent_scope still EXISTS on both tables, so
+-- the catalog parent_deny loop below keeps excluding them and verify-prod-rls check B stays green.
+
 -- conversation — threads about the child AND on the parent's OWN stored phone (a co-guardian's thread
--- must not appear). NULL-student threads are excluded (NULL IN (...) is not TRUE).
+-- must not appear). NULL-student threads are excluded (NULL IN (...) is not TRUE). WITH CHECK = USING
+-- (FOR ALL): a parent INSERT is constrained to own-child + own-phone; UPDATE/DELETE are denied below.
 DROP POLICY IF EXISTS parent_deny ON conversation;
 DROP POLICY IF EXISTS parent_scope ON conversation;
+DROP POLICY IF EXISTS parent_no_update ON conversation;
+DROP POLICY IF EXISTS parent_no_delete ON conversation;
 CREATE POLICY parent_scope ON conversation AS RESTRICTIVE FOR ALL TO public
   USING (
     NULLIF(current_setting('app.current_parent_user', true), '') IS NULL
@@ -458,10 +489,20 @@ CREATE POLICY parent_scope ON conversation AS RESTRICTIVE FOR ALL TO public
       )
     )
   );
+-- Deny a parent session UPDATE/DELETE on conversation (INSERT + SELECT only). `pu IS NULL` → staff
+-- session → TRUE → no-op; parent session → FALSE → zero rows updatable/deletable.
+CREATE POLICY parent_no_update ON conversation AS RESTRICTIVE FOR UPDATE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_delete ON conversation AS RESTRICTIVE FOR DELETE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
 
--- inbox_message — reaches the child (and the parent's own phone) through its conversation.
+-- inbox_message — reaches the child (and the parent's own phone) through its conversation. READ USING
+-- is unchanged; the WITH CHECK additionally pins a parent INSERT to direction='INBOUND' and
+-- sent_by_user_id = the parent GUC (defence in depth behind the server action). UPDATE/DELETE denied.
 DROP POLICY IF EXISTS parent_deny ON inbox_message;
 DROP POLICY IF EXISTS parent_scope ON inbox_message;
+DROP POLICY IF EXISTS parent_no_update ON inbox_message;
+DROP POLICY IF EXISTS parent_no_delete ON inbox_message;
 CREATE POLICY parent_scope ON inbox_message AS RESTRICTIVE FOR ALL TO public
   USING (
     NULLIF(current_setting('app.current_parent_user', true), '') IS NULL
@@ -478,7 +519,83 @@ CREATE POLICY parent_scope ON inbox_message AS RESTRICTIVE FOR ALL TO public
             AND g.user_id = NULLIF(current_setting('app.current_parent_user', true), '')::uuid
         )
     )
+  )
+  WITH CHECK (
+    NULLIF(current_setting('app.current_parent_user', true), '') IS NULL
+    OR (
+      direction = 'INBOUND'
+      AND sent_by_user_id = NULLIF(current_setting('app.current_parent_user', true), '')::uuid
+      AND conversation_id IN (
+        SELECT cv.id FROM conversation cv
+        WHERE cv.school_id = inbox_message.school_id
+          AND cv.student_id IN (
+            SELECT parent_student_ids(
+              inbox_message.school_id, NULLIF(current_setting('app.current_parent_user', true), '')::uuid)
+          )
+          AND cv.contact_phone IN (
+            SELECT g.phone FROM student_guardian g
+            WHERE g.school_id = inbox_message.school_id
+              AND g.user_id = NULLIF(current_setting('app.current_parent_user', true), '')::uuid
+          )
+      )
+    )
   );
+-- Deny a parent session UPDATE/DELETE on inbox_message (INSERT + SELECT only) — no editing or
+-- deleting history, own or staff OUTBOUND. `pu IS NULL` → staff → TRUE → no-op.
+CREATE POLICY parent_no_update ON inbox_message AS RESTRICTIVE FOR UPDATE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_delete ON inbox_message AS RESTRICTIVE FOR DELETE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+
+-- ---- the scoped bump helper: a parent reply must advance conversation.last_message_at + reopen a
+-- CLOSED thread, but parent_no_update (above) DENIES every direct parent UPDATE on conversation. The
+-- staff inbox derives unread / recency / the OPEN unread-count from those two columns (app/(app)/inbox),
+-- so without this the parent's reply is INVISIBLE to staff on prod and a CLOSED thread never reopens.
+-- 🔴 A naive `SET last_message_at=now()` inside withParentScope hits parent_no_update → 0 rows,
+-- SILENTLY. On DEV the superuser owner masks it (RLS bypassed); on PROD (non-superuser owner, FORCE
+-- RLS) it fails. This SECURITY DEFINER fn is the sanctioned bump: it CLEARS `app.current_parent_user`
+-- for exactly the one privileged UPDATE so parent_no_update passes (pu IS NULL → TRUE), then RESTORES
+-- it. Ownership CANNOT do this job here — there is no BYPASSRLS role and FORCE binds the owner too — so
+-- the GUC clear (the same portable device as app.bypass_rls) is the mechanism. `app.current_school`
+-- stays set → tenant_isolation still fences the school (defence in depth); the WHERE (own school + own
+-- child via parent_student_ids + own STORED phone, all on the CAPTURED pu) is the parent scope. Only
+-- last_message_at + status are written — never read_at / assigned_to_user_id / topic / routed_by_*.
+-- STAFF ARE UNAFFECTED: a staff/webhook/escalated session never sets app.current_parent_user, so pu IS
+-- NULL → early RETURN → total no-op; staff bump their own threads by direct UPDATE as before.
+-- 🔴 search_path = public, pg_temp (pg_temp LAST, same discipline as parent_student_ids) so a session
+-- TEMP relation cannot shadow conversation / student_guardian inside the definer body.
+-- Kept in sync with db/sql/prod-paste-0094-parent-inbox-write.sql (this block is DEV; that file is the
+-- hand-paste on PROD; ⚠ RLS/functions are NOT auto-applied on prod).
+CREATE OR REPLACE FUNCTION parent_bump_conversation(p_conversation_id uuid) RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public, pg_temp
+AS $$
+DECLARE
+  pu uuid := NULLIF(current_setting('app.current_parent_user', true), '')::uuid;
+  sc uuid := NULLIF(current_setting('app.current_school', true), '')::uuid;
+BEGIN
+  IF pu IS NULL OR sc IS NULL THEN RETURN; END IF;  -- only a parent session bumps via this fn
+  PERFORM set_config('app.current_parent_user', '', true);  -- relax parent_no_update for THIS update only
+  UPDATE conversation c
+     SET last_message_at = now(), status = 'OPEN'
+   WHERE c.id = p_conversation_id
+     AND c.school_id = sc
+     AND c.student_id IN (SELECT parent_student_ids(c.school_id, pu))
+     AND c.contact_phone IN (
+       SELECT g.phone FROM student_guardian g
+       WHERE g.school_id = c.school_id AND g.user_id = pu);
+  PERFORM set_config('app.current_parent_user', pu::text, true);  -- restore the caller's session GUC
+END;
+$$;
+-- On Supabase every public function is a PostgREST RPC and EXECUTE defaults to PUBLIC. A privileged
+-- SECURITY DEFINER write must not be anon-callable (it is a no-op without the GUCs, but harden anyway).
+REVOKE EXECUTE ON FUNCTION parent_bump_conversation(uuid) FROM PUBLIC;
+DO $$ BEGIN
+  IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'omnischools_app') THEN
+    GRANT EXECUTE ON FUNCTION parent_bump_conversation(uuid) TO omnischools_app;
+  END IF;
+END $$;
 
 -- ---- INCR-29: the FIRST widening of the 19a parent boundary since it shipped (9 → 11 parent_scope
 -- tables). A parent gains ROW access to their own child's sickbay_admission + sickbay_referral so the

--- a/omnischools/db/sql/prod-paste-0094-parent-inbox-write.sql
+++ b/omnischools/db/sql/prod-paste-0094-parent-inbox-write.sql
@@ -1,0 +1,219 @@
+-- Omnischools — PROD paste 0094: PARENT COMMUNICATIONS WRITE (INCR — parent-portal Communications tab,
+-- the FIRST parent WRITE path). POLICY-ONLY — ZERO new tables, ZERO enums, ZERO altered columns, ZERO
+-- backfills. It RESHAPES the write half of the existing parent_scope on TWO tables (conversation,
+-- inbox_message) and adds per-command DENY policies. Idempotent — safe to run more than once. Paste into
+-- the Supabase SQL editor on PROD after merging. Byte-identical in effect to the "INCR — PARENT
+-- COMMUNICATIONS" block in db/sql/policies.sql (dev, db:policies).
+--
+-- WHAT IT SHIPS. Until now the parent boundary was READ-ONLY by contract (Kofi R4): conversation and
+-- inbox_message carried parent_scope AS RESTRICTIVE FOR ALL with WITH CHECK left = USING, because no app
+-- write ever ran inside withParentScope. The Communications tab makes a parent post an in-app INBOUND
+-- message to a thread about their OWN child, on their OWN stored phone. FOR-ALL-with-USING-as-WITH-CHECK
+-- would OVER-grant that write three ways, and this paste closes all three:
+--   1. Direction spoofing — a parent could INSERT direction='OUTBOUND', forging a "from the school"
+--      message that STAFF also see in the shared thread. The tightened WITH CHECK requires INBOUND.
+--   2. Impersonation — a parent could set any sent_by_user_id (another user, or NULL/anon). The WITH
+--      CHECK pins sent_by_user_id = the parent GUC.
+--   3. Tampering — FOR ALL authorises UPDATE/DELETE, so a parent could edit or delete history (their
+--      own OR a staff OUTBOUND message; reassign / flip status / topic / read_at on a conversation). New
+--      per-command parent_no_update / parent_no_delete DENY policies make the parent seam INSERT+SELECT
+--      only.
+-- The READ stays byte-identical (same USING); conversation's INSERT was already correctly constrained by
+-- its existing WITH CHECK = USING (own-child, NULL student excluded, + own-phone) and is UNCHANGED.
+--
+-- 🔴 STAFF ARE UNAFFECTED — THE LOAD-BEARING REGRESSION CHECK. Every added clause is guarded
+-- `pu IS NULL OR <rule>` (WITH CHECK) or `pu IS NULL` (the deny policies), where
+-- pu = NULLIF(current_setting('app.current_parent_user', true), ''). Staff (withSchool), the inbound
+-- webhook POST /api/inbox/inbound (withSchool) and escalated (withoutTenantScope) sessions NEVER set that
+-- GUC → pu IS NULL → every clause is TRUE → a total no-op → the staff inbox (OUTBOUND replies, status
+-- changes, deletes, thread reassignment) behaves byte-for-byte as before. Depends on parent_student_ids()
+-- (prod-paste-0055) and the conversation/inbox_message parent_scope (prod-paste-0055), both already on prod.
+--
+-- 🔴 RLS IS ROW-LEVEL — IT CANNOT MASK COLUMNS AND IT DOES NOT CONSTRAIN NON-PREDICATE COLUMNS. The
+-- server action (lib/parent/*) still owns direction=INBOUND, sent_by_user_id=the parent, body length /
+-- sanitisation and the conversation defaults (status=OPEN, assigned=null, topic). RLS enforces the
+-- security-critical INVARIANTS only: which ROWS a parent may INSERT (own scoped thread), that a parent
+-- INSERT is INBOUND + attributed to the parent, and that a parent may never UPDATE/DELETE.
+--
+-- ⚠ WHAT HAPPENS IF THIS IS NOT RUN — FAIL-OPEN ON THE WRITE, NOT A CROSS-TENANT LEAK. db:policies
+-- configures LOCAL DEV ONLY. Without this paste, conversation and inbox_message keep their old FOR ALL
+-- USING-as-WITH-CHECK on prod: the parent tab still reads correctly and is still tenant/child-isolated,
+-- but a crafted request from a parent session could INSERT an OUTBOUND / mis-attributed message into a
+-- thread it can see, or UPDATE/DELETE a message in scope. There is NO cross-tenant or cross-child exposure
+-- either way (the reach predicate is unchanged) — the risk is in-thread forgery/tampering, so run this
+-- before the Communications tab goes live on prod.
+--
+-- SCOPE — EXACTLY TWO TABLES CHANGE. conversation and inbox_message. Tenant isolation is untouched on
+-- every table. The catalog parent_deny loop at the tail re-affirms parent_deny on every other tenant
+-- table (auto-EXCLUDING the tables that carry parent_scope — both of these still do), so nothing else
+-- moves and a future tenant table stays auto-denied with zero edits.
+--
+-- Verify afterwards:
+--   -- both tables carry parent_scope + parent_no_update + parent_no_delete, all RESTRICTIVE:
+--   select c.relname, p.polname, p.polcmd, p.polpermissive
+--   from pg_policy p join pg_class c on c.oid = p.polrelid
+--   where c.relname in ('conversation','inbox_message') and p.polname like 'parent%'
+--   order by 1, 2;
+--   -- and db/sql/verify-prod-rls.sql: Query 1 must still return ZERO ROWS; parent_readable unchanged.
+
+-- ---- conversation — READ + INSERT unchanged (own-child + own-phone); UPDATE/DELETE denied for parents.
+DROP POLICY IF EXISTS parent_deny ON conversation;
+DROP POLICY IF EXISTS parent_scope ON conversation;
+DROP POLICY IF EXISTS parent_no_update ON conversation;
+DROP POLICY IF EXISTS parent_no_delete ON conversation;
+CREATE POLICY parent_scope ON conversation AS RESTRICTIVE FOR ALL TO public
+  USING (
+    NULLIF(current_setting('app.current_parent_user', true), '') IS NULL
+    OR (
+      student_id IN (
+        SELECT parent_student_ids(
+          school_id, NULLIF(current_setting('app.current_parent_user', true), '')::uuid)
+      )
+      AND contact_phone IN (
+        SELECT g.phone FROM student_guardian g
+        WHERE g.school_id = conversation.school_id
+          AND g.user_id = NULLIF(current_setting('app.current_parent_user', true), '')::uuid
+      )
+    )
+  );
+CREATE POLICY parent_no_update ON conversation AS RESTRICTIVE FOR UPDATE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_delete ON conversation AS RESTRICTIVE FOR DELETE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+
+-- ---- inbox_message — READ unchanged; parent INSERT pinned to INBOUND + own sent_by + own scoped
+-- thread; UPDATE/DELETE denied for parents.
+DROP POLICY IF EXISTS parent_deny ON inbox_message;
+DROP POLICY IF EXISTS parent_scope ON inbox_message;
+DROP POLICY IF EXISTS parent_no_update ON inbox_message;
+DROP POLICY IF EXISTS parent_no_delete ON inbox_message;
+CREATE POLICY parent_scope ON inbox_message AS RESTRICTIVE FOR ALL TO public
+  USING (
+    NULLIF(current_setting('app.current_parent_user', true), '') IS NULL
+    OR conversation_id IN (
+      SELECT cv.id FROM conversation cv
+      WHERE cv.school_id = inbox_message.school_id
+        AND cv.student_id IN (
+          SELECT parent_student_ids(
+            inbox_message.school_id, NULLIF(current_setting('app.current_parent_user', true), '')::uuid)
+        )
+        AND cv.contact_phone IN (
+          SELECT g.phone FROM student_guardian g
+          WHERE g.school_id = inbox_message.school_id
+            AND g.user_id = NULLIF(current_setting('app.current_parent_user', true), '')::uuid
+        )
+    )
+  )
+  WITH CHECK (
+    NULLIF(current_setting('app.current_parent_user', true), '') IS NULL
+    OR (
+      direction = 'INBOUND'
+      AND sent_by_user_id = NULLIF(current_setting('app.current_parent_user', true), '')::uuid
+      AND conversation_id IN (
+        SELECT cv.id FROM conversation cv
+        WHERE cv.school_id = inbox_message.school_id
+          AND cv.student_id IN (
+            SELECT parent_student_ids(
+              inbox_message.school_id, NULLIF(current_setting('app.current_parent_user', true), '')::uuid)
+          )
+          AND cv.contact_phone IN (
+            SELECT g.phone FROM student_guardian g
+            WHERE g.school_id = inbox_message.school_id
+              AND g.user_id = NULLIF(current_setting('app.current_parent_user', true), '')::uuid
+          )
+      )
+    )
+  );
+CREATE POLICY parent_no_update ON inbox_message AS RESTRICTIVE FOR UPDATE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_delete ON inbox_message AS RESTRICTIVE FOR DELETE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+
+-- ---- parent_bump_conversation — the scoped SECURITY DEFINER bump the parent write action calls.
+-- 🔴 WHY THIS EXISTS. A parent reply must advance conversation.last_message_at AND reopen a CLOSED
+-- thread, but parent_no_update (just above) DENIES every direct parent UPDATE on conversation. The
+-- staff inbox derives unread (read_at IS NULL OR last_message_at > read_at), recency (ORDER BY
+-- last_message_at DESC) and the OPEN unread-count from those two columns — so a naive
+-- `tx.update(conversation).set({last_message_at, status})` inside withParentScope hits parent_no_update
+-- and updates 0 ROWS *SILENTLY*: the inbox_message INSERT still succeeds (the parent sees their reply),
+-- but staff NEVER see the unread/recency signal and a CLOSED thread never reopens. DEV masks this — its
+-- superuser owner bypasses RLS — so 22/22 policy-shape + source-shape tests stayed green (Quinn MAJOR).
+-- 🔴 MECHANISM. This SECURITY DEFINER fn performs the bump with elevated privilege but is INTERNALLY
+-- scoped. Ownership alone CANNOT bypass the deny here: there is NO BYPASSRLS role and FORCE RLS binds
+-- the owner too, so the fn CLEARS `app.current_parent_user` for exactly the one privileged UPDATE
+-- (parent_no_update USING pu IS NULL → TRUE) then RESTORES it — the same portable device as
+-- app.bypass_rls, applied surgically to just the parent GUC. `app.current_school` stays set so
+-- tenant_isolation still fences the school (defence in depth); the WHERE (own school + own child via
+-- parent_student_ids + own STORED phone, all on the CAPTURED pu) is the parent scope. It writes ONLY
+-- last_message_at + status — never read_at / assigned_to_user_id / topic / routed_by_* — so
+-- parent_no_update stays intact for every other column and for a direct parent UPDATE.
+-- STAFF ARE UNAFFECTED: staff/webhook/escalated sessions never set app.current_parent_user → pu IS
+-- NULL → early RETURN → total no-op; staff bump their own threads by direct UPDATE exactly as before.
+-- search_path = public, pg_temp (pg_temp LAST) so a session TEMP relation cannot shadow the tables in
+-- the definer body. Depends on parent_student_ids() (prod-paste-0055), already on prod. Idempotent.
+CREATE OR REPLACE FUNCTION parent_bump_conversation(p_conversation_id uuid) RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public, pg_temp
+AS $$
+DECLARE
+  pu uuid := NULLIF(current_setting('app.current_parent_user', true), '')::uuid;
+  sc uuid := NULLIF(current_setting('app.current_school', true), '')::uuid;
+BEGIN
+  IF pu IS NULL OR sc IS NULL THEN RETURN; END IF;  -- only a parent session bumps via this fn
+  PERFORM set_config('app.current_parent_user', '', true);  -- relax parent_no_update for THIS update only
+  UPDATE conversation c
+     SET last_message_at = now(), status = 'OPEN'
+   WHERE c.id = p_conversation_id
+     AND c.school_id = sc
+     AND c.student_id IN (SELECT parent_student_ids(c.school_id, pu))
+     AND c.contact_phone IN (
+       SELECT g.phone FROM student_guardian g
+       WHERE g.school_id = c.school_id AND g.user_id = pu);
+  PERFORM set_config('app.current_parent_user', pu::text, true);  -- restore the caller's session GUC
+END;
+$$;
+-- On Supabase every public function is a PostgREST RPC (EXECUTE defaults to PUBLIC); a privileged
+-- SECURITY DEFINER write must not be anon-callable. The owner keeps EXECUTE regardless of the REVOKE.
+REVOKE EXECUTE ON FUNCTION parent_bump_conversation(uuid) FROM PUBLIC;
+DO $$ BEGIN
+  IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'omnischools_app') THEN
+    GRANT EXECUTE ON FUNCTION parent_bump_conversation(uuid) TO omnischools_app;
+  END IF;
+END $$;
+
+-- ---- layer 1: parent_deny — the CATALOG-DRIVEN loop, verbatim from db/sql/policies.sql ----
+-- 🔴 RUN THIS. It re-affirms RESTRICTIVE parent_deny on every FORCE-RLS + school_id table that does NOT
+-- already carry a parent_scope policy. conversation + inbox_message still carry parent_scope, so they stay
+-- EXCLUDED; every other tenant table (and any future one) stays auto-denied. Idempotent.
+DO $$
+DECLARE
+  tbl text;
+BEGIN
+  FOR tbl IN
+    SELECT c.relname
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = 'public'
+    WHERE c.relkind = 'r'
+      AND c.relforcerowsecurity
+      AND EXISTS (
+        SELECT 1 FROM information_schema.columns col
+        WHERE col.table_schema = 'public'
+          AND col.table_name = c.relname
+          AND col.column_name = 'school_id'
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_policy p
+        WHERE p.polrelid = c.oid AND p.polname = 'parent_scope'
+      )
+    ORDER BY c.relname
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS parent_deny ON %I;', tbl);
+    EXECUTE format(
+      'CREATE POLICY parent_deny ON %I AS RESTRICTIVE FOR ALL TO public '
+      'USING (NULLIF(current_setting(''app.current_parent_user'', true), '''') IS NULL);',
+      tbl
+    );
+  END LOOP;
+END
+$$;

--- a/omnischools/lib/actions/parent-comms.ts
+++ b/omnischools/lib/actions/parent-comms.ts
@@ -1,0 +1,118 @@
+"use server";
+import { and, desc, eq, gt, sql } from "drizzle-orm";
+import { z } from "zod";
+import { requireParent } from "@/lib/auth/server";
+import { withParentScope } from "@/lib/db/rls";
+import { loadParentPortal } from "@/lib/parent/parent-portal-data";
+import { safeRevalidate } from "@/lib/revalidate";
+import { conversations, inboxMessages } from "@/db/schema";
+
+/**
+ * 🔴 INCR-COMM · the parent Communications WRITE — the FIRST and ONLY sanctioned parent write path in the
+ * portal (Kofi R-COMM-1/2, Lucy §6). A parent posts an in-app message to their school. Deliberately NOT the
+ * staff `sendReply`/`startConversation` path (which call `sendSms`): this is the in-app equivalent of the
+ * inbound webhook — direction=INBOUND, ZERO SMS/gateway (SMS stays deferred).
+ *
+ * Trust boundary (belt = server-forcing, braces = Wells's RLS WITH CHECK, prod-paste-0094):
+ *  • `direction` is SERVER-FORCED to "INBOUND"; a parent can never author an OUTBOUND "from the school"
+ *    message (the RLS WITH CHECK independently rejects a forged OUTBOUND).
+ *  • `sent_by_user_id` is SERVER-FORCED to the session parent's id (the WITH CHECK requires
+ *    sent_by_user_id = app.current_parent_user, so a forged sender is DB-rejected too).
+ *  • the thread is RESOLVED from the session (child + the parent's OWN stored phone) — the client supplies
+ *    ONLY `body`, never a conversation id / phone / child (so a parent can't name an arbitrary thread).
+ *  • `read_at` is left UNTOUCHED so the parent's message correctly marks the thread UNREAD for staff.
+ *  • runs under `withParentScope` ONLY. No `sendSms`. No staff-field mutation (assigned/routing/topic).
+ */
+
+const Schema = z.object({ body: z.string().min(1, "Enter a message").max(1000, "Message is too long") });
+
+type Result = { ok: boolean; error?: string };
+
+const DUP_WINDOW_MS = 60_000; // ignore an identical resend within 60s (double-tap / retry guard, AC-COMM-14)
+
+export async function sendParentMessage(input: unknown): Promise<Result> {
+  const { user, school } = await requireParent();
+  const parsed = Schema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid message" };
+  const body = parsed.data.body.trim();
+  if (!body) return { ok: false, error: "Enter a message" };
+
+  const portal = await loadParentPortal(school.id, user.id);
+  const child = portal.children[0] ?? null;
+  const phone = portal.guardianPhone;
+  // A thread is keyed on the parent's OWN stored phone + their child; without either there is no scope to
+  // write into (and the RLS own-child+own-phone WITH CHECK would reject the insert).
+  if (!child || !phone) {
+    return { ok: false, error: "We couldn't find your linked child. Please contact the school office." };
+  }
+
+  try {
+    await withParentScope(school.id, user.id, async (tx) => {
+      // Find the parent's own most-recent thread (RLS fences to own child + own phone); else start one.
+      const [existing] = await tx
+        .select({ id: conversations.id })
+        .from(conversations)
+        .where(and(eq(conversations.schoolId, school.id), eq(conversations.contactPhone, phone)))
+        .orderBy(desc(conversations.lastMessageAt))
+        .limit(1);
+
+      const isReply = existing != null;
+      let conversationId = existing?.id;
+      const now = new Date();
+
+      if (!conversationId) {
+        // Start a thread — every column is server-forced; the RLS WITH CHECK also pins it to own-child +
+        // own-phone (OC-COMM-NEWTHREAD: parent-initiated threads are enabled). NO read_at (→ unread to staff).
+        const [created] = await tx
+          .insert(conversations)
+          .values({
+            schoolId: school.id,
+            contactPhone: phone,
+            studentId: child.studentId,
+            status: "OPEN",
+            lastMessageAt: now,
+          })
+          .returning({ id: conversations.id });
+        conversationId = created.id;
+      } else {
+        // Duplicate-submit guard — an identical INBOUND body to the same thread within the window is a no-op.
+        const [dup] = await tx
+          .select({ id: inboxMessages.id })
+          .from(inboxMessages)
+          .where(
+            and(
+              eq(inboxMessages.schoolId, school.id),
+              eq(inboxMessages.conversationId, conversationId),
+              eq(inboxMessages.direction, "INBOUND"),
+              eq(inboxMessages.body, body),
+              gt(inboxMessages.createdAt, new Date(now.getTime() - DUP_WINDOW_MS)),
+            ),
+          )
+          .limit(1);
+        if (dup) return; // idempotent: no second row, no second bump
+      }
+
+      // The one parent write — direction + sender SERVER-FORCED (and RLS-checked).
+      await tx.insert(inboxMessages).values({
+        schoolId: school.id,
+        conversationId,
+        direction: "INBOUND",
+        body,
+        sentByUserId: user.id,
+      });
+      // Bump activity so the thread surfaces as unread to staff + reopen a CLOSED thread (OC-COMM-REOPEN)
+      // — via the scoped SECURITY DEFINER `parent_bump_conversation`. A DIRECT parent UPDATE is denied by
+      // `parent_no_update` (INSERT+SELECT-only seam), so the bump must go through the fn, which is
+      // own-child+own-phone scoped and touches ONLY last_message_at + status (never read_at/assigned/topic).
+      // A freshly-created thread already carries now()+OPEN from its INSERT, so only a reply needs the bump.
+      if (isReply) {
+        await tx.execute(sql`select parent_bump_conversation(${conversationId}::uuid)`);
+      }
+    });
+  } catch {
+    return { ok: false, error: "Couldn't send your message. Please try again." };
+  }
+
+  safeRevalidate("/messages");
+  return { ok: true };
+}

--- a/omnischools/lib/db/rls.ts
+++ b/omnischools/lib/db/rls.ts
@@ -39,8 +39,13 @@ export async function withSchool<T>(
  * parent-readable set (their child + that child's WASSCE artefacts + their own comms). The GUC is set
  * only here, in trusted server code, never from request input, so it cannot be forged.
  *
- * Read-only by contract: there is NO parent write path (Kofi R4). Do NOT issue writes inside this
- * helper.
+ * Almost read-only: the ONLY sanctioned parent write is the Communications INBOUND message (+ its
+ * own-child/own-phone conversation, INCR-COMM). It is safe ONLY because the `parent_scope` policies are
+ * `FOR ALL` with a CONSTRAINED `WITH CHECK` (inbox_message: direction='INBOUND' AND sent_by_user_id = the
+ * parent, plus the own-child+own-phone reach; conversation: own-child + own-phone) and `parent_no_update` /
+ * `parent_no_delete` make the parent seam INSERT + SELECT only (db/sql/policies.sql, prod-paste-0094). Any
+ * OTHER write inside this helper is a bug: a tenant table without that constrained WITH CHECK would let a
+ * parent forge rows (the FOR ALL USING would double as the write gate).
  */
 export async function withParentScope<T>(
   schoolId: string,

--- a/omnischools/lib/parent/parent-attendance.test.ts
+++ b/omnischools/lib/parent/parent-attendance.test.ts
@@ -148,10 +148,11 @@ describe("parent-chrome · Attendance is the 5th live tab (source-shape)", () =>
   const nav = () => readCode("app/(parent)/parent-chrome.tsx");
   const page = () => readCode("app/(parent)/attendance-summary/page.tsx");
 
-  it("TABS/HREF/ParentTab carry Attendance → /attendance, still no inert span", () => {
+  // Count-robust: assert Attendance is a live tab at its unique URL, not the whole TABS literal — so a
+  // later tab addition can't red this test (the trap that bit the #278 calendar test when Attendance landed).
+  it("Attendance is a live tab at /attendance-summary, still no inert span", () => {
     const s = nav();
-    expect(s).toMatch(/const TABS = \["WASSCE", "Attendance", "Sickbay", "PTA", "School calendar"\] as const;/);
-    expect(s).toMatch(/ParentTab = "WASSCE" \| "Attendance" \| "Sickbay" \| "PTA" \| "School calendar"/);
+    expect(s).toMatch(/"Attendance"/); // present in TABS + the ParentTab union
     expect(s).toMatch(/Attendance: "\/attendance-summary"/); // unique parent URL (/attendance is the staff route)
     expect(s).not.toMatch(/Partial<Record/);
     expect((s.match(/<span/g) ?? []).length).toBe(1); // only the active tab is a span

--- a/omnischools/lib/parent/parent-comms-data.ts
+++ b/omnischools/lib/parent/parent-comms-data.ts
@@ -1,0 +1,101 @@
+import "server-only";
+import { and, asc, eq, inArray } from "drizzle-orm";
+import { withParentScope } from "@/lib/db/rls";
+import type { Tx } from "@/lib/db";
+import { conversations, inboxMessages } from "@/db/schema";
+
+/**
+ * 🔴 INCR-COMM · the PARENT-facing Communications (2-way messages) READER (SHS module 4.3 · Kofi
+ * AC-COMM-01..05, Lucy §9). SERVER-ONLY — imports the db driver, so a client component must never import
+ * it (only `pnpm build` catches that leak; the parent-*-data precedent).
+ *
+ * RLS is ROW-level and CANNOT mask a column, so THIS PROJECTION is the ONLY column guard. `conversation` +
+ * `inbox_message` carry `parent_scope` (own child + own phone), so the parent already reads only their own
+ * threads — but the SAFE KEY-SET is enforced HERE by selecting ONLY the parent-facing fields. NEVER select
+ * (the deny-list, Lucy §9 / Kofi R-COMM-5): `assigned_to_user_id` (staff routing PII), `routed_by_rule_id`
+ * / `routed_by_rule_name` / `topic` (system routing provenance), `read_at` (STAFF read-state — leaking it
+ * tells the parent whether staff opened it), the raw `sent_by_user_id` UUID, `channel` / any cost/segment
+ * provenance (that lives on `notification_log`, which stays parent_deny). `direction` is mapped to the
+ * sender SIDE ("school" / "you") — never the raw "outbound/inbound" admin vocabulary. Staff NAMES are not
+ * read at all (an OUTBOUND message is labelled by the school, keeping this reader off the `users` table).
+ *
+ * Scope by the parent's OWN stored phone (`contact_phone = guardianPhone`), NOT by student — a child with
+ * two guardians has two phone-keyed threads, so scoping by student would leak the co-guardian's thread
+ * (RLS already fences this; the explicit phone predicate is the matching belt).
+ */
+
+export type ParentCommsMessage = {
+  sender: "school" | "you"; // OUTBOUND → school, INBOUND → you (never the raw admin direction)
+  body: string;
+  createdAt: Date;
+};
+
+export type ParentComms = {
+  messages: ParentCommsMessage[]; // ONE merged stream, chronological (ascending)
+  total: number;
+  repliedByYou: number; // count of the parent's own (INBOUND) messages
+  lastMessageAt: Date | null;
+};
+
+/** A raw message row as read from `inbox_message` (the only three parent-facing columns). */
+export type CommsRow = { direction: string; body: string; createdAt: Date };
+
+/** PURE — map the safe rows (already ordered ascending) into the parent stream. No db, unit-tested. */
+export function buildParentComms(rows: CommsRow[]): ParentComms {
+  const messages: ParentCommsMessage[] = rows.map((r) => ({
+    sender: r.direction === "OUTBOUND" ? "school" : "you",
+    body: r.body,
+    createdAt: r.createdAt,
+  }));
+  return {
+    messages,
+    total: messages.length,
+    repliedByYou: messages.filter((m) => m.sender === "you").length,
+    lastMessageAt: messages.length ? messages[messages.length - 1].createdAt : null,
+  };
+}
+
+/** MUST run on a `tx` already scoped by `withParentScope`. */
+export async function loadParentCommsTx(
+  tx: Tx,
+  schoolId: string,
+  guardianPhone: string,
+): Promise<ParentComms> {
+  // The parent's own threads (RLS additionally fences to own child + own phone). Belt: own phone only.
+  const convs = await tx
+    .select({ id: conversations.id })
+    .from(conversations)
+    .where(and(eq(conversations.schoolId, schoolId), eq(conversations.contactPhone, guardianPhone)));
+  if (convs.length === 0) return buildParentComms([]);
+
+  // Safe key-set ONLY: direction/body/created_at. Merge every own-thread's messages into one stream.
+  const rows = await tx
+    .select({
+      direction: inboxMessages.direction,
+      body: inboxMessages.body,
+      createdAt: inboxMessages.createdAt,
+    })
+    .from(inboxMessages)
+    .where(
+      and(
+        eq(inboxMessages.schoolId, schoolId),
+        inArray(
+          inboxMessages.conversationId,
+          convs.map((c) => c.id),
+        ),
+      ),
+    )
+    .orderBy(asc(inboxMessages.createdAt));
+
+  return buildParentComms(rows);
+}
+
+/** Entry point — the parent's message stream under `withParentScope` (never `withSchool`). */
+export async function loadParentComms(
+  schoolId: string,
+  userId: string,
+  guardianPhone: string | null,
+): Promise<ParentComms> {
+  if (!guardianPhone) return buildParentComms([]); // no stored phone → no threads (honest empty)
+  return withParentScope(schoolId, userId, (tx) => loadParentCommsTx(tx, schoolId, guardianPhone));
+}

--- a/omnischools/lib/parent/parent-comms.test.ts
+++ b/omnischools/lib/parent/parent-comms.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { readCode } from "@/lib/test-utils/source-shape";
+import { buildParentComms, type CommsRow } from "./parent-comms-data";
+
+/**
+ * INCR-COMM · parent-portal Communications (2-way messages). This is the FIRST parent WRITE path, so the
+ * write action's trust boundary is the centerpiece. Guards:
+ *  1. the PURE read derivation (buildParentComms) — direction→sender mapping + honest counts.
+ *  2. source-shape: the reader stays a safe key-set under withParentScope; the WRITE action server-forces
+ *     direction=INBOUND + own sender, sends NO SMS, never touches read_at, and validates the body.
+ */
+
+const D = (iso: string) => new Date(iso);
+const ROWS: CommsRow[] = [
+  { direction: "OUTBOUND", body: "Fees reminder", createdAt: D("2026-05-01T09:00:00Z") },
+  { direction: "INBOUND", body: "I'll pay Friday", createdAt: D("2026-05-01T10:00:00Z") },
+  { direction: "OUTBOUND", body: "Noted, thank you", createdAt: D("2026-05-02T08:00:00Z") },
+];
+
+describe("buildParentComms · read derivation (AC-COMM-02/03)", () => {
+  it("maps direction to sender side and counts the parent's own replies", () => {
+    const c = buildParentComms(ROWS);
+    expect(c.messages.map((m) => m.sender)).toEqual(["school", "you", "school"]);
+    expect(c.total).toBe(3);
+    expect(c.repliedByYou).toBe(1); // one INBOUND
+    expect(c.lastMessageAt).toEqual(D("2026-05-02T08:00:00Z"));
+    // never the raw admin vocabulary
+    expect(c.messages.every((m) => m.sender === "school" || m.sender === "you")).toBe(true);
+  });
+
+  it("empty thread → honest zero (no fabricated messages)", () => {
+    const c = buildParentComms([]);
+    expect(c).toEqual({ messages: [], total: 0, repliedByYou: 0, lastMessageAt: null });
+  });
+});
+
+describe("parent-comms-data · reader is a safe key-set under withParentScope (AC-COMM-01/05)", () => {
+  const reader = () => readCode("lib/parent/parent-comms-data.ts");
+
+  it("runs under withParentScope only — never withSchool / withoutTenantScope", () => {
+    const s = reader();
+    expect(s).toMatch(/withParentScope/);
+    expect(s).not.toMatch(/withSchool|withoutTenantScope/);
+  });
+
+  it("selects only the parent-facing message columns; never staff/routing/read-state fields", () => {
+    const s = reader();
+    expect(s).toMatch(/inboxMessages\.direction/);
+    expect(s).toMatch(/inboxMessages\.body/);
+    // the deny-list — target actual Drizzle column access (comments name them as the deny-list).
+    expect(s).not.toMatch(/inboxMessages\.sentByUserId/);
+    expect(s).not.toMatch(/conversations\.assignedToUserId/);
+    expect(s).not.toMatch(/conversations\.routedByRule/);
+    expect(s).not.toMatch(/conversations\.topic/);
+    expect(s).not.toMatch(/conversations\.readAt/);
+    expect(s).not.toMatch(/conversations\.channel/);
+    // scoped by the parent's OWN phone, not by student (co-guardian-thread leak guard)
+    expect(s).toMatch(/eq\(conversations\.contactPhone, guardianPhone\)/);
+  });
+});
+
+describe("parent-comms action · the write trust boundary (AC-COMM-05..11)", () => {
+  const action = () => readCode("lib/actions/parent-comms.ts");
+
+  it("is a parent-gated server action under withParentScope", () => {
+    const s = action();
+    expect(s).toMatch(/^"use server"/m);
+    expect(s).toMatch(/requireParent\(\)/); // NOT requireSchool
+    expect(s).not.toMatch(/requireSchool/);
+    expect(s).toMatch(/withParentScope/);
+    expect(s).not.toMatch(/\bwithSchool\b/);
+  });
+
+  it("SERVER-FORCES direction=INBOUND and the parent's own id as sender (anti-spoof)", () => {
+    const s = action();
+    expect(s).toMatch(/direction: "INBOUND"/);
+    expect(s).toMatch(/sentByUserId: user\.id/);
+    // direction/sender are never taken from client input — the Zod schema accepts ONLY body.
+    expect(s).toMatch(/z\.object\(\{ body:/);
+    expect(s).not.toMatch(/direction: input|direction: parsed/);
+  });
+
+  it("sends NO SMS and never touches read_at (leaves the thread unread for staff)", () => {
+    const s = action();
+    expect(s).not.toMatch(/sendSms|sendSMS/); // in-app only — SMS stays deferred
+    expect(s).not.toMatch(/readAt/); // read_at is deliberately left untouched (comment uses snake_case)
+  });
+
+  it("bumps the thread via the scoped SECURITY DEFINER fn, not a denied direct UPDATE (AC-COMM-09)", () => {
+    const s = action();
+    // parent_no_update denies a direct parent UPDATE on conversation; the bump must go through the fn.
+    expect(s).toMatch(/parent_bump_conversation/);
+    expect(s).not.toMatch(/\.update\(conversations\)/);
+  });
+
+  it("validates the body and guards duplicate submits", () => {
+    const s = action();
+    expect(s).toMatch(/\.min\(1/);
+    expect(s).toMatch(/\.max\(1000/);
+    expect(s).toMatch(/DUP_WINDOW_MS/); // duplicate-submit guard
+  });
+});
+
+describe("parent-chrome / page · Messages is the 6th live tab (AC-COMM-01)", () => {
+  const nav = () => readCode("app/(parent)/parent-chrome.tsx");
+  const page = () => readCode("app/(parent)/messages/page.tsx");
+
+  // Count-robust (not the whole TABS literal) so the next tab can't red this — the calendar/attendance lesson.
+  it("Messages is a live tab at /messages, still no inert span", () => {
+    const s = nav();
+    expect(s).toMatch(/"Messages"/); // present in TABS + the ParentTab union
+    expect(s).toMatch(/Messages: "\/messages"/);
+    expect(s).not.toMatch(/Partial<Record/);
+    expect((s.match(/<span/g) ?? []).length).toBe(1);
+  });
+
+  it("the messages route is child-gated, renders its own active nav, and sends no SMS", () => {
+    const s = page();
+    expect(s).toMatch(/ParentNav active="Messages"/);
+    expect(s).toMatch(/NoChild/); // per-child/per-parent surface → linked-child gate
+    expect(s).not.toMatch(/sendSms/);
+  });
+});

--- a/omnischools/scripts/rls-test.ts
+++ b/omnischools/scripts/rls-test.ts
@@ -52,6 +52,10 @@ function assertAtLeast(label: string, actual: number, min: number) {
   console.log(`${ok ? "✓" : "✗"} ${label}: got ${actual}, expected ≥ ${min}`);
   if (!ok) failures++;
 }
+function assertTrue(label: string, ok: boolean) {
+  console.log(`${ok ? "✓" : "✗"} ${label}`);
+  if (!ok) failures++;
+}
 
 async function main() {
   const sql = postgres(url, { max: 1 });
@@ -117,6 +121,117 @@ async function main() {
       const [{ n }] = await tx`select count(*)::int as n from ref_school`;
       assert("ref_school (unscoped)", n, 0);
     });
+
+    // ---------------------------------------------------------------------------------------------
+    // Parent Communications WRITE path — BEHAVIORAL RLS probe (Quinn MAJOR: the tenant-isolation
+    // loop above is shape-only; it can't catch a write that the superuser dev DB silently masks).
+    //
+    // A parent posts an INBOUND reply then calls parent_bump_conversation() to advance the thread's
+    // last_message_at + reopen a CLOSED thread. A naive direct `UPDATE conversation` inside the parent
+    // session hits parent_no_update → 0 ROWS SILENTLY on prod (staff never see the reply's unread /
+    // recency signal); the SECURITY DEFINER bump fn is the fix. This probe proves the fix LANDS while
+    // every forbidden write stays denied.
+    //
+    // 🔴 Run under PROD-SHAPED ownership: the fn owner is switched to the non-superuser omnischools_app
+    // so FORCE RLS actually binds the SECURITY DEFINER body. A superuser owner (the dev default) would
+    // bypass RLS inside the fn and MASK a regression — the very trap this task exists to close. All test
+    // rows AND the owner switch live in one transaction that is rolled back, so nothing persists.
+    console.log("\nParent Communications write path (behavioral):");
+    const parentRows = await sql<{ id: string }[]>`select id from ref_user limit 1`;
+    const kids = await sql<{ id: string }[]>`
+      select id from students where school_id = ${schoolId} order by id limit 2`;
+    if (parentRows.length < 1 || kids.length < 2) {
+      console.log("• skipped — needs ≥1 ref_user and ≥2 students in the seeded school.");
+    } else {
+      const parent = parentRows[0].id;
+      const ownChild = kids[0].id;
+      const otherChild = kids[1].id; // a real child in the SAME school, NOT linked to this parent
+      const ownThread = "aaaaaaaa-0000-4000-8000-00000000a001";
+      const otherThread = "bbbbbbbb-0000-4000-8000-00000000b002";
+      const OLD = "2020-01-01T00:00:00.000Z";
+      const ROLLBACK = "__parent_comms_probe_rollback__";
+      try {
+        await sql.begin(async (tx) => {
+          // ---- superuser setup (seeded owner bypasses RLS) ----
+          await tx`insert into student_guardian
+                     (id, school_id, student_id, name, relationship, phone, is_primary, user_id)
+                   values (gen_random_uuid(), ${schoolId}, ${ownChild}, 'RLSTEST', 'MOTHER',
+                           '+233RLSTEST01', true, ${parent})`;
+          await tx`insert into conversation
+                     (id, school_id, contact_phone, student_id, status, channel,
+                      last_message_at, created_at, read_at, assigned_to_user_id, topic)
+                   values (${ownThread}, ${schoolId}, '+233RLSTEST01', ${ownChild}, 'CLOSED', 'sms',
+                           ${OLD}, now(), ${OLD}, ${parent}, 'FEES')`;
+          await tx`insert into conversation
+                     (id, school_id, contact_phone, student_id, status, channel, last_message_at, created_at)
+                   values (${otherThread}, ${schoolId}, '+233OTHER02', ${otherChild}, 'CLOSED', 'sms',
+                           ${OLD}, now())`;
+          // prod-shape: definer owner = the non-superuser role subject to FORCE RLS
+          await tx`alter function parent_bump_conversation(uuid) owner to omnischools_app`;
+
+          // ---- act as the parent (RLS enforced) ----
+          await tx`set local role omnischools_app`;
+          await tx`select set_config('app.current_school', ${schoolId}, true)`;
+          await tx`select set_config('app.current_parent_user', ${parent}, true)`;
+
+          // (a) INBOUND reply into own thread → allowed + attributed to the parent
+          await tx`insert into inbox_message
+                     (id, school_id, conversation_id, direction, body, sent_by_user_id, created_at)
+                   values (gen_random_uuid(), ${schoolId}, ${ownThread}, 'INBOUND', 'RLSTEST reply',
+                           ${parent}, now())`;
+          const [msg] = await tx<{ direction: string; sent_by_user_id: string }[]>`
+            select direction, sent_by_user_id from inbox_message where body = 'RLSTEST reply'`;
+          assertTrue("parent reply row is INBOUND", msg?.direction === "INBOUND");
+          assertTrue("parent reply attributed to the parent", msg?.sent_by_user_id === parent);
+
+          // (d) OUTBOUND insert → denied (savepoint so the expected RLS error doesn't poison the tx)
+          let outboundDenied = false;
+          try {
+            await tx.savepoint(async (sp) => {
+              await sp`insert into inbox_message
+                         (id, school_id, conversation_id, direction, body, sent_by_user_id, created_at)
+                       values (gen_random_uuid(), ${schoolId}, ${ownThread}, 'OUTBOUND', 'RLSTEST forge',
+                               ${parent}, now())`;
+            });
+          } catch {
+            outboundDenied = true;
+          }
+          assertTrue("parent OUTBOUND insert denied", outboundDenied);
+
+          // (d) direct parent UPDATE conversation → denied (0 rows: the very bug a naive action hits)
+          const upd = await tx`update conversation set last_message_at = now() where id = ${ownThread}`;
+          assert("parent direct conversation UPDATE denied (rows)", upd.count, 0);
+
+          // (b) the bump fn LANDS: last_message_at advances + CLOSED → OPEN
+          const [before] = await tx<{ lma: Date }[]>`
+            select last_message_at as lma from conversation where id = ${ownThread}`;
+          await tx`select parent_bump_conversation(${ownThread})`;
+          const [after] = await tx<{ lma: Date; status: string }[]>`
+            select last_message_at as lma, status from conversation where id = ${ownThread}`;
+          assertTrue("bump advances last_message_at", after.lma > before.lma);
+          assertTrue("bump reopens the CLOSED thread", after.status === "OPEN");
+
+          // (c) bump on another child's thread → no-op (still 2020, read as superuser)
+          await tx`select parent_bump_conversation(${otherThread})`;
+          await tx`reset role`;
+          const [other] = await tx<{ lma: Date }[]>`
+            select last_message_at as lma from conversation where id = ${otherThread}`;
+          assertTrue(
+            "out-of-scope bump is a no-op",
+            other.lma.getTime() === new Date(OLD).getTime(),
+          );
+
+          // (d) parent DELETE → denied (0 rows)
+          await tx`set local role omnischools_app`;
+          const del = await tx`delete from inbox_message where conversation_id = ${ownThread}`;
+          assert("parent inbox_message DELETE denied (rows)", del.count, 0);
+
+          throw new Error(ROLLBACK); // discard all probe rows + the owner switch
+        });
+      } catch (e) {
+        if ((e as Error).message !== ROLLBACK) throw e;
+      }
+    }
   } finally {
     await sql.end();
   }


### PR DESCRIPTION
## What this ships

The **sixth live parent-portal tab** and the **first sanctioned parent WRITE path**: a 2-way in-app message thread between a parent and their school. The parent reads staff replies and sends messages — **in-app only, no SMS** (SMS stays deferred). Tab label "Messages", URL `/messages` (the staff route is `/communication`).

## Changes
- **`lib/parent/parent-comms-data.ts`** — parent-scoped reader (`withParentScope` only). Safe key-set: only `{direction→sender, body, created_at}`; NEVER `assigned_to`/`routed_by`/`topic`/`read_at`/`sent_by_user_id`/`channel`. Scoped by the parent's **own phone** (not student — avoids a co-guardian's thread). Pure `buildParentComms`.
- **`lib/actions/parent-comms.ts`** — the write. `requireParent` + `withParentScope`; **`direction=INBOUND` and sender server-forced** (client sends only `body`); thread resolved from the session (never a client id); `read_at` untouched; **no `sendSms`**; body 1–1000 + 60s dup-guard; find-or-create (OC-COMM-NEWTHREAD enabled — Wells proved the conversation `WITH CHECK` gates it to own-child+own-phone).
- **`app/(parent)/messages/{page.tsx,compose.tsx}`** — the tab + the first interactive parent control (a client compose box calling the action). Child-gated; honest empties; in-app framing (no "via SMS").
- **`parent-chrome.tsx`** — Messages added as the 3rd tab.
- **`db/sql/{policies.sql, prod-paste-0094-parent-inbox-write.sql}`** — the write RLS: `inbox_message` `parent_scope` gains a constrained `WITH CHECK` (INBOUND + own sender); both tables get `parent_no_update`/`parent_no_delete` (parent seam = INSERT+SELECT only); a scoped `SECURITY DEFINER parent_bump_conversation`. Staff path unchanged. No new readable table (still 25).
- **`scripts/rls-test.ts`** — a non-superuser behavioral probe (prod-shaped fn-owner switch) for the parent-write flow.
- **`lib/db/rls.ts`** — doc-sync (records the one sanctioned parent write).

## The one non-obvious bug caught and fixed (Quinn)
The parent's `conversation` bump (so staff see the reply as unread/recent/reopened) was a direct UPDATE — **denied by `parent_no_update`**, so on prod a reply would insert but stay invisible to staff. The superuser dev DB masked it. A naive `SECURITY DEFINER` fix wouldn't work either: this repo has **no `BYPASSRLS` role** and FORCE RLS binds the definer's owner. So `parent_bump_conversation` clears `app.current_parent_user` for its single own-child+own-phone-scoped UPDATE (two columns only) and restores it, keeping `app.current_school` set so tenant isolation still fences. Verified **non-superoser (prod-shaped)** via `scripts/rls-test.ts`.

## Gates
- **Quinn (QA): GREEN** — all AC-COMM; the bump MAJOR fixed and proven behaviorally (`db:rls-test`: INBOUND-only, direct UPDATE denied 0 rows, bump lands + reopens, out-of-scope no-op, DELETE denied); 133 tests; `pnpm build` ✓; `tsc` 0.
- **Dex (architecture/portability): APPROVE** — the bump-via-fn is a scoped-write privilege device (like `parent_student_ids`), not business logic; zero new lock-in; conventions clean.
- **Sarah (security): CLEAR-TO-MERGE** — the GUC-clear device proven safe on all six sub-checks (tenant fence survives, captured `pu` can't be widened, tx-local clear can't leak, two-column confinement, revoked-from-PUBLIC, search_path guarded); anti-spoof/anti-tamper server- and RLS-enforced; fail-closed before the paste.

Diff vs `origin/main` is exactly **1 commit / 11 files** (any "stacked on #340–#343" reading is a stale *local* `main`; the sibling PRs are already on `origin/main`).

## ⚠️ Owner action at deploy
**Hand-paste `db/sql/prod-paste-0094-parent-inbox-write.sql`** on prod before the tab goes live (`db:policies` is dev-only). Policy-only + a function, idempotent, depends only on already-deployed helpers. If skipped: **no cross-tenant/child leak** (tables keep their prior isolation) — the write fails closed (the missing fn aborts the tx) — but replies won't surface, so paste before go-live.

## Owner-confirmable / notes
- **OC-COMM-NEWTHREAD** enabled (parents can start a thread); **OC-COMM-REOPEN** (a reply reopens a CLOSED thread); **OC-COMM-RATELIMIT** deferred; staff-name-on-OUTBOUND omitted (labelled by the school).
- A parent-started thread's `channel` defaults to `SMS`; benign while SMS is console-only (the reader never surfaces it; the staff reply path is untouched). Worth a look when SMS is eventually wired.
- Multi-child guardians can currently message about their first linked child only (RLS still fences to an owned child) — a fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)