### PR TITLE
feat(parent): Billing (Fees) tab — read-only fee statement (safe projection)

### DIFF
--- a/omnischools/app/(parent)/parent-chrome.tsx
+++ b/omnischools/app/(parent)/parent-chrome.tsx
@@ -53,12 +53,19 @@ export function ParentHeader({
 }
 
 /** Every tab is a live route today. */
-export type ParentTab = "WASSCE" | "Attendance" | "Messages" | "Sickbay" | "PTA" | "School calendar";
+export type ParentTab =
+  | "WASSCE"
+  | "Attendance"
+  | "Messages"
+  | "Fees"
+  | "Sickbay"
+  | "PTA"
+  | "School calendar";
 
-// INCR-278 → +Attendance → +Messages — flat tabs, ALL live routes (Billing / Boarding return behind their
-// own increments). Attendance is second (the most-checked daily fact); "Messages" is the 2-way parent↔school
-// thread. Every entry below has an HREF.
-const TABS = ["WASSCE", "Attendance", "Messages", "Sickbay", "PTA", "School calendar"] as const;
+// INCR-278 → +Attendance → +Messages → +Fees — flat tabs, ALL live routes (Boarding returns behind its own
+// increment). "Fees" is the read-only fee statement (URL /statement — the staff routes are /fees + /billing).
+// 7 < 12, so the nav stays flat. Every entry below has an HREF.
+const TABS = ["WASSCE", "Attendance", "Messages", "Fees", "Sickbay", "PTA", "School calendar"] as const;
 const HREF: Record<(typeof TABS)[number], string> = {
   WASSCE: "/wassce",
   // URL is /attendance-summary (the /attendance path is the STAFF marking route — parent routes share the
@@ -66,6 +73,8 @@ const HREF: Record<(typeof TABS)[number], string> = {
   Attendance: "/attendance-summary",
   // URL is /messages — the STAFF route is /communication (parent routes share the (app) namespace).
   Messages: "/messages",
+  // URL is /statement — BOTH /fees and /billing are STAFF routes; the tab LABEL is "Fees".
+  Fees: "/statement",
   Sickbay: "/sickbay",
   PTA: "/pta",
   "School calendar": "/calendar",

--- a/omnischools/app/(parent)/statement/page.tsx
+++ b/omnischools/app/(parent)/statement/page.tsx
@@ -1,0 +1,278 @@
+import { requireParent } from "@/lib/auth/server";
+import { loadParentPortal } from "@/lib/parent/parent-portal-data";
+import {
+  loadParentBilling,
+  type BillStatus,
+  type ParentBillingChild,
+  type ParentBillingInvoice,
+  type ParentBillingReceipt,
+} from "@/lib/parent/parent-billing-data";
+import { relationshipLabel } from "@/lib/wassce/parent-copy";
+import { ParentHeader, ParentNav } from "../parent-chrome";
+
+/**
+ * INCR-BILL · the parent-portal Billing ("Fees") tab — a parent's read of their OWN children's fee status
+ * (reader is parent-billing-data, the column-guard projection). Same PARENT session gate; children resolved
+ * from the SESSION. READ-ONLY — no gateway, no "pay now"; a calm offline how-to-pay note instead. Every
+ * figure derives from real invoices (R90): no fabricated GHS 0 hero; DRAFT/VOIDED invoices excluded; the
+ * discount shows only as a net scalar (never the sibling-rank mechanic). URL /statement (staff own /fees + /billing).
+ */
+export const dynamic = "force-dynamic";
+
+const STATUS_TONE: Record<BillStatus, string> = {
+  Paid: "bg-green-bg text-green",
+  "Partly paid": "bg-gold-bg text-navy",
+  Unpaid: "bg-warn-bg text-warn",
+  Overdue: "bg-terra-bg text-terra",
+  Covered: "bg-bg text-navy-3",
+};
+
+export default async function ParentStatementPage() {
+  const { user, school } = await requireParent();
+  const [data, billing] = await Promise.all([
+    loadParentPortal(school.id, user.id),
+    loadParentBilling(school.id, user.id),
+  ]);
+  const headerChild = data.children[0] ?? null;
+  const guardianDisplay = data.guardianName ?? user.name ?? "Parent";
+  const relation = data.guardianRelationship ? relationshipLabel(data.guardianRelationship) : "Parent";
+
+  const children = billing.children;
+  const multi = children.length > 1;
+
+  return (
+    <div className="mx-auto max-w-[980px]">
+      <ParentHeader
+        schoolName={school.name}
+        childName={headerChild?.fullName ?? null}
+        guardianDisplay={guardianDisplay}
+        relation={relation}
+      />
+      <ParentNav active="Fees" />
+
+      <div className="px-7 pb-9 pt-6">
+        {children.length === 0 ? (
+          <NoChild />
+        ) : (
+          <div className="space-y-7">
+            <div>
+              <div className="text-[9px] font-bold uppercase tracking-[0.16em] text-gold">
+                {school.name} · Fees
+              </div>
+              <h2 className="mt-1 font-display text-2xl font-medium tracking-[-0.018em] text-navy">
+                Your <em className="text-gold">fee statement</em>
+              </h2>
+            </div>
+
+            {multi && (
+              <section className="rounded-xl border border-gold-soft bg-gold-bg px-6 py-[18px]">
+                <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-navy-3">
+                  Across your children
+                </div>
+                <div className="mt-1 flex items-baseline gap-2">
+                  <span className="text-[11px] text-navy-2">Total outstanding</span>
+                  <span
+                    className={
+                      "font-display text-[26px] font-semibold " +
+                      (billing.totalOutstandingValue > 0 ? "text-terra" : "text-green")
+                    }
+                  >
+                    {billing.totalOutstanding}
+                  </span>
+                </div>
+              </section>
+            )}
+
+            {children.map((c, i) => (
+              <ChildBlock key={i} child={c} showName={multi} />
+            ))}
+
+            <HowToPay />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** No portal-linked child — a linking issue, not a fee fact (mirrors the sibling tabs). */
+function NoChild() {
+  return (
+    <div className="rounded-xl border border-border bg-surface px-6 py-8 text-center text-[13px] leading-relaxed text-navy-2">
+      No student is linked to this portal yet. Please contact the school office.
+    </div>
+  );
+}
+
+/* ────────────────────────────────────────────────────────────────── per-child block ── */
+
+function ChildBlock({ child, showName }: { child: ParentBillingChild; showName: boolean }) {
+  const owes = child.outstandingValue > 0;
+  return (
+    <section className="space-y-4">
+      {showName && (
+        <h3 className="font-display text-lg font-medium text-navy">{child.name}</h3>
+      )}
+
+      {/* balance triad */}
+      <div className="grid grid-cols-3 gap-3">
+        <Tile label="Billed" value={child.billed} />
+        <Tile label="Paid" value={child.paid} />
+        <Tile
+          label="Outstanding"
+          value={owes ? child.outstanding : "GHS 0.00 — paid up"}
+          valueClass={owes ? "text-terra" : "text-green"}
+        />
+      </div>
+
+      {child.invoices.length === 0 ? (
+        <div className="rounded-xl border border-border bg-surface px-6 py-6 text-center text-[13px] leading-relaxed text-navy-2">
+          The school hasn&apos;t issued any fees for {child.name.split(" ")[0]} yet. Bills and balance will
+          appear here once it does.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {child.invoices.map((inv, i) => (
+            <InvoiceCard key={i} inv={inv} />
+          ))}
+        </div>
+      )}
+
+      {child.receipts.length > 0 && <Receipts receipts={child.receipts} />}
+    </section>
+  );
+}
+
+function Tile({ label, value, valueClass }: { label: string; value: string; valueClass?: string }) {
+  return (
+    <div className="rounded-xl border border-border bg-surface p-4 text-center">
+      <div className="text-[10px] font-semibold uppercase tracking-[0.1em] text-navy-3">{label}</div>
+      <div className={"mt-1 font-display text-[19px] font-semibold " + (valueClass ?? "text-navy")}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── invoice card ── */
+
+function InvoiceCard({ inv }: { inv: ParentBillingInvoice }) {
+  return (
+    <div className="overflow-hidden rounded-xl border border-border bg-surface">
+      <div className="flex items-start justify-between gap-3 border-b border-border bg-bg px-5 py-3.5">
+        <div>
+          <div className="font-display text-[15px] font-medium text-navy">
+            {inv.termLabel ? `${inv.termLabel} · ${inv.academicYear}` : inv.academicYear}
+          </div>
+          <div className="font-mono text-[11px] text-navy-3">
+            {inv.invoiceNumber}
+            {inv.dueLabel ? ` · due ${inv.dueLabel}` : ""}
+          </div>
+        </div>
+        <span
+          className={
+            "inline-flex items-center rounded-pill px-2.5 py-[3px] text-[11px] font-semibold " +
+            STATUS_TONE[inv.status]
+          }
+        >
+          {inv.status}
+        </span>
+      </div>
+
+      {inv.lineItems.length > 0 && (
+        <div className="divide-y divide-border px-5">
+          {inv.lineItems.map((li, i) => (
+            <div key={i} className="flex items-center justify-between gap-3 py-2.5 text-[13px]">
+              <span className="text-navy-2">
+                {li.description}
+                {li.isOptional && (
+                  <span className="ml-2 rounded-pill bg-bg px-1.5 py-[1px] text-[10px] text-navy-3">
+                    optional
+                  </span>
+                )}
+              </span>
+              <span className="font-mono text-navy-2">{li.amount}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="grid grid-cols-3 gap-2 border-t border-border px-5 py-3 text-center">
+        <Mini label="Billed" value={inv.billed} />
+        <Mini label="Paid" value={inv.paid} />
+        <Mini label="Balance" value={inv.outstanding} valueClass="font-semibold text-navy" />
+      </div>
+      {inv.discount && (
+        <div className="border-t border-border bg-bg px-5 py-2 text-right text-[11px] text-navy-3">
+          Discount applied <span className="font-mono text-green">−{inv.discount}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Mini({ label, value, valueClass }: { label: string; value: string; valueClass?: string }) {
+  return (
+    <div>
+      <div className="text-[9px] font-semibold uppercase tracking-[0.08em] text-navy-3">{label}</div>
+      <div className={"font-mono text-[13px] " + (valueClass ?? "text-navy-2")}>{value}</div>
+    </div>
+  );
+}
+
+/* ────────────────────────────────────────────────────────────────── receipts list ── */
+
+function Receipts({ receipts }: { receipts: ParentBillingReceipt[] }) {
+  return (
+    <div className="overflow-hidden rounded-xl border border-border bg-surface">
+      <div className="border-b border-border bg-bg px-5 py-3">
+        <h4 className="font-display text-sm font-medium text-navy">Payments &amp; receipts</h4>
+      </div>
+      {receipts.map((r, i) => (
+        <div
+          key={i}
+          className={
+            "grid grid-cols-[auto_1fr_auto] items-center gap-3 border-b border-border px-5 py-3 last:border-b-0 " +
+            (r.voided ? "opacity-60" : "")
+          }
+        >
+          <span className="font-mono text-[11px] text-navy-3">{r.date}</span>
+          <div>
+            <div className="text-[13px] font-medium text-navy">{r.amount}</div>
+            <div className="text-[11px] text-navy-3">
+              {r.method}
+              {r.voidLabel ? ` · ${r.voidLabel}` : ""}
+            </div>
+          </div>
+          {r.receiptLink ? (
+            <a
+              href={r.receiptLink}
+              className="font-mono text-[11px] font-semibold text-gold hover:underline"
+            >
+              {r.receiptNumber} →
+            </a>
+          ) : (
+            <span className="font-mono text-[11px] text-navy-3">{r.receiptNumber}</span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────────── how to pay ── */
+
+function HowToPay() {
+  return (
+    <section className="rounded-xl border border-border bg-surface px-[26px] py-[22px]">
+      <h3 className="font-display text-base font-medium text-navy">How to pay</h3>
+      <p className="mt-2 text-[13px] leading-relaxed text-navy-2">
+        You can pay by Mobile Money, bank transfer, or in person at the school office. When the school records
+        your payment, your receipt appears here.
+      </p>
+      <p className="mt-2 text-xs leading-relaxed text-navy-3">
+        Bring your child&apos;s name and student number when you pay at the office.
+      </p>
+    </section>
+  );
+}

--- a/omnischools/db/sql/policies.sql
+++ b/omnischools/db/sql/policies.sql
@@ -1132,6 +1132,123 @@ CREATE POLICY parent_scope ON attendance_record AS RESTRICTIVE FOR ALL TO public
     )
   );
 
+-- ---- INCR — PARENT BILLING: the NINTH widening of the 19a parent boundary (25 → 29 parent_scope tables)
+-- — the parent-portal BILLING tab (READ-ONLY, owner-authorised; approach a = narrow parent_scope grant).
+-- A parent gains ROW access to their OWN CHILD's invoices (invoice), the per-line breakdown
+-- (invoice_line_item), and the payments/receipts history (payment / receipt). Kept in sync with
+-- db/sql/prod-paste-0095-parent-billing.sql — this block is DEV; that file is the hand-paste on PROD (⚠ RLS
+-- is NOT auto-applied on prod; without the paste all four keep parent_deny and the Billing tab is an honest
+-- empty state — fail-closed, never a leak).
+--
+-- 🔴 THIS BLOCK IS STRUCTURALLY READ-ONLY — THE ONE DEPARTURE FROM EVERY prior parent_scope. Every earlier
+-- policy is `FOR ALL` with USING as WITH CHECK, trusting "no app write path runs inside withParentScope"
+-- (Kofi R4). Money is different: forging a `payment` (marking fees paid) or an `invoice` is the high-value
+-- attack, and a FOR-ALL scope would let a parent WRITE own-child rows. So billing uses SELECT reach + explicit
+-- write denial: parent_scope AS RESTRICTIVE FOR SELECT (own-child read, NO WITH CHECK) + parent_no_insert
+-- (FOR INSERT WITH CHECK pu IS NULL — without it tenant_isolation's permissive WITH CHECK alone would admit
+-- an own-school INSERT, the forge hole) + parent_no_update / parent_no_delete (FOR UPDATE/DELETE USING
+-- pu IS NULL → 0 rows). `pu IS NULL` (staff/webhook/escalated) → SELECT scope AND every write-deny are TRUE →
+-- total no-op, so staff finance read+write is byte-unchanged. Proven NON-SUPERUSER in scripts/rls-test.ts.
+--
+-- 🔴 OWN-CHILD, TENANT-FENCED. invoice/payment/receipt reach a specific child via parent_student_ids(school_id,
+-- pu). invoice_line_item has no student_id → reachable ONLY via an own-child invoice of the same tenant (a
+-- direct subquery on `invoice`, a DIFFERENT table → acyclic under prod FORCE RLS). RLS gates ROWS not COLUMNS:
+-- the discount TOTAL is the denormalised scalar invoice.discount_amount and the line text is
+-- invoice_line_item.description, so NO discount/mechanic table is ever reached. NEVER-WIDEN (stay parent_deny,
+-- re-affirmed by the catalog loop below): payment_allocation, invoice_discount_application, discount,
+-- discount_tier, fee_structure, fee_structure_item, fee_category, payment_audit_log.
+
+-- invoice — the child's issued bills (own-child only, via parent_student_ids). READ-ONLY.
+DROP POLICY IF EXISTS parent_deny ON invoice;
+DROP POLICY IF EXISTS parent_scope ON invoice;
+DROP POLICY IF EXISTS parent_no_insert ON invoice;
+DROP POLICY IF EXISTS parent_no_update ON invoice;
+DROP POLICY IF EXISTS parent_no_delete ON invoice;
+CREATE POLICY parent_scope ON invoice AS RESTRICTIVE FOR SELECT TO public
+  USING (
+    NULLIF(current_setting('app.current_parent_user', true), '') IS NULL
+    OR student_id IN (
+      SELECT parent_student_ids(
+        school_id, NULLIF(current_setting('app.current_parent_user', true), '')::uuid)
+    )
+  );
+CREATE POLICY parent_no_insert ON invoice AS RESTRICTIVE FOR INSERT TO public
+  WITH CHECK (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_update ON invoice AS RESTRICTIVE FOR UPDATE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_delete ON invoice AS RESTRICTIVE FOR DELETE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+
+-- invoice_line_item — the per-line breakdown, reachable ONLY via an OWN-CHILD invoice of the same tenant
+-- (no student_id on the row). Reads `invoice` (a different table → acyclic). READ-ONLY.
+DROP POLICY IF EXISTS parent_deny ON invoice_line_item;
+DROP POLICY IF EXISTS parent_scope ON invoice_line_item;
+DROP POLICY IF EXISTS parent_no_insert ON invoice_line_item;
+DROP POLICY IF EXISTS parent_no_update ON invoice_line_item;
+DROP POLICY IF EXISTS parent_no_delete ON invoice_line_item;
+CREATE POLICY parent_scope ON invoice_line_item AS RESTRICTIVE FOR SELECT TO public
+  USING (
+    NULLIF(current_setting('app.current_parent_user', true), '') IS NULL
+    OR invoice_id IN (
+      SELECT i.id FROM invoice i
+      WHERE i.school_id = invoice_line_item.school_id
+        AND i.student_id IN (
+          SELECT parent_student_ids(
+            invoice_line_item.school_id,
+            NULLIF(current_setting('app.current_parent_user', true), '')::uuid)
+        )
+    )
+  );
+CREATE POLICY parent_no_insert ON invoice_line_item AS RESTRICTIVE FOR INSERT TO public
+  WITH CHECK (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_update ON invoice_line_item AS RESTRICTIVE FOR UPDATE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_delete ON invoice_line_item AS RESTRICTIVE FOR DELETE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+
+-- payment — the child's payments history (own-child only, via parent_student_ids). READ-ONLY: forging a
+-- payment (marking fees paid) is the high-value attack, denied structurally by parent_no_insert.
+DROP POLICY IF EXISTS parent_deny ON payment;
+DROP POLICY IF EXISTS parent_scope ON payment;
+DROP POLICY IF EXISTS parent_no_insert ON payment;
+DROP POLICY IF EXISTS parent_no_update ON payment;
+DROP POLICY IF EXISTS parent_no_delete ON payment;
+CREATE POLICY parent_scope ON payment AS RESTRICTIVE FOR SELECT TO public
+  USING (
+    NULLIF(current_setting('app.current_parent_user', true), '') IS NULL
+    OR student_id IN (
+      SELECT parent_student_ids(
+        school_id, NULLIF(current_setting('app.current_parent_user', true), '')::uuid)
+    )
+  );
+CREATE POLICY parent_no_insert ON payment AS RESTRICTIVE FOR INSERT TO public
+  WITH CHECK (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_update ON payment AS RESTRICTIVE FOR UPDATE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_delete ON payment AS RESTRICTIVE FOR DELETE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+
+-- receipt — the child's receipts history (own-child only, via parent_student_ids). READ-ONLY.
+DROP POLICY IF EXISTS parent_deny ON receipt;
+DROP POLICY IF EXISTS parent_scope ON receipt;
+DROP POLICY IF EXISTS parent_no_insert ON receipt;
+DROP POLICY IF EXISTS parent_no_update ON receipt;
+DROP POLICY IF EXISTS parent_no_delete ON receipt;
+CREATE POLICY parent_scope ON receipt AS RESTRICTIVE FOR SELECT TO public
+  USING (
+    NULLIF(current_setting('app.current_parent_user', true), '') IS NULL
+    OR student_id IN (
+      SELECT parent_student_ids(
+        school_id, NULLIF(current_setting('app.current_parent_user', true), '')::uuid)
+    )
+  );
+CREATE POLICY parent_no_insert ON receipt AS RESTRICTIVE FOR INSERT TO public
+  WITH CHECK (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_update ON receipt AS RESTRICTIVE FOR UPDATE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_delete ON receipt AS RESTRICTIVE FOR DELETE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+
 -- ---- layer 1: parent_deny on every tenant table EXCEPT the parent-readable set (CATALOG-DRIVEN) ----
 -- This USED to be a hand-maintained 77-name array; a new tenant table that got tenant_isolation but was
 -- forgotten here escaped the parent boundary silently (Dex BLOCK; student_health_record was the leak).

--- a/omnischools/db/sql/prod-paste-0095-parent-billing.sql
+++ b/omnischools/db/sql/prod-paste-0095-parent-billing.sql
@@ -1,0 +1,208 @@
+-- Omnischools — PROD paste 0095: PARENT BILLING SCOPE (INCR — parent-portal Billing tab, READ-ONLY).
+-- POLICY-ONLY — ZERO new tables, ZERO enums, ZERO altered columns, ZERO backfills. It adds a narrow,
+-- SELECT-ONLY `parent_scope` (plus write-deny policies) to EXACTLY FOUR existing tables (invoice,
+-- invoice_line_item, payment, receipt) and re-runs the catalog-driven parent_deny loop. Idempotent —
+-- safe to run more than once. Paste into the Supabase SQL editor on PROD after merging. Byte-identical
+-- in effect to the "INCR — PARENT BILLING" block in db/sql/policies.sql (dev, db:policies).
+--
+-- WHAT IT SHIPS. A read-only parent BILLING tab in the parent portal: a parent linked to a school READS
+-- their OWN CHILD's issued bills (invoice: totals + discount scalar + status), the per-line breakdown
+-- (invoice_line_item: description + amount), and the payments/receipts history (payment / receipt). This
+-- is the NINTH widening of the INCR-19a parent boundary (25 → 29 parent_scope tables). Owner chose the
+-- narrow parent_scope grant (approach a) over a SECURITY DEFINER projection — implemented here as (a),
+-- read-only.
+--
+-- 🔴 THE ONE THING THAT MAKES BILLING DIFFERENT FROM EVERY PRIOR WIDENING: IT IS STRUCTURALLY READ-ONLY.
+-- Every earlier parent_scope policy is `AS RESTRICTIVE FOR ALL` with USING doubling as WITH CHECK, relying
+-- on the contract "no app write path runs inside withParentScope" (Kofi R4). That contract is NOT strong
+-- enough for money: forging a `payment` (marking fees paid) or an `invoice` is the high-value attack, and a
+-- FOR-ALL parent_scope would let a parent WRITE its own-child rows (USING doubles as WITH CHECK on
+-- INSERT/UPDATE). So billing uses a different, tighter shape — SELECT reach + explicit write denial:
+--   • parent_scope     AS RESTRICTIVE FOR SELECT — opens ONLY the own-child ROWS to a read; it carries NO
+--     WITH CHECK, so it can never combine to PERMIT a write.
+--   • parent_no_insert AS RESTRICTIVE FOR INSERT WITH CHECK (pu IS NULL) — a parent INSERT is REJECTED
+--     (without it, tenant_isolation's permissive WITH CHECK alone would admit an own-school INSERT — the
+--     forge hole).
+--   • parent_no_update AS RESTRICTIVE FOR UPDATE USING (pu IS NULL) — a parent UPDATE matches 0 rows.
+--   • parent_no_delete AS RESTRICTIVE FOR DELETE USING (pu IS NULL) — a parent DELETE matches 0 rows.
+-- Net: a parent SELECTs own-child billing rows and can do NOTHING else to these tables. Same device as the
+-- parent_no_update/parent_no_delete in prod-paste-0094, extended to INSERT and paired with a SELECT-only
+-- scope. Proven NON-SUPERUSER (omnischools_app) in scripts/rls-test.ts — the dev superuser masks RLS.
+--
+-- 🔴 OWN-CHILD ONLY — PER-CHILD JOIN, tenant-fenced, pu-guarded. invoice / payment / receipt carry
+-- student_id and reach a SPECIFIC child through the SECURITY DEFINER helper parent_student_ids(school_id, pu)
+-- — byte-shaped like the attendance_record / wassce_candidates policies. invoice_line_item carries no
+-- student_id; it is reachable ONLY via its OWN-CHILD invoice (invoice_id IN own-child invoices of the same
+-- tenant) — a direct subquery on `invoice` (a DIFFERENT table, so acyclic under prod FORCE RLS; and belt-
+-- and-suspenders, that inner read re-fires invoice's own parent_scope). All four predicates are
+-- `pu IS NULL OR <own-child reach>`, where pu = NULLIF(current_setting('app.current_parent_user', true), '').
+-- A parent of school A reads ONLY their own child's rows; ANOTHER child of the SAME school → 0 rows;
+-- CROSS-TENANT → 0 rows. `pu IS NULL` → staff (withSchool) / webhook / escalated session → total no-op:
+-- the SELECT scope is TRUE, the write-denies are TRUE, so staff finance (read AND write) is byte-unchanged.
+-- Depends on parent_student_ids() (prod-paste-0055), already on prod.
+--
+-- 🔴 RLS IS ROW-LEVEL — IT CANNOT MASK COLUMNS. This opens the child's billing ROWS. The reader
+-- (lib/parent/*, under withParentScope ONLY) is the column guard. The DISCOUNT design keeps confidential
+-- mechanics off the wire structurally: the discount TOTAL is the denormalised scalar invoice.discount_amount
+-- and the line text is invoice_line_item.description — so NO discount/mechanic table is ever reached.
+--
+-- 🔴 NEVER WIDEN — these stay parent_deny (half the security; they carry NO parent_scope, so the catalog
+-- loop below re-affirms parent_deny on each): payment_allocation, invoice_discount_application, discount,
+-- discount_tier, fee_structure, fee_structure_item, fee_category, payment_audit_log. A parent reads the four
+-- tables above and NOTHING else in the billing domain — no allocation ledger, no discount scheme/tier, no
+-- fee-structure catalogue, no audit log.
+--
+-- ⚠ WHAT HAPPENS IF THIS IS NOT RUN — FAIL-CLOSED, NEVER A LEAK. db:policies configures LOCAL DEV ONLY.
+-- Without this paste, all four tables keep their existing parent_deny on prod, so a parent session
+-- (app.current_parent_user set) reads ZERO rows → the parent Billing tab is an honest empty state, never a
+-- cross-tenant or cross-child leak, and the write-forge surface never opens. The cost of skipping is a blank
+-- tab, not exposure. Run it to ship the tab.
+--
+-- SCOPE — EXACTLY FOUR TABLES CHANGE (invoice, invoice_line_item, payment, receipt gain SELECT-only
+-- parent_scope + parent_no_insert/update/delete; their old parent_deny is dropped). Tenant isolation is
+-- untouched on every table. The catalog parent_deny loop at the tail re-affirms parent_deny on every other
+-- tenant table (auto-EXCLUDING the four that now carry parent_scope), so the never-widen list stays denied
+-- and a future tenant table stays auto-denied with zero edits.
+--
+-- Verify afterwards:
+--   -- the four tables carry parent_scope (SELECT) + parent_no_insert/update/delete; never-widen still denied:
+--   select c.relname, p.polname, p.polcmd from pg_policy p join pg_class c on c.oid = p.polrelid
+--   where c.relname in ('invoice','invoice_line_item','payment','receipt',
+--                       'payment_allocation','discount','fee_category','payment_audit_log')
+--   order by 1, 2;
+--   -- and db/sql/verify-prod-rls.sql: Query 1 must return ZERO ROWS; tenant_tables unchanged;
+--   -- parent_readable up by 4 (29) and parent_denied down by 4.
+
+-- ---- layer 2: the four new SELECT-only parent_scope policies + per-command write denials (byte-identical
+-- to db/sql/policies.sql "INCR — PARENT BILLING" block) ---- `pu IS NULL` → staff/bypass session → the
+-- SELECT scope AND every write-deny are TRUE → total no-op. `pu` set → SELECT is fenced to own-child rows
+-- and INSERT/UPDATE/DELETE are denied outright.
+
+-- invoice — the child's issued bills (own-child only, via parent_student_ids). READ-ONLY.
+DROP POLICY IF EXISTS parent_deny ON invoice;
+DROP POLICY IF EXISTS parent_scope ON invoice;
+DROP POLICY IF EXISTS parent_no_insert ON invoice;
+DROP POLICY IF EXISTS parent_no_update ON invoice;
+DROP POLICY IF EXISTS parent_no_delete ON invoice;
+CREATE POLICY parent_scope ON invoice AS RESTRICTIVE FOR SELECT TO public
+  USING (
+    NULLIF(current_setting('app.current_parent_user', true), '') IS NULL
+    OR student_id IN (
+      SELECT parent_student_ids(
+        school_id, NULLIF(current_setting('app.current_parent_user', true), '')::uuid)
+    )
+  );
+CREATE POLICY parent_no_insert ON invoice AS RESTRICTIVE FOR INSERT TO public
+  WITH CHECK (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_update ON invoice AS RESTRICTIVE FOR UPDATE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_delete ON invoice AS RESTRICTIVE FOR DELETE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+
+-- invoice_line_item — the per-line breakdown, reachable ONLY via an OWN-CHILD invoice of the same tenant
+-- (no student_id on the row). Reads `invoice` (a different table → acyclic). READ-ONLY.
+DROP POLICY IF EXISTS parent_deny ON invoice_line_item;
+DROP POLICY IF EXISTS parent_scope ON invoice_line_item;
+DROP POLICY IF EXISTS parent_no_insert ON invoice_line_item;
+DROP POLICY IF EXISTS parent_no_update ON invoice_line_item;
+DROP POLICY IF EXISTS parent_no_delete ON invoice_line_item;
+CREATE POLICY parent_scope ON invoice_line_item AS RESTRICTIVE FOR SELECT TO public
+  USING (
+    NULLIF(current_setting('app.current_parent_user', true), '') IS NULL
+    OR invoice_id IN (
+      SELECT i.id FROM invoice i
+      WHERE i.school_id = invoice_line_item.school_id
+        AND i.student_id IN (
+          SELECT parent_student_ids(
+            invoice_line_item.school_id,
+            NULLIF(current_setting('app.current_parent_user', true), '')::uuid)
+        )
+    )
+  );
+CREATE POLICY parent_no_insert ON invoice_line_item AS RESTRICTIVE FOR INSERT TO public
+  WITH CHECK (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_update ON invoice_line_item AS RESTRICTIVE FOR UPDATE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_delete ON invoice_line_item AS RESTRICTIVE FOR DELETE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+
+-- payment — the child's payments history (own-child only, via parent_student_ids). READ-ONLY: forging a
+-- payment (marking fees paid) is the high-value attack, denied structurally by parent_no_insert.
+DROP POLICY IF EXISTS parent_deny ON payment;
+DROP POLICY IF EXISTS parent_scope ON payment;
+DROP POLICY IF EXISTS parent_no_insert ON payment;
+DROP POLICY IF EXISTS parent_no_update ON payment;
+DROP POLICY IF EXISTS parent_no_delete ON payment;
+CREATE POLICY parent_scope ON payment AS RESTRICTIVE FOR SELECT TO public
+  USING (
+    NULLIF(current_setting('app.current_parent_user', true), '') IS NULL
+    OR student_id IN (
+      SELECT parent_student_ids(
+        school_id, NULLIF(current_setting('app.current_parent_user', true), '')::uuid)
+    )
+  );
+CREATE POLICY parent_no_insert ON payment AS RESTRICTIVE FOR INSERT TO public
+  WITH CHECK (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_update ON payment AS RESTRICTIVE FOR UPDATE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_delete ON payment AS RESTRICTIVE FOR DELETE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+
+-- receipt — the child's receipts history (own-child only, via parent_student_ids). READ-ONLY.
+DROP POLICY IF EXISTS parent_deny ON receipt;
+DROP POLICY IF EXISTS parent_scope ON receipt;
+DROP POLICY IF EXISTS parent_no_insert ON receipt;
+DROP POLICY IF EXISTS parent_no_update ON receipt;
+DROP POLICY IF EXISTS parent_no_delete ON receipt;
+CREATE POLICY parent_scope ON receipt AS RESTRICTIVE FOR SELECT TO public
+  USING (
+    NULLIF(current_setting('app.current_parent_user', true), '') IS NULL
+    OR student_id IN (
+      SELECT parent_student_ids(
+        school_id, NULLIF(current_setting('app.current_parent_user', true), '')::uuid)
+    )
+  );
+CREATE POLICY parent_no_insert ON receipt AS RESTRICTIVE FOR INSERT TO public
+  WITH CHECK (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_update ON receipt AS RESTRICTIVE FOR UPDATE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_delete ON receipt AS RESTRICTIVE FOR DELETE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+
+-- ---- layer 1: parent_deny — the CATALOG-DRIVEN loop, verbatim from db/sql/policies.sql ----
+-- 🔴 RUN THIS. It re-affirms RESTRICTIVE parent_deny on every FORCE-RLS + school_id table that does NOT
+-- already carry a parent_scope policy. The four tables above now carry parent_scope, so they stay EXCLUDED;
+-- every never-widen billing table (payment_allocation, invoice_discount_application, discount, discount_tier,
+-- fee_structure, fee_structure_item, fee_category, payment_audit_log) and every other tenant table (and any
+-- future one) stays auto-denied. Idempotent.
+DO $$
+DECLARE
+  tbl text;
+BEGIN
+  FOR tbl IN
+    SELECT c.relname
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = 'public'
+    WHERE c.relkind = 'r'
+      AND c.relforcerowsecurity
+      AND EXISTS (
+        SELECT 1 FROM information_schema.columns col
+        WHERE col.table_schema = 'public'
+          AND col.table_name = c.relname
+          AND col.column_name = 'school_id'
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_policy p
+        WHERE p.polrelid = c.oid AND p.polname = 'parent_scope'
+      )
+    ORDER BY c.relname
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS parent_deny ON %I;', tbl);
+    EXECUTE format(
+      'CREATE POLICY parent_deny ON %I AS RESTRICTIVE FOR ALL TO public '
+      'USING (NULLIF(current_setting(''app.current_parent_user'', true), '''') IS NULL);',
+      tbl
+    );
+  END LOOP;
+END
+$$;

--- a/omnischools/docs/senior/parent-billing-safe-projection-design.md
+++ b/omnischools/docs/senior/parent-billing-safe-projection-design.md
@@ -1,0 +1,37 @@
+# INCR-BILL — Parent Billing ("Fees") tab · approved safe-projection design
+
+**Status:** owner-approved (design-first checkpoint). Route `/statement`, tab label **"Fees"** (7th parent tab; both `/billing` and `/fees` are staff routes). This is the deferred R476 full-billing view (the PTA increment used a dues bridge + deferred paid/outstanding — un-deferred here).
+
+## Owner decisions
+- **Mechanism = narrow `parent_scope` grants (option a)**, NOT the SECURITY DEFINER projection (Wells recommended b for money; owner chose a — consistent with attendance/sickbay). ⇒ the reader PROJECTION is the sole column guard; grants must be **READ-ONLY** (a parent must never forge a payment/invoice).
+- **v1 scope = FULL**: own-child line-item breakdown + payments/receipts history + multi-child aggregate.
+
+## RLS (Wells, prod-paste-0095) — the 9th boundary widening (parent_readable 25 → 29)
+READ-ONLY own-child `parent_scope` (SELECT + write-denied) on exactly four tables:
+`invoice`, `invoice_line_item` (via own-child invoice), `payment`, `receipt` — each `student_id IN parent_student_ids(school, pu)` (line_item via invoice), tenant-fenced, `pu IS NULL OR …`. **A parent can SELECT but NOT INSERT/UPDATE/DELETE** (forging a payment is the attack — Wells proves write-denial non-superuser + a scripts/rls-test.ts probe).
+**NEVER widen (stay parent_deny — structural half of the security):** `payment_allocation`, `invoice_discount_application`, `discount`, `discount_tier`, `fee_structure`, `fee_structure_item`, `fee_category`, `payment_audit_log`.
+
+## Reader (`lib/parent/parent-billing-data.ts`) — the column guard
+`loadParentBilling` under `withParentScope` only. Reads students (own children) + invoice (+ academic_period for the term label — parent-readable since #278) + invoice_line_item + payment (leftJoin receipt). Excludes DRAFT + VOIDED invoices. Multi-child: own children only; household sibling discount surfaces as the net `billed` per child (never another child's amount or the rank).
+
+**Exposed safe field-set** (the frozen projection):
+- Per invoice: `invoiceNumber`, `termLabel` + `academicYear`, `billed`, `paid`, `outstanding` (=billed−paid, must equal stored balance), `discount` scalar (only when > 0), `status` (Paid/Partly paid/Unpaid/Overdue/Covered=EXEMPT), `dueLabel`, `lineItems[{description, amount, isOptional}]`.
+- Per child: name, studentCode, billed/paid/outstanding totals.
+- Per receipt: date, method label, gross amount, receiptNumber, `/r/{token}` link (existing code-gated page), voided/refunded label.
+- Aggregate: totalOutstanding across own children.
+
+**Deny-list — NEVER selected** (RLS opens the row; the projection is the only column guard): `payment.{netAmount,feeAmount,aggregator,settlementStatus,methodReference,currency,recordedByUserId,voidedByUserId,voidReason}`, `invoice.{subtotalAmount, void internals}`, `receipt.{pdfUrl}`, and every never-widen table.
+
+## UI (`app/(parent)/statement/page.tsx`) — READ-ONLY, no gateway
+Balance triad per child + aggregate strip (when >1 child); invoice cards (term/number/due, line-item breakdown, billed/paid/balance, discount line, status pill); payments & receipts list (linking to `/r/{token}`); a "how to pay" OFFLINE note (MoMo/bank/office) — **no "Pay now", no gateway** (never provisioned; `payment.aggregator` null in MVP1). Honest empties (no linked child → NoChild; child with no invoices → honest empty; paid-up → "GHS 0.00 — paid up", never blank).
+
+## OC decisions (owner-approved defaults)
+- Line items: **SHOW** own-child breakdown (owner picked full scope). *Known minor:* a PTA-dues line item (the `pta_dues_charge`→`invoice_line_item` bridge) can appear here AND on the PTA tab — shown honestly by description in v1; exclude-or-label is a fast-follow.
+- Payments/receipts: **SHOW**. Amount = **gross** (tendered, matches the receipt). method_reference **hidden** in the list (still on the receipt PDF).
+- Multi-child: **SHOW** aggregate + per-child.
+- Discount: **net scalar only**; mechanic/rank structurally denied.
+- Void: voided **invoices** excluded; voided/refunded **payments** shown labelled (reconcile with a held receipt); the balance nets voids via the denormalised invoice fields.
+- Term label: shown via `academic_period` (parent-readable since #278), not year-only.
+- OC-BILL-RECEIPT-PDF: the linked `/r/{token}` PDF (shipped) shows the cashier name + ref — a normal physical-receipt convention; left unchanged. The in-app tab's deny-list is intentionally tighter.
+
+Sources: Kofi R486–R493 / AC-BILL-01..26, Lucy surface synthesis + SHOW/OMIT table, Wells mechanism proposal + feasibility — in the session transcript.

--- a/omnischools/lib/parent/parent-billing-data.ts
+++ b/omnischools/lib/parent/parent-billing-data.ts
@@ -1,0 +1,261 @@
+import "server-only";
+import { and, asc, desc, eq, inArray, isNull, ne } from "drizzle-orm";
+import { withParentScope } from "@/lib/db/rls";
+import type { Tx } from "@/lib/db";
+import {
+  invoices,
+  invoiceLineItems,
+  payments,
+  receipts,
+  students,
+  academicPeriod,
+} from "@/db/schema";
+import { num, daysOverdue } from "@/lib/fees-helpers";
+
+/**
+ * 🔴 INCR-BILL · the PARENT-facing Billing ("Fees") reader (SHS module 4.3 × Fees · Kofi R486–R493,
+ * AC-BILL-*). The 9th widening of the 19a parent boundary. SERVER-ONLY — imports the db driver, so a client
+ * component must never import it (only `pnpm build` catches that leak).
+ *
+ * MECHANISM (owner chose narrow grants, option a): Wells's READ-ONLY `parent_scope` opens the ROWS of
+ * `invoice` / `invoice_line_item` / `payment` / `receipt` to a parent session, scoped to their OWN children
+ * (a parent can SELECT but not INSERT/UPDATE/DELETE — forging a payment is denied at the DB). RLS is
+ * row-level and CANNOT mask a column, so THIS PROJECTION is the ONLY column guard. NEVER select / NEVER join
+ * (the deny-list — these tables STAY parent_deny, so the leak is structural too): `payment_allocation`,
+ * `invoice_discount_application`, `discount` / `discount_tier` (scheme + SIBLING RANK), `fee_structure*`,
+ * `fee_category`, `payment_audit_log`, and on the widened tables the confidential columns —
+ * `payment.{net_amount,fee_amount,aggregator,settlement_status,method_reference,currency,recorded_by,
+ * voided_by,void_reason}`, `receipt.{pdf_url}`, `invoice.{subtotal_amount,void internals}`. The discount is
+ * shown ONLY as the denormalised scalar `invoice.discount_amount` — no scheme/rank table is reached.
+ *
+ * Own children only (RLS `student_id IN parent_student_ids`); a household sibling discount surfaces solely as
+ * the NET `billed` on each child's own invoice, never another child's amount or the rank. Read-only by
+ * construction — no write, no gateway, no "pay now". DRAFT + VOIDED invoices are excluded (a draft isn't
+ * issued; a void was never owed). `outstanding` is computed `billed − paid` (must equal stored balance).
+ */
+
+export type BillStatus = "Paid" | "Partly paid" | "Unpaid" | "Overdue" | "Covered";
+
+export type ParentBillingLineItem = { description: string; amount: string; isOptional: boolean };
+export type ParentBillingInvoice = {
+  invoiceNumber: string;
+  termLabel: string | null; // academic_period.period_label (parent-readable since #278), else null
+  academicYear: string;
+  billed: string; // formatted GHS
+  paid: string;
+  outstanding: string;
+  discount: string | null; // the net total scalar, only when > 0 (never the scheme/rank)
+  status: BillStatus;
+  dueLabel: string | null;
+  lineItems: ParentBillingLineItem[];
+};
+export type ParentBillingReceipt = {
+  date: string;
+  method: string; // friendly label
+  amount: string; // gross tendered
+  receiptNumber: string;
+  receiptLink: string | null; // /r/{token} when a public token exists
+  voided: boolean;
+  voidLabel: string | null; // "Refunded" | "Voided" when voided
+};
+export type ParentBillingChild = {
+  name: string;
+  studentCode: string;
+  billed: string; // Σ own non-void invoices, formatted (the triad)
+  paid: string;
+  outstanding: string;
+  outstandingValue: number; // raw, for the aggregate + zero-state
+  invoices: ParentBillingInvoice[];
+  receipts: ParentBillingReceipt[];
+};
+export type ParentBilling = {
+  children: ParentBillingChild[];
+  totalOutstanding: string; // Σ across the parent's own children (active school)
+  totalOutstandingValue: number;
+};
+
+/* ── pure helpers (no db) ────────────────────────────────────────────────────────────────────── */
+
+/** GHS with thousands separators (the Billing localiser — grouped digits read better on a statement). */
+export const ghs = (n: number): string =>
+  `GHS ${n.toLocaleString("en-GH", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+/**
+ * Derive the parent-facing status from the stored status + the money + whether the invoice is overdue
+ * (pure, unit-tested). `overdue` is the caller's `daysOverdue(dueAt) > 0` — the SAME full-day threshold the
+ * staff billing dashboard uses, so a parent never sees "Overdue" a day before the office does (Dex MIN-1).
+ */
+export function billStatus(
+  stored: string,
+  paid: number,
+  outstanding: number,
+  overdue: boolean,
+): BillStatus {
+  if (stored === "EXEMPT") return "Covered"; // Free-SHS / bursary — a real zero-balance, not a fabricated bill
+  if (outstanding <= 0) return "Paid";
+  if (overdue) return "Overdue";
+  if (paid > 0) return "Partly paid";
+  return "Unpaid";
+}
+
+const METHOD_LABEL: Record<string, string> = {
+  MTN_MOMO: "MTN MoMo",
+  TELECEL_CASH: "Telecel Cash",
+  AIRTELTIGO_MONEY: "AirtelTigo Money",
+  BANK_TRANSFER: "Bank transfer",
+  CASH: "Cash",
+  CHEQUE: "Cheque",
+  OTHER: "Other",
+};
+const methodLabel = (m: string): string => METHOD_LABEL[m] ?? "Other";
+
+const DATE = new Intl.DateTimeFormat("en-GB", {
+  day: "numeric", month: "short", year: "numeric", timeZone: "UTC",
+});
+const dayLabel = (d: Date): string => DATE.format(d);
+
+/* ── the loader ──────────────────────────────────────────────────────────────────────────────── */
+
+/** MUST run on a `tx` already scoped by `withParentScope`. */
+export async function loadParentBillingTx(tx: Tx, schoolId: string): Promise<ParentBilling> {
+  // The parent's own children (RLS scopes `students` to own children). No child columns beyond these.
+  const kids = await tx
+    .select({
+      id: students.id,
+      firstName: students.firstName,
+      lastName: students.lastName,
+      studentCode: students.studentCode,
+    })
+    .from(students)
+    .where(eq(students.schoolId, schoolId))
+    .orderBy(asc(students.firstName));
+  if (kids.length === 0) return { children: [], totalOutstanding: ghs(0), totalOutstandingValue: 0 };
+
+  const childIds = kids.map((k) => k.id);
+
+  // Invoices — own children, ISSUED reality only (DRAFT never issued; VOIDED never owed). term label via
+  // academic_period (parent-readable since #278). Column guard: only the safe scalars.
+  const invRows = await tx
+    .select({
+      id: invoices.id,
+      studentId: invoices.studentId,
+      invoiceNumber: invoices.invoiceNumber,
+      academicYear: invoices.academicYear,
+      termLabel: academicPeriod.periodLabel,
+      billed: invoices.billedAmount,
+      paid: invoices.paidAmount,
+      discount: invoices.discountAmount,
+      status: invoices.status,
+      dueAt: invoices.dueAt,
+    })
+    .from(invoices)
+    .leftJoin(
+      academicPeriod,
+      and(eq(academicPeriod.schoolId, invoices.schoolId), eq(academicPeriod.periodId, invoices.periodId)),
+    )
+    .where(
+      and(
+        eq(invoices.schoolId, schoolId),
+        inArray(invoices.studentId, childIds),
+        isNull(invoices.voidedAt),
+        ne(invoices.status, "DRAFT"),
+        ne(invoices.status, "VOIDED"),
+      ),
+    )
+    .orderBy(desc(invoices.issuedAt));
+
+  // Line items for those invoices — own-child breakdown; description/amount/isOptional ONLY.
+  const invIds = invRows.map((r) => r.id);
+  const liRows = invIds.length
+    ? await tx
+        .select({
+          invoiceId: invoiceLineItems.invoiceId,
+          description: invoiceLineItems.description,
+          amount: invoiceLineItems.amount,
+          isOptional: invoiceLineItems.isOptional,
+        })
+        .from(invoiceLineItems)
+        .where(and(eq(invoiceLineItems.schoolId, schoolId), inArray(invoiceLineItems.invoiceId, invIds)))
+    : [];
+  // ponytail: a PTA-dues line item (the pta_dues_charge → invoice_line_item bridge) shows here by its
+  // description AND on the PTA tab — a defensible v1 (honest, own-child). Exclude-or-label is the fast-follow.
+  const liByInvoice = new Map<string, ParentBillingLineItem[]>();
+  for (const li of liRows) {
+    const arr = liByInvoice.get(li.invoiceId) ?? [];
+    arr.push({ description: li.description, amount: ghs(num(li.amount)), isOptional: li.isOptional });
+    liByInvoice.set(li.invoiceId, arr);
+  }
+
+  // Payments + their receipt (1:1). gross tendered, method, date, receipt number + /r/ link. NEVER
+  // net/fee/aggregator/settlement/ref/staff — not selected.
+  const payRows = await tx
+    .select({
+      studentId: payments.studentId,
+      gross: payments.grossAmount,
+      method: payments.method,
+      paidAt: payments.paidAt,
+      voidedAt: payments.voidedAt,
+      voidIsRefund: payments.voidIsRefund,
+      receiptNumber: receipts.receiptNumber,
+      publicToken: receipts.publicToken,
+    })
+    .from(payments)
+    .leftJoin(receipts, and(eq(receipts.schoolId, payments.schoolId), eq(receipts.paymentId, payments.id)))
+    .where(and(eq(payments.schoolId, schoolId), inArray(payments.studentId, childIds)))
+    .orderBy(desc(payments.paidAt));
+
+  const children: ParentBillingChild[] = kids.map((kid) => {
+    const myInv = invRows.filter((r) => r.studentId === kid.id);
+    const invoicesOut: ParentBillingInvoice[] = myInv.map((r) => {
+      const billed = num(r.billed);
+      const paid = num(r.paid);
+      const outstanding = billed - paid;
+      const disc = num(r.discount);
+      return {
+        invoiceNumber: r.invoiceNumber,
+        termLabel: r.termLabel,
+        academicYear: r.academicYear,
+        billed: ghs(billed),
+        paid: ghs(paid),
+        outstanding: ghs(outstanding),
+        discount: disc > 0 ? ghs(disc) : null,
+        status: billStatus(r.status, paid, outstanding, daysOverdue(r.dueAt) > 0),
+        dueLabel: r.dueAt ? dayLabel(r.dueAt) : null,
+        lineItems: liByInvoice.get(r.id) ?? [],
+      };
+    });
+    const billedTotal = myInv.reduce((s, r) => s + num(r.billed), 0);
+    const paidTotal = myInv.reduce((s, r) => s + num(r.paid), 0);
+    const outstandingValue = billedTotal - paidTotal;
+
+    const myPay = payRows.filter((p) => p.studentId === kid.id);
+    const receiptsOut: ParentBillingReceipt[] = myPay.map((p) => ({
+      date: dayLabel(p.paidAt),
+      method: methodLabel(p.method),
+      amount: ghs(num(p.gross)),
+      receiptNumber: p.receiptNumber ?? "—",
+      receiptLink: p.publicToken ? `/r/${p.publicToken}` : null,
+      voided: p.voidedAt != null,
+      voidLabel: p.voidedAt != null ? (p.voidIsRefund ? "Refunded" : "Voided") : null,
+    }));
+
+    return {
+      name: `${kid.firstName} ${kid.lastName}`.trim(),
+      studentCode: kid.studentCode,
+      billed: ghs(billedTotal),
+      paid: ghs(paidTotal),
+      outstanding: ghs(outstandingValue),
+      outstandingValue,
+      invoices: invoicesOut,
+      receipts: receiptsOut,
+    };
+  });
+
+  const totalOutstandingValue = children.reduce((s, c) => s + c.outstandingValue, 0);
+  return { children, totalOutstanding: ghs(totalOutstandingValue), totalOutstandingValue };
+}
+
+/** Entry point — the parent's fee statement (own children) under `withParentScope` (never `withSchool`). */
+export async function loadParentBilling(schoolId: string, userId: string): Promise<ParentBilling> {
+  return withParentScope(schoolId, userId, (tx) => loadParentBillingTx(tx, schoolId));
+}

--- a/omnischools/lib/parent/parent-billing.test.ts
+++ b/omnischools/lib/parent/parent-billing.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { readCode } from "@/lib/test-utils/source-shape";
+import { billStatus, ghs } from "./parent-billing-data";
+
+/**
+ * INCR-BILL · parent-portal Billing ("Fees") tab. Under narrow parent_scope grants (option a) the reader
+ * PROJECTION is the sole column guard, so source-shape locks the deny-list hardest. Plus the pure status +
+ * money derivations.
+ */
+
+describe("billStatus · pure derivation (AC-BILL-08)", () => {
+  it("EXEMPT → Covered (a real zero balance, never a fabricated bill)", () => {
+    expect(billStatus("EXEMPT", 0, 0, false)).toBe("Covered");
+  });
+  it("outstanding ≤ 0 → Paid (paid-up beats an overdue flag)", () => {
+    expect(billStatus("PAID", 300, 0, true)).toBe("Paid");
+  });
+  it("outstanding > 0 and overdue (full day past due) → Overdue", () => {
+    expect(billStatus("ISSUED", 0, 100, true)).toBe("Overdue");
+  });
+  it("outstanding > 0, some paid, not overdue → Partly paid", () => {
+    expect(billStatus("PARTIAL", 200, 100, false)).toBe("Partly paid");
+  });
+  it("outstanding > 0, nothing paid, not overdue → Unpaid", () => {
+    expect(billStatus("ISSUED", 0, 300, false)).toBe("Unpaid");
+  });
+});
+
+describe("ghs · money format", () => {
+  it("groups thousands and pads 2dp", () => {
+    expect(ghs(1234.5)).toBe("GHS 1,234.50");
+    expect(ghs(0)).toBe("GHS 0.00");
+  });
+});
+
+describe("parent-billing-data · column guard under narrow grants (AC-BILL-04/05/22)", () => {
+  const reader = () => readCode("lib/parent/parent-billing-data.ts");
+
+  it("runs under withParentScope only — never withSchool / withoutTenantScope", () => {
+    const s = reader();
+    expect(s).toMatch(/withParentScope/);
+    expect(s).not.toMatch(/withSchool|withoutTenantScope/);
+  });
+
+  it("excludes DRAFT + VOIDED invoices (issued reality only)", () => {
+    const s = reader();
+    expect(s).toMatch(/ne\(invoices\.status, "DRAFT"\)/);
+    expect(s).toMatch(/ne\(invoices\.status, "VOIDED"\)/);
+    expect(s).toMatch(/isNull\(invoices\.voidedAt\)/);
+  });
+
+  it("never selects the confidential payment/invoice/receipt columns (target real Drizzle refs)", () => {
+    const s = reader();
+    for (const col of [
+      /payments\.netAmount/,
+      /payments\.feeAmount/,
+      /payments\.aggregator/,
+      /payments\.settlementStatus/,
+      /payments\.methodReference/,
+      /payments\.recordedByUserId/,
+      /payments\.voidedByUserId/,
+      /payments\.voidReason/,
+      /invoices\.subtotalAmount/,
+      /receipts\.pdfUrl/,
+    ]) {
+      expect(s).not.toMatch(col);
+    }
+  });
+
+  it("never touches the never-widen mechanic/config/audit tables", () => {
+    const s = reader();
+    // these Drizzle table symbols are never imported/used (comments name them only in snake_case)
+    expect(s).not.toMatch(/paymentAllocations/);
+    expect(s).not.toMatch(/invoiceDiscountApplications/);
+    expect(s).not.toMatch(/\bdiscounts\b/); // the discount SCHEME table (plural) — the scalar is invoices.discountAmount
+    expect(s).not.toMatch(/discountTiers/);
+    expect(s).not.toMatch(/paymentAuditLog/);
+    expect(s).not.toMatch(/feeStructures|feeStructureItems/);
+    expect(s).not.toMatch(/feeCategories/);
+  });
+});
+
+describe("parent-chrome / page · Fees is the 7th live tab, read-only (AC-BILL-23)", () => {
+  const nav = () => readCode("app/(parent)/parent-chrome.tsx");
+  const page = () => readCode("app/(parent)/statement/page.tsx");
+
+  it("Fees is a live tab at /statement, still no inert span", () => {
+    const s = nav();
+    expect(s).toMatch(/"Fees"/); // present in TABS + the ParentTab union
+    expect(s).toMatch(/Fees: "\/statement"/);
+    expect(s).not.toMatch(/Partial<Record/);
+    expect((s.match(/<span/g) ?? []).length).toBe(1);
+  });
+
+  it("the statement route is a read-only server component with an active nav + child gate", () => {
+    const s = page();
+    expect(s).toMatch(/ParentNav active="Fees"/);
+    expect(s).toMatch(/NoChild/);
+    expect(s).not.toMatch(/^"use client"/m); // read-only server component
+    expect(s).not.toMatch(/Pay now|sendSms|gateway|checkout/i); // no payment gateway / write path
+  });
+});

--- a/omnischools/scripts/rls-test.ts
+++ b/omnischools/scripts/rls-test.ts
@@ -232,6 +232,112 @@ async function main() {
         if ((e as Error).message !== ROLLBACK) throw e;
       }
     }
+
+    // ---------------------------------------------------------------------------------------------
+    // Parent BILLING (read-only) — BEHAVIORAL RLS probe (INCR — parent Billing tab, prod-paste-0095).
+    //
+    // Billing is the FIRST parent_scope that is STRUCTURALLY read-only: forging a `payment` (marking
+    // fees paid) or an `invoice` is the high-value attack, so unlike the FOR-ALL parent_scope tables
+    // the four billing tables use `parent_scope AS RESTRICTIVE FOR SELECT` + parent_no_insert/update/
+    // delete. This probe proves — as the NON-SUPERUSER omnischools_app (the dev superuser masks RLS) —
+    // that a parent READS own-child invoice/line_item/payment/receipt, sees 0 for another child / a
+    // foreign tenant, and can NEVER INSERT/UPDATE/DELETE invoice or payment. All rows are set up as the
+    // seeded (superuser) owner, then acted on as omnischools_app, in one rolled-back transaction.
+    console.log("\nParent Billing read-only path (behavioral):");
+    const bParentRows = await sql<{ id: string }[]>`select id from ref_user limit 1`;
+    const bKids = await sql<{ id: string }[]>`
+      select id from students where school_id = ${schoolId} order by id limit 2`;
+    if (bParentRows.length < 1 || bKids.length < 2) {
+      console.log("• skipped — needs ≥1 ref_user and ≥2 students in the seeded school.");
+    } else {
+      const bParent = bParentRows[0].id;
+      const bOwn = bKids[0].id;
+      const bOther = bKids[1].id; // a real child in the SAME school, NOT linked to this parent
+      const ownInv = "aaaaaaaa-0000-4000-8000-0000000c1001";
+      const othInv = "bbbbbbbb-0000-4000-8000-0000000c2002";
+      const ownPay = "cccccccc-0000-4000-8000-0000000c3003";
+      const othPay = "dddddddd-0000-4000-8000-0000000c4004";
+      const ROLLBACK_B = "__parent_billing_probe_rollback__";
+      try {
+        await sql.begin(async (tx) => {
+          // ---- superuser setup ----
+          await tx`insert into student_guardian
+                     (id, school_id, student_id, name, relationship, phone, is_primary, user_id)
+                   values (gen_random_uuid(), ${schoolId}, ${bOwn}, 'RLSTEST', 'MOTHER',
+                           '+233RLSTESTB1', true, ${bParent})`;
+          for (const [inv, kid, num, pay] of [
+            [ownInv, bOwn, "RLST-OWN", ownPay],
+            [othInv, bOther, "RLST-OTH", othPay],
+          ] as const) {
+            await tx`insert into invoice
+                       (id, school_id, student_id, invoice_number, academic_year,
+                        subtotal_amount, billed_amount, balance_amount)
+                     values (${inv}, ${schoolId}, ${kid}, ${num}, '2025/26', 300, 300, 300)`;
+            await tx`insert into invoice_line_item (id, school_id, invoice_id, description, amount)
+                     values (gen_random_uuid(), ${schoolId}, ${inv}, 'Tuition', 300)`;
+            await tx`insert into payment (id, school_id, student_id, gross_amount, net_amount, method)
+                     values (${pay}, ${schoolId}, ${kid}, 100, 100, 'CASH')`;
+            await tx`insert into receipt (id, school_id, payment_id, receipt_number, student_id)
+                     values (gen_random_uuid(), ${schoolId}, ${pay}, ${"RCPT-" + pay.slice(0, 6)}, ${kid})`;
+          }
+
+          // ---- act as the parent (RLS enforced, non-superuser) ----
+          await tx`set local role omnischools_app`;
+          await tx`select set_config('app.current_school', ${schoolId}, true)`;
+          await tx`select set_config('app.current_parent_user', ${bParent}, true)`;
+
+          // own-child READ works (all four tables)
+          const c = async (t: string, w: string) =>
+            (await tx.unsafe(`select count(*)::int n from ${t} ${w}`))[0].n as number;
+          assert("parent reads own invoice", await c("invoice", `where id='${ownInv}'`), 1);
+          assert("parent reads own line_item", await c("invoice_line_item", `where invoice_id='${ownInv}'`), 1);
+          assert("parent reads own payment", await c("payment", `where id='${ownPay}'`), 1);
+          assert("parent reads own receipt", await c("receipt", `where payment_id='${ownPay}'`), 1);
+
+          // cross-CHILD (same school, not linked) → 0 (all four)
+          assert("parent CANNOT read other-child invoice", await c("invoice", `where id='${othInv}'`), 0);
+          assert("parent CANNOT read other-child line_item", await c("invoice_line_item", `where invoice_id='${othInv}'`), 0);
+          assert("parent CANNOT read other-child payment", await c("payment", `where id='${othPay}'`), 0);
+          assert("parent CANNOT read other-child receipt", await c("receipt", `where payment_id='${othPay}'`), 0);
+
+          // WRITE DENIAL on invoice + payment — the read-only proof (savepoint so the RLS error can't poison the tx)
+          const insDenied = async (label: string, stmt: string) => {
+            let denied = false;
+            try {
+              await tx.savepoint(async (sp) => {
+                await sp.unsafe(stmt);
+              });
+            } catch {
+              denied = true;
+            }
+            assertTrue(label, denied);
+          };
+          await insDenied(
+            "parent INSERT invoice denied",
+            `insert into invoice (id, school_id, student_id, invoice_number, academic_year, subtotal_amount, billed_amount, balance_amount)
+               values (gen_random_uuid(), '${schoolId}', '${bOwn}', 'FORGE-INV', '2025/26', 1, 1, 1)`,
+          );
+          await insDenied(
+            "parent INSERT payment denied (fees-paid forge)",
+            `insert into payment (id, school_id, student_id, gross_amount, net_amount, method)
+               values (gen_random_uuid(), '${schoolId}', '${bOwn}', 999, 999, 'CASH')`,
+          );
+          assert("parent UPDATE invoice denied (rows)", (await tx`update invoice set paid_amount=300 where id=${ownInv}`).count, 0);
+          assert("parent UPDATE payment denied (rows)", (await tx`update payment set net_amount=1 where id=${ownPay}`).count, 0);
+          assert("parent DELETE invoice denied (rows)", (await tx`delete from invoice where id=${ownInv}`).count, 0);
+          assert("parent DELETE payment denied (rows)", (await tx`delete from payment where id=${ownPay}`).count, 0);
+
+          // cross-TENANT: a parent scoped to a FOREIGN school sees 0 of their own child's rows
+          await tx`select set_config('app.current_school', ${FOREIGN_ID}, true)`;
+          assert("parent in foreign tenant reads 0 invoices", await c("invoice", `where id='${ownInv}'`), 0);
+          assert("parent in foreign tenant reads 0 payments", await c("payment", `where id='${ownPay}'`), 0);
+
+          throw new Error(ROLLBACK_B); // discard all probe rows
+        });
+      } catch (e) {
+        if ((e as Error).message !== ROLLBACK_B) throw e;
+      }
+    }
   } finally {
     await sql.end();
   }


### PR DESCRIPTION
## What this ships

The **seventh live parent-portal tab** — a parent's **read-only** view of their own children's fee status: per-child billed/paid/outstanding + a household total, invoices (number, term, billed/paid/balance, status, due, **line-item breakdown**, discount net scalar), and **payments + receipts** linking to the existing `/r/{token}` page. This is the deferred **R476 full-billing view** (the PTA increment used a dues bridge + deferred paid/outstanding — un-deferred here). **No payment gateway** — a calm offline "how to pay" note (MoMo/bank/office). URL **`/statement`**, tab label **"Fees"** (both `/fees` and `/billing` are staff routes).

Designed-first and owner-approved: mechanism = **narrow parent_scope grants** + full v1 (line items + payments/receipts + multi-child).

## Changes
- **`db/sql/{policies.sql, prod-paste-0095-parent-billing.sql}`** — the 9th widening (parent_readable 25 → 29). **READ-ONLY** own-child `parent_scope` on `invoice` / `invoice_line_item` / `payment` / `receipt`: `FOR SELECT` scope + `parent_no_insert`/`parent_no_update`/`parent_no_delete` per table. The `parent_no_insert` is **load-bearing** — without it, `tenant_isolation`'s permissive `WITH CHECK` alone would admit an own-school parent INSERT (a parent **forging a payment** to mark fees paid). Verified non-superuser: INSERT invoice/payment **denied**, UPDATE/DELETE 0 rows. The mechanic/config/audit tables (`payment_allocation`, `discount*`, `invoice_discount_application`, `fee_structure*`, `fee_category`, `payment_audit_log`) **stay `parent_deny`**.
- **`lib/parent/parent-billing-data.ts`** — the reader (`withParentScope` only). Under narrow grants the projection is the **sole column guard**: it never selects the confidential columns (`payment` net/fee/aggregator/settlement/ref/staff/void internals, `invoice.subtotal`, `receipt.pdf_url`) and never touches a never-widen table. Own children only; discount shown only as the net scalar (mechanic + sibling-rank structurally denied); DRAFT/VOIDED invoices excluded; outstanding = billed − paid. Overdue uses the shared `daysOverdue` helper (same full-day threshold as the staff dashboard). Pure `billStatus`/`ghs`.
- **`app/(parent)/statement/page.tsx`** — the tab (read-only server component): balance triad + aggregate, invoice cards, receipts, offline how-to-pay note.
- **`parent-chrome.tsx`** — Fees added as the 4th tab.
- **`scripts/rls-test.ts`** — behavioral parent-billing read + write-denial probe (non-superuser).
- **`docs/senior/parent-billing-safe-projection-design.md`** — the approved design.

## Gates
- **Quinn (QA): GREEN** — all AC-BILL-01..26; 9/9 mutation probes fired (the column-guard is confirmed the sole guard); 145 tests; `pnpm build` ✓; forge-protection proven behaviorally (`db:rls-test`).
- **Dex (architecture/portability): APPROVE** — clean seam/conventions, zero new lock-in. Two notes applied: overdue now aligns with the staff `daysOverdue` threshold; the PTA-dues double-appearance is documented as a v1 ceiling.
- **Sarah (security): CLEAR-TO-MERGE** — all 8 attacker checks pass: the forge is structurally impossible, own-child scoping is acyclic (no PTA-recursion trap), the column guard selects only the safe set, never-widen tables stay denied, fail-closed before the paste (read *and* write-forge), staff unchanged.

Diff vs `origin/main` is exactly **1 commit / 8 files**.

## ⚠️ Owner action at deploy
**Hand-paste `db/sql/prod-paste-0095-parent-billing.sql`** on prod before the tab goes live (`db:policies` is dev-only). Policy-only, idempotent, no gateway. If skipped: the four tables keep `parent_deny` → the tab is a fail-closed honest empty **and** the write-forge surface never opens — no leak either way.

## Notes / fast-follows
- A PTA-dues line item (the `pta_dues_charge` bridge) can appear here **and** on the PTA tab — shown honestly by description in v1; exclude-or-label is a fast-follow (documented in the reader + design doc).
- The linked `/r/{token}` receipt PDF (shipped, unchanged) shows the cashier name + ref — a normal physical-receipt convention; the in-app tab's deny-list is intentionally tighter.
- Separately, a real prod bug was found in passing (not billing): `parent_house_names` (PTA House-name relabel) silently returns 0 on prod — spun off as its own task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)