### PR TITLE
fix(rls): parent_house_names GUC-clear — prod-only 0-rows defect

### DIFF
--- a/omnischools/db/sql/policies.sql
+++ b/omnischools/db/sql/policies.sql
@@ -1032,33 +1032,62 @@ CREATE POLICY parent_scope ON pta_resolution AS RESTRICTIVE FOR ALL TO public
 -- itself keeps parent_deny (re-affirmed by the catalog loop below, which still covers it — no parent_scope
 -- policy exists on it, so the NOT EXISTS(parent_scope) filter includes it).
 --
+-- 🔴 PROD-ONLY DEFECT — THE GUC-CLEAR DEVICE (fix 0096). The definer body reads `house`, a parent_deny
+-- table. On PROD the definer owner is a NON-SUPERUSER bound by FORCE RLS, so when a parent session is
+-- active (app.current_parent_user set) house.parent_deny (USING pu IS NULL) DENIES that read → the original
+-- LANGUAGE sql function returned 0 ROWS and the parent House-PTA card silently fell back to the generic
+-- "House PTA" (fail-closed — never a crash, never a leak). DEV's superuser owner bypassed RLS and MASKED
+-- it. The fix: convert to plpgsql and CLEAR app.current_parent_user for exactly the one scoped read
+-- (house.parent_deny USING pu IS NULL → TRUE) then RESTORE it — the same portable device as
+-- parent_bump_conversation. app.current_school STAYS set so tenant_isolation still fences the school
+-- (defence in depth); the own-child scope uses the CAPTURED arg `pu` (never the cleared GUC), so relaxing
+-- the GUC cannot widen the result. set_config(...,true) is transaction-local — an error mid-RETURN aborts
+-- the enclosing tx and rolls the clear back, so the caller's session GUC can never leak across statements.
+--
 -- ACYCLIC / PII GUARD: because no parent_scope policy on `house` exists (it stays denied), there is no
--- policy-reads-its-own-table concern — this is a plain definer read, the parent_student_ids / parent_pta_ids
--- idiom (STABLE, SECURITY DEFINER, search_path public,pg_temp LAST — pg_temp last so an injected temp
+-- policy-reads-its-own-table concern — this is the parent_student_ids / parent_pta_ids definer idiom
+-- (STABLE, SECURITY DEFINER, search_path public,pg_temp LAST — pg_temp last so an injected temp
 -- `house`/`students` cannot spoof the answer). The reach set = the parent's OWN children's houses via
 -- students.house_id — the SAME set as parent_in_pta's HOUSE branch above (policies.sql HOUSE tier). `pu` is
--- the GUC arg, NEVER a row column; a NULL pu → empty parent_student_ids → 0 rows (fail-closed). Kept in sync
--- with db/sql/prod-paste-0084-pta-parent-house-name.sql (the PROD hand-paste; ⚠ RLS is NOT auto-applied on
--- prod — without it the function is simply absent and the parent tab keeps the generic "House PTA" label,
--- never a leak). Depends on parent_student_ids() (prod-paste-0055), which already ships on prod.
+-- the GUC arg, NEVER a row column; a NULL pu / school → early RETURN → 0 rows (fail-closed). Kept in sync
+-- with db/sql/prod-paste-0096-fix-parent-house-names.sql (the PROD hand-paste; ⚠ RLS is NOT auto-applied on
+-- prod — without it the parent tab keeps the generic "House PTA" label, never a leak). Depends on
+-- parent_student_ids() (prod-paste-0055), which already ships on prod.
 CREATE OR REPLACE FUNCTION parent_house_names(school uuid, pu uuid)
   RETURNS TABLE(house_id uuid, house_name text)
-  LANGUAGE sql
+  LANGUAGE plpgsql
   STABLE
   SECURITY DEFINER
   SET search_path = public, pg_temp
 AS $$
-  SELECT DISTINCT h.id, h.name
-  FROM house h
-  WHERE h.school_id = school
-    AND h.id IN (
-      SELECT DISTINCT s.house_id
-      FROM students s
-      WHERE s.school_id = school
-        AND s.house_id IS NOT NULL
-        AND s.id IN (SELECT parent_student_ids(school, pu))
-    )
+DECLARE
+  prev text := current_setting('app.current_parent_user', true);  -- capture, restore verbatim (pu is an ARG)
+BEGIN
+  IF pu IS NULL OR school IS NULL THEN RETURN; END IF;
+  PERFORM set_config('app.current_parent_user', '', true);  -- relax house.parent_deny for the scoped read
+  RETURN QUERY
+    SELECT DISTINCT h.id, h.name
+    FROM house h
+    WHERE h.school_id = school
+      AND h.id IN (
+        SELECT DISTINCT s.house_id
+        FROM students s
+        WHERE s.school_id = school
+          AND s.house_id IS NOT NULL
+          AND s.id IN (SELECT parent_student_ids(school, pu))
+      );
+  PERFORM set_config('app.current_parent_user', COALESCE(prev, ''), true);  -- restore the caller's own GUC
+END;
 $$;
+-- On Supabase every public function is a PostgREST RPC and EXECUTE defaults to PUBLIC. This fn now CLEARS
+-- the parent GUC as the definer owner, so harden it: it must not be anon-callable (the owner keeps EXECUTE
+-- regardless of the REVOKE; a caller without app.current_school is still fenced by tenant_isolation).
+REVOKE EXECUTE ON FUNCTION parent_house_names(uuid, uuid) FROM PUBLIC;
+DO $$ BEGIN
+  IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'omnischools_app') THEN
+    GRANT EXECUTE ON FUNCTION parent_house_names(uuid, uuid) TO omnischools_app;
+  END IF;
+END $$;
 
 -- ---- INCR-278: the SEVENTH widening of the 19a parent boundary (22 → 24 parent_scope tables) — the
 -- parent SCHOOL CALENDAR tab (owner-authorised). A parent gains ROW access to the term/semester dates

--- a/omnischools/db/sql/prod-paste-0096-fix-parent-house-names.sql
+++ b/omnischools/db/sql/prod-paste-0096-fix-parent-house-names.sql
@@ -1,0 +1,86 @@
+-- Omnischools — PROD paste 0096: FIX the PROD-ONLY defect in parent_house_names (SHS module 4.7 / INCR-58
+-- Item 1; Kofi R483/R484). FUNCTION ONLY — ZERO new tables, ZERO enums, ZERO altered columns, ZERO
+-- backfills, ZERO migration, ZERO policy changes. It replaces the ONE SECURITY DEFINER helper
+-- parent_house_names(school uuid, pu uuid) with a GUC-clearing plpgsql version. Idempotent (CREATE OR
+-- REPLACE) — safe to run more than once. Paste into the Supabase SQL editor on PROD after merging.
+-- Byte-identical in effect to the INCR-58 block in db/sql/policies.sql (dev, db:policies). SUPERSEDES
+-- prod-paste-0084-pta-parent-house-name.sql (same name + signature; callers are unaffected).
+--
+-- 🔴 THE BUG (prod-only, fail-closed, masked by dev's superuser owner). The function reads `house`, which
+-- is a parent_deny table (house.parent_deny USING app.current_parent_user IS NULL). On PROD the SECURITY
+-- DEFINER owner is a NON-SUPERUSER bound by FORCE RLS (there is no BYPASSRLS role). So when the parent
+-- portal calls it inside a parent session (app.current_parent_user set), house.parent_deny DENIES the
+-- read → the original LANGUAGE sql function returned 0 ROWS → the parent House-PTA card silently fell back
+-- to the generic "House PTA" label instead of the real House name (R483/R484). This is FAIL-CLOSED: no
+-- crash, no leak — the cost was a generic label, never another family's house or a housemaster's identity.
+-- DEV never saw it because its superuser owner bypasses RLS inside the definer body (the same class of trap
+-- Quinn caught on parent_bump_conversation).
+--
+-- 🔴 THE FIX — THE GUC-CLEAR DEVICE (same as parent_bump_conversation, prod-paste-0094). Convert to
+-- plpgsql and CLEAR app.current_parent_user for exactly the one scoped read (house.parent_deny USING
+-- pu IS NULL → TRUE), then RESTORE it. app.current_school STAYS set, so tenant_isolation still fences the
+-- school (defence in depth). The own-child scope uses the CAPTURED function ARG `pu` (never the cleared
+-- GUC), so relaxing the GUC cannot widen the result — a parent still sees ONLY their own children's houses.
+-- set_config(...,true) is transaction-local: an error mid-RETURN aborts the enclosing tx and rolls the
+-- clear back, so the caller's session GUC can never leak across statements (the reasoning Sarah accepted
+-- for parent_bump_conversation).
+--
+-- 🔴 STILL THE IMMUTABLE COLUMN GUARD. The projection is unchanged: it returns ONLY (id, name), so a
+-- parent can never reach hm_user_id / colour / capacity / etc. `house` STAYS parent_deny — this paste does
+-- NOT open the row and does NOT change any table's parent_scope status, so the parent_deny catalog is
+-- UNCHANGED (a function was replaced, no policy moved). search_path = public, pg_temp with pg_temp LAST so
+-- an injected temp `house`/`students` cannot spoof the answer. `pu` is the GUC arg, never a row column; a
+-- NULL pu / school → early RETURN → 0 rows (fail-closed). parent_student_ids() (prod-paste-0055) already
+-- ships on prod and is NOT re-created here.
+--
+-- 🔴 STAFF ARE UNAFFECTED. Staff / webhook / escalated sessions never set app.current_parent_user. The
+-- portal only calls this fn from a parent session; a staff caller passing a `pu` would still only read
+-- that pu's own children's houses (the projection + own-child scope are unchanged), and clearing an
+-- already-unset GUC is a no-op. No staff access is widened or narrowed.
+--
+-- ⚠ WHAT HAPPENS IF THIS IS NOT RUN — FAIL-CLOSED, NEVER A LEAK. db:policies configures LOCAL DEV ONLY.
+-- Without this paste the OLD LANGUAGE sql function stays on prod and the parent House-PTA card keeps the
+-- generic "House PTA" label — the cost of skipping is a generic label, not exposure.
+--
+-- Verify afterwards (db/sql/verify-prod-rls.sql):
+--   -- Query 1 must return ZERO ROWS (no table opened); tenant_tables / parent_readable / parent_denied
+--   -- are ALL UNCHANGED (a function was replaced, no policy moved).
+--   -- Language check: SELECT l.lanname FROM pg_proc p JOIN pg_language l ON l.oid = p.prolang
+--   --                 WHERE p.proname = 'parent_house_names';  -- must be 'plpgsql'.
+
+-- ---- SECURITY DEFINER helper: the parent's OWN children's houses as (id, name) ONLY, with the GUC-clear.
+CREATE OR REPLACE FUNCTION parent_house_names(school uuid, pu uuid)
+  RETURNS TABLE(house_id uuid, house_name text)
+  LANGUAGE plpgsql
+  STABLE
+  SECURITY DEFINER
+  SET search_path = public, pg_temp
+AS $$
+DECLARE
+  prev text := current_setting('app.current_parent_user', true);  -- capture, restore verbatim (pu is an ARG)
+BEGIN
+  IF pu IS NULL OR school IS NULL THEN RETURN; END IF;
+  PERFORM set_config('app.current_parent_user', '', true);  -- relax house.parent_deny for the scoped read
+  RETURN QUERY
+    SELECT DISTINCT h.id, h.name
+    FROM house h
+    WHERE h.school_id = school
+      AND h.id IN (
+        SELECT DISTINCT s.house_id
+        FROM students s
+        WHERE s.school_id = school
+          AND s.house_id IS NOT NULL
+          AND s.id IN (SELECT parent_student_ids(school, pu))
+      );
+  PERFORM set_config('app.current_parent_user', COALESCE(prev, ''), true);  -- restore the caller's own GUC
+END;
+$$;
+-- On Supabase every public function is a PostgREST RPC and EXECUTE defaults to PUBLIC. This fn now CLEARS
+-- the parent GUC as the definer owner, so harden it: it must not be anon-callable (the owner keeps EXECUTE
+-- regardless of the REVOKE; a caller without app.current_school is still fenced by tenant_isolation).
+REVOKE EXECUTE ON FUNCTION parent_house_names(uuid, uuid) FROM PUBLIC;
+DO $$ BEGIN
+  IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'omnischools_app') THEN
+    GRANT EXECUTE ON FUNCTION parent_house_names(uuid, uuid) TO omnischools_app;
+  END IF;
+END $$;

--- a/omnischools/scripts/rls-test.ts
+++ b/omnischools/scripts/rls-test.ts
@@ -338,6 +338,84 @@ async function main() {
         if ((e as Error).message !== ROLLBACK_B) throw e;
       }
     }
+
+    // ---------------------------------------------------------------------------------------------
+    // Parent House-PTA relabel — BEHAVIORAL RLS probe (INCR-58 R483/R484, prod-paste-0096).
+    //
+    // parent_house_names() is a SECURITY DEFINER helper that reads `house` (a parent_deny table) to give
+    // the parent portal the NAME of their OWN children's houses so it can relabel the generic "House PTA".
+    // On PROD the definer owner is a NON-SUPERUSER bound by FORCE RLS, so the ORIGINAL LANGUAGE sql body
+    // hit house.parent_deny inside a parent session and returned 0 ROWS → the tab silently fell back to
+    // "House PTA" (fail-closed, prod-only, masked by the dev superuser owner). The fix clears
+    // app.current_parent_user for the scoped read then restores it. This probe proves — as the NON-
+    // SUPERUSER omnischools_app owner (prod-shaped) — that a parent RESOLVES their own child's real house
+    // name (not the generic fallback), never another (unlinked) house's name, and 0 across a foreign
+    // tenant. A revert to the un-cleared LANGUAGE sql body turns "own house name resolves" red here.
+    console.log("\nParent House-PTA relabel (behavioral):");
+    const hParentRows = await sql<{ id: string }[]>`select id from ref_user limit 1`;
+    const houseKids = await sql<{ sid: string; hname: string }[]>`
+      select distinct on (s.house_id) s.id as sid, h.name as hname
+      from students s join house h on h.id = s.house_id
+      where s.school_id = ${schoolId} and s.house_id is not null
+      order by s.house_id, s.id`;
+    if (hParentRows.length < 1 || houseKids.length < 2) {
+      console.log("• skipped — needs ≥1 ref_user and ≥2 students in DISTINCT houses in the seeded school.");
+    } else {
+      const hParent = hParentRows[0].id;
+      const ownKid = houseKids[0].sid;
+      const ownHouse = houseKids[0].hname; // the parent's OWN child's house name
+      const otherHouse = houseKids[1].hname; // a real house the parent is NOT linked to
+      const ROLLBACK_H = "__parent_house_probe_rollback__";
+      try {
+        await sql.begin(async (tx) => {
+          // ---- superuser setup: link the parent to ONE child (in ownHouse) ----
+          await tx`insert into student_guardian
+                     (id, school_id, student_id, name, relationship, phone, is_primary, user_id)
+                   values (gen_random_uuid(), ${schoolId}, ${ownKid}, 'RLSTEST', 'MOTHER',
+                           '+233RLSHOUSE1', true, ${hParent})`;
+          // prod-shape: definer owner = the non-superuser role subject to FORCE RLS (dev default owner is
+          // a superuser that bypasses RLS inside the body and would MASK the prod-only defect).
+          await tx`alter function parent_house_names(uuid, uuid) owner to omnischools_app`;
+
+          // ---- act as the parent (RLS enforced) ----
+          await tx`set local role omnischools_app`;
+          await tx`select set_config('app.current_school', ${schoolId}, true)`;
+          await tx`select set_config('app.current_parent_user', ${hParent}, true)`;
+
+          const own = await tx<{ house_name: string }[]>`
+            select house_name from parent_house_names(${schoolId}, ${hParent})`;
+          const names = own.map((r) => r.house_name);
+          assertTrue("parent resolves own child's house name (not the generic fallback)", names.includes(ownHouse));
+          assertTrue("parent does NOT resolve an unlinked house's name", !names.includes(otherHouse));
+
+          // cross-TENANT: scoped to a FOREIGN school, tenant_isolation still fences (GUC-clear can't widen)
+          await tx`select set_config('app.current_school', ${FOREIGN_ID}, true)`;
+          const foreign = await tx<{ house_name: string }[]>`
+            select house_name from parent_house_names(${schoolId}, ${hParent})`;
+          assert("parent in foreign tenant resolves 0 house names", foreign.length, 0);
+
+          // prev-restore lock (Wells's nuance): the fn restores the PREVIOUS parent GUC, NOT the `pu` ARG.
+          // Parent-shape → restored verbatim; staff-shape (GUC unset, a pu passed as an arg) → left EMPTY,
+          // never mis-scoped as pu. A naive `pu::text` restore would fail the staff assertion below.
+          await tx`select set_config('app.current_school', ${schoolId}, true)`; // back to own school
+          const afterParent = await tx<{ v: string | null }[]>`
+            select current_setting('app.current_parent_user', true) as v`;
+          assertTrue("parent GUC restored to the caller's value after a call", afterParent[0]?.v === hParent);
+          await tx`select set_config('app.current_parent_user', '', true)`; // staff/escalated shape (GUC unset)
+          await tx`select house_name from parent_house_names(${schoolId}, ${hParent})`;
+          const afterStaff = await tx<{ v: string | null }[]>`
+            select current_setting('app.current_parent_user', true) as v`;
+          assertTrue(
+            "a pu-arg call leaves an unset parent GUC empty (not mis-scoped as pu)",
+            (afterStaff[0]?.v ?? "") === "",
+          );
+
+          throw new Error(ROLLBACK_H); // discard the probe row + the owner switch
+        });
+      } catch (e) {
+        if ((e as Error).message !== ROLLBACK_H) throw e;
+      }
+    }
   } finally {
     await sql.end();
   }


### PR DESCRIPTION
## The bug (prod-only, masked by the dev superuser)

`parent_house_names` (INCR-58) is a `SECURITY DEFINER` function that reads the `parent_deny` `house` table to give the parent PTA tab the **name** of the child's own house (for the House-PTA relabel, R483/R484). It read `house` **without clearing `app.current_parent_user`**. On **prod** the definer owner is a non-superuser bound by FORCE RLS, so a parent-session call hit `house.parent_deny` → **0 rows** → the tab silently fell back to the generic "House PTA" label. Fail-closed (no crash, no leak), which is why it went unnoticed — dev's superuser owner bypasses RLS and masks it. Found in passing during the Billing design.

## The fix

Convert `LANGUAGE sql` → `plpgsql` with the **GUC-clear device** (the same pattern shipped + vetted in `parent_bump_conversation`): clear `app.current_parent_user` for the scoped `house` read, keep `app.current_school` set (so `tenant_isolation` still fences), restore afterward. Own-child scope uses the captured fn **arg** `pu`, so relaxing the GUC cannot widen the result. Added `REVOKE EXECUTE FROM PUBLIC` + grant to the app role.

**One subtle correctness point:** because `pu` here is a function **arg** (not GUC-derived as in `parent_bump_conversation`), the restore captures and re-sets the **previous** GUC value (`COALESCE(prev,'')`), **not** `pu::text` — otherwise a staff caller passing a `pu` arg would be left mis-scoped as that parent for the rest of the tx. Regression-locked in the probe.

## Verification (non-superuser, prod-shaped — fn owner switched to `omnischools_app`)
`scripts/rls-test.ts` "Parent House-PTA relabel" — 5/5 green: before = 0 rows (bug reproduced), after = the child's real house name; unlinked house not resolved; foreign tenant 0; **parent GUC restored verbatim; a pu-arg call leaves an unset GUC empty (not mis-scoped)**. Mutation-probe: removing the clear reds the "resolves own house name" assertion.

## Same-class scan
`parent_house_names` was the **only** `SECURITY DEFINER` function reading a `parent_deny` table in a parent session without the clear — every other parent-session definer reads parent-readable tables; the staff-session definers that read denied tables are never invoked in a parent session (`pu IS NULL` no-op). Nothing else to fix.

## Gates
- **Quinn: GREEN** — behavioral (prod-shaped), mutation-probe, prev-restore verified, no app regression (145 tests, `tsc` 0; signature unchanged so the PTA reader is untouched).
- **Sarah: CLEAR-TO-MERGE** — all 8 attacker checks pass; security-positive (closes a fail-closed defect, opens nothing); the GUC-clear can't widen (arg-scoped), the tenant fence survives, prev-restore prevents mis-scoping.
- Dex not run — DB-only, no app/architecture surface (only non-SQL change is test-only); Sarah concurred.

## ⚠️ Owner action at deploy
**Hand-run `db/sql/prod-paste-0096-fix-parent-house-names.sql`** on prod (supersedes 0084; same name/signature, callers unaffected). Verify: the function's `lanname` is `plpgsql`; `verify-prod-rls.sql` Query 1 returns 0 rows (no policy moved). Until pasted, prod stays fail-closed on the generic label — never a leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)