### PR TITLE
feat(parent): Boarding tab (lean v1) — placement + visiting + term dates

### DIFF
--- a/omnischools/app/(parent)/boarding/page.tsx
+++ b/omnischools/app/(parent)/boarding/page.tsx
@@ -1,0 +1,212 @@
+import { requireParent } from "@/lib/auth/server";
+import { loadParentPortal } from "@/lib/parent/parent-portal-data";
+import {
+  loadParentBoarding,
+  type ParentBoarderChild,
+  type ParentBoardingDate,
+  type ParentVisitingDay,
+  type ParentVisitingPolicy,
+} from "@/lib/parent/parent-boarding-data";
+import { relationshipLabel, parentLongDate } from "@/lib/wassce/parent-copy";
+import { ParentHeader, ParentNav } from "../parent-chrome";
+
+/**
+ * INCR-BOARD · the parent-portal Boarding tab (lean v1) — a boarder's guardian sees their own child's House/
+ * dormitory + prefect badge, the school's visiting days + policy, and resumption/vacation dates. Read-only.
+ * Gates on the child being a BOARDER — DAY / DEBOARDINIZED children collapse to a neutral "not a boarder"
+ * state, never revealing a removal (the discipline ledger stays parent_deny). Placement is own-child only
+ * (the projection never enumerates the dorm roster). No bunk number (owner call), no exeat (phase 2), no
+ * gateway/write. URL /boarding; the tab shows only at boarding schools (ParentNav gates on schoolType).
+ */
+export const dynamic = "force-dynamic";
+
+const longDay = (iso: string): string => parentLongDate(new Date(`${iso}T00:00:00Z`));
+
+export default async function ParentBoardingPage() {
+  const { user, school } = await requireParent();
+  const [data, boarding] = await Promise.all([
+    loadParentPortal(school.id, user.id),
+    loadParentBoarding(school.id, user.id),
+  ]);
+  const child = data.children[0] ?? null;
+  const guardianDisplay = data.guardianName ?? user.name ?? "Parent";
+  const relation = data.guardianRelationship ? relationshipLabel(data.guardianRelationship) : "Parent";
+
+  return (
+    <div className="mx-auto max-w-[980px]">
+      <ParentHeader
+        schoolName={school.name}
+        childName={child?.fullName ?? null}
+        guardianDisplay={guardianDisplay}
+        relation={relation}
+      />
+      <ParentNav active="Boarding" />
+
+      <div className="px-7 pb-9 pt-6">
+        {!child ? (
+          <NoChild />
+        ) : !boarding.hasBoarder ? (
+          <NotABoarder firstName={child.firstName} />
+        ) : (
+          <div className="space-y-6">
+            {boarding.boarders.map((b, i) => (
+              <PlacementCard key={i} boarder={b} />
+            ))}
+            <Visiting days={boarding.visitingDays} policy={boarding.visitingPolicy} />
+            <TermDates dates={boarding.termDates} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** No portal-linked child — a linking issue (mirrors the sibling tabs). */
+function NoChild() {
+  return (
+    <div className="rounded-xl border border-border bg-surface px-6 py-8 text-center text-[13px] leading-relaxed text-navy-2">
+      No student is linked to this portal yet. Please contact the school office.
+    </div>
+  );
+}
+
+/** Neutral not-a-boarder state — DAY and (silently) DEBOARDINIZED both land here; no removal is ever shown. */
+function NotABoarder({ firstName }: { firstName: string }) {
+  return (
+    <div className="rounded-xl border border-border bg-surface px-6 py-8 text-center">
+      <div className="font-display text-base font-medium text-navy">{firstName} is a day student.</div>
+      <div className="mt-1.5 text-[13px] leading-relaxed text-navy-2">
+        Boarding information appears here for boarders.
+      </div>
+    </div>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────── placement ── */
+
+function PlacementCard({ boarder }: { boarder: ParentBoarderChild }) {
+  if (boarder.state === "AWAITING") {
+    return (
+      <section className="rounded-xl border border-border bg-surface px-[26px] py-[22px]">
+        <div className="mb-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-navy-3">
+          Boarding placement
+        </div>
+        <p className="text-[13px] leading-relaxed text-navy-2">
+          {boarder.firstName}&apos;s bunk hasn&apos;t been assigned yet. The House will place {boarder.firstName}{" "}
+          at resumption.
+        </p>
+      </section>
+    );
+  }
+  return (
+    <section
+      className="rounded-xl border border-gold-soft px-[26px] py-[22px]"
+      style={{ background: "linear-gradient(135deg,#F5EBDC 0%,#FAF7F2 100%)" }}
+    >
+      <div className="mb-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-navy-3">
+        Boarding placement
+      </div>
+      <h2 className="font-display text-xl font-medium leading-snug text-navy">
+        {boarder.firstName} boards in <em className="text-gold">{boarder.houseName}</em>.
+      </h2>
+      {boarder.dormName && (
+        <p className="mt-1 font-mono text-[13px] text-navy-2">{boarder.dormName}</p>
+      )}
+      {boarder.prefectLabel && (
+        <div className="mt-3">
+          <span className="inline-flex items-center rounded-pill bg-gold px-2.5 py-[3px] text-[11px] font-semibold text-navy">
+            {boarder.prefectLabel}
+          </span>
+          <p className="mt-1.5 text-xs leading-relaxed text-navy-3">
+            An honour role in {boarder.houseName}. Well done, {boarder.firstName}.
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────── visiting ── */
+
+function Visiting({
+  days,
+  policy,
+}: {
+  days: ParentVisitingDay[];
+  policy: ParentVisitingPolicy | null;
+}) {
+  return (
+    <section className="overflow-hidden rounded-xl border border-border bg-surface">
+      <div className="border-b border-border bg-bg px-6 py-[18px]">
+        <h3 className="font-display text-base font-medium text-navy">Visiting days</h3>
+        <div className="text-[11px] text-navy-3">Approved visitors only</div>
+      </div>
+      {days.length === 0 ? (
+        <div className="px-6 py-6 text-[13px] leading-relaxed text-navy-2">
+          No visiting days have been published for this term yet.
+        </div>
+      ) : (
+        days.map((d, i) => (
+          <div
+            key={i}
+            className="grid grid-cols-[1fr_auto] items-center gap-4 border-b border-border px-6 py-4 last:border-b-0"
+          >
+            <span className="font-display text-[15px] font-medium text-navy">{d.label}</span>
+            <span className="text-right font-mono text-[13px] text-navy-2">{longDay(d.date)}</span>
+          </div>
+        ))
+      )}
+      {policy && (
+        <div className="border-t border-border bg-bg px-6 py-4">
+          <div className="mb-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-navy-3">
+            Visiting policy
+          </div>
+          <dl className="space-y-1.5 text-[13px]">
+            <PolicyRow label="Cadence" value={policy.cadence} />
+            <PolicyRow label="Hours" value={policy.hours} />
+            <PolicyRow label="Lunch served" value={policy.lunch} />
+            <PolicyRow label="Dormitories" value={policy.dormitories} />
+            <PolicyRow label="Who may visit" value={policy.approvedVisitors} />
+          </dl>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function PolicyRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-4">
+      <dt className="text-navy-3">{label}</dt>
+      <dd className="text-right font-medium text-navy-2">{value}</dd>
+    </div>
+  );
+}
+
+/* ────────────────────────────────────────────────────── resumption/vacation ── */
+
+function TermDates({ dates }: { dates: ParentBoardingDate[] }) {
+  return (
+    <section className="overflow-hidden rounded-xl border border-border bg-surface">
+      <div className="border-b border-border bg-bg px-6 py-[18px]">
+        <h3 className="font-display text-base font-medium text-navy">Resumption &amp; vacation</h3>
+        <div className="text-[11px] text-navy-3">Boarding term dates</div>
+      </div>
+      {dates.length === 0 ? (
+        <div className="px-6 py-6 text-[13px] leading-relaxed text-navy-2">
+          Your school hasn&apos;t published its boarding term dates yet.
+        </div>
+      ) : (
+        dates.map((d, i) => (
+          <div
+            key={i}
+            className="grid grid-cols-[1fr_auto] items-center gap-4 border-b border-border px-6 py-4 last:border-b-0"
+          >
+            <span className="text-[15px] text-navy">{d.label}</span>
+            <span className="text-right font-mono text-[13px] text-navy-2">{longDay(d.date)}</span>
+          </div>
+        ))
+      )}
+    </section>
+  );
+}

--- a/omnischools/app/(parent)/parent-chrome.tsx
+++ b/omnischools/app/(parent)/parent-chrome.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { avatarInitials, initialSurname } from "@/lib/wassce/parent-copy";
+import { requireParent } from "@/lib/auth/server";
 
 /**
  * The shared parent-portal chrome (SHS module 4.3) — header + flat nav, extracted from the wassce page so
@@ -60,34 +61,39 @@ export type ParentTab =
   | "Fees"
   | "Sickbay"
   | "PTA"
+  | "Boarding"
   | "School calendar";
 
-// INCR-278 → +Attendance → +Messages → +Fees — flat tabs, ALL live routes (Boarding returns behind its own
-// increment). "Fees" is the read-only fee statement (URL /statement — the staff routes are /fees + /billing).
-// 7 < 12, so the nav stays flat. Every entry below has an HREF.
-const TABS = ["WASSCE", "Attendance", "Messages", "Fees", "Sickbay", "PTA", "School calendar"] as const;
-const HREF: Record<(typeof TABS)[number], string> = {
+// INCR-278 → +Attendance → +Messages → +Fees → +Boarding. Unique URLs where a staff route owns the obvious
+// segment (parent routes share the (app) namespace): Attendance→/attendance-summary (staff /attendance),
+// Messages→/messages (staff /communication), Fees→/statement (staff /fees + /billing). Boarding→/boarding
+// (free — staff boarding is nested at /senior/boarding) and shows ONLY at boarding schools
+// (schoolType !== "BASIC"); ParentNav gates it. 8 < 12 → the nav stays flat.
+const ALL_TABS = ["WASSCE", "Attendance", "Messages", "Fees", "Sickbay", "PTA", "Boarding", "School calendar"] as const;
+const HREF: Record<(typeof ALL_TABS)[number], string> = {
   WASSCE: "/wassce",
-  // URL is /attendance-summary (the /attendance path is the STAFF marking route — parent routes share the
-  // (app) route namespace, so the parent tab needs a unique segment); the tab LABEL stays "Attendance".
   Attendance: "/attendance-summary",
-  // URL is /messages — the STAFF route is /communication (parent routes share the (app) namespace).
   Messages: "/messages",
-  // URL is /statement — BOTH /fees and /billing are STAFF routes; the tab LABEL is "Fees".
   Fees: "/statement",
   Sickbay: "/sickbay",
   PTA: "/pta",
+  Boarding: "/boarding",
   "School calendar": "/calendar",
 };
 
 /**
- * The flat parent nav; `active` is the current one. Every non-active tab is a real <Link> (all four are live
- * routes — no inert spans, R234). NO unread dot — it would be faked with no open-episode source (R234).
+ * The flat parent nav; `active` is the current one. Every non-active tab is a real <Link> (no inert spans,
+ * R234). NO unread dot — it would be faked with no open-episode source (R234). Async server component: it
+ * self-gates the Boarding tab on the school type (via requireParent — already resolved this request), so the
+ * shipped pages need no new prop; a BASIC (non-boarding) school never sees Boarding.
  */
-export function ParentNav({ active }: { active: ParentTab }) {
+export async function ParentNav({ active }: { active: ParentTab }) {
+  const { school } = await requireParent();
+  const boardingSchool = school.schoolType !== "BASIC"; // SENIOR / COMBINED board; BASIC never does
+  const tabs = ALL_TABS.filter((t) => t !== "Boarding" || boardingSchool);
   return (
     <nav className="flex gap-0 overflow-x-auto border-b border-border bg-surface px-7">
-      {TABS.map((t) => {
+      {tabs.map((t) => {
         const isActive = t === active;
         const cls = isActive
           ? "whitespace-nowrap border-b-2 border-gold px-4 py-3.5 text-[13px] font-semibold text-navy"

--- a/omnischools/db/sql/policies.sql
+++ b/omnischools/db/sql/policies.sql
@@ -1278,6 +1278,129 @@ CREATE POLICY parent_no_update ON receipt AS RESTRICTIVE FOR UPDATE TO public
 CREATE POLICY parent_no_delete ON receipt AS RESTRICTIVE FOR DELETE TO public
   USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
 
+-- ---- INCR — PARENT BOARDING: the TENTH widening of the 19a parent boundary (29 → 31 parent_scope
+-- tables) — the parent-portal BOARDING tab (READ-ONLY, owner-authorised; lean v1). Kept in sync with
+-- db/sql/prod-paste-0097-parent-boarding.sql — this block is DEV; that file is the hand-paste on PROD
+-- (⚠ RLS/functions are NOT auto-applied on prod; without the paste boarding_calendar_event /
+-- boarding_settings keep parent_deny and parent_boarding_placement is simply absent, so the Boarding tab
+-- is an honest empty state — fail-closed, never a leak).
+--
+-- Three parts. (1) TWO school-wide READ-ONLY grants (the visiting-day calendar + the visiting-policy
+-- config) using the billing read-only posture. (2) A SECURITY DEFINER placement PROJECTION that returns
+-- ONLY the own PLACED boarder's House name + dormitory name + prefect badge — NEVER the bunk number
+-- (owner: "full placement except bunk number"). (3) boarding_bunk / boarding_dormitory / house and every
+-- other boarding table stay parent_deny (re-affirmed by the catalog loop below).
+--
+-- 🔴 (1a) boarding_calendar_event — the visiting-Sunday calendar. SCHOOL-WIDE (identical for every child;
+-- no per-student data), tenant-fenced on app.current_school (the INCR-278 calendar shape). BUT the SELECT
+-- scope is STRUCTURALLY CONSTRAINED to `event_type = 'VISITING'`: an EXEAT_WINDOW row is DENIED to a parent
+-- at the RLS layer (Kofi OC-BOARD-EXEAT belt+braces — exeat/leave is phase-2 and must not be reachable via
+-- the visiting grant, not merely filtered by the reader). READ-ONLY: a parent must not forge a visiting day,
+-- so it is the billing posture — parent_scope AS RESTRICTIVE FOR SELECT (own predicate, NO WITH CHECK) +
+-- parent_no_insert (load-bearing: without it tenant_isolation's permissive WITH CHECK admits an own-school
+-- parent INSERT — the forge hole) + parent_no_update / parent_no_delete (0 rows). `pu IS NULL` (staff /
+-- webhook / escalated) → SELECT scope AND every write-deny are TRUE → total no-op; staff calendar is
+-- byte-unchanged.
+--
+-- 🔴 (1b) boarding_settings — the per-school visiting policy (one row/school). Same school-wide read-only
+-- posture; no event_type constraint (the whole row is visiting/inspection policy config a parent may read).
+-- A parent must not forge school policy → the same parent_no_insert/update/delete deny the write.
+--
+-- 🔴 (2) parent_boarding_placement(school, pu) — the placement PROJECTION. boarding_bunk / boarding_dormitory
+-- / house are all parent_deny, so a parent cannot read the spine directly; this SECURITY DEFINER fn is the
+-- immutable column guard AND uses the GUC-CLEAR DEVICE (the parent_bump_conversation / parent_house_names
+-- idiom). Under prod's non-superuser FORCE-RLS definer owner, a plain read of those three parent_deny tables
+-- with the parent GUC still set returns 0 rows → the projection would fail-close; so it CLEARS
+-- app.current_parent_user for the one read (parent_deny's `pu IS NULL` → TRUE, the definer traverses the
+-- spine) then RESTORES it. app.current_school stays set → tenant_isolation still fences the school. Own-child
+-- fencing does NOT rely on the GUC — it uses the CAPTURED pu ARG via parent_student_ids. It returns ONLY
+-- (student_id, house_name, dorm_name, prefect_role) — NEVER bunk_position / house_id / dorm_id / bunk_id /
+-- hm_user_id / colour / capacity / gender / section_label — so a parent can never reach the bunk number or
+-- staff PII even via a mutated reader. One row per own PLACED boarder (current_bunk_id NOT NULL); an
+-- unplaced boarder → no row. STABLE, search_path public,pg_temp (pg_temp LAST). REVOKE PUBLIC + GRANT app.
+
+-- boarding_calendar_event — the visiting-Sunday calendar. SCHOOL-WIDE, CONSTRAINED to event_type='VISITING'
+-- (EXEAT_WINDOW rows are denied at the RLS layer, not just filtered). READ-ONLY.
+DROP POLICY IF EXISTS parent_deny ON boarding_calendar_event;
+DROP POLICY IF EXISTS parent_scope ON boarding_calendar_event;
+DROP POLICY IF EXISTS parent_no_insert ON boarding_calendar_event;
+DROP POLICY IF EXISTS parent_no_update ON boarding_calendar_event;
+DROP POLICY IF EXISTS parent_no_delete ON boarding_calendar_event;
+CREATE POLICY parent_scope ON boarding_calendar_event AS RESTRICTIVE FOR SELECT TO public
+  USING (
+    NULLIF(current_setting('app.current_parent_user', true), '') IS NULL
+    OR (
+      school_id = NULLIF(current_setting('app.current_school', true), '')::uuid
+      AND event_type = 'VISITING'
+    )
+  );
+CREATE POLICY parent_no_insert ON boarding_calendar_event AS RESTRICTIVE FOR INSERT TO public
+  WITH CHECK (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_update ON boarding_calendar_event AS RESTRICTIVE FOR UPDATE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_delete ON boarding_calendar_event AS RESTRICTIVE FOR DELETE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+
+-- boarding_settings — the per-school visiting policy (one row/school). SCHOOL-WIDE. READ-ONLY.
+DROP POLICY IF EXISTS parent_deny ON boarding_settings;
+DROP POLICY IF EXISTS parent_scope ON boarding_settings;
+DROP POLICY IF EXISTS parent_no_insert ON boarding_settings;
+DROP POLICY IF EXISTS parent_no_update ON boarding_settings;
+DROP POLICY IF EXISTS parent_no_delete ON boarding_settings;
+CREATE POLICY parent_scope ON boarding_settings AS RESTRICTIVE FOR SELECT TO public
+  USING (
+    NULLIF(current_setting('app.current_parent_user', true), '') IS NULL
+    OR school_id = NULLIF(current_setting('app.current_school', true), '')::uuid
+  );
+CREATE POLICY parent_no_insert ON boarding_settings AS RESTRICTIVE FOR INSERT TO public
+  WITH CHECK (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_update ON boarding_settings AS RESTRICTIVE FOR UPDATE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_delete ON boarding_settings AS RESTRICTIVE FOR DELETE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+
+-- parent_boarding_placement — the own-PLACED-boarder placement projection (House + dorm + prefect, NEVER
+-- the bunk number). GUC-clear device: boarding_bunk / boarding_dormitory / house stay parent_deny, so this
+-- SECURITY DEFINER fn clears app.current_parent_user for the one read then restores it VERBATIM.
+CREATE OR REPLACE FUNCTION parent_boarding_placement(school uuid, pu uuid)
+  RETURNS TABLE(student_id uuid, house_name text, dorm_name text, prefect_role text)
+  LANGUAGE plpgsql
+  STABLE
+  SECURITY DEFINER
+  SET search_path = public, pg_temp
+AS $$
+DECLARE
+  prev text := current_setting('app.current_parent_user', true);  -- caller's GUC, captured VERBATIM
+BEGIN
+  IF pu IS NULL THEN RETURN; END IF;  -- no parent arg → 0 rows (fail-closed); GUC untouched
+  -- Relax parent_deny on the spatial spine for THIS read only (parent_deny's `pu IS NULL` → TRUE). Own-child
+  -- fencing uses the CAPTURED pu ARG (parent_student_ids), NOT the now-cleared GUC; app.current_school stays
+  -- set so tenant_isolation still fences the school.
+  PERFORM set_config('app.current_parent_user', '', true);
+  RETURN QUERY
+    SELECT s.id, h.name, d.name, b.prefect_role::text
+    FROM students s
+    JOIN boarding_bunk b      ON b.school_id = s.school_id AND b.id = s.current_bunk_id
+    JOIN boarding_dormitory d ON d.school_id = b.school_id AND d.id = b.dormitory_id
+    JOIN house h              ON h.school_id = d.school_id AND h.id = d.house_id
+    WHERE s.school_id = school
+      AND s.current_bunk_id IS NOT NULL
+      AND s.id IN (SELECT parent_student_ids(school, pu));
+  -- RESTORE the caller's GUC VERBATIM. COALESCE(prev,'') because current_setting(...,true) yields NULL when
+  -- unset. NEVER pu::text: pu is a fn ARG that may differ from the caller's session GUC — a pu::text restore
+  -- would mis-scope a caller whose GUC is unset (or differs), forging a scope that was never there.
+  PERFORM set_config('app.current_parent_user', COALESCE(prev, ''), true);
+END;
+$$;
+-- On Supabase every public function is a PostgREST RPC and EXECUTE defaults to PUBLIC; a privileged
+-- SECURITY DEFINER read must not be anon-callable (no-op without the GUCs, but harden anyway).
+REVOKE EXECUTE ON FUNCTION parent_boarding_placement(uuid, uuid) FROM PUBLIC;
+DO $$ BEGIN
+  IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'omnischools_app') THEN
+    GRANT EXECUTE ON FUNCTION parent_boarding_placement(uuid, uuid) TO omnischools_app;
+  END IF;
+END $$;
+
 -- ---- layer 1: parent_deny on every tenant table EXCEPT the parent-readable set (CATALOG-DRIVEN) ----
 -- This USED to be a hand-maintained 77-name array; a new tenant table that got tenant_isolation but was
 -- forgotten here escaped the parent boundary silently (Dex BLOCK; student_health_record was the leak).

--- a/omnischools/db/sql/prod-paste-0097-parent-boarding.sql
+++ b/omnischools/db/sql/prod-paste-0097-parent-boarding.sql
@@ -1,0 +1,202 @@
+-- Omnischools — PROD paste 0097: PARENT BOARDING SCOPE (INCR — parent-portal Boarding tab, READ-ONLY, lean v1).
+-- POLICY + FUNCTION ONLY — ZERO new tables, ZERO enums, ZERO altered columns, ZERO backfills. It adds two
+-- narrow SELECT-only school-wide `parent_scope` grants (+ write-deny policies) to EXACTLY TWO existing tables
+-- (boarding_calendar_event, boarding_settings), one SECURITY DEFINER placement projection
+-- (parent_boarding_placement), and re-runs the catalog-driven parent_deny loop. Idempotent — safe to run
+-- more than once. Paste into the Supabase SQL editor on PROD after merging. Byte-identical in effect to the
+-- "INCR — PARENT BOARDING" block in db/sql/policies.sql (dev, db:policies).
+--
+-- WHAT IT SHIPS. A read-only parent BOARDING tab: a parent linked to a school READS the school's VISITING-day
+-- calendar (boarding_calendar_event, constrained to event_type='VISITING'), the school's visiting policy
+-- (boarding_settings), and — via the projection fn — their OWN PLACED boarder child's placement as House name
+-- + dormitory name + prefect badge. This is the TENTH widening of the INCR-19a parent boundary
+-- (29 → 31 parent_scope tables). Exeat/leave is DEFERRED to phase 2; the bunk NUMBER is deliberately NOT
+-- surfaced (owner: "full placement except bunk number").
+--
+-- 🔴 THE VISITING CONSTRAINT IS STRUCTURAL, NOT A READER FILTER (Kofi OC-BOARD-EXEAT belt+braces). The
+-- boarding_calendar_event SELECT scope is `pu IS NULL OR (school_id = current_school AND event_type='VISITING')`
+-- — an EXEAT_WINDOW row is DENIED to a parent at the RLS layer. Exeat/leave is phase-2 and must not be
+-- reachable via the visiting grant even if a future reader forgets to filter.
+--
+-- 🔴 STRUCTURALLY READ-ONLY (the billing posture). Both config tables use SELECT reach + explicit write
+-- denial — a parent must NOT forge a visiting day or school policy:
+--   • parent_scope     AS RESTRICTIVE FOR SELECT — opens ONLY the readable rows; NO WITH CHECK, so it can
+--     never combine to PERMIT a write.
+--   • parent_no_insert AS RESTRICTIVE FOR INSERT WITH CHECK (pu IS NULL) — a parent INSERT is REJECTED
+--     (without it, tenant_isolation's permissive WITH CHECK alone would admit an own-school INSERT — the
+--     forge hole).
+--   • parent_no_update / parent_no_delete AS RESTRICTIVE FOR UPDATE/DELETE USING (pu IS NULL) — 0 rows.
+-- `pu IS NULL` (staff / webhook / escalated) → the SELECT scope AND every write-deny are TRUE → total no-op;
+-- staff boarding read+write is byte-unchanged. Proven NON-SUPERUSER (omnischools_app) in scripts/rls-test.ts.
+--
+-- 🔴 SCHOOL-WIDE, NOT PER-CHILD (for the two tables). The visiting calendar and the visiting policy are
+-- identical for every child in the school and carry ZERO per-student data, so the scope is the SCHOOL itself,
+-- keyed on the app.current_school GUC withParentScope already sets (and that the permissive tenant_isolation
+-- policy already enforces) — the INCR-278 school-calendar shape. Any parent linked to the school may read them.
+--
+-- 🔴 THE PLACEMENT PROJECTION USES THE GUC-CLEAR DEVICE. boarding_bunk / boarding_dormitory / house are all
+-- parent_deny, so a parent cannot read the spatial spine directly. parent_boarding_placement(school, pu) is a
+-- SECURITY DEFINER fn that is BOTH the immutable column guard (it returns ONLY house_name / dorm_name /
+-- prefect_role — NEVER bunk_position / house_id / dorm_id / bunk_id / hm_user_id / colour / capacity / gender /
+-- section_label, so a parent can never reach the bunk number or staff PII even via a mutated reader) AND uses
+-- the parent_bump_conversation / parent_house_names GUC-clear idiom: under prod's non-superuser FORCE-RLS
+-- definer owner, a plain read of those parent_deny tables with the parent GUC still set returns 0 rows and the
+-- projection fail-closes; so it CLEARS app.current_parent_user for the one read (parent_deny's `pu IS NULL` →
+-- TRUE, the definer traverses the spine) then RESTORES it VERBATIM. app.current_school stays set →
+-- tenant_isolation still fences the school. Own-child fencing does NOT rely on the GUC — it uses the CAPTURED
+-- pu ARG via parent_student_ids(). One row per own PLACED boarder (current_bunk_id NOT NULL); an unplaced
+-- boarder → no row; another child / family / tenant → 0. Depends on parent_student_ids() (prod-paste-0055),
+-- already on prod.
+--
+-- 🔴 RESTORE VERBATIM, NEVER pu::text. `pu` is a fn ARG that may differ from the caller's session GUC (unlike
+-- parent_bump_conversation, whose pu is DERIVED from the GUC). The fn captures `prev := current_setting(
+-- 'app.current_parent_user', true)` and restores `COALESCE(prev, '')`; a pu::text restore would mis-scope a
+-- caller whose GUC is unset (or differs), forging a scope that was never there.
+--
+-- 🔴 NEVER WIDEN — these stay parent_deny (re-affirmed by the catalog loop below, which covers every FORCE-RLS
+-- + school_id table with NO parent_scope): boarding_bunk, boarding_dormitory, house, boarding_approved_visitor,
+-- boarding_visit, boarding_visit_notification, boarding_exeat, exeat_notification, inspections, prep_attendance,
+-- boarding_arrival, bunk_allocation, daily_schedule_template (and every non-boarding tenant table). A parent
+-- reads the two config tables + the projection and NOTHING else in the boarding domain.
+--
+-- ⚠ WHAT HAPPENS IF THIS IS NOT RUN — FAIL-CLOSED, NEVER A LEAK (but paste it WITH the code, not after).
+-- db:policies configures LOCAL DEV ONLY. Without this paste, both grant tables keep parent_deny AND the
+-- function is ABSENT. A DAY / non-boarder parent short-circuits before the placement call → honest empty. But
+-- a parent of a BOARDER child hits the placement call `select … from parent_boarding_placement(…)`, which
+-- 500s ("function does not exist") — fail-CLOSED (a 500 leaks NOTHING: no cross-tenant/cross-child data), but
+-- a LOUD "the paste didn't run" signal, not a silent empty. So run this WITH/BEFORE the code release.
+--
+-- Verify afterwards:
+--   -- the two tables carry parent_scope (SELECT) + parent_no_insert/update/delete; never-widen still denied:
+--   select c.relname, p.polname, p.polcmd from pg_policy p join pg_class c on c.oid = p.polrelid
+--   where c.relname in ('boarding_calendar_event','boarding_settings',
+--                       'boarding_bunk','boarding_dormitory','house','boarding_exeat')
+--   order by 1, 2;
+--   -- the projection fn exists and is owned by / executable to omnischools_app:
+--   select proname, proowner::regrole from pg_proc where proname = 'parent_boarding_placement';
+--   -- and db/sql/verify-prod-rls.sql: Query 1 must return ZERO ROWS; parent_readable up by 2 (31).
+
+-- ---- layer 2: the two new SELECT-only school-wide parent_scope grants + per-command write denials + the
+-- placement projection (byte-identical to db/sql/policies.sql "INCR — PARENT BOARDING" block). `pu IS NULL`
+-- → staff/bypass session → the SELECT scope AND every write-deny are TRUE → total no-op.
+
+-- boarding_calendar_event — the visiting-Sunday calendar. SCHOOL-WIDE, CONSTRAINED to event_type='VISITING'
+-- (EXEAT_WINDOW rows are denied at the RLS layer, not just filtered). READ-ONLY.
+DROP POLICY IF EXISTS parent_deny ON boarding_calendar_event;
+DROP POLICY IF EXISTS parent_scope ON boarding_calendar_event;
+DROP POLICY IF EXISTS parent_no_insert ON boarding_calendar_event;
+DROP POLICY IF EXISTS parent_no_update ON boarding_calendar_event;
+DROP POLICY IF EXISTS parent_no_delete ON boarding_calendar_event;
+CREATE POLICY parent_scope ON boarding_calendar_event AS RESTRICTIVE FOR SELECT TO public
+  USING (
+    NULLIF(current_setting('app.current_parent_user', true), '') IS NULL
+    OR (
+      school_id = NULLIF(current_setting('app.current_school', true), '')::uuid
+      AND event_type = 'VISITING'
+    )
+  );
+CREATE POLICY parent_no_insert ON boarding_calendar_event AS RESTRICTIVE FOR INSERT TO public
+  WITH CHECK (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_update ON boarding_calendar_event AS RESTRICTIVE FOR UPDATE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_delete ON boarding_calendar_event AS RESTRICTIVE FOR DELETE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+
+-- boarding_settings — the per-school visiting policy (one row/school). SCHOOL-WIDE. READ-ONLY.
+DROP POLICY IF EXISTS parent_deny ON boarding_settings;
+DROP POLICY IF EXISTS parent_scope ON boarding_settings;
+DROP POLICY IF EXISTS parent_no_insert ON boarding_settings;
+DROP POLICY IF EXISTS parent_no_update ON boarding_settings;
+DROP POLICY IF EXISTS parent_no_delete ON boarding_settings;
+CREATE POLICY parent_scope ON boarding_settings AS RESTRICTIVE FOR SELECT TO public
+  USING (
+    NULLIF(current_setting('app.current_parent_user', true), '') IS NULL
+    OR school_id = NULLIF(current_setting('app.current_school', true), '')::uuid
+  );
+CREATE POLICY parent_no_insert ON boarding_settings AS RESTRICTIVE FOR INSERT TO public
+  WITH CHECK (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_update ON boarding_settings AS RESTRICTIVE FOR UPDATE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+CREATE POLICY parent_no_delete ON boarding_settings AS RESTRICTIVE FOR DELETE TO public
+  USING (NULLIF(current_setting('app.current_parent_user', true), '') IS NULL);
+
+-- parent_boarding_placement — the own-PLACED-boarder placement projection (House + dorm + prefect, NEVER
+-- the bunk number). GUC-clear device: boarding_bunk / boarding_dormitory / house stay parent_deny, so this
+-- SECURITY DEFINER fn clears app.current_parent_user for the one read then restores it VERBATIM.
+CREATE OR REPLACE FUNCTION parent_boarding_placement(school uuid, pu uuid)
+  RETURNS TABLE(student_id uuid, house_name text, dorm_name text, prefect_role text)
+  LANGUAGE plpgsql
+  STABLE
+  SECURITY DEFINER
+  SET search_path = public, pg_temp
+AS $$
+DECLARE
+  prev text := current_setting('app.current_parent_user', true);  -- caller's GUC, captured VERBATIM
+BEGIN
+  IF pu IS NULL THEN RETURN; END IF;  -- no parent arg → 0 rows (fail-closed); GUC untouched
+  -- Relax parent_deny on the spatial spine for THIS read only (parent_deny's `pu IS NULL` → TRUE). Own-child
+  -- fencing uses the CAPTURED pu ARG (parent_student_ids), NOT the now-cleared GUC; app.current_school stays
+  -- set so tenant_isolation still fences the school.
+  PERFORM set_config('app.current_parent_user', '', true);
+  RETURN QUERY
+    SELECT s.id, h.name, d.name, b.prefect_role::text
+    FROM students s
+    JOIN boarding_bunk b      ON b.school_id = s.school_id AND b.id = s.current_bunk_id
+    JOIN boarding_dormitory d ON d.school_id = b.school_id AND d.id = b.dormitory_id
+    JOIN house h              ON h.school_id = d.school_id AND h.id = d.house_id
+    WHERE s.school_id = school
+      AND s.current_bunk_id IS NOT NULL
+      AND s.id IN (SELECT parent_student_ids(school, pu));
+  -- RESTORE the caller's GUC VERBATIM. COALESCE(prev,'') because current_setting(...,true) yields NULL when
+  -- unset. NEVER pu::text: pu is a fn ARG that may differ from the caller's session GUC — a pu::text restore
+  -- would mis-scope a caller whose GUC is unset (or differs), forging a scope that was never there.
+  PERFORM set_config('app.current_parent_user', COALESCE(prev, ''), true);
+END;
+$$;
+-- On Supabase every public function is a PostgREST RPC and EXECUTE defaults to PUBLIC; a privileged
+-- SECURITY DEFINER read must not be anon-callable (no-op without the GUCs, but harden anyway).
+REVOKE EXECUTE ON FUNCTION parent_boarding_placement(uuid, uuid) FROM PUBLIC;
+DO $$ BEGIN
+  IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'omnischools_app') THEN
+    GRANT EXECUTE ON FUNCTION parent_boarding_placement(uuid, uuid) TO omnischools_app;
+  END IF;
+END $$;
+
+-- ---- layer 1: parent_deny — the CATALOG-DRIVEN loop, verbatim from db/sql/policies.sql ----
+-- 🔴 RUN THIS. It re-affirms RESTRICTIVE parent_deny on every FORCE-RLS + school_id table that does NOT
+-- already carry a parent_scope policy. The two tables above now carry parent_scope, so they stay EXCLUDED;
+-- every never-widen boarding table (boarding_bunk, boarding_dormitory, house, boarding_approved_visitor,
+-- boarding_visit, boarding_visit_notification, boarding_exeat, exeat_notification, inspections,
+-- prep_attendance, boarding_arrival, bunk_allocation, daily_schedule_template) and every other tenant table
+-- (and any future one) stays auto-denied. Idempotent.
+DO $$
+DECLARE
+  tbl text;
+BEGIN
+  FOR tbl IN
+    SELECT c.relname
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = 'public'
+    WHERE c.relkind = 'r'
+      AND c.relforcerowsecurity
+      AND EXISTS (
+        SELECT 1 FROM information_schema.columns col
+        WHERE col.table_schema = 'public'
+          AND col.table_name = c.relname
+          AND col.column_name = 'school_id'
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_policy p
+        WHERE p.polrelid = c.oid AND p.polname = 'parent_scope'
+      )
+    ORDER BY c.relname
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS parent_deny ON %I;', tbl);
+    EXECUTE format(
+      'CREATE POLICY parent_deny ON %I AS RESTRICTIVE FOR ALL TO public '
+      'USING (NULLIF(current_setting(''app.current_parent_user'', true), '''') IS NULL);',
+      tbl
+    );
+  END LOOP;
+END
+$$;

--- a/omnischools/lib/auth/server.ts
+++ b/omnischools/lib/auth/server.ts
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import { redirect } from "next/navigation";
 import { headers } from "next/headers";
 import { eq, and } from "drizzle-orm";
@@ -279,14 +280,19 @@ export async function requireSchoolRole(
  * a school row lands on /start — never a leak. The child(ren) are resolved from the SESSION downstream
  * (resolveParentContext / loadParentPortal under withParentScope), never a URL parameter (Lucy L.2).
  */
-export async function requireParent(): Promise<{ user: AppUser; school: ActiveSchool }> {
-  const user = await requireUser();
-  if (!user.roles.includes("PARENT")) redirect("/dashboard");
-  const school = await getActiveSchool(user);
-  if (!school) redirect("/start");
-  await enforceSessionAge(school);
-  return { user, school };
-}
+// `cache()` — request-level single-flight. requireParent takes no args, so every caller in one render
+// (a page body AND the async ParentNav that self-gates on school.schoolType) shares ONE identity/school
+// resolution instead of re-running the GoTrue hop + identity/getActiveSchool reads per call (Dex INCR-BOARD).
+export const requireParent = cache(
+  async (): Promise<{ user: AppUser; school: ActiveSchool }> => {
+    const user = await requireUser();
+    if (!user.roles.includes("PARENT")) redirect("/dashboard");
+    const school = await getActiveSchool(user);
+    if (!school) redirect("/start");
+    await enforceSessionAge(school);
+    return { user, school };
+  },
+);
 
 /**
  * Page guard for the read-only BOARD/DIRECTOR overview (GOV-2 / R335) — its OWN `(board)` route group,

--- a/omnischools/lib/parent/parent-boarding-data.ts
+++ b/omnischools/lib/parent/parent-boarding-data.ts
@@ -1,0 +1,176 @@
+import "server-only";
+import { and, asc, eq, ne, sql } from "drizzle-orm";
+import { withParentScope } from "@/lib/db/rls";
+import type { Tx } from "@/lib/db";
+import { students, boardingCalendarEvent, boardingSettings, academicPeriod } from "@/db/schema";
+
+/**
+ * 🔴 INCR-BOARD · the PARENT-facing Boarding reader (lean v1 · Kofi AC-BOARD-*). SERVER-ONLY — imports the
+ * db driver, so a client component must never import it (only `pnpm build` catches that leak).
+ *
+ * Three panels, three RLS classes:
+ *  • PLACEMENT (own child) — House/dorm/prefect via the SECURITY DEFINER `parent_boarding_placement` fn
+ *    (prod-paste-0097; boarding_bunk/boarding_dormitory/house STAY parent_deny — the fn is the guard, GUC-clear
+ *    device). The OWNER dropped the bunk NUMBER, so the projection returns house_name/dorm_name/prefect_role only.
+ *  • VISITING (school-wide) — `boarding_calendar_event` (grant CONSTRAINED to event_type='VISITING' — exeat
+ *    windows are structurally denied) + `boarding_settings` (visiting policy fields only; never
+ *    visiting_book_owner / exeat_* / inspection_*).
+ *  • RESUMPTION/VACATION (school-wide) — `academic_period` (already parent-readable since #278), INCLUDING
+ *    SENIOR_F3 (the calendar reader excludes it; here Form-3 early vacation is in scope).
+ *
+ * Residency gate (own child, students is parent-readable): only residency='BOARDER' children get a placement
+ * panel. DAY / DEBOARDINIZED / null collapse to the honest "not a boarder" empty — the removal + its reason
+ * are NEVER surfaced (the discipline/deboardinization ledger stays parent_deny). One row per own child; the
+ * dorm roster / bunk-mates are never enumerated.
+ */
+
+export type BoarderState = "PLACED" | "AWAITING";
+export type ParentBoarderChild = {
+  firstName: string;
+  state: BoarderState;
+  houseName: string | null;
+  dormName: string | null;
+  prefectLabel: string | null; // celebratory badge label, own child only
+};
+export type ParentVisitingDay = { label: string; date: string };
+export type ParentVisitingPolicy = {
+  cadence: string;
+  hours: string; // "12:00 → 16:00"
+  lunch: string;
+  dormitories: string;
+  approvedVisitors: string;
+};
+export type ParentBoardingDate = { label: string; date: string };
+export type ParentBoarding = {
+  hasBoarder: boolean; // any own child residency='BOARDER'
+  boarders: ParentBoarderChild[];
+  visitingDays: ParentVisitingDay[];
+  visitingPolicy: ParentVisitingPolicy | null;
+  termDates: ParentBoardingDate[]; // resumption + vacation, SENIOR + SENIOR_F3
+};
+
+/** Celebratory, parent-facing prefect labels (never the operational HM phrasing). */
+const PREFECT_LABEL: Record<string, string> = {
+  HEAD: "Head of House Prefect",
+  DINING: "Dining Hall Prefect",
+  SANITATION: "Sanitation Prefect",
+  PREP: "Prep Prefect",
+  SICKBAY: "Sickbay Prefect",
+};
+
+/** MUST run on a `tx` already scoped by `withParentScope`. */
+export async function loadParentBoardingTx(
+  tx: Tx,
+  schoolId: string,
+  userId: string,
+  today: string = new Date().toISOString().slice(0, 10),
+): Promise<ParentBoarding> {
+  // Own children + residency (students is parent-readable). NO bunk id / house id read here.
+  const kids = await tx
+    .select({ id: students.id, firstName: students.firstName, residency: students.residency })
+    .from(students)
+    .where(eq(students.schoolId, schoolId))
+    .orderBy(asc(students.firstName));
+  const boarderKids = kids.filter((k) => k.residency === "BOARDER");
+
+  if (boarderKids.length === 0) {
+    // Not a boarder (incl. DAY / DEBOARDINIZED — the removal is never revealed). Nothing else to show.
+    return { hasBoarder: false, boarders: [], visitingDays: [], visitingPolicy: null, termDates: [] };
+  }
+
+  // Placement — the SECURITY DEFINER projection (own child; boarding tables stay parent_deny). No bunk number.
+  const placeRows = (await tx.execute(
+    sql`select student_id, house_name, dorm_name, prefect_role
+        from parent_boarding_placement(${schoolId}::uuid, ${userId}::uuid)`,
+  )) as unknown as { student_id: string; house_name: string; dorm_name: string; prefect_role: string | null }[];
+  const placeById = new Map(placeRows.map((p) => [p.student_id, p]));
+
+  const boarders: ParentBoarderChild[] = boarderKids.map((k) => {
+    const p = placeById.get(k.id);
+    return {
+      firstName: k.firstName,
+      state: p ? "PLACED" : "AWAITING",
+      houseName: p?.house_name ?? null,
+      dormName: p?.dorm_name ?? null,
+      prefectLabel: p?.prefect_role ? (PREFECT_LABEL[p.prefect_role] ?? null) : null,
+    };
+  });
+
+  // Resumption / vacation — SENIOR + SENIOR_F3 (SENIOR_F3 = Form 3 early vacation, IN scope here). Determine
+  // the reference academic year (the term containing today, else the most recent) to bound the visiting list.
+  const periods = await tx
+    .select({
+      label: academicPeriod.periodLabel,
+      academicYear: academicPeriod.academicYear,
+      startsOn: academicPeriod.startsOn,
+      endsOn: academicPeriod.endsOn,
+      productLine: academicPeriod.productLine,
+    })
+    .from(academicPeriod)
+    .where(and(eq(academicPeriod.schoolId, schoolId), ne(academicPeriod.productLine, "BASIC")))
+    .orderBy(asc(academicPeriod.startsOn), asc(academicPeriod.periodNumber));
+
+  const refYear =
+    periods.find((p) => p.startsOn <= today && today <= p.endsOn)?.academicYear ??
+    periods[periods.length - 1]?.academicYear ??
+    null;
+
+  const termDates: ParentBoardingDate[] = [];
+  for (const p of periods.filter((p) => refYear == null || p.academicYear === refYear)) {
+    const f3 = p.productLine === "SENIOR_F3";
+    termDates.push({ label: `${f3 ? "Form 3" : p.label} · resumes`, date: p.startsOn });
+    termDates.push({ label: `${f3 ? "Form 3" : p.label} · vacates`, date: p.endsOn });
+  }
+  termDates.sort((a, b) => a.date.localeCompare(b.date));
+
+  // Visiting days — VISITING events for the reference year (the grant already denies EXEAT_WINDOW; the
+  // reader belt re-affirms it). ascending.
+  const visitRows = await tx
+    .select({
+      label: boardingCalendarEvent.label,
+      date: boardingCalendarEvent.eventDate,
+      academicYear: boardingCalendarEvent.academicYear,
+    })
+    .from(boardingCalendarEvent)
+    .where(
+      and(
+        eq(boardingCalendarEvent.schoolId, schoolId),
+        eq(boardingCalendarEvent.eventType, "VISITING"),
+      ),
+    )
+    .orderBy(asc(boardingCalendarEvent.eventDate));
+  const visitingDays: ParentVisitingDay[] = visitRows
+    .filter((v) => refYear == null || v.academicYear === refYear)
+    .map((v) => ({ label: v.label, date: v.date }));
+
+  // Visiting policy — boarding_settings (one row/school). Column guard: the visiting fields ONLY; never
+  // visiting_book_owner, nor any exeat_*/inspection_* column on the same row.
+  const [s] = await tx
+    .select({
+      cadence: boardingSettings.visitingCadence,
+      hoursStart: boardingSettings.visitingHoursStart,
+      hoursEnd: boardingSettings.visitingHoursEnd,
+      lunch: boardingSettings.visitingLunchTime,
+      dormitories: boardingSettings.visitingDormitoriesRule,
+      approvedVisitors: boardingSettings.visitingApprovedVisitors,
+    })
+    .from(boardingSettings)
+    .where(eq(boardingSettings.schoolId, schoolId))
+    .limit(1);
+  const visitingPolicy: ParentVisitingPolicy | null = s
+    ? {
+        cadence: s.cadence,
+        hours: `${s.hoursStart} → ${s.hoursEnd}`,
+        lunch: s.lunch,
+        dormitories: s.dormitories,
+        approvedVisitors: s.approvedVisitors,
+      }
+    : null;
+
+  return { hasBoarder: true, boarders, visitingDays, visitingPolicy, termDates };
+}
+
+/** Entry point — the parent's boarding view (own children) under `withParentScope` (never `withSchool`). */
+export async function loadParentBoarding(schoolId: string, userId: string): Promise<ParentBoarding> {
+  return withParentScope(schoolId, userId, (tx) => loadParentBoardingTx(tx, schoolId, userId));
+}

--- a/omnischools/lib/parent/parent-boarding.test.ts
+++ b/omnischools/lib/parent/parent-boarding.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { readCode } from "@/lib/test-utils/source-shape";
+
+/**
+ * INCR-BOARD · parent-portal Boarding tab (lean v1). The reader is mostly an IO projection over the
+ * placement RPC + school-wide grants, so source-shape is the guard: placement via the SECURITY DEFINER fn
+ * (boarding tables stay parent_deny), visiting constrained to VISITING (no exeat), the visiting-policy
+ * column guard, residency-gated, and the nav gated to boarding schools. RLS behaviour lives in db:rls-test.
+ */
+
+describe("parent-boarding-data · safe reads under withParentScope (AC-BOARD-*)", () => {
+  const reader = () => readCode("lib/parent/parent-boarding-data.ts");
+
+  it("runs under withParentScope only — never withSchool / withoutTenantScope", () => {
+    const s = reader();
+    expect(s).toMatch(/withParentScope/);
+    expect(s).not.toMatch(/withSchool|withoutTenantScope/);
+  });
+
+  it("placement goes through the SECURITY DEFINER projection — boarding tables are never read directly", () => {
+    const s = reader();
+    expect(s).toMatch(/parent_boarding_placement/); // the guard (house/dorm/prefect; no bunk number)
+    // the parent_deny boarding tables are never imported/selected (the fn is the only reach):
+    expect(s).not.toMatch(/boardingBunk/);
+    expect(s).not.toMatch(/boardingDormitory/);
+    expect(s).not.toMatch(/boardingApprovedVisitor/);
+    expect(s).not.toMatch(/boardingExeat/);
+    expect(s).not.toMatch(/\binspections\b/);
+    expect(s).not.toMatch(/prepAttendance/);
+  });
+
+  it("visiting is constrained to VISITING (exeat windows excluded) and the policy column-guard holds", () => {
+    const s = reader();
+    expect(s).toMatch(/eq\(boardingCalendarEvent\.eventType, "VISITING"\)/); // no EXEAT_WINDOW
+    // boarding_settings: visiting fields only — never the ops/exeat/inspection columns on the same row.
+    expect(s).not.toMatch(/boardingSettings\.visitingBookOwner/);
+    expect(s).not.toMatch(/boardingSettings\.exeat/);
+    expect(s).not.toMatch(/boardingSettings\.inspection/);
+  });
+
+  it("resumption/vacation includes SENIOR_F3 (Form 3 early vacation), unlike the calendar reader", () => {
+    const s = reader();
+    expect(s).toMatch(/ne\(academicPeriod\.productLine, "BASIC"\)/); // SENIOR + SENIOR_F3, not just SENIOR
+    expect(s).not.toMatch(/ne\(academicPeriod\.productLine, "SENIOR_F3"\)/); // must NOT exclude F3
+  });
+
+  it("gates on residency = BOARDER (day/deboardinized collapse to not-a-boarder)", () => {
+    const s = reader();
+    expect(s).toMatch(/residency === "BOARDER"/);
+  });
+});
+
+describe("parent-chrome · Boarding is a boarding-school-only 8th tab", () => {
+  const nav = () => readCode("app/(parent)/parent-chrome.tsx");
+  const page = () => readCode("app/(parent)/boarding/page.tsx");
+
+  it("Boarding is in the tab set at /boarding, gated on schoolType, and self-gating via requireParent", () => {
+    const s = nav();
+    expect(s).toMatch(/"Boarding"/);
+    expect(s).toMatch(/Boarding: "\/boarding"/);
+    expect(s).toMatch(/async function ParentNav/); // async so it can gate
+    expect(s).toMatch(/schoolType !== "BASIC"/); // boarding schools only
+    expect(s).toMatch(/t !== "Boarding" \|\| boardingSchool/); // filtered out for BASIC schools
+    expect(s).not.toMatch(/Partial<Record/);
+    expect((s.match(/<span/g) ?? []).length).toBe(1);
+  });
+
+  it("the boarding route is read-only, active-nav, and never reveals a removal or exeat", () => {
+    const s = page();
+    expect(s).toMatch(/ParentNav active="Boarding"/);
+    expect(s).toMatch(/NoChild/);
+    expect(s).toMatch(/NotABoarder/); // day/deboardinized collapse
+    expect(s).not.toMatch(/^"use client"/m); // read-only server component
+    expect(s).not.toMatch(/Pay now|sendSms|gateway/i); // no write/gateway
+    expect(s).not.toMatch(/deboardiniz|expelled|removed from board/i); // the removal is never shown
+    expect(s).not.toMatch(/\bexeat\b/i); // exeat is phase 2
+  });
+});

--- a/omnischools/lib/parent/parent-calendar.test.ts
+++ b/omnischools/lib/parent/parent-calendar.test.ts
@@ -97,9 +97,10 @@ describe("parent-chrome · no inert tabs, calendar live (AC-CAL-01..04)", () => 
   it("the three inert tabs are gone and School calendar is a live route (no inert spans)", () => {
     const s = nav();
     // quoted → only TABS/HREF/the ParentTab union carry these, never the prose comment.
+    // The two still-unbuilt inert tabs stay absent; "Boarding" returned as a REAL live tab (INCR-BOARD), so
+    // it's no longer asserted absent — the no-inert-span invariant is covered by the checks below.
     expect(s).not.toMatch(/"Communications"/); // AC-CAL-01
     expect(s).not.toMatch(/"Billing"/);
-    expect(s).not.toMatch(/"Boarding"/);
     expect(s).toMatch(/"School calendar": "\/calendar"/); // still a live route — AC-CAL-03
     expect(s).not.toMatch(/Partial<Record/); // HREF is total → no tab can be an inert span — AC-CAL-02
     expect(s).not.toMatch(/coming soon|disabled|greyed/i); // AC-CAL-04

--- a/omnischools/scripts/rls-test.ts
+++ b/omnischools/scripts/rls-test.ts
@@ -416,6 +416,160 @@ async function main() {
         if ((e as Error).message !== ROLLBACK_H) throw e;
       }
     }
+
+    // Parent BOARDING (read-only, lean v1) — BEHAVIORAL RLS probe (INCR — parent Boarding tab,
+    // prod-paste-0097). Proven as the NON-SUPERUSER omnischools_app; the dev superuser masks RLS.
+    //
+    // Three things this closes that a superuser run cannot:
+    //  (1) THE GUC-CLEAR PROJECTION. boarding_bunk/boarding_dormitory/house are parent_deny, so a parent's
+    //      DIRECT read of them returns 0 (asserted below). The placement projection returns 1 row ONLY
+    //      because parent_boarding_placement() clears app.current_parent_user for the definer read — under
+    //      the PROD-SHAPED owner (omnischools_app, FORCE RLS binds the definer body) a no-clear version
+    //      would return 0. So "direct read 0" + "projection 1" together prove the clear is load-bearing.
+    //  (2) THE VISITING CONSTRAINT. A parent SELECT on boarding_calendar_event returns the VISITING row but
+    //      0 EXEAT_WINDOW rows — denied at the RLS layer, not a reader filter.
+    //  (3) READ-ONLY + prev-restore nuance. Every parent write on both config tables is denied; the fn
+    //      restores the caller's GUC VERBATIM (a pu-arg call with the GUC unset leaves it EMPTY, never
+    //      mis-scoped to pu). NO bunk_position column ever leaves the projection.
+    // All rows AND the fn owner switch live in one rolled-back transaction, so nothing persists.
+    console.log("\nParent Boarding read-only path (behavioral):");
+    const brParentRows = await sql<{ id: string }[]>`select id from ref_user limit 1`;
+    const brKids = await sql<{ id: string }[]>`
+      select id from students where school_id = ${schoolId} order by id limit 2`;
+    if (brParentRows.length < 1 || brKids.length < 2) {
+      console.log("• skipped — needs ≥1 ref_user and ≥2 students in the seeded school.");
+    } else {
+      const brParent = brParentRows[0].id;
+      const brOwn = brKids[0].id;
+      const brOther = brKids[1].id; // a real child in the SAME school, NOT linked to this parent
+      const houseId = "11111111-0000-4000-8000-0000000b0001";
+      const dormId = "22222222-0000-4000-8000-0000000b0002";
+      const bunk1 = "33333333-0000-4000-8000-0000000b0003"; // own child, prefect HEAD
+      const bunk2 = "44444444-0000-4000-8000-0000000b0004"; // other child
+      const visitEvt = "55555555-0000-4000-8000-0000000b0005"; // VISITING → parent-readable
+      const exeatEvt = "66666666-0000-4000-8000-0000000b0006"; // EXEAT_WINDOW → parent-DENIED
+      const ROLLBACK_BR = "__parent_boarding_probe_rollback__";
+      try {
+        await sql.begin(async (tx) => {
+          // ---- superuser setup (bypasses RLS) ----
+          await tx`insert into student_guardian
+                     (id, school_id, student_id, name, relationship, phone, is_primary, user_id)
+                   values (gen_random_uuid(), ${schoolId}, ${brOwn}, 'RLSTEST', 'MOTHER',
+                           '+233RLSTESTBR', true, ${brParent})`;
+          await tx`insert into house (id, school_id, name) values (${houseId}, ${schoolId}, 'RLST House')`;
+          await tx`insert into boarding_dormitory (id, school_id, house_id, name)
+                   values (${dormId}, ${schoolId}, ${houseId}, 'RLST Dorm')`;
+          await tx`insert into boarding_bunk (id, school_id, dormitory_id, position_number, prefect_role)
+                   values (${bunk1}, ${schoolId}, ${dormId}, 1, 'HEAD')`;
+          await tx`insert into boarding_bunk (id, school_id, dormitory_id, position_number)
+                   values (${bunk2}, ${schoolId}, ${dormId}, 2)`;
+          await tx`update students set current_bunk_id = ${bunk1} where id = ${brOwn}`; // own PLACED
+          await tx`update students set current_bunk_id = ${bunk2} where id = ${brOther}`; // other PLACED, unlinked
+          await tx`insert into boarding_settings (school_id) values (${schoolId})
+                   on conflict (school_id) do nothing`;
+          await tx`insert into boarding_calendar_event
+                     (id, school_id, academic_year, event_type, event_date, label)
+                   values (${visitEvt}, ${schoolId}, '2025/26', 'VISITING', '2026-03-08', 'RLST Visiting')`;
+          await tx`insert into boarding_calendar_event
+                     (id, school_id, academic_year, event_type, event_date, label)
+                   values (${exeatEvt}, ${schoolId}, '2025/26', 'EXEAT_WINDOW', '2026-03-15', 'RLST Exeat')`;
+          await tx`insert into boarding_approved_visitor (id, school_id, student_id, name, relationship)
+                   values (gen_random_uuid(), ${schoolId}, ${brOwn}, 'RLST Visitor', 'Uncle')`;
+          // prod-shape: definer owner = the non-superuser role FORCE RLS actually binds
+          await tx`alter function parent_boarding_placement(uuid, uuid) owner to omnischools_app`;
+
+          // ---- act as the parent (RLS enforced, non-superuser) ----
+          await tx`set local role omnischools_app`;
+          await tx`select set_config('app.current_school', ${schoolId}, true)`;
+          await tx`select set_config('app.current_parent_user', ${brParent}, true)`;
+          const c = async (t: string, w: string) =>
+            (await tx.unsafe(`select count(*)::int n from ${t} ${w}`))[0].n as number;
+
+          // (1) placement projection — own PLACED child → exactly 1 row with REAL house+dorm+prefect,
+          // NO bunk_position (the GUC-clear works under the prod-shaped owner; a no-clear version → 0).
+          const placement = await tx<
+            { student_id: string; house_name: string; dorm_name: string; prefect_role: string }[]
+          >`select * from parent_boarding_placement(${schoolId}::uuid, ${brParent}::uuid)`;
+          assert("placement returns exactly own placed child", placement.length, 1);
+          assertTrue("placement is the OWN child (not the other placed child)", placement[0]?.student_id === brOwn);
+          assertTrue("placement house_name is the real House", placement[0]?.house_name === "RLST House");
+          assertTrue("placement dorm_name is the real dormitory", placement[0]?.dorm_name === "RLST Dorm");
+          assertTrue("placement prefect_role surfaced", placement[0]?.prefect_role === "HEAD");
+          const pkeys = Object.keys(placement[0] ?? {}).sort().join(",");
+          assertTrue(
+            "placement columns are EXACTLY {student_id,house_name,dorm_name,prefect_role} — no bunk_position/ids",
+            pkeys === "dorm_name,house_name,prefect_role,student_id",
+          );
+          assertTrue("placement row has NO bunk_position column", !("bunk_position" in (placement[0] ?? {})));
+
+          // (3a) prev-restore VERBATIM: the caller's GUC is untouched after the fn returns.
+          const [{ cur }] = await tx<{ cur: string }[]>`
+            select current_setting('app.current_parent_user', true) as cur`;
+          assertTrue("parent GUC restored VERBATIM after placement call", cur === brParent);
+
+          // (2) VISITING readable, EXEAT_WINDOW denied at the RLS layer; boarding_settings readable.
+          assert("parent reads the VISITING event", await c("boarding_calendar_event", `where id='${visitEvt}'`), 1);
+          assert("parent CANNOT read the EXEAT_WINDOW event", await c("boarding_calendar_event", `where id='${exeatEvt}'`), 0);
+          assertAtLeast("parent reads boarding_settings", await c("boarding_settings", `where school_id='${schoolId}'`), 1);
+
+          // (3b) READ-ONLY: every parent write on both config tables is denied.
+          const insDenied = async (label: string, stmt: string) => {
+            let denied = false;
+            try {
+              await tx.savepoint(async (sp) => {
+                await sp.unsafe(stmt);
+              });
+            } catch {
+              denied = true;
+            }
+            assertTrue(label, denied);
+          };
+          await insDenied(
+            "parent INSERT boarding_calendar_event denied (visiting-day forge)",
+            `insert into boarding_calendar_event (id, school_id, academic_year, event_type, event_date, label)
+               values (gen_random_uuid(), '${schoolId}', '2025/26', 'VISITING', '2026-04-12', 'FORGE')`,
+          );
+          await insDenied(
+            "parent INSERT boarding_settings denied (policy forge)",
+            `insert into boarding_settings (id, school_id) values (gen_random_uuid(), '${FOREIGN_ID}')`,
+          );
+          assert("parent UPDATE boarding_calendar_event denied (rows)", (await tx`update boarding_calendar_event set label='X' where id=${visitEvt}`).count, 0);
+          assert("parent UPDATE boarding_settings denied (rows)", (await tx`update boarding_settings set visiting_cadence='X' where school_id=${schoolId}`).count, 0);
+          assert("parent DELETE boarding_calendar_event denied (rows)", (await tx`delete from boarding_calendar_event where id=${visitEvt}`).count, 0);
+          assert("parent DELETE boarding_settings denied (rows)", (await tx`delete from boarding_settings where school_id=${schoolId}`).count, 0);
+
+          // never-widen: a parent's DIRECT read of the spine + exeat/visitor/inspection tables → 0
+          // (boarding_bunk / boarding_approved_visitor have REAL rows here, so 0 proves DENIAL, not emptiness).
+          assert("parent CANNOT read boarding_bunk (spine denied)", await c("boarding_bunk", `where school_id='${schoolId}'`), 0);
+          assert("parent CANNOT read boarding_dormitory (spine denied)", await c("boarding_dormitory", `where school_id='${schoolId}'`), 0);
+          assert("parent CANNOT read house (spine denied)", await c("house", `where id='${houseId}'`), 0);
+          assert("parent CANNOT read boarding_approved_visitor", await c("boarding_approved_visitor", `where student_id='${brOwn}'`), 0);
+          assert("parent CANNOT read boarding_exeat", await c("boarding_exeat", `where school_id='${schoolId}'`), 0);
+          assert("parent CANNOT read inspections", await c("inspections", `where school_id='${schoolId}'`), 0);
+
+          // cross-TENANT: a parent scoped to a FOREIGN school gets 0 placement rows.
+          await tx`select set_config('app.current_school', ${FOREIGN_ID}, true)`;
+          const foreignPlacement = await tx`select * from parent_boarding_placement(${schoolId}::uuid, ${brParent}::uuid)`;
+          assert("placement in foreign tenant returns 0", foreignPlacement.length, 0);
+          await tx`select set_config('app.current_school', ${schoolId}, true)`;
+
+          // (3c) prev-restore with the GUC UNSET: a pu-arg call must leave the GUC EMPTY, not mis-scoped to pu.
+          await tx`select set_config('app.current_parent_user', '', true)`; // simulate an unset caller GUC
+          await tx`select * from parent_boarding_placement(${schoolId}::uuid, ${brParent}::uuid)`;
+          const [{ cur2 }] = await tx<{ cur2: string }[]>`
+            select current_setting('app.current_parent_user', true) as cur2`;
+          assertTrue("pu-arg call with GUC unset leaves it EMPTY (never mis-scoped to pu)", cur2 === "");
+
+          // staff (no parent GUC — pu IS NULL) is byte-unchanged: sees the EXEAT_WINDOW event AND the spine.
+          assert("staff sees the EXEAT_WINDOW event (VISITING constraint is parent-only)", await c("boarding_calendar_event", `where id='${exeatEvt}'`), 1);
+          assertAtLeast("staff sees the boarding spine (≥ the 2 probe bunks)", await c("boarding_bunk", `where school_id='${schoolId}'`), 2);
+
+          throw new Error(ROLLBACK_BR); // discard all probe rows + the fn owner switch
+        });
+      } catch (e) {
+        if ((e as Error).message !== ROLLBACK_BR) throw e;
+      }
+    }
   } finally {
     await sql.end();
   }


### PR DESCRIPTION
## What this ships

The **eighth and final** parent-portal tab — shown **only at boarding schools** (`schoolType !== "BASIC"`). A boarder's guardian sees their own child's **House + dormitory + prefect badge**, the school's **visiting days + policy**, and **resumption/vacation** dates. Read-only, no gateway. Owner-approved lean-v1 scope (design-first checkpoint): full placement **except the bunk number**; **exeat deferred to phase 2**.

The **parent portal is now complete** — WASSCE, Attendance, Messages, Fees, Sickbay, PTA, Boarding, School calendar.

## Changes
- **`db/sql/{policies.sql, prod-paste-0097-parent-boarding.sql}`** — the 10th widening (parent_readable 29 → 31). Two school-wide **READ-ONLY** grants: `boarding_calendar_event` (predicate **constrained to `event_type='VISITING'`** → EXEAT_WINDOW structurally denied) + `boarding_settings`, each `FOR SELECT` + `parent_no_insert`/`update`/`delete`. `parent_boarding_placement(school, pu)` **SECURITY DEFINER** projection (GUC-clear + prev-restore, like the `parent_house_names` fix) returns `{house_name, dorm_name, prefect_role}` — **no bunk number, no ids/PII**; `boarding_bunk`/`dormitory`/`house` stay `parent_deny`. Discipline / approved-visitor / inspection / exeat tables stay denied. Verified non-superuser.
- **`lib/parent/parent-boarding-data.ts`** — reader (`withParentScope` only). Placement via the projection RPC; visiting via the VISITING-constrained grant; policy column-guarded (visiting fields only — never `visiting_book_owner`/exeat/inspection on the same row); resumption/vacation from `academic_period` **including SENIOR_F3**. Residency-gated: only `BOARDER` children get a placement; **DAY and DEBOARDINIZED both collapse to a neutral "not a boarder" — a removal is never revealed.**
- **`app/(parent)/boarding/page.tsx`** — the tab (read-only server component); honest empties.
- **`app/(parent)/parent-chrome.tsx`** — `ParentNav` is now **async** and self-gates the Boarding tab on `school.schoolType` (the 6 shipped pages need no change). URL `/boarding` (staff boarding is nested at `/senior/boarding`).
- **`lib/auth/server.ts`** — `requireParent` wrapped in React `cache()` (request-level single-flight) so the page body + the async nav share one identity/school resolution (Dex — removes the double-auth the async nav would otherwise add portal-wide).
- **`scripts/rls-test.ts`** — behavioral boarding probe (placement own-child + no bunk; exeat/writes/never-widen denied; GUC restored).

## Gates
- **Quinn (QA): GREEN** — all AC-BOARD-01..24; 6/6 probes; 152 tests; `pnpm build` ✓ (all parent routes build under the async cached nav; `/boarding` distinct from `/senior/boarding`); `db:rls-test` green.
- **Dex (architecture): APPROVE** — the self-gating async nav is the right pattern; the required `cache()` fix applied + confirmed; zero new lock-in.
- **Sarah (security): CLEAR-TO-MERGE** — all 8 attacker checks pass (GUC-clear can't widen, exeat structurally denied, write-forge closed, never-widen tables denied, the removal-never-revealed confidentiality boundary holds).

Rebased onto current `main` (over #346's `parent_house_names` fix); the `rls-test.ts` keep-both was resolved here, so the PR is **conflict-free**. Diff vs `origin/main` = **1 commit / 9 files**.

## ⚠️ Owner action at deploy
**Hand-run `db/sql/prod-paste-0097-parent-boarding.sql` on prod *with* the release** (not after). Without it, a DAY/non-boarder parent sees an honest empty, but a **BOARDER** parent's `/boarding` **500s** (the placement function is absent) — fail-closed (no cross-tenant/cross-child leak), but a loud "the paste didn't run" signal.

## Notes / fast-follows
- Exeat/leave (phase 2 — the highest-value item, needs your field-level ruling), the bunk number (you dropped it), an F3-visibility toggle.
- `boarding_settings` is a wide config row; the reader projection is the only column guard there (a future `select *` would surface exeat/inspection policy) — noted in the reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)