### PR TITLE
Exeat Phase 2 — parent SPECIAL request + own-child status (leak-closed)

### DIFF
--- a/omnischools/app/(app)/senior/boarding/exeats/page.tsx
+++ b/omnischools/app/(app)/senior/boarding/exeats/page.tsx
@@ -5,7 +5,7 @@ import { getCurrentUser } from "@/lib/auth";
 import { BOARDING_ROLES } from "@/lib/access";
 import { getExeatBoard, listExeatBoarders, type ExeatRow, type ExeatStage } from "@/lib/boarding/exeat-data";
 import { canSignSpecial } from "@/lib/boarding/exeat-decision";
-import { ActionBar, BulkApprove, NewExeatButton, RunLateChecks } from "@/components/boarding/exeat-console";
+import { ActionBar, BulkApprove, NewExeatButton, ParentChip, RunLateChecks } from "@/components/boarding/exeat-console";
 
 export const dynamic = "force-dynamic";
 
@@ -164,10 +164,11 @@ export default async function ExeatManagementPage() {
                 key={r.id}
                 className="grid grid-cols-[80px_1fr_1fr_140px_110px_120px_minmax(180px,auto)] items-center gap-3 border-b border-border px-4 py-2.5 text-[12px] last:border-0"
               >
-                <div>
+                <div className="flex flex-col items-start gap-1">
                   <span className={`inline-block rounded-pill px-2 py-0.5 text-[9px] font-bold tracking-wide ${TYPE_PILL[r.type].cls}`}>
                     {TYPE_PILL[r.type].label}
                   </span>
+                  {r.parentInitiated && <ParentChip />}
                 </div>
                 <div className="flex items-center gap-2">
                   <span className="flex h-6 w-6 items-center justify-center rounded-full bg-navy text-[9px] font-bold text-gold">

--- a/omnischools/app/(app)/senior/boarding/exeats/page.tsx
+++ b/omnischools/app/(app)/senior/boarding/exeats/page.tsx
@@ -168,7 +168,7 @@ export default async function ExeatManagementPage() {
                   <span className={`inline-block rounded-pill px-2 py-0.5 text-[9px] font-bold tracking-wide ${TYPE_PILL[r.type].cls}`}>
                     {TYPE_PILL[r.type].label}
                   </span>
-                  {r.parentInitiated && <ParentChip />}
+                  {r.viaParentPortal && <ParentChip />}
                 </div>
                 <div className="flex items-center gap-2">
                   <span className="flex h-6 w-6 items-center justify-center rounded-full bg-navy text-[9px] font-bold text-gold">

--- a/omnischools/app/(parent)/boarding/exeat-request.tsx
+++ b/omnischools/app/(parent)/boarding/exeat-request.tsx
@@ -1,0 +1,143 @@
+"use client";
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { requestParentExeat } from "@/lib/actions/parent-exeat";
+
+/**
+ * EXEAT PHASE 2 · the parent's "Request leave" form — calls the `requestParentExeat` server action ONLY (no
+ * server-only import, so it can be a client component). Native <input type="date"> (no picker lib). The child
+ * <select> shows only when the parent has more than one boarder; a single boarder is defaulted and hidden.
+ * Submit disabled while an open request exists (advisory — the fn's open-guard is authoritative). On success
+ * it shows the ref code + clears + router.refresh() so the status list re-reads.
+ */
+export function ExeatRequestForm({
+  wards,
+  hasOpenRequest,
+}: {
+  wards: { studentId: string; firstName: string }[];
+  hasOpenRequest: boolean;
+}) {
+  const [studentId, setStudentId] = useState(wards[0]?.studentId ?? "");
+  const [reason, setReason] = useState("");
+  const [departDate, setDepartDate] = useState("");
+  const [returnDate, setReturnDate] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [refCode, setRefCode] = useState<string | null>(null);
+  const [pending, start] = useTransition();
+  const router = useRouter();
+
+  const canSubmit = !!studentId && reason.trim().length >= 4 && !!departDate && !!returnDate && !pending;
+
+  function submit() {
+    if (!canSubmit) return;
+    setError(null);
+    setRefCode(null);
+    start(async () => {
+      const res = await requestParentExeat({ studentId, reason, departDate, returnDate });
+      if (res.ok) {
+        setRefCode(res.refCode ?? null);
+        setReason("");
+        setDepartDate("");
+        setReturnDate("");
+        router.refresh();
+      } else {
+        setError(res.error ?? "Couldn't submit your request. Please try again.");
+      }
+    });
+  }
+
+  const field =
+    "mt-1 w-full rounded-md border border-border-2 bg-bg px-3 py-2 text-[13px] text-navy outline-none focus:border-gold disabled:opacity-60";
+  const label = "text-[11px] font-semibold text-navy-3";
+
+  return (
+    <section className="rounded-xl border border-border bg-surface px-[26px] py-[22px]">
+      <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-navy-3">Request leave</div>
+      <p className="mt-1 text-[13px] leading-relaxed text-navy-2">
+        Ask the House to let your ward leave campus (a funeral, illness in the family, a church engagement).
+        The House reviews and the Senior Housemaster signs off — you&apos;ll see the status below.
+      </p>
+
+      {refCode && (
+        <div className="mt-4 rounded-md border border-gold-soft bg-gold-bg px-3.5 py-2.5 text-[13px] text-navy">
+          Request submitted — ref <span className="font-mono font-semibold">{refCode}</span>. The House will
+          review it.
+        </div>
+      )}
+
+      <div className="mt-4 space-y-3.5">
+        {wards.length > 1 && (
+          <label className="block">
+            <span className={label}>Which ward</span>
+            <select
+              className={field}
+              value={studentId}
+              disabled={pending}
+              onChange={(e) => setStudentId(e.target.value)}
+            >
+              {wards.map((c) => (
+                <option key={c.studentId} value={c.studentId}>
+                  {c.firstName}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+
+        <label className="block">
+          <span className={label}>Reason</span>
+          <textarea
+            className={`${field} resize-none`}
+            rows={3}
+            value={reason}
+            disabled={pending}
+            placeholder="Funeral · illness in the family · church engagement…"
+            onChange={(e) => setReason(e.target.value)}
+          />
+        </label>
+
+        <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2">
+          <label className="block">
+            <span className={label}>Leave date</span>
+            <input
+              type="date"
+              className={field}
+              value={departDate}
+              disabled={pending}
+              onChange={(e) => setDepartDate(e.target.value)}
+            />
+          </label>
+          <label className="block">
+            <span className={label}>Return date</span>
+            <input
+              type="date"
+              className={field}
+              value={returnDate}
+              disabled={pending}
+              onChange={(e) => setReturnDate(e.target.value)}
+            />
+          </label>
+        </div>
+      </div>
+
+      {error && <p className="mt-3 text-[12px] text-terra">{error}</p>}
+      {hasOpenRequest && !refCode && (
+        <p className="mt-3 text-[11px] leading-relaxed text-navy-3">
+          Your ward already has a leave request in progress — please wait for it to close before making
+          another.
+        </p>
+      )}
+
+      <div className="mt-4 flex justify-end">
+        <button
+          type="button"
+          onClick={submit}
+          disabled={!canSubmit || hasOpenRequest}
+          className="rounded-md bg-navy px-5 py-2 text-[13px] font-semibold text-bg transition-opacity hover:opacity-90 disabled:opacity-60"
+        >
+          {pending ? "Submitting…" : "Submit request"}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/omnischools/app/(parent)/boarding/page.tsx
+++ b/omnischools/app/(parent)/boarding/page.tsx
@@ -135,12 +135,17 @@ function PlacementCard({ boarder }: { boarder: ParentBoarderChild }) {
 /** The "Leave / exeat" section — the request form + the child's exeat status list (own child only). */
 function Leave({ boarders, exeats }: { boarders: ParentBoarderChild[]; exeats: ParentExeatRow[] }) {
   const hasOpenRequest = exeats.some((e) => e.isOpen);
+  // Only an ACTIVE boarder can request leave (the fn refuses a non-active student — A5). A withdrawn-but-
+  // still-BOARDER ward simply isn't offered the form (never revealing why); the status list still shows below.
+  const activeWards = boarders.filter((b) => b.isActive);
   return (
     <div className="space-y-4">
-      <ExeatRequestForm
-        wards={boarders.map((b) => ({ studentId: b.studentId, firstName: b.firstName }))}
-        hasOpenRequest={hasOpenRequest}
-      />
+      {activeWards.length > 0 && (
+        <ExeatRequestForm
+          wards={activeWards.map((b) => ({ studentId: b.studentId, firstName: b.firstName }))}
+          hasOpenRequest={hasOpenRequest}
+        />
+      )}
       <section className="overflow-hidden rounded-xl border border-border bg-surface">
         <div className="border-b border-border bg-bg px-6 py-[18px]">
           <h3 className="font-display text-base font-medium text-navy">Leave requests</h3>

--- a/omnischools/app/(parent)/boarding/page.tsx
+++ b/omnischools/app/(parent)/boarding/page.tsx
@@ -7,8 +7,10 @@ import {
   type ParentVisitingDay,
   type ParentVisitingPolicy,
 } from "@/lib/parent/parent-boarding-data";
+import { loadParentExeats, type ParentExeatRow } from "@/lib/parent/parent-exeat-data";
 import { relationshipLabel, parentLongDate } from "@/lib/wassce/parent-copy";
 import { ParentHeader, ParentNav } from "../parent-chrome";
+import { ExeatRequestForm } from "./exeat-request";
 
 /**
  * INCR-BOARD · the parent-portal Boarding tab (lean v1) — a boarder's guardian sees their own child's House/
@@ -24,9 +26,10 @@ const longDay = (iso: string): string => parentLongDate(new Date(`${iso}T00:00:0
 
 export default async function ParentBoardingPage() {
   const { user, school } = await requireParent();
-  const [data, boarding] = await Promise.all([
+  const [data, boarding, exeats] = await Promise.all([
     loadParentPortal(school.id, user.id),
     loadParentBoarding(school.id, user.id),
+    loadParentExeats(school.id, user.id),
   ]);
   const child = data.children[0] ?? null;
   const guardianDisplay = data.guardianName ?? user.name ?? "Parent";
@@ -52,6 +55,7 @@ export default async function ParentBoardingPage() {
             {boarding.boarders.map((b, i) => (
               <PlacementCard key={i} boarder={b} />
             ))}
+            <Leave boarders={boarding.boarders} exeats={exeats} />
             <Visiting days={boarding.visitingDays} policy={boarding.visitingPolicy} />
             <TermDates dates={boarding.termDates} />
           </div>
@@ -123,6 +127,52 @@ function PlacementCard({ boarder }: { boarder: ParentBoarderChild }) {
         </div>
       )}
     </section>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────── leave / exeat ── */
+
+/** The "Leave / exeat" section — the request form + the child's exeat status list (own child only). */
+function Leave({ boarders, exeats }: { boarders: ParentBoarderChild[]; exeats: ParentExeatRow[] }) {
+  const hasOpenRequest = exeats.some((e) => e.isOpen);
+  return (
+    <div className="space-y-4">
+      <ExeatRequestForm
+        wards={boarders.map((b) => ({ studentId: b.studentId, firstName: b.firstName }))}
+        hasOpenRequest={hasOpenRequest}
+      />
+      <section className="overflow-hidden rounded-xl border border-border bg-surface">
+        <div className="border-b border-border bg-bg px-6 py-[18px]">
+          <h3 className="font-display text-base font-medium text-navy">Leave requests</h3>
+          <div className="text-[11px] text-navy-3">Your ward&apos;s exeats</div>
+        </div>
+        {exeats.length === 0 ? (
+          <div className="px-6 py-6 text-[13px] leading-relaxed text-navy-2">No leave requests yet.</div>
+        ) : (
+          exeats.map((e) => <ExeatRow key={e.id} exeat={e} />)
+        )}
+      </section>
+    </div>
+  );
+}
+
+function ExeatRow({ exeat }: { exeat: ParentExeatRow }) {
+  return (
+    <div className="border-b border-border px-6 py-4 last:border-b-0">
+      <div className="flex items-baseline justify-between gap-4">
+        <span className="font-display text-[15px] font-medium text-navy">{exeat.statusLabel}</span>
+        <span className="text-right font-mono text-[11px] text-navy-3">{exeat.refCode}</span>
+      </div>
+      <div className="mt-1 text-[13px] leading-relaxed text-navy-2">{exeat.detail}</div>
+      <div className="mt-2 flex flex-wrap gap-x-5 gap-y-1 text-[11px] text-navy-3">
+        {exeat.houseName && <span>{exeat.houseName}</span>}
+        {exeat.milestones.map((m, i) => (
+          <span key={i}>
+            {m.label}: <span className="font-mono text-navy-2">{m.value}</span>
+          </span>
+        ))}
+      </div>
+    </div>
   );
 }
 

--- a/omnischools/components/boarding/exeat-console.tsx
+++ b/omnischools/components/boarding/exeat-console.tsx
@@ -41,9 +41,9 @@ const btnGold = `${btn} border-gold bg-gold text-navy`;
 const btnTerra = `${btn} border-terra bg-terra text-bg`;
 
 /**
- * B12 · a small "from parent" chip flagging a parent-asked exeat on the staff queue (Exeat Phase 2).
- * Purely presentational; the row already carries `parentInitiated` from the projection. Gold accent to
- * echo the parent-portal (surface copy: "request from parent" / "parent-initiated").
+ * B12 · a small "from parent" chip flagging a genuinely portal-origin exeat on the staff queue (Exeat Phase 2).
+ * Purely presentational; the row carries `viaParentPortal` (TRUE only for a parent_request_exeat row) from the
+ * projection — parent_initiated is broadly true and NOT a provenance signal. Gold accent to echo the portal.
  */
 export function ParentChip() {
   return (

--- a/omnischools/components/boarding/exeat-console.tsx
+++ b/omnischools/components/boarding/exeat-console.tsx
@@ -40,6 +40,19 @@ const btnPrimary = `${btn} border-navy bg-navy text-bg`;
 const btnGold = `${btn} border-gold bg-gold text-navy`;
 const btnTerra = `${btn} border-terra bg-terra text-bg`;
 
+/**
+ * B12 · a small "from parent" chip flagging a parent-asked exeat on the staff queue (Exeat Phase 2).
+ * Purely presentational; the row already carries `parentInitiated` from the projection. Gold accent to
+ * echo the parent-portal (surface copy: "request from parent" / "parent-initiated").
+ */
+export function ParentChip() {
+  return (
+    <span className="inline-block rounded-pill border border-gold-soft bg-gold-bg px-1.5 py-0.5 text-[8px] font-bold uppercase tracking-wide text-navy-2">
+      From parent
+    </span>
+  );
+}
+
 /** The per-exeat action buttons (used in the in-flight card and every queue row). */
 export function ActionBar({ exeat, canSign }: { exeat: ExeatRow; canSign: boolean }) {
   const { pending, error, run } = useAction();

--- a/omnischools/db/migrations/0089_kind_blindfold.sql
+++ b/omnischools/db/migrations/0089_kind_blindfold.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "boarding_exeat" ADD COLUMN "via_parent_portal" boolean DEFAULT false NOT NULL;

--- a/omnischools/db/migrations/meta/0089_snapshot.json
+++ b/omnischools/db/migrations/meta/0089_snapshot.json
@@ -1,0 +1,26276 @@
+{
+  "id": "4ac8bb8b-6e1a-4b60-bc23-7bbdf3224f21",
+  "prevId": "37ec615b-c744-4e15-b8d4-846c391141c8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ref_district": {
+      "name": "ref_district",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_district_region_id_ref_region_id_fk": {
+          "name": "ref_district_region_id_ref_region_id_fk",
+          "tableFrom": "ref_district",
+          "tableTo": "ref_region",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_district_code_unique": {
+          "name": "ref_district_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_region": {
+      "name": "ref_region",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_region_code_unique": {
+          "name": "ref_region_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_school_product": {
+      "name": "ref_school_product",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product": {
+          "name": "product",
+          "type": "product",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_school_product_school_id_ref_school_id_fk": {
+          "name": "ref_school_product_school_id_ref_school_id_fk",
+          "tableFrom": "ref_school_product",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_school_product": {
+          "name": "uniq_school_product",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "product"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_school": {
+      "name": "ref_school",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ges_code": {
+          "name": "ges_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cssps_code": {
+          "name": "cssps_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_type": {
+          "name": "school_type",
+          "type": "school_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'BASIC'"
+        },
+        "subtype": {
+          "name": "subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shs_category": {
+          "name": "shs_category",
+          "type": "shs_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownership_type": {
+          "name": "ownership_type",
+          "type": "ownership_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRIVATE'"
+        },
+        "year_founded": {
+          "name": "year_founded",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stamp_url": {
+          "name": "stamp_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_color": {
+          "name": "brand_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cadence": {
+          "name": "billing_cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_methods": {
+          "name": "payment_methods",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residency_model": {
+          "name": "residency_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "house_count": {
+          "name": "house_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visiting_day": {
+          "name": "visiting_day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waec_centre_code": {
+          "name": "waec_centre_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waec_office": {
+          "name": "waec_office",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_wassce_year": {
+          "name": "first_wassce_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_retention_months": {
+          "name": "record_retention_months",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audit_retention_months": {
+          "name": "audit_retention_months",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_2fa": {
+          "name": "require_2fa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_hours": {
+          "name": "session_hours",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "district_id": {
+          "name": "district_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_school_district_id_ref_district_id_fk": {
+          "name": "ref_school_district_id_ref_district_id_fk",
+          "tableFrom": "ref_school",
+          "tableTo": "ref_district",
+          "columnsFrom": [
+            "district_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ref_school_region_id_ref_region_id_fk": {
+          "name": "ref_school_region_id_ref_region_id_fk",
+          "tableFrom": "ref_school",
+          "tableTo": "ref_region",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_school_ges_code_unique": {
+          "name": "ref_school_ges_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "ges_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_assignment": {
+      "name": "role_assignment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_ref": {
+          "name": "scope_ref",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_assignment_user_id_ref_user_id_fk": {
+          "name": "role_assignment_user_id_ref_user_id_fk",
+          "tableFrom": "role_assignment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_assignment_school_id_ref_school_id_fk": {
+          "name": "role_assignment_school_id_ref_school_id_fk",
+          "tableFrom": "role_assignment",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_assignment_role_id_ref_role_id_fk": {
+          "name": "role_assignment_role_id_ref_role_id_fk",
+          "tableFrom": "role_assignment",
+          "tableTo": "ref_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_role": {
+      "name": "ref_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_role_code_unique": {
+          "name": "ref_role_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_school_block": {
+      "name": "user_school_block",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_by": {
+          "name": "blocked_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_at": {
+          "name": "blocked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_school_block_school_id_ref_school_id_fk": {
+          "name": "user_school_block_school_id_ref_school_id_fk",
+          "tableFrom": "user_school_block",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_school_block_user_id_ref_user_id_fk": {
+          "name": "user_school_block_user_id_ref_user_id_fk",
+          "tableFrom": "user_school_block",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_school_block_blocked_by_ref_user_id_fk": {
+          "name": "user_school_block_blocked_by_ref_user_id_fk",
+          "tableFrom": "user_school_block",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "blocked_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_school_block_school_user_uk": {
+          "name": "user_school_block_school_user_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_user": {
+      "name": "ref_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_user_phone_unique": {
+          "name": "ref_user_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_compensation": {
+      "name": "staff_compensation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "salary_status": {
+          "name": "salary_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SCHOOL_PAID'"
+        },
+        "monthly_amount": {
+          "name": "monthly_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "pay_method": {
+          "name": "pay_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'BANK'"
+        },
+        "pay_cadence": {
+          "name": "pay_cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MONTHLY'"
+        },
+        "ssnit_deduction": {
+          "name": "ssnit_deduction",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "paye_deduction": {
+          "name": "paye_deduction",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "staff_compensation_school_idx": {
+          "name": "staff_compensation_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_compensation_school_id_ref_school_id_fk": {
+          "name": "staff_compensation_school_id_ref_school_id_fk",
+          "tableFrom": "staff_compensation",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "staff_compensation_user_id_ref_user_id_fk": {
+          "name": "staff_compensation_user_id_ref_user_id_fk",
+          "tableFrom": "staff_compensation",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_staff_compensation_per_school": {
+          "name": "uniq_staff_compensation_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_profile": {
+      "name": "staff_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qualification_level": {
+          "name": "qualification_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highest_qualification": {
+          "name": "highest_qualification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "undergraduate": {
+          "name": "undergraduate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ntc_licence_number": {
+          "name": "ntc_licence_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ntc_licence_expiry": {
+          "name": "ntc_licence_expiry",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nmc_licence_number": {
+          "name": "nmc_licence_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nmc_licence_expiry": {
+          "name": "nmc_licence_expiry",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialisations": {
+          "name": "specialisations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "staff_profile_school_idx": {
+          "name": "staff_profile_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_profile_school_id_ref_school_id_fk": {
+          "name": "staff_profile_school_id_ref_school_id_fk",
+          "tableFrom": "staff_profile",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "staff_profile_user_id_ref_user_id_fk": {
+          "name": "staff_profile_user_id_ref_user_id_fk",
+          "tableFrom": "staff_profile",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_staff_profile_per_school": {
+          "name": "uniq_staff_profile_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.academic_period": {
+      "name": "academic_period",
+      "schema": "",
+      "columns": {
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_number": {
+          "name": "period_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_label": {
+          "name": "period_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_on": {
+          "name": "ends_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_line": {
+          "name": "product_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by_user_id": {
+          "name": "closed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "academic_period_closed_by_user_id_ref_user_id_fk": {
+          "name": "academic_period_closed_by_user_id_ref_user_id_fk",
+          "tableFrom": "academic_period",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "closed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "academic_period_school_id_academic_year_ref_academic_period_config_school_id_academic_year_fk": {
+          "name": "academic_period_school_id_academic_year_ref_academic_period_config_school_id_academic_year_fk",
+          "tableFrom": "academic_period",
+          "tableTo": "ref_academic_period_config",
+          "columnsFrom": [
+            "school_id",
+            "academic_year"
+          ],
+          "columnsTo": [
+            "school_id",
+            "academic_year"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "academic_period_tenant_uk": {
+          "name": "academic_period_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_academic_period_config": {
+      "name": "ref_academic_period_config",
+      "schema": "",
+      "columns": {
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_type": {
+          "name": "period_type",
+          "type": "period_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_count": {
+          "name": "period_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "period_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured_at": {
+          "name": "configured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "configured_by": {
+          "name": "configured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ref_academic_period_config_school_id_ref_school_id_fk": {
+          "name": "ref_academic_period_config_school_id_ref_school_id_fk",
+          "tableFrom": "ref_academic_period_config",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ref_academic_period_config_configured_by_ref_user_id_fk": {
+          "name": "ref_academic_period_config_configured_by_ref_user_id_fk",
+          "tableFrom": "ref_academic_period_config",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "configured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ref_academic_period_config_school_id_academic_year_pk": {
+          "name": "ref_academic_period_config_school_id_academic_year_pk",
+          "columns": [
+            "school_id",
+            "academic_year"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gen_period_defaults": {
+      "name": "gen_period_defaults",
+      "schema": "",
+      "columns": {
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_line": {
+          "name": "product_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_number": {
+          "name": "period_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_label": {
+          "name": "period_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_on": {
+          "name": "ends_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_at": {
+          "name": "extracted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gen_period_defaults_reviewed_by_ref_user_id_fk": {
+          "name": "gen_period_defaults_reviewed_by_ref_user_id_fk",
+          "tableFrom": "gen_period_defaults",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gen_period_defaults_academic_year_product_line_period_number_pk": {
+          "name": "gen_period_defaults_academic_year_product_line_period_number_pk",
+          "columns": [
+            "academic_year",
+            "product_line",
+            "period_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.school_holiday": {
+      "name": "school_holiday",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_on": {
+          "name": "ends_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PUBLIC'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "school_holiday_school_idx": {
+          "name": "school_holiday_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "school_holiday_school_id_ref_school_id_fk": {
+          "name": "school_holiday_school_id_ref_school_id_fk",
+          "tableFrom": "school_holiday",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "audit_id": {
+          "name": "audit_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_role": {
+          "name": "actor_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before_jsonb": {
+          "name": "before_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_jsonb": {
+          "name": "after_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_school_time_idx": {
+          "name": "audit_school_time_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_entity_idx": {
+          "name": "audit_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_school_id_ref_school_id_fk": {
+          "name": "audit_log_school_id_ref_school_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_log_actor_user_id_ref_user_id_fk": {
+          "name": "audit_log_actor_user_id_ref_user_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_anomaly_rule": {
+      "name": "ref_anomaly_rule",
+      "schema": "",
+      "columns": {
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_code": {
+          "name": "rule_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "anomaly_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applies_to": {
+          "name": "applies_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold_jsonb": {
+          "name": "threshold_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ref_anomaly_rule_rule_code_unique": {
+          "name": "ref_anomaly_rule_rule_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rule_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.marketing_lead": {
+      "name": "marketing_lead",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organisation": {
+          "name": "organisation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'demo_form'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.class": {
+      "name": "class",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "programme": {
+          "name": "programme",
+          "type": "programme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_teacher_user_id": {
+          "name": "class_teacher_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_capacity": {
+          "name": "target_capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "class_school_id_ref_school_id_fk": {
+          "name": "class_school_id_ref_school_id_fk",
+          "tableFrom": "class",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "class_class_teacher_user_id_ref_user_id_fk": {
+          "name": "class_class_teacher_user_id_ref_user_id_fk",
+          "tableFrom": "class",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "class_teacher_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_class_per_school": {
+          "name": "uniq_class_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        },
+        "class_tenant_uk": {
+          "name": "class_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.household": {
+      "name": "household",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "household_school_idx": {
+          "name": "household_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "household_school_id_ref_school_id_fk": {
+          "name": "household_school_id_ref_school_id_fk",
+          "tableFrom": "household",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "household_tenant_uk": {
+          "name": "household_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.house": {
+      "name": "house",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "colour": {
+          "name": "colour",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "house_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'BOARDING'"
+        },
+        "gender": {
+          "name": "gender",
+          "type": "house_gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "founded_year": {
+          "name": "founded_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "named_after": {
+          "name": "named_after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hm_user_id": {
+          "name": "hm_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "house_school_id_ref_school_id_fk": {
+          "name": "house_school_id_ref_school_id_fk",
+          "tableFrom": "house",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "house_hm_user_id_ref_user_id_fk": {
+          "name": "house_hm_user_id_ref_user_id_fk",
+          "tableFrom": "house",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "hm_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_house_per_school": {
+          "name": "uniq_house_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        },
+        "house_tenant_uk": {
+          "name": "house_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_guardian": {
+      "name": "student_guardian",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "guardian_relation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GUARDIAN'"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "guardian_student_idx": {
+          "name": "guardian_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "guardian_user_idx": {
+          "name": "guardian_user_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_guardian_user_per_child": {
+          "name": "uniq_guardian_user_per_child",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"student_guardian\".\"user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_guardian_school_id_ref_school_id_fk": {
+          "name": "student_guardian_school_id_ref_school_id_fk",
+          "tableFrom": "student_guardian",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_guardian_user_id_ref_user_id_fk": {
+          "name": "student_guardian_user_id_ref_user_id_fk",
+          "tableFrom": "student_guardian",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "student_guardian_school_id_student_id_students_school_id_id_fk": {
+          "name": "student_guardian_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "student_guardian",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_health_record": {
+      "name": "student_health_record",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blood_group": {
+          "name": "blood_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medications": {
+          "name": "medications",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_relation": {
+          "name": "emergency_contact_relation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "health_student_idx": {
+          "name": "health_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_health_record_school_id_ref_school_id_fk": {
+          "name": "student_health_record_school_id_ref_school_id_fk",
+          "tableFrom": "student_health_record",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_health_record_updated_by_user_id_ref_user_id_fk": {
+          "name": "student_health_record_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "student_health_record",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "student_health_record_school_id_student_id_students_school_id_id_fk": {
+          "name": "student_health_record_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "student_health_record",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "student_health_record_student_id_unique": {
+          "name": "student_health_record_student_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.students": {
+      "name": "students",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_code": {
+          "name": "student_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "other_names": {
+          "name": "other_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "student_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "current_class_label": {
+          "name": "current_class_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "programme": {
+          "name": "programme",
+          "type": "programme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residency": {
+          "name": "residency",
+          "type": "residency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "house_id": {
+          "name": "house_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_bunk_id": {
+          "name": "current_bunk_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stpshs_ref": {
+          "name": "stpshs_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrolled_on": {
+          "name": "enrolled_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admission_application_id": {
+          "name": "admission_application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "students_school_idx": {
+          "name": "students_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_student_current_bunk": {
+          "name": "uniq_student_current_bunk",
+          "columns": [
+            {
+              "expression": "current_bunk_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"students\".\"current_bunk_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "students_school_id_ref_school_id_fk": {
+          "name": "students_school_id_ref_school_id_fk",
+          "tableFrom": "students",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "students_household_id_household_id_fk": {
+          "name": "students_household_id_household_id_fk",
+          "tableFrom": "students",
+          "tableTo": "household",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "students_school_id_class_id_class_school_id_id_fk": {
+          "name": "students_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "students",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "students_school_id_house_id_house_school_id_id_fk": {
+          "name": "students_school_id_house_id_house_school_id_id_fk",
+          "tableFrom": "students",
+          "tableTo": "house",
+          "columnsFrom": [
+            "school_id",
+            "house_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "students_school_id_current_bunk_id_boarding_bunk_school_id_id_fk": {
+          "name": "students_school_id_current_bunk_id_boarding_bunk_school_id_id_fk",
+          "tableFrom": "students",
+          "tableTo": "boarding_bunk",
+          "columnsFrom": [
+            "school_id",
+            "current_bunk_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_student_code_per_school": {
+          "name": "uniq_student_code_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_code"
+          ]
+        },
+        "students_tenant_uk": {
+          "name": "students_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boarding_approved_visitor": {
+      "name": "boarding_approved_visitor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id_hint": {
+          "name": "id_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "visitor_approval_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING_REVIEW'"
+        },
+        "pastoral_review": {
+          "name": "pastoral_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_by_user_id": {
+          "name": "added_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "boarding_approved_visitor_student_idx": {
+          "name": "boarding_approved_visitor_student_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "boarding_approved_visitor_school_id_ref_school_id_fk": {
+          "name": "boarding_approved_visitor_school_id_ref_school_id_fk",
+          "tableFrom": "boarding_approved_visitor",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_approved_visitor_added_by_user_id_ref_user_id_fk": {
+          "name": "boarding_approved_visitor_added_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_approved_visitor",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "added_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_approved_visitor_approved_by_user_id_ref_user_id_fk": {
+          "name": "boarding_approved_visitor_approved_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_approved_visitor",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_approved_visitor_school_id_student_id_students_school_id_id_fk": {
+          "name": "boarding_approved_visitor_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "boarding_approved_visitor",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boarding_approved_visitor_tenant_uk": {
+          "name": "boarding_approved_visitor_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boarding_arrival": {
+      "name": "boarding_arrival",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "house_id": {
+          "name": "house_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_period_id": {
+          "name": "academic_period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "boarding_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checklist_json": {
+          "name": "checklist_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_owing_snapshot": {
+          "name": "fee_owing_snapshot",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "checked_by_user_id": {
+          "name": "checked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "boarding_arrival_house_period_mode_idx": {
+          "name": "boarding_arrival_house_period_mode_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "house_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "boarding_arrival_school_id_ref_school_id_fk": {
+          "name": "boarding_arrival_school_id_ref_school_id_fk",
+          "tableFrom": "boarding_arrival",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_arrival_checked_by_user_id_ref_user_id_fk": {
+          "name": "boarding_arrival_checked_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_arrival",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "checked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_arrival_school_id_student_id_students_school_id_id_fk": {
+          "name": "boarding_arrival_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "boarding_arrival",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_arrival_school_id_house_id_house_school_id_id_fk": {
+          "name": "boarding_arrival_school_id_house_id_house_school_id_id_fk",
+          "tableFrom": "boarding_arrival",
+          "tableTo": "house",
+          "columnsFrom": [
+            "school_id",
+            "house_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_arrival_school_id_academic_period_id_academic_period_school_id_period_id_fk": {
+          "name": "boarding_arrival_school_id_academic_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "boarding_arrival",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "academic_period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_boarding_arrival": {
+          "name": "uniq_boarding_arrival",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "academic_period_id",
+            "mode"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boarding_bunk": {
+      "name": "boarding_bunk",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dormitory_id": {
+          "name": "dormitory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_number": {
+          "name": "position_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefect_role": {
+          "name": "prefect_role",
+          "type": "prefect_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "boarding_bunk_school_id_ref_school_id_fk": {
+          "name": "boarding_bunk_school_id_ref_school_id_fk",
+          "tableFrom": "boarding_bunk",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_bunk_school_id_dormitory_id_boarding_dormitory_school_id_id_fk": {
+          "name": "boarding_bunk_school_id_dormitory_id_boarding_dormitory_school_id_id_fk",
+          "tableFrom": "boarding_bunk",
+          "tableTo": "boarding_dormitory",
+          "columnsFrom": [
+            "school_id",
+            "dormitory_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_bunk_per_dormitory": {
+          "name": "uniq_bunk_per_dormitory",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "dormitory_id",
+            "position_number"
+          ]
+        },
+        "boarding_bunk_tenant_uk": {
+          "name": "boarding_bunk_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boarding_calendar_event": {
+      "name": "boarding_calendar_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "boarding_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form_scope": {
+          "name": "form_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "boarding_calendar_event_year_idx": {
+          "name": "boarding_calendar_event_year_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "boarding_calendar_event_school_id_ref_school_id_fk": {
+          "name": "boarding_calendar_event_school_id_ref_school_id_fk",
+          "tableFrom": "boarding_calendar_event",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_boarding_calendar_event": {
+          "name": "uniq_boarding_calendar_event",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "academic_year",
+            "event_type",
+            "event_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boarding_dormitory": {
+      "name": "boarding_dormitory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "house_id": {
+          "name": "house_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_label": {
+          "name": "section_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bunk_count": {
+          "name": "bunk_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "boarding_dormitory_school_id_ref_school_id_fk": {
+          "name": "boarding_dormitory_school_id_ref_school_id_fk",
+          "tableFrom": "boarding_dormitory",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_dormitory_school_id_house_id_house_school_id_id_fk": {
+          "name": "boarding_dormitory_school_id_house_id_house_school_id_id_fk",
+          "tableFrom": "boarding_dormitory",
+          "tableTo": "house",
+          "columnsFrom": [
+            "school_id",
+            "house_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_dormitory_per_house": {
+          "name": "uniq_dormitory_per_house",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "house_id",
+            "name"
+          ]
+        },
+        "boarding_dormitory_tenant_uk": {
+          "name": "boarding_dormitory_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boarding_exeat": {
+      "name": "boarding_exeat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "house_id": {
+          "name": "house_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_period_id": {
+          "name": "academic_period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_event_id": {
+          "name": "calendar_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exeat_type": {
+          "name": "exeat_type",
+          "type": "exeat_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "exeat_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REQUESTED'"
+        },
+        "ref_code": {
+          "name": "ref_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_initiated": {
+          "name": "parent_initiated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "via_parent_portal": {
+          "name": "via_parent_portal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "depart_at": {
+          "name": "depart_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "return_by": {
+          "name": "return_by",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hm_approved_at": {
+          "name": "hm_approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hm_approved_by_user_id": {
+          "name": "hm_approved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sr_hm_signed_at": {
+          "name": "sr_hm_signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sr_hm_signed_by_user_id": {
+          "name": "sr_hm_signed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "departed_at": {
+          "name": "departed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "departed_by_user_id": {
+          "name": "departed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "returned_at": {
+          "name": "returned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "returned_by_user_id": {
+          "name": "returned_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "declined_at": {
+          "name": "declined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "declined_by_user_id": {
+          "name": "declined_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decline_reason": {
+          "name": "decline_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_owing_snapshot": {
+          "name": "fee_owing_snapshot",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "boarding_exeat_student_period_idx": {
+          "name": "boarding_exeat_student_period_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "boarding_exeat_school_id_ref_school_id_fk": {
+          "name": "boarding_exeat_school_id_ref_school_id_fk",
+          "tableFrom": "boarding_exeat",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_exeat_calendar_event_id_boarding_calendar_event_id_fk": {
+          "name": "boarding_exeat_calendar_event_id_boarding_calendar_event_id_fk",
+          "tableFrom": "boarding_exeat",
+          "tableTo": "boarding_calendar_event",
+          "columnsFrom": [
+            "calendar_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_exeat_requested_by_user_id_ref_user_id_fk": {
+          "name": "boarding_exeat_requested_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_exeat",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_exeat_hm_approved_by_user_id_ref_user_id_fk": {
+          "name": "boarding_exeat_hm_approved_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_exeat",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "hm_approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_exeat_sr_hm_signed_by_user_id_ref_user_id_fk": {
+          "name": "boarding_exeat_sr_hm_signed_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_exeat",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "sr_hm_signed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_exeat_departed_by_user_id_ref_user_id_fk": {
+          "name": "boarding_exeat_departed_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_exeat",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "departed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_exeat_returned_by_user_id_ref_user_id_fk": {
+          "name": "boarding_exeat_returned_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_exeat",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "returned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_exeat_declined_by_user_id_ref_user_id_fk": {
+          "name": "boarding_exeat_declined_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_exeat",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "declined_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_exeat_school_id_student_id_students_school_id_id_fk": {
+          "name": "boarding_exeat_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "boarding_exeat",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_exeat_school_id_house_id_house_school_id_id_fk": {
+          "name": "boarding_exeat_school_id_house_id_house_school_id_id_fk",
+          "tableFrom": "boarding_exeat",
+          "tableTo": "house",
+          "columnsFrom": [
+            "school_id",
+            "house_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_exeat_school_id_academic_period_id_academic_period_school_id_period_id_fk": {
+          "name": "boarding_exeat_school_id_academic_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "boarding_exeat",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "academic_period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boarding_exeat_tenant_uk": {
+          "name": "boarding_exeat_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        },
+        "uniq_exeat_ref_code": {
+          "name": "uniq_exeat_ref_code",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "ref_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boarding_infractions": {
+      "name": "boarding_infractions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "house_id": {
+          "name": "house_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "infraction_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "narrative_text": {
+          "name": "narrative_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "infraction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "co_signs_json": {
+          "name": "co_signs_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_infraction_id": {
+          "name": "parent_infraction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "infraction_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MANUAL'"
+        },
+        "source_ref_id": {
+          "name": "source_ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logged_by_user_id": {
+          "name": "logged_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "parents_notified_at": {
+          "name": "parents_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_infraction_source": {
+          "name": "uniq_infraction_source",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"boarding_infractions\".\"source_ref_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boarding_infractions_student_idx": {
+          "name": "boarding_infractions_student_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boarding_infractions_status_idx": {
+          "name": "boarding_infractions_status_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "boarding_infractions_school_id_ref_school_id_fk": {
+          "name": "boarding_infractions_school_id_ref_school_id_fk",
+          "tableFrom": "boarding_infractions",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_infractions_logged_by_user_id_ref_user_id_fk": {
+          "name": "boarding_infractions_logged_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_infractions",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "logged_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_infractions_school_id_student_id_students_school_id_id_fk": {
+          "name": "boarding_infractions_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "boarding_infractions",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_infractions_school_id_house_id_house_school_id_id_fk": {
+          "name": "boarding_infractions_school_id_house_id_house_school_id_id_fk",
+          "tableFrom": "boarding_infractions",
+          "tableTo": "house",
+          "columnsFrom": [
+            "school_id",
+            "house_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_infractions_school_id_parent_infraction_id_boarding_infractions_school_id_id_fk": {
+          "name": "boarding_infractions_school_id_parent_infraction_id_boarding_infractions_school_id_id_fk",
+          "tableFrom": "boarding_infractions",
+          "tableTo": "boarding_infractions",
+          "columnsFrom": [
+            "school_id",
+            "parent_infraction_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boarding_infractions_tenant_uk": {
+          "name": "boarding_infractions_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boarding_settings": {
+      "name": "boarding_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exeat_scheduled_per_term": {
+          "name": "exeat_scheduled_per_term",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "exeat_return_by": {
+          "name": "exeat_return_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'16:00'"
+        },
+        "exeat_fee_owing_must_collect": {
+          "name": "exeat_fee_owing_must_collect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "exeat_special_approver": {
+          "name": "exeat_special_approver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Senior HM only'"
+        },
+        "exeat_parent_initiated": {
+          "name": "exeat_parent_initiated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "exeat_dress_code": {
+          "name": "exeat_dress_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Uniform or outing dress'"
+        },
+        "exeat_card_signer": {
+          "name": "exeat_card_signer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Signed by Housemaster'"
+        },
+        "visiting_cadence": {
+          "name": "visiting_cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2nd Sun · monthly'"
+        },
+        "visiting_hours_start": {
+          "name": "visiting_hours_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'12:00'"
+        },
+        "visiting_hours_end": {
+          "name": "visiting_hours_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'16:00'"
+        },
+        "visiting_lunch_time": {
+          "name": "visiting_lunch_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'11:30'"
+        },
+        "visiting_dormitories_rule": {
+          "name": "visiting_dormitories_rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Out of bounds'"
+        },
+        "visiting_approved_visitors": {
+          "name": "visiting_approved_visitors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Parent · guardian · sibling'"
+        },
+        "visiting_book_owner": {
+          "name": "visiting_book_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Digital · SoD owns'"
+        },
+        "inspection_daily_start": {
+          "name": "inspection_daily_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'06:10'"
+        },
+        "inspection_daily_end": {
+          "name": "inspection_daily_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'06:20'"
+        },
+        "inspection_daily_scope": {
+          "name": "inspection_daily_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Bunks · lockers · attire'"
+        },
+        "inspection_weekly": {
+          "name": "inspection_weekly",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Saturday 08:00'"
+        },
+        "inspection_weekly_scope": {
+          "name": "inspection_weekly_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Whole House · top to bottom'"
+        },
+        "inspection_scrubbing": {
+          "name": "inspection_scrubbing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Wed 16:00 — 17:00'"
+        },
+        "inspection_washing_days": {
+          "name": "inspection_washing_days",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Wed & Fri afternoons'"
+        },
+        "inspection_inspector": {
+          "name": "inspection_inspector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'HM & House Prefects'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "boarding_settings_school_id_ref_school_id_fk": {
+          "name": "boarding_settings_school_id_ref_school_id_fk",
+          "tableFrom": "boarding_settings",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boarding_settings_school_id_unique": {
+          "name": "boarding_settings_school_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boarding_visit": {
+      "name": "boarding_visit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "house_id": {
+          "name": "house_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_event_id": {
+          "name": "calendar_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_visitor_id": {
+          "name": "approved_visitor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitor_name": {
+          "name": "visitor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visitor_phone": {
+          "name": "visitor_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'RSVP'"
+        },
+        "verification": {
+          "name": "verification",
+          "type": "visit_verification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'FLAGGED'"
+        },
+        "zone_key": {
+          "name": "zone_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rsvp_by_user_id": {
+          "name": "rsvp_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arrived_by_user_id": {
+          "name": "arrived_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "departed_at": {
+          "name": "departed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "departed_by_user_id": {
+          "name": "departed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorised_at": {
+          "name": "authorised_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorised_by_user_id": {
+          "name": "authorised_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "boarding_visit_event_house_idx": {
+          "name": "boarding_visit_event_house_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "calendar_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "house_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "boarding_visit_school_id_ref_school_id_fk": {
+          "name": "boarding_visit_school_id_ref_school_id_fk",
+          "tableFrom": "boarding_visit",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_calendar_event_id_boarding_calendar_event_id_fk": {
+          "name": "boarding_visit_calendar_event_id_boarding_calendar_event_id_fk",
+          "tableFrom": "boarding_visit",
+          "tableTo": "boarding_calendar_event",
+          "columnsFrom": [
+            "calendar_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_approved_visitor_id_boarding_approved_visitor_id_fk": {
+          "name": "boarding_visit_approved_visitor_id_boarding_approved_visitor_id_fk",
+          "tableFrom": "boarding_visit",
+          "tableTo": "boarding_approved_visitor",
+          "columnsFrom": [
+            "approved_visitor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_rsvp_by_user_id_ref_user_id_fk": {
+          "name": "boarding_visit_rsvp_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_visit",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "rsvp_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_arrived_by_user_id_ref_user_id_fk": {
+          "name": "boarding_visit_arrived_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_visit",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "arrived_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_departed_by_user_id_ref_user_id_fk": {
+          "name": "boarding_visit_departed_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_visit",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "departed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_authorised_by_user_id_ref_user_id_fk": {
+          "name": "boarding_visit_authorised_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_visit",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "authorised_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_school_id_student_id_students_school_id_id_fk": {
+          "name": "boarding_visit_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "boarding_visit",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_school_id_house_id_house_school_id_id_fk": {
+          "name": "boarding_visit_school_id_house_id_house_school_id_id_fk",
+          "tableFrom": "boarding_visit",
+          "tableTo": "house",
+          "columnsFrom": [
+            "school_id",
+            "house_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boarding_visit_tenant_uk": {
+          "name": "boarding_visit_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        },
+        "uniq_boarding_visit_rsvp": {
+          "name": "uniq_boarding_visit_rsvp",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "calendar_event_id",
+            "approved_visitor_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boarding_visit_notification": {
+      "name": "boarding_visit_notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visit_id": {
+          "name": "visit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_event_id": {
+          "name": "calendar_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "visit_notification_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_phone": {
+          "name": "to_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sent_by_user_id": {
+          "name": "sent_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "boarding_visit_notification_visit_idx": {
+          "name": "boarding_visit_notification_visit_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boarding_visit_notification_event_idx": {
+          "name": "boarding_visit_notification_event_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "calendar_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "boarding_visit_notification_school_id_ref_school_id_fk": {
+          "name": "boarding_visit_notification_school_id_ref_school_id_fk",
+          "tableFrom": "boarding_visit_notification",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_notification_calendar_event_id_boarding_calendar_event_id_fk": {
+          "name": "boarding_visit_notification_calendar_event_id_boarding_calendar_event_id_fk",
+          "tableFrom": "boarding_visit_notification",
+          "tableTo": "boarding_calendar_event",
+          "columnsFrom": [
+            "calendar_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_notification_sent_by_user_id_ref_user_id_fk": {
+          "name": "boarding_visit_notification_sent_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_visit_notification",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "sent_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_notification_school_id_visit_id_boarding_visit_school_id_id_fk": {
+          "name": "boarding_visit_notification_school_id_visit_id_boarding_visit_school_id_id_fk",
+          "tableFrom": "boarding_visit_notification",
+          "tableTo": "boarding_visit",
+          "columnsFrom": [
+            "school_id",
+            "visit_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boarding_visit_rsvp_token": {
+      "name": "boarding_visit_rsvp_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_event_id": {
+          "name": "calendar_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_to_phone": {
+          "name": "issued_to_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guardian_id": {
+          "name": "guardian_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visit_id": {
+          "name": "visit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "boarding_visit_rsvp_token_event_idx": {
+          "name": "boarding_visit_rsvp_token_event_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "calendar_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "boarding_visit_rsvp_token_school_id_ref_school_id_fk": {
+          "name": "boarding_visit_rsvp_token_school_id_ref_school_id_fk",
+          "tableFrom": "boarding_visit_rsvp_token",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_rsvp_token_calendar_event_id_boarding_calendar_event_id_fk": {
+          "name": "boarding_visit_rsvp_token_calendar_event_id_boarding_calendar_event_id_fk",
+          "tableFrom": "boarding_visit_rsvp_token",
+          "tableTo": "boarding_calendar_event",
+          "columnsFrom": [
+            "calendar_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_rsvp_token_guardian_id_student_guardian_id_fk": {
+          "name": "boarding_visit_rsvp_token_guardian_id_student_guardian_id_fk",
+          "tableFrom": "boarding_visit_rsvp_token",
+          "tableTo": "student_guardian",
+          "columnsFrom": [
+            "guardian_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_rsvp_token_visit_id_boarding_visit_id_fk": {
+          "name": "boarding_visit_rsvp_token_visit_id_boarding_visit_id_fk",
+          "tableFrom": "boarding_visit_rsvp_token",
+          "tableTo": "boarding_visit",
+          "columnsFrom": [
+            "visit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_rsvp_token_issued_by_user_id_ref_user_id_fk": {
+          "name": "boarding_visit_rsvp_token_issued_by_user_id_ref_user_id_fk",
+          "tableFrom": "boarding_visit_rsvp_token",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boarding_visit_rsvp_token_school_id_student_id_students_school_id_id_fk": {
+          "name": "boarding_visit_rsvp_token_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "boarding_visit_rsvp_token",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_boarding_visit_rsvp_token_hash": {
+          "name": "uniq_boarding_visit_rsvp_token_hash",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bond_artefacts": {
+      "name": "bond_artefacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "infraction_id": {
+          "name": "infraction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_signature_at": {
+          "name": "student_signature_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hm_witness_user_id": {
+          "name": "hm_witness_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hm_witness_at": {
+          "name": "hm_witness_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "senior_hm_witness_user_id": {
+          "name": "senior_hm_witness_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "senior_hm_witness_at": {
+          "name": "senior_hm_witness_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scanned_pdf_file_id": {
+          "name": "scanned_pdf_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bond_text": {
+          "name": "bond_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bond_artefacts_school_id_ref_school_id_fk": {
+          "name": "bond_artefacts_school_id_ref_school_id_fk",
+          "tableFrom": "bond_artefacts",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bond_artefacts_hm_witness_user_id_ref_user_id_fk": {
+          "name": "bond_artefacts_hm_witness_user_id_ref_user_id_fk",
+          "tableFrom": "bond_artefacts",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "hm_witness_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bond_artefacts_senior_hm_witness_user_id_ref_user_id_fk": {
+          "name": "bond_artefacts_senior_hm_witness_user_id_ref_user_id_fk",
+          "tableFrom": "bond_artefacts",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "senior_hm_witness_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bond_artefacts_school_id_infraction_id_boarding_infractions_school_id_id_fk": {
+          "name": "bond_artefacts_school_id_infraction_id_boarding_infractions_school_id_id_fk",
+          "tableFrom": "bond_artefacts",
+          "tableTo": "boarding_infractions",
+          "columnsFrom": [
+            "school_id",
+            "infraction_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_bond_per_infraction": {
+          "name": "uniq_bond_per_infraction",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "infraction_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bunk_allocation": {
+      "name": "bunk_allocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bunk_id": {
+          "name": "bunk_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_at": {
+          "name": "from_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "to_at": {
+          "name": "to_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allocated_by_user_id": {
+          "name": "allocated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bunk_allocation_student_idx": {
+          "name": "bunk_allocation_student_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bunk_allocation_school_id_ref_school_id_fk": {
+          "name": "bunk_allocation_school_id_ref_school_id_fk",
+          "tableFrom": "bunk_allocation",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bunk_allocation_allocated_by_user_id_ref_user_id_fk": {
+          "name": "bunk_allocation_allocated_by_user_id_ref_user_id_fk",
+          "tableFrom": "bunk_allocation",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "allocated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bunk_allocation_school_id_student_id_students_school_id_id_fk": {
+          "name": "bunk_allocation_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "bunk_allocation",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bunk_allocation_school_id_bunk_id_boarding_bunk_school_id_id_fk": {
+          "name": "bunk_allocation_school_id_bunk_id_boarding_bunk_school_id_id_fk",
+          "tableFrom": "bunk_allocation",
+          "tableTo": "boarding_bunk",
+          "columnsFrom": [
+            "school_id",
+            "bunk_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_schedule_template": {
+      "name": "daily_schedule_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_type": {
+          "name": "day_type",
+          "type": "boarding_day_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form_scope": {
+          "name": "form_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ALL'"
+        },
+        "activities_json": {
+          "name": "activities_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "daily_schedule_template_school_id_ref_school_id_fk": {
+          "name": "daily_schedule_template_school_id_ref_school_id_fk",
+          "tableFrom": "daily_schedule_template",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_schedule_template": {
+          "name": "uniq_schedule_template",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "day_type",
+            "form_scope"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deboardinization_records": {
+      "name": "deboardinization_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "infraction_id": {
+          "name": "infraction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hm_sign_user_id": {
+          "name": "hm_sign_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hm_sign_at": {
+          "name": "hm_sign_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "senior_hm_sign_user_id": {
+          "name": "senior_hm_sign_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "senior_hm_sign_at": {
+          "name": "senior_hm_sign_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headmaster_sign_user_id": {
+          "name": "headmaster_sign_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headmaster_sign_at": {
+          "name": "headmaster_sign_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_review_at": {
+          "name": "board_review_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_decision_text": {
+          "name": "board_decision_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstated_at": {
+          "name": "reinstated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstated_by_user_id": {
+          "name": "reinstated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_penalty_invoice_id": {
+          "name": "fee_penalty_invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "penalty_days": {
+          "name": "penalty_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "penalty_per_day_amount": {
+          "name": "penalty_per_day_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "penalty_adjusted_amount": {
+          "name": "penalty_adjusted_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "penalty_adjustment_reason": {
+          "name": "penalty_adjustment_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "one_active_deboard_per_student": {
+          "name": "one_active_deboard_per_student",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"deboardinization_records\".\"effective_at\" IS NOT NULL AND \"deboardinization_records\".\"reinstated_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deboardinization_records_school_id_ref_school_id_fk": {
+          "name": "deboardinization_records_school_id_ref_school_id_fk",
+          "tableFrom": "deboardinization_records",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deboardinization_records_hm_sign_user_id_ref_user_id_fk": {
+          "name": "deboardinization_records_hm_sign_user_id_ref_user_id_fk",
+          "tableFrom": "deboardinization_records",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "hm_sign_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "deboardinization_records_senior_hm_sign_user_id_ref_user_id_fk": {
+          "name": "deboardinization_records_senior_hm_sign_user_id_ref_user_id_fk",
+          "tableFrom": "deboardinization_records",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "senior_hm_sign_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "deboardinization_records_headmaster_sign_user_id_ref_user_id_fk": {
+          "name": "deboardinization_records_headmaster_sign_user_id_ref_user_id_fk",
+          "tableFrom": "deboardinization_records",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "headmaster_sign_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "deboardinization_records_reinstated_by_user_id_ref_user_id_fk": {
+          "name": "deboardinization_records_reinstated_by_user_id_ref_user_id_fk",
+          "tableFrom": "deboardinization_records",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "reinstated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "deboardinization_records_school_id_student_id_students_school_id_id_fk": {
+          "name": "deboardinization_records_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "deboardinization_records",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deboardinization_records_school_id_infraction_id_boarding_infractions_school_id_id_fk": {
+          "name": "deboardinization_records_school_id_infraction_id_boarding_infractions_school_id_id_fk",
+          "tableFrom": "deboardinization_records",
+          "tableTo": "boarding_infractions",
+          "columnsFrom": [
+            "school_id",
+            "infraction_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "deboard_effective_needs_all_signs": {
+          "name": "deboard_effective_needs_all_signs",
+          "value": "\"deboardinization_records\".\"effective_at\" IS NULL OR (\"deboardinization_records\".\"hm_sign_at\" IS NOT NULL AND \"deboardinization_records\".\"senior_hm_sign_at\" IS NOT NULL AND \"deboardinization_records\".\"headmaster_sign_at\" IS NOT NULL)"
+        },
+        "reinstate_needs_board_decision": {
+          "name": "reinstate_needs_board_decision",
+          "value": "\"deboardinization_records\".\"reinstated_at\" IS NULL OR \"deboardinization_records\".\"board_decision_text\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.exeat_notification": {
+      "name": "exeat_notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exeat_id": {
+          "name": "exeat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "exeat_notification_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_phone": {
+          "name": "to_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sent_by_user_id": {
+          "name": "sent_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "exeat_notification_exeat_idx": {
+          "name": "exeat_notification_exeat_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "exeat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exeat_notification_school_id_ref_school_id_fk": {
+          "name": "exeat_notification_school_id_ref_school_id_fk",
+          "tableFrom": "exeat_notification",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exeat_notification_sent_by_user_id_ref_user_id_fk": {
+          "name": "exeat_notification_sent_by_user_id_ref_user_id_fk",
+          "tableFrom": "exeat_notification",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "sent_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "exeat_notification_school_id_exeat_id_boarding_exeat_school_id_id_fk": {
+          "name": "exeat_notification_school_id_exeat_id_boarding_exeat_school_id_id_fk",
+          "tableFrom": "exeat_notification",
+          "tableTo": "boarding_exeat",
+          "columnsFrom": [
+            "school_id",
+            "exeat_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inspections": {
+      "name": "inspections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dormitory_id": {
+          "name": "dormitory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "house_id": {
+          "name": "house_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "inspection_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "inspection_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bunks_clean": {
+          "name": "bunks_clean",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bunks_total": {
+          "name": "bunks_total",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings_json": {
+          "name": "findings_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anomalies_count": {
+          "name": "anomalies_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "inspected_at": {
+          "name": "inspected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inspected_by_user_id": {
+          "name": "inspected_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inspections_dorm_time_idx": {
+          "name": "inspections_dorm_time_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dormitory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "inspected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inspections_house_time_idx": {
+          "name": "inspections_house_time_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "house_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "inspected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inspections_school_id_ref_school_id_fk": {
+          "name": "inspections_school_id_ref_school_id_fk",
+          "tableFrom": "inspections",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inspections_inspected_by_user_id_ref_user_id_fk": {
+          "name": "inspections_inspected_by_user_id_ref_user_id_fk",
+          "tableFrom": "inspections",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "inspected_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inspections_school_id_dormitory_id_boarding_dormitory_school_id_id_fk": {
+          "name": "inspections_school_id_dormitory_id_boarding_dormitory_school_id_id_fk",
+          "tableFrom": "inspections",
+          "tableTo": "boarding_dormitory",
+          "columnsFrom": [
+            "school_id",
+            "dormitory_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inspections_school_id_house_id_house_school_id_id_fk": {
+          "name": "inspections_school_id_house_id_house_school_id_id_fk",
+          "tableFrom": "inspections",
+          "tableTo": "house",
+          "columnsFrom": [
+            "school_id",
+            "house_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prep_attendance": {
+      "name": "prep_attendance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "house_id": {
+          "name": "house_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_date": {
+          "name": "session_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "attendance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minutes_late": {
+          "name": "minutes_late",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "logged_by_user_id": {
+          "name": "logged_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "prep_attendance_house_date_idx": {
+          "name": "prep_attendance_house_date_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "house_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prep_attendance_school_id_ref_school_id_fk": {
+          "name": "prep_attendance_school_id_ref_school_id_fk",
+          "tableFrom": "prep_attendance",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "prep_attendance_logged_by_user_id_ref_user_id_fk": {
+          "name": "prep_attendance_logged_by_user_id_ref_user_id_fk",
+          "tableFrom": "prep_attendance",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "logged_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "prep_attendance_school_id_student_id_students_school_id_id_fk": {
+          "name": "prep_attendance_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "prep_attendance",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "prep_attendance_school_id_house_id_house_school_id_id_fk": {
+          "name": "prep_attendance_school_id_house_id_house_school_id_id_fk",
+          "tableFrom": "prep_attendance",
+          "tableTo": "house",
+          "columnsFrom": [
+            "school_id",
+            "house_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_prep_attendance": {
+          "name": "uniq_prep_attendance",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "session_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admission_application": {
+      "name": "admission_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_first_name": {
+          "name": "applicant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_last_name": {
+          "name": "applicant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_other_names": {
+          "name": "applicant_other_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desired_class_label": {
+          "name": "desired_class_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guardian_name": {
+          "name": "guardian_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guardian_phone": {
+          "name": "guardian_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guardian_email": {
+          "name": "guardian_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "admission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SUBMITTED'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admission_school_status_idx": {
+          "name": "admission_school_status_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admission_application_school_id_ref_school_id_fk": {
+          "name": "admission_application_school_id_ref_school_id_fk",
+          "tableFrom": "admission_application",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admission_application_decided_by_user_id_ref_user_id_fk": {
+          "name": "admission_application_decided_by_user_id_ref_user_id_fk",
+          "tableFrom": "admission_application",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "admission_application_school_id_student_id_students_school_id_id_fk": {
+          "name": "admission_application_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "admission_application",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admission_application_tenant_uk": {
+          "name": "admission_application_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admission_document": {
+      "name": "admission_document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admission_document_school_id_ref_school_id_fk": {
+          "name": "admission_document_school_id_ref_school_id_fk",
+          "tableFrom": "admission_document",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admission_document_school_id_application_id_admission_application_school_id_id_fk": {
+          "name": "admission_document_school_id_application_id_admission_application_school_id_id_fk",
+          "tableFrom": "admission_document",
+          "tableTo": "admission_application",
+          "columnsFrom": [
+            "school_id",
+            "application_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_category": {
+      "name": "fee_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_category_school_id_ref_school_id_fk": {
+          "name": "fee_category_school_id_ref_school_id_fk",
+          "tableFrom": "fee_category",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_fee_category_per_school": {
+          "name": "uniq_fee_category_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        },
+        "fee_category_tenant_uk": {
+          "name": "fee_category_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_line_item": {
+      "name": "invoice_line_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_category_id": {
+          "name": "fee_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_optional": {
+          "name": "is_optional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_line_item_school_id_ref_school_id_fk": {
+          "name": "invoice_line_item_school_id_ref_school_id_fk",
+          "tableFrom": "invoice_line_item",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_line_item_school_id_invoice_id_invoice_school_id_id_fk": {
+          "name": "invoice_line_item_school_id_invoice_id_invoice_school_id_id_fk",
+          "tableFrom": "invoice_line_item",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "school_id",
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_line_item_school_id_fee_category_id_fee_category_school_id_id_fk": {
+          "name": "invoice_line_item_school_id_fee_category_id_fee_category_school_id_id_fk",
+          "tableFrom": "invoice_line_item",
+          "tableTo": "fee_category",
+          "columnsFrom": [
+            "school_id",
+            "fee_category_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoice_line_item_tenant_uk": {
+          "name": "invoice_line_item_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice": {
+      "name": "invoice",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal_amount": {
+          "name": "subtotal_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "billed_amount": {
+          "name": "billed_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "balance_amount": {
+          "name": "balance_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ISSUED'"
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_student_idx": {
+          "name": "invoice_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_school_id_ref_school_id_fk": {
+          "name": "invoice_school_id_ref_school_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_school_id_student_id_students_school_id_id_fk": {
+          "name": "invoice_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "invoice_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_invoice_number_per_school": {
+          "name": "uniq_invoice_number_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "invoice_number"
+          ]
+        },
+        "invoice_tenant_uk": {
+          "name": "invoice_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_allocation": {
+      "name": "payment_allocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allocation_type": {
+          "name": "allocation_type",
+          "type": "allocation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INVOICE'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allocation_method": {
+          "name": "allocation_method",
+          "type": "allocation_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MANUAL'"
+        },
+        "allocated_by_user_id": {
+          "name": "allocated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allocated_at": {
+          "name": "allocated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payment_allocation_school_id_ref_school_id_fk": {
+          "name": "payment_allocation_school_id_ref_school_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_allocation_allocated_by_user_id_ref_user_id_fk": {
+          "name": "payment_allocation_allocated_by_user_id_ref_user_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "allocated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_allocation_school_id_payment_id_payment_school_id_id_fk": {
+          "name": "payment_allocation_school_id_payment_id_payment_school_id_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "payment",
+          "columnsFrom": [
+            "school_id",
+            "payment_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_allocation_school_id_invoice_id_invoice_school_id_id_fk": {
+          "name": "payment_allocation_school_id_invoice_id_invoice_school_id_id_fk",
+          "tableFrom": "payment_allocation",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "school_id",
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_audit_log": {
+      "name": "payment_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "payment_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "payment_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ADMIN'"
+        },
+        "before_state": {
+          "name": "before_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_state": {
+          "name": "after_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_audit_school_time_idx": {
+          "name": "payment_audit_school_time_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_audit_log_school_id_ref_school_id_fk": {
+          "name": "payment_audit_log_school_id_ref_school_id_fk",
+          "tableFrom": "payment_audit_log",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_audit_log_actor_user_id_ref_user_id_fk": {
+          "name": "payment_audit_log_actor_user_id_ref_user_id_fk",
+          "tableFrom": "payment_audit_log",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment": {
+      "name": "payment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gross_amount": {
+          "name": "gross_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_amount": {
+          "name": "fee_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "net_amount": {
+          "name": "net_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GHS'"
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method_reference": {
+          "name": "method_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregator": {
+          "name": "aggregator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settlement_status": {
+          "name": "settlement_status",
+          "type": "settlement_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_by_user_id": {
+          "name": "voided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_is_refund": {
+          "name": "void_is_refund",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "payment_student_idx": {
+          "name": "payment_student_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_school_id_ref_school_id_fk": {
+          "name": "payment_school_id_ref_school_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_recorded_by_user_id_ref_user_id_fk": {
+          "name": "payment_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_voided_by_user_id_ref_user_id_fk": {
+          "name": "payment_voided_by_user_id_ref_user_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "voided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_school_id_student_id_students_school_id_id_fk": {
+          "name": "payment_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "payment_tenant_uk": {
+          "name": "payment_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.receipt": {
+      "name": "receipt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receipt_number": {
+          "name": "receipt_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_token": {
+          "name": "public_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_replacement_id": {
+          "name": "void_replacement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "receipt_school_id_ref_school_id_fk": {
+          "name": "receipt_school_id_ref_school_id_fk",
+          "tableFrom": "receipt",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "receipt_school_id_payment_id_payment_school_id_id_fk": {
+          "name": "receipt_school_id_payment_id_payment_school_id_id_fk",
+          "tableFrom": "receipt",
+          "tableTo": "payment",
+          "columnsFrom": [
+            "school_id",
+            "payment_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "receipt_school_id_student_id_students_school_id_id_fk": {
+          "name": "receipt_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "receipt",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "receipt_payment_id_unique": {
+          "name": "receipt_payment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "payment_id"
+          ]
+        },
+        "receipt_public_token_unique": {
+          "name": "receipt_public_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_token"
+          ]
+        },
+        "uniq_receipt_number_per_school": {
+          "name": "uniq_receipt_number_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "receipt_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discount_tier": {
+      "name": "discount_tier",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_id": {
+          "name": "discount_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "discount_tier_school_id_ref_school_id_fk": {
+          "name": "discount_tier_school_id_ref_school_id_fk",
+          "tableFrom": "discount_tier",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discount_tier_school_id_discount_id_discount_school_id_id_fk": {
+          "name": "discount_tier_school_id_discount_id_discount_school_id_id_fk",
+          "tableFrom": "discount_tier",
+          "tableTo": "discount",
+          "columnsFrom": [
+            "school_id",
+            "discount_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_discount_tier_rank": {
+          "name": "uniq_discount_tier_rank",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discount_id",
+            "rank"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discount": {
+      "name": "discount",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "discount_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'FIXED'"
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applies_to_category_id": {
+          "name": "applies_to_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_label": {
+          "name": "duration_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_approval": {
+          "name": "requires_approval",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stackable": {
+          "name": "stackable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_tiered": {
+          "name": "is_tiered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "applied_count": {
+          "name": "applied_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "discount_school_id_ref_school_id_fk": {
+          "name": "discount_school_id_ref_school_id_fk",
+          "tableFrom": "discount",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discount_applies_to_category_id_fee_category_id_fk": {
+          "name": "discount_applies_to_category_id_fee_category_id_fk",
+          "tableFrom": "discount",
+          "tableTo": "fee_category",
+          "columnsFrom": [
+            "applies_to_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "discount_approved_by_user_id_ref_user_id_fk": {
+          "name": "discount_approved_by_user_id_ref_user_id_fk",
+          "tableFrom": "discount",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_discount_per_school": {
+          "name": "uniq_discount_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        },
+        "discount_tenant_uk": {
+          "name": "discount_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_structure_item": {
+      "name": "fee_structure_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_structure_id": {
+          "name": "fee_structure_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_category_id": {
+          "name": "fee_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_structure_item_school_id_ref_school_id_fk": {
+          "name": "fee_structure_item_school_id_ref_school_id_fk",
+          "tableFrom": "fee_structure_item",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fee_structure_item_fee_category_id_fee_category_id_fk": {
+          "name": "fee_structure_item_fee_category_id_fee_category_id_fk",
+          "tableFrom": "fee_structure_item",
+          "tableTo": "fee_category",
+          "columnsFrom": [
+            "fee_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "fee_structure_item_school_id_fee_structure_id_fee_structure_school_id_id_fk": {
+          "name": "fee_structure_item_school_id_fee_structure_id_fee_structure_school_id_id_fk",
+          "tableFrom": "fee_structure_item",
+          "tableTo": "fee_structure",
+          "columnsFrom": [
+            "school_id",
+            "fee_structure_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_structure": {
+      "name": "fee_structure",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_structure_school_id_ref_school_id_fk": {
+          "name": "fee_structure_school_id_ref_school_id_fk",
+          "tableFrom": "fee_structure",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_fee_structure_per_school": {
+          "name": "uniq_fee_structure_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        },
+        "fee_structure_tenant_uk": {
+          "name": "fee_structure_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_discount_application": {
+      "name": "invoice_discount_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_id": {
+          "name": "discount_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind_snapshot": {
+          "name": "kind_snapshot",
+          "type": "discount_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "applied_by_user_id": {
+          "name": "applied_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_discount_app_school_idx": {
+          "name": "invoice_discount_app_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_discount_app_invoice_idx": {
+          "name": "invoice_discount_app_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_discount_app_discount_idx": {
+          "name": "invoice_discount_app_discount_idx",
+          "columns": [
+            {
+              "expression": "discount_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_discount_application_school_id_ref_school_id_fk": {
+          "name": "invoice_discount_application_school_id_ref_school_id_fk",
+          "tableFrom": "invoice_discount_application",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_discount_application_applied_by_user_id_ref_user_id_fk": {
+          "name": "invoice_discount_application_applied_by_user_id_ref_user_id_fk",
+          "tableFrom": "invoice_discount_application",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "applied_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_discount_application_school_id_invoice_id_invoice_school_id_id_fk": {
+          "name": "invoice_discount_application_school_id_invoice_id_invoice_school_id_id_fk",
+          "tableFrom": "invoice_discount_application",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "school_id",
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_discount_application_school_id_student_id_students_school_id_id_fk": {
+          "name": "invoice_discount_application_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "invoice_discount_application",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_discount_application_school_id_discount_id_discount_school_id_id_fk": {
+          "name": "invoice_discount_application_school_id_discount_id_discount_school_id_id_fk",
+          "tableFrom": "invoice_discount_application",
+          "tableTo": "discount",
+          "columnsFrom": [
+            "school_id",
+            "discount_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attendance_correction": {
+      "name": "attendance_correction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_record_id": {
+          "name": "attendance_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_status": {
+          "name": "requested_status",
+          "type": "attendance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "correction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "decision_note": {
+          "name": "decision_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attendance_correction_school_id_ref_school_id_fk": {
+          "name": "attendance_correction_school_id_ref_school_id_fk",
+          "tableFrom": "attendance_correction",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_correction_requested_by_user_id_ref_user_id_fk": {
+          "name": "attendance_correction_requested_by_user_id_ref_user_id_fk",
+          "tableFrom": "attendance_correction",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attendance_correction_decided_by_user_id_ref_user_id_fk": {
+          "name": "attendance_correction_decided_by_user_id_ref_user_id_fk",
+          "tableFrom": "attendance_correction",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attendance_correction_school_id_attendance_record_id_attendance_record_school_id_id_fk": {
+          "name": "attendance_correction_school_id_attendance_record_id_attendance_record_school_id_id_fk",
+          "tableFrom": "attendance_correction",
+          "tableTo": "attendance_record",
+          "columnsFrom": [
+            "school_id",
+            "attendance_record_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attendance_record": {
+      "name": "attendance_record",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "attendance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marked_by_user_id": {
+          "name": "marked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marked_at": {
+          "name": "marked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attendance_class_date_idx": {
+          "name": "attendance_class_date_idx",
+          "columns": [
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attendance_record_school_id_ref_school_id_fk": {
+          "name": "attendance_record_school_id_ref_school_id_fk",
+          "tableFrom": "attendance_record",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_record_marked_by_user_id_ref_user_id_fk": {
+          "name": "attendance_record_marked_by_user_id_ref_user_id_fk",
+          "tableFrom": "attendance_record",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "marked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attendance_record_school_id_student_id_students_school_id_id_fk": {
+          "name": "attendance_record_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "attendance_record",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_record_school_id_class_id_class_school_id_id_fk": {
+          "name": "attendance_record_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "attendance_record",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_attendance_student_day": {
+          "name": "uniq_attendance_student_day",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "date"
+          ]
+        },
+        "attendance_record_tenant_uk": {
+          "name": "attendance_record_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attendance_settings": {
+      "name": "attendance_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_start": {
+          "name": "day_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'08:00'"
+        },
+        "late_threshold": {
+          "name": "late_threshold",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'08:15'"
+        },
+        "day_end": {
+          "name": "day_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'15:00'"
+        },
+        "edit_window_hours": {
+          "name": "edit_window_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 24
+        },
+        "absence_sms": {
+          "name": "absence_sms",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "abs_watch_days": {
+          "name": "abs_watch_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "abs_critical_days": {
+          "name": "abs_critical_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "pct_watch": {
+          "name": "pct_watch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 70
+        },
+        "pct_critical": {
+          "name": "pct_critical",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attendance_settings_school_id_ref_school_id_fk": {
+          "name": "attendance_settings_school_id_ref_school_id_fk",
+          "tableFrom": "attendance_settings",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "attendance_settings_school_id_unique": {
+          "name": "attendance_settings_school_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.grade_scale": {
+      "name": "grade_scale",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_score": {
+          "name": "min_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grade_scale_school_idx": {
+          "name": "grade_scale_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grade_scale_school_id_ref_school_id_fk": {
+          "name": "grade_scale_school_id_ref_school_id_fk",
+          "tableFrom": "grade_scale",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_grade_per_school": {
+          "name": "uniq_grade_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "grade"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gradebook_column_score": {
+      "name": "gradebook_column_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_score": {
+          "name": "raw_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gradebook_column_score_column_idx": {
+          "name": "gradebook_column_score_column_idx",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gradebook_column_score_school_id_ref_school_id_fk": {
+          "name": "gradebook_column_score_school_id_ref_school_id_fk",
+          "tableFrom": "gradebook_column_score",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_score_updated_by_user_id_ref_user_id_fk": {
+          "name": "gradebook_column_score_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "gradebook_column_score",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_score_school_id_column_id_gradebook_column_school_id_id_fk": {
+          "name": "gradebook_column_score_school_id_column_id_gradebook_column_school_id_id_fk",
+          "tableFrom": "gradebook_column_score",
+          "tableTo": "gradebook_column",
+          "columnsFrom": [
+            "school_id",
+            "column_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_score_school_id_student_id_students_school_id_id_fk": {
+          "name": "gradebook_column_score_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "gradebook_column_score",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_column_score_per_student": {
+          "name": "uniq_column_score_per_student",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "column_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gradebook_column": {
+      "name": "gradebook_column",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CA'"
+        },
+        "max_score": {
+          "name": "max_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gradebook_column_context_idx": {
+          "name": "gradebook_column_context_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gradebook_column_school_id_ref_school_id_fk": {
+          "name": "gradebook_column_school_id_ref_school_id_fk",
+          "tableFrom": "gradebook_column",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_created_by_user_id_ref_user_id_fk": {
+          "name": "gradebook_column_created_by_user_id_ref_user_id_fk",
+          "tableFrom": "gradebook_column",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_school_id_class_id_class_school_id_id_fk": {
+          "name": "gradebook_column_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "gradebook_column",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "gradebook_column_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "gradebook_column",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_column_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "gradebook_column_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "gradebook_column",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_column_per_class_subject_period": {
+          "name": "uniq_column_per_class_subject_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "class_id",
+            "subject_id",
+            "period_id",
+            "name"
+          ]
+        },
+        "gradebook_column_tenant_uk": {
+          "name": "gradebook_column_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gradebook_config": {
+      "name": "gradebook_config",
+      "schema": "",
+      "columns": {
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "class_weight": {
+          "name": "class_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "exam_weight": {
+          "name": "exam_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gradebook_config_school_id_ref_school_id_fk": {
+          "name": "gradebook_config_school_id_ref_school_id_fk",
+          "tableFrom": "gradebook_config",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gradebook_score": {
+      "name": "gradebook_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_score": {
+          "name": "class_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exam_score": {
+          "name": "exam_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "score_period_subject_idx": {
+          "name": "score_period_subject_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gradebook_score_school_id_ref_school_id_fk": {
+          "name": "gradebook_score_school_id_ref_school_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_score_updated_by_user_id_ref_user_id_fk": {
+          "name": "gradebook_score_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gradebook_score_school_id_student_id_students_school_id_id_fk": {
+          "name": "gradebook_score_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_score_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "gradebook_score_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gradebook_score_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "gradebook_score_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "gradebook_score",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_score_student_subject_period": {
+          "name": "uniq_score_student_subject_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "subject_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_card": {
+      "name": "report_card",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overall_total": {
+          "name": "overall_total",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overall_grade": {
+          "name": "overall_grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_count": {
+          "name": "subject_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "report_card_school_id_ref_school_id_fk": {
+          "name": "report_card_school_id_ref_school_id_fk",
+          "tableFrom": "report_card",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "report_card_generated_by_user_id_ref_user_id_fk": {
+          "name": "report_card_generated_by_user_id_ref_user_id_fk",
+          "tableFrom": "report_card",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "report_card_school_id_student_id_students_school_id_id_fk": {
+          "name": "report_card_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "report_card",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "report_card_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "report_card_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "report_card",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_report_student_period": {
+          "name": "uniq_report_student_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subject": {
+      "name": "subject",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subject_school_id_ref_school_id_fk": {
+          "name": "subject_school_id_ref_school_id_fk",
+          "tableFrom": "subject",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_subject_per_school": {
+          "name": "uniq_subject_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        },
+        "subject_tenant_uk": {
+          "name": "subject_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ref_assessment_weights": {
+      "name": "ref_assessment_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asgn_weight": {
+          "name": "asgn_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "mid_sem_weight": {
+          "name": "mid_sem_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "end_sem_weight": {
+          "name": "end_sem_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 40
+        },
+        "project_weight": {
+          "name": "project_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "portfolio_weight": {
+          "name": "portfolio_weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "asgn_denominator": {
+          "name": "asgn_denominator",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "mid_sem_denominator": {
+          "name": "mid_sem_denominator",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "end_sem_denominator": {
+          "name": "end_sem_denominator",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "project_denominator": {
+          "name": "project_denominator",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "portfolio_denominator": {
+          "name": "portfolio_denominator",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_school_default_weights": {
+          "name": "uniq_school_default_weights",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"ref_assessment_weights\".\"subject_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ref_assessment_weights_school_id_ref_school_id_fk": {
+          "name": "ref_assessment_weights_school_id_ref_school_id_fk",
+          "tableFrom": "ref_assessment_weights",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ref_assessment_weights_updated_by_user_id_ref_user_id_fk": {
+          "name": "ref_assessment_weights_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "ref_assessment_weights",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ref_assessment_weights_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "ref_assessment_weights_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "ref_assessment_weights",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_weights_per_school_subject": {
+          "name": "uniq_weights_per_school_subject",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "subject_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "assessment_weights_sum_100": {
+          "name": "assessment_weights_sum_100",
+          "value": "\"ref_assessment_weights\".\"asgn_weight\" + \"ref_assessment_weights\".\"mid_sem_weight\" + \"ref_assessment_weights\".\"end_sem_weight\" + \"ref_assessment_weights\".\"project_weight\" + \"ref_assessment_weights\".\"portfolio_weight\" = 100"
+        },
+        "assessment_denominators_positive": {
+          "name": "assessment_denominators_positive",
+          "value": "\"ref_assessment_weights\".\"asgn_denominator\" > 0 AND \"ref_assessment_weights\".\"mid_sem_denominator\" > 0 AND \"ref_assessment_weights\".\"end_sem_denominator\" > 0 AND \"ref_assessment_weights\".\"project_denominator\" > 0 AND \"ref_assessment_weights\".\"portfolio_denominator\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.senior_assessment_score": {
+      "name": "senior_assessment_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assessment_id": {
+          "name": "assessment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_mark": {
+          "name": "raw_mark",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "senior_assessment_score_assessment_idx": {
+          "name": "senior_assessment_score_assessment_idx",
+          "columns": [
+            {
+              "expression": "assessment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "senior_assessment_score_school_id_ref_school_id_fk": {
+          "name": "senior_assessment_score_school_id_ref_school_id_fk",
+          "tableFrom": "senior_assessment_score",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_score_updated_by_user_id_ref_user_id_fk": {
+          "name": "senior_assessment_score_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "senior_assessment_score",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_score_school_id_assessment_id_senior_assessment_school_id_id_fk": {
+          "name": "senior_assessment_score_school_id_assessment_id_senior_assessment_school_id_id_fk",
+          "tableFrom": "senior_assessment_score",
+          "tableTo": "senior_assessment",
+          "columnsFrom": [
+            "school_id",
+            "assessment_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_score_school_id_student_id_students_school_id_id_fk": {
+          "name": "senior_assessment_score_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "senior_assessment_score",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_assessment_score_per_student": {
+          "name": "uniq_assessment_score_per_student",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "assessment_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.senior_assessment": {
+      "name": "senior_assessment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "assessment_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_mark": {
+          "name": "max_mark",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assessed_on": {
+          "name": "assessed_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_one_mid_sem_per_context": {
+          "name": "uniq_one_mid_sem_per_context",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"senior_assessment\".\"category\" = 'MID_SEM_EXAM'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_one_end_sem_per_context": {
+          "name": "uniq_one_end_sem_per_context",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"senior_assessment\".\"category\" = 'END_SEM_EXAM'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "senior_assessment_context_idx": {
+          "name": "senior_assessment_context_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "senior_assessment_school_id_ref_school_id_fk": {
+          "name": "senior_assessment_school_id_ref_school_id_fk",
+          "tableFrom": "senior_assessment",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_created_by_user_id_ref_user_id_fk": {
+          "name": "senior_assessment_created_by_user_id_ref_user_id_fk",
+          "tableFrom": "senior_assessment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_school_id_class_id_class_school_id_id_fk": {
+          "name": "senior_assessment_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "senior_assessment",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "senior_assessment_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "senior_assessment",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_assessment_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "senior_assessment_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "senior_assessment",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_assessment_per_context": {
+          "name": "uniq_assessment_per_context",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "class_id",
+            "subject_id",
+            "period_id",
+            "category",
+            "title"
+          ]
+        },
+        "senior_assessment_tenant_uk": {
+          "name": "senior_assessment_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.senior_ledger_path": {
+      "name": "senior_ledger_path",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "capture_path",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AUTO_COMPILE'"
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "senior_ledger_path_school_id_ref_school_id_fk": {
+          "name": "senior_ledger_path_school_id_ref_school_id_fk",
+          "tableFrom": "senior_ledger_path",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_ledger_path_updated_by_user_id_ref_user_id_fk": {
+          "name": "senior_ledger_path_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "senior_ledger_path",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "senior_ledger_path_school_id_class_id_class_school_id_id_fk": {
+          "name": "senior_ledger_path_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "senior_ledger_path",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_ledger_path_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "senior_ledger_path_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "senior_ledger_path",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_ledger_path_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "senior_ledger_path_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "senior_ledger_path",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_ledger_path_context": {
+          "name": "uniq_ledger_path_context",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "class_id",
+            "subject_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.senior_score_ledger": {
+      "name": "senior_score_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asgn_score": {
+          "name": "asgn_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mid_sem_score": {
+          "name": "mid_sem_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_sem_score": {
+          "name": "end_sem_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_score": {
+          "name": "project_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "portfolio_score": {
+          "name": "portfolio_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weighted_total": {
+          "name": "weighted_total",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asgn_weight_used": {
+          "name": "asgn_weight_used",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mid_sem_weight_used": {
+          "name": "mid_sem_weight_used",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_sem_weight_used": {
+          "name": "end_sem_weight_used",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_weight_used": {
+          "name": "project_weight_used",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "portfolio_weight_used": {
+          "name": "portfolio_weight_used",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "portfolio_manual": {
+          "name": "portfolio_manual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ledger_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "compiled_by_user_id": {
+          "name": "compiled_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compiled_at": {
+          "name": "compiled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "senior_ledger_period_subject_idx": {
+          "name": "senior_ledger_period_subject_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "senior_score_ledger_school_id_ref_school_id_fk": {
+          "name": "senior_score_ledger_school_id_ref_school_id_fk",
+          "tableFrom": "senior_score_ledger",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_compiled_by_user_id_ref_user_id_fk": {
+          "name": "senior_score_ledger_compiled_by_user_id_ref_user_id_fk",
+          "tableFrom": "senior_score_ledger",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "compiled_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_school_id_student_id_students_school_id_id_fk": {
+          "name": "senior_score_ledger_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "senior_score_ledger",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "senior_score_ledger_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "senior_score_ledger",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "senior_score_ledger_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "senior_score_ledger",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_ledger_student_subject_period": {
+          "name": "uniq_ledger_student_subject_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "subject_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.senior_score_ledger_version": {
+      "name": "senior_score_ledger_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asgn_score": {
+          "name": "asgn_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mid_sem_score": {
+          "name": "mid_sem_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_sem_score": {
+          "name": "end_sem_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_score": {
+          "name": "project_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "portfolio_score": {
+          "name": "portfolio_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weighted_total": {
+          "name": "weighted_total",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ledger_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_used": {
+          "name": "path_used",
+          "type": "capture_path",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "committed_by_user_id": {
+          "name": "committed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "supersedes_id": {
+          "name": "supersedes_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "senior_ledger_version_prune_idx": {
+          "name": "senior_ledger_version_prune_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "senior_score_ledger_version_school_id_ref_school_id_fk": {
+          "name": "senior_score_ledger_version_school_id_ref_school_id_fk",
+          "tableFrom": "senior_score_ledger_version",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_version_committed_by_user_id_ref_user_id_fk": {
+          "name": "senior_score_ledger_version_committed_by_user_id_ref_user_id_fk",
+          "tableFrom": "senior_score_ledger_version",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "committed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_version_school_id_student_id_students_school_id_id_fk": {
+          "name": "senior_score_ledger_version_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "senior_score_ledger_version",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_version_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "senior_score_ledger_version_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "senior_score_ledger_version",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_version_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "senior_score_ledger_version_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "senior_score_ledger_version",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_score_ledger_version_school_id_supersedes_id_senior_score_ledger_version_school_id_id_fk": {
+          "name": "senior_score_ledger_version_school_id_supersedes_id_senior_score_ledger_version_school_id_id_fk",
+          "tableFrom": "senior_score_ledger_version",
+          "tableTo": "senior_score_ledger_version",
+          "columnsFrom": [
+            "school_id",
+            "supersedes_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "senior_score_ledger_version_tenant_uk": {
+          "name": "senior_score_ledger_version_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        },
+        "uniq_ledger_version_grain_number": {
+          "name": "uniq_ledger_version_grain_number",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "subject_id",
+            "period_id",
+            "version_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.senior_subject_teacher": {
+      "name": "senior_subject_teacher",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teacher_user_id": {
+          "name": "teacher_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "senior_subject_teacher_school_id_ref_school_id_fk": {
+          "name": "senior_subject_teacher_school_id_ref_school_id_fk",
+          "tableFrom": "senior_subject_teacher",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_subject_teacher_teacher_user_id_ref_user_id_fk": {
+          "name": "senior_subject_teacher_teacher_user_id_ref_user_id_fk",
+          "tableFrom": "senior_subject_teacher",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "teacher_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "senior_subject_teacher_school_id_class_id_class_school_id_id_fk": {
+          "name": "senior_subject_teacher_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "senior_subject_teacher",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "senior_subject_teacher_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "senior_subject_teacher_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "senior_subject_teacher",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_subject_teacher_context": {
+          "name": "uniq_subject_teacher_context",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "class_id",
+            "subject_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_subject_enrolment": {
+      "name": "student_subject_enrolment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "student_subject_enrolment_subject_idx": {
+          "name": "student_subject_enrolment_subject_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_subject_enrolment_school_id_ref_school_id_fk": {
+          "name": "student_subject_enrolment_school_id_ref_school_id_fk",
+          "tableFrom": "student_subject_enrolment",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_subject_enrolment_created_by_user_id_ref_user_id_fk": {
+          "name": "student_subject_enrolment_created_by_user_id_ref_user_id_fk",
+          "tableFrom": "student_subject_enrolment",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "student_subject_enrolment_school_id_student_id_students_school_id_id_fk": {
+          "name": "student_subject_enrolment_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "student_subject_enrolment",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_subject_enrolment_school_id_subject_id_subject_school_id_id_fk": {
+          "name": "student_subject_enrolment_school_id_subject_id_subject_school_id_id_fk",
+          "tableFrom": "student_subject_enrolment",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_student_subject_enrolment": {
+          "name": "uniq_student_subject_enrolment",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id",
+            "subject_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.benchmark_data_points": {
+      "name": "benchmark_data_points",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "benchmark_metric",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "benchmark_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "benchmark_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quality": {
+          "name": "quality",
+          "type": "benchmark_quality",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence_interval_pp": {
+          "name": "confidence_interval_pp",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_year": {
+          "name": "reference_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "benchmark_data_points_school_id_ref_school_id_fk": {
+          "name": "benchmark_data_points_school_id_ref_school_id_fk",
+          "tableFrom": "benchmark_data_points",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "benchmark_data_points_school_id_subject_id_wassce_subjects_school_id_id_fk": {
+          "name": "benchmark_data_points_school_id_subject_id_wassce_subjects_school_id_id_fk",
+          "tableFrom": "benchmark_data_points",
+          "tableTo": "wassce_subjects",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.benchmark_reference": {
+      "name": "benchmark_reference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_name": {
+          "name": "subject_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "benchmark_metric",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "benchmark_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "benchmark_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quality": {
+          "name": "quality",
+          "type": "benchmark_quality",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence_interval_pp": {
+          "name": "confidence_interval_pp",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_year": {
+          "name": "reference_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mock_exams": {
+      "name": "mock_exams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cohort_id": {
+          "name": "cohort_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mock_number": {
+          "name": "mock_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_predictor": {
+          "name": "is_predictor",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "scheduled_start": {
+          "name": "scheduled_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_end": {
+          "name": "scheduled_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marking_complete_at": {
+          "name": "marking_complete_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_mock_exam_predictor": {
+          "name": "uniq_mock_exam_predictor",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cohort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mock_exams\".\"is_predictor\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mock_exams_school_id_ref_school_id_fk": {
+          "name": "mock_exams_school_id_ref_school_id_fk",
+          "tableFrom": "mock_exams",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_exams_school_id_cohort_id_wassce_cohort_school_id_id_fk": {
+          "name": "mock_exams_school_id_cohort_id_wassce_cohort_school_id_id_fk",
+          "tableFrom": "mock_exams",
+          "tableTo": "wassce_cohort",
+          "columnsFrom": [
+            "school_id",
+            "cohort_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_mock_exam_number": {
+          "name": "uniq_mock_exam_number",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "cohort_id",
+            "mock_number"
+          ]
+        },
+        "mock_exams_tenant_uk": {
+          "name": "mock_exams_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mock_results": {
+      "name": "mock_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mock_id": {
+          "name": "mock_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade": {
+          "name": "grade",
+          "type": "wassce_grade",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_score": {
+          "name": "raw_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_score": {
+          "name": "max_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marked_by_user_id": {
+          "name": "marked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marked_at": {
+          "name": "marked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderated_grade": {
+          "name": "moderated_grade",
+          "type": "wassce_grade",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderator_user_id": {
+          "name": "moderator_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderated_at": {
+          "name": "moderated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderation_reason": {
+          "name": "moderation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mock_results_mock_subject_idx": {
+          "name": "mock_results_mock_subject_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mock_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mock_results_candidate_idx": {
+          "name": "mock_results_candidate_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mock_results_school_id_ref_school_id_fk": {
+          "name": "mock_results_school_id_ref_school_id_fk",
+          "tableFrom": "mock_results",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_results_marked_by_user_id_ref_user_id_fk": {
+          "name": "mock_results_marked_by_user_id_ref_user_id_fk",
+          "tableFrom": "mock_results",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "marked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mock_results_moderator_user_id_ref_user_id_fk": {
+          "name": "mock_results_moderator_user_id_ref_user_id_fk",
+          "tableFrom": "mock_results",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "moderator_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mock_results_school_id_mock_id_mock_exams_school_id_id_fk": {
+          "name": "mock_results_school_id_mock_id_mock_exams_school_id_id_fk",
+          "tableFrom": "mock_results",
+          "tableTo": "mock_exams",
+          "columnsFrom": [
+            "school_id",
+            "mock_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_results_school_id_candidate_id_wassce_candidates_school_id_id_fk": {
+          "name": "mock_results_school_id_candidate_id_wassce_candidates_school_id_id_fk",
+          "tableFrom": "mock_results",
+          "tableTo": "wassce_candidates",
+          "columnsFrom": [
+            "school_id",
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_results_school_id_subject_id_wassce_subjects_school_id_id_fk": {
+          "name": "mock_results_school_id_subject_id_wassce_subjects_school_id_id_fk",
+          "tableFrom": "mock_results",
+          "tableTo": "wassce_subjects",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_mock_result": {
+          "name": "uniq_mock_result",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "mock_id",
+            "candidate_id",
+            "subject_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mock_results_moderation_trail": {
+          "name": "mock_results_moderation_trail",
+          "value": "\"mock_results\".\"moderated_grade\" IS NULL OR (\"mock_results\".\"moderator_user_id\" IS NOT NULL AND \"mock_results\".\"moderated_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.readiness_statements": {
+      "name": "readiness_statements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mock_2_id": {
+          "name": "mock_2_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projected_aggregate": {
+          "name": "projected_aggregate",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projected_band": {
+          "name": "projected_band",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projection_snapshot_json": {
+          "name": "projection_snapshot_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_universities_json": {
+          "name": "target_universities_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_acknowledged_at": {
+          "name": "parent_acknowledged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_acknowledged_signature_method": {
+          "name": "parent_acknowledged_signature_method",
+          "type": "parent_ack_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_acknowledged_phone": {
+          "name": "parent_acknowledged_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_concerns_text": {
+          "name": "parent_concerns_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_signature_pdf_file_id": {
+          "name": "parent_signature_pdf_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "readiness_statements_candidate_idx": {
+          "name": "readiness_statements_candidate_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "readiness_statements_current_idx": {
+          "name": "readiness_statements_current_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"readiness_statements\".\"superseded_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "readiness_statements_school_id_ref_school_id_fk": {
+          "name": "readiness_statements_school_id_ref_school_id_fk",
+          "tableFrom": "readiness_statements",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "readiness_statements_generated_by_user_id_ref_user_id_fk": {
+          "name": "readiness_statements_generated_by_user_id_ref_user_id_fk",
+          "tableFrom": "readiness_statements",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "readiness_statements_school_id_candidate_id_wassce_candidates_school_id_id_fk": {
+          "name": "readiness_statements_school_id_candidate_id_wassce_candidates_school_id_id_fk",
+          "tableFrom": "readiness_statements",
+          "tableTo": "wassce_candidates",
+          "columnsFrom": [
+            "school_id",
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "readiness_statements_school_id_mock_2_id_mock_exams_school_id_id_fk": {
+          "name": "readiness_statements_school_id_mock_2_id_mock_exams_school_id_id_fk",
+          "tableFrom": "readiness_statements",
+          "tableTo": "mock_exams",
+          "columnsFrom": [
+            "school_id",
+            "mock_2_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "readiness_statements_projected_aggregate_range": {
+          "name": "readiness_statements_projected_aggregate_range",
+          "value": "\"readiness_statements\".\"projected_aggregate\" IS NULL OR (\"readiness_statements\".\"projected_aggregate\" BETWEEN 6 AND 54)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.universities": {
+      "name": "universities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "university_type": {
+          "name": "university_type",
+          "type": "university_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.university_programmes": {
+      "name": "university_programmes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "university_id": {
+          "name": "university_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qualification": {
+          "name": "qualification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_years": {
+          "name": "duration_years",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_cut_off": {
+          "name": "current_cut_off",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cut_off_reference_year": {
+          "name": "cut_off_reference_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cut_off_history_json": {
+          "name": "cut_off_history_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prerequisite_subjects_json": {
+          "name": "prerequisite_subjects_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "university_programmes_university_idx": {
+          "name": "university_programmes_university_idx",
+          "columns": [
+            {
+              "expression": "university_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "university_programmes_university_id_universities_id_fk": {
+          "name": "university_programmes_university_id_universities_id_fk",
+          "tableFrom": "university_programmes",
+          "tableTo": "universities",
+          "columnsFrom": [
+            "university_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "university_programmes_current_cut_off_range": {
+          "name": "university_programmes_current_cut_off_range",
+          "value": "\"university_programmes\".\"current_cut_off\" BETWEEN 6 AND 54"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.university_targets": {
+      "name": "university_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "university_programme_id": {
+          "name": "university_programme_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_rank": {
+          "name": "target_rank",
+          "type": "target_rank",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tagged_at": {
+          "name": "tagged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tagged_by_user_id": {
+          "name": "tagged_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_acknowledged_at": {
+          "name": "parent_acknowledged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_university_target_rank": {
+          "name": "uniq_university_target_rank",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"university_targets\".\"target_rank\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "university_targets_candidate_idx": {
+          "name": "university_targets_candidate_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "university_targets_school_id_ref_school_id_fk": {
+          "name": "university_targets_school_id_ref_school_id_fk",
+          "tableFrom": "university_targets",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "university_targets_university_programme_id_university_programmes_id_fk": {
+          "name": "university_targets_university_programme_id_university_programmes_id_fk",
+          "tableFrom": "university_targets",
+          "tableTo": "university_programmes",
+          "columnsFrom": [
+            "university_programme_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "university_targets_tagged_by_user_id_ref_user_id_fk": {
+          "name": "university_targets_tagged_by_user_id_ref_user_id_fk",
+          "tableFrom": "university_targets",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "tagged_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "university_targets_school_id_candidate_id_wassce_candidates_school_id_id_fk": {
+          "name": "university_targets_school_id_candidate_id_wassce_candidates_school_id_id_fk",
+          "tableFrom": "university_targets",
+          "tableTo": "wassce_candidates",
+          "columnsFrom": [
+            "school_id",
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_university_target_programme": {
+          "name": "uniq_university_target_programme",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "candidate_id",
+            "university_programme_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.waec_special_consideration": {
+      "name": "waec_special_consideration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sc_form": {
+          "name": "sc_form",
+          "type": "sc_form",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "sc_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filed_by_user_id": {
+          "name": "filed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_cert_file_id": {
+          "name": "medical_cert_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinician_letter_file_id": {
+          "name": "clinician_letter_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waec_acknowledged_at": {
+          "name": "waec_acknowledged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waec_ref": {
+          "name": "waec_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "make_up_scheduled_at": {
+          "name": "make_up_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "make_up_centre": {
+          "name": "make_up_centre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "waec_special_consideration_school_id_ref_school_id_fk": {
+          "name": "waec_special_consideration_school_id_ref_school_id_fk",
+          "tableFrom": "waec_special_consideration",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "waec_special_consideration_filed_by_user_id_ref_user_id_fk": {
+          "name": "waec_special_consideration_filed_by_user_id_ref_user_id_fk",
+          "tableFrom": "waec_special_consideration",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "filed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "waec_special_consideration_school_id_candidate_id_wassce_candidates_school_id_id_fk": {
+          "name": "waec_special_consideration_school_id_candidate_id_wassce_candidates_school_id_id_fk",
+          "tableFrom": "waec_special_consideration",
+          "tableTo": "wassce_candidates",
+          "columnsFrom": [
+            "school_id",
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_waec_sc_candidate_form": {
+          "name": "uniq_waec_sc_candidate_form",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "candidate_id",
+            "sc_form"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wassce_candidate_subject": {
+      "name": "wassce_candidate_subject",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wassce_candidate_subject_subject_idx": {
+          "name": "wassce_candidate_subject_subject_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wassce_candidate_subject_school_id_ref_school_id_fk": {
+          "name": "wassce_candidate_subject_school_id_ref_school_id_fk",
+          "tableFrom": "wassce_candidate_subject",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wassce_candidate_subject_school_id_candidate_id_wassce_candidates_school_id_id_fk": {
+          "name": "wassce_candidate_subject_school_id_candidate_id_wassce_candidates_school_id_id_fk",
+          "tableFrom": "wassce_candidate_subject",
+          "tableTo": "wassce_candidates",
+          "columnsFrom": [
+            "school_id",
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wassce_candidate_subject_school_id_subject_id_wassce_subjects_school_id_id_fk": {
+          "name": "wassce_candidate_subject_school_id_subject_id_wassce_subjects_school_id_id_fk",
+          "tableFrom": "wassce_candidate_subject",
+          "tableTo": "wassce_subjects",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_wassce_candidate_subject": {
+          "name": "uniq_wassce_candidate_subject",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "candidate_id",
+            "subject_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wassce_candidates": {
+      "name": "wassce_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cohort_id": {
+          "name": "cohort_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "programme_id": {
+          "name": "programme_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index_number": {
+          "name": "index_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "centre_code": {
+          "name": "centre_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_status": {
+          "name": "candidate_status",
+          "type": "wassce_candidate_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REGISTERED'"
+        },
+        "reg_flag": {
+          "name": "reg_flag",
+          "type": "wassce_reg_flag",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodations_json": {
+          "name": "accommodations_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mock_2_aggregate": {
+          "name": "mock_2_aggregate",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projected_aggregate": {
+          "name": "projected_aggregate",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wassce_candidates_cohort_idx": {
+          "name": "wassce_candidates_cohort_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cohort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wassce_candidates_programme_idx": {
+          "name": "wassce_candidates_programme_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "programme_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wassce_candidates_school_id_ref_school_id_fk": {
+          "name": "wassce_candidates_school_id_ref_school_id_fk",
+          "tableFrom": "wassce_candidates",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wassce_candidates_school_id_cohort_id_wassce_cohort_school_id_id_fk": {
+          "name": "wassce_candidates_school_id_cohort_id_wassce_cohort_school_id_id_fk",
+          "tableFrom": "wassce_candidates",
+          "tableTo": "wassce_cohort",
+          "columnsFrom": [
+            "school_id",
+            "cohort_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wassce_candidates_school_id_student_id_students_school_id_id_fk": {
+          "name": "wassce_candidates_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "wassce_candidates",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wassce_candidates_school_id_programme_id_wassce_programmes_school_id_id_fk": {
+          "name": "wassce_candidates_school_id_programme_id_wassce_programmes_school_id_id_fk",
+          "tableFrom": "wassce_candidates",
+          "tableTo": "wassce_programmes",
+          "columnsFrom": [
+            "school_id",
+            "programme_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_wassce_index_number": {
+          "name": "uniq_wassce_index_number",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "index_number"
+          ]
+        },
+        "uniq_wassce_candidate_student_cohort": {
+          "name": "uniq_wassce_candidate_student_cohort",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "cohort_id",
+            "student_id"
+          ]
+        },
+        "wassce_candidates_tenant_uk": {
+          "name": "wassce_candidates_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wassce_cohort": {
+      "name": "wassce_cohort",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exam_year": {
+          "name": "exam_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setup_frozen_at": {
+          "name": "setup_frozen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headmaster_cosign_user_id": {
+          "name": "headmaster_cosign_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headmaster_cosign_at": {
+          "name": "headmaster_cosign_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_cosign_user_id": {
+          "name": "academic_cosign_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_cosign_at": {
+          "name": "academic_cosign_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wassce_cohort_school_id_ref_school_id_fk": {
+          "name": "wassce_cohort_school_id_ref_school_id_fk",
+          "tableFrom": "wassce_cohort",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wassce_cohort_headmaster_cosign_user_id_ref_user_id_fk": {
+          "name": "wassce_cohort_headmaster_cosign_user_id_ref_user_id_fk",
+          "tableFrom": "wassce_cohort",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "headmaster_cosign_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "wassce_cohort_academic_cosign_user_id_ref_user_id_fk": {
+          "name": "wassce_cohort_academic_cosign_user_id_ref_user_id_fk",
+          "tableFrom": "wassce_cohort",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "academic_cosign_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_wassce_cohort_per_year": {
+          "name": "uniq_wassce_cohort_per_year",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "exam_year"
+          ]
+        },
+        "wassce_cohort_tenant_uk": {
+          "name": "wassce_cohort_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "wassce_cohort_freeze_needs_both_cosigns": {
+          "name": "wassce_cohort_freeze_needs_both_cosigns",
+          "value": "\"wassce_cohort\".\"setup_frozen_at\" IS NULL OR (\"wassce_cohort\".\"headmaster_cosign_at\" IS NOT NULL AND \"wassce_cohort\".\"academic_cosign_at\" IS NOT NULL)"
+        },
+        "wassce_cohort_distinct_cosigners": {
+          "name": "wassce_cohort_distinct_cosigners",
+          "value": "\"wassce_cohort\".\"headmaster_cosign_user_id\" IS NULL OR \"wassce_cohort\".\"academic_cosign_user_id\" IS NULL OR \"wassce_cohort\".\"headmaster_cosign_user_id\" <> \"wassce_cohort\".\"academic_cosign_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.wassce_paper_sittings": {
+      "name": "wassce_paper_sittings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paper_id": {
+          "name": "paper_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sat_at": {
+          "name": "sat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exempted_at": {
+          "name": "exempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exemption_reason_text": {
+          "name": "exemption_reason_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "make_up_at": {
+          "name": "make_up_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "make_up_centre": {
+          "name": "make_up_centre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wassce_paper_sittings_paper_idx": {
+          "name": "wassce_paper_sittings_paper_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "paper_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wassce_paper_sittings_school_id_ref_school_id_fk": {
+          "name": "wassce_paper_sittings_school_id_ref_school_id_fk",
+          "tableFrom": "wassce_paper_sittings",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wassce_paper_sittings_school_id_candidate_id_wassce_candidates_school_id_id_fk": {
+          "name": "wassce_paper_sittings_school_id_candidate_id_wassce_candidates_school_id_id_fk",
+          "tableFrom": "wassce_paper_sittings",
+          "tableTo": "wassce_candidates",
+          "columnsFrom": [
+            "school_id",
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wassce_paper_sittings_school_id_paper_id_wassce_papers_school_id_id_fk": {
+          "name": "wassce_paper_sittings_school_id_paper_id_wassce_papers_school_id_id_fk",
+          "tableFrom": "wassce_paper_sittings",
+          "tableTo": "wassce_papers",
+          "columnsFrom": [
+            "school_id",
+            "paper_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_wassce_paper_sitting": {
+          "name": "uniq_wassce_paper_sitting",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "candidate_id",
+            "paper_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wassce_papers": {
+      "name": "wassce_papers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cohort_id": {
+          "name": "cohort_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paper_number": {
+          "name": "paper_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paper_type": {
+          "name": "paper_type",
+          "type": "wassce_paper_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "waec_paper_code": {
+          "name": "waec_paper_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_date": {
+          "name": "scheduled_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_time": {
+          "name": "scheduled_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wassce_papers_cohort_subject_idx": {
+          "name": "wassce_papers_cohort_subject_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cohort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wassce_papers_school_id_ref_school_id_fk": {
+          "name": "wassce_papers_school_id_ref_school_id_fk",
+          "tableFrom": "wassce_papers",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wassce_papers_school_id_cohort_id_wassce_cohort_school_id_id_fk": {
+          "name": "wassce_papers_school_id_cohort_id_wassce_cohort_school_id_id_fk",
+          "tableFrom": "wassce_papers",
+          "tableTo": "wassce_cohort",
+          "columnsFrom": [
+            "school_id",
+            "cohort_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wassce_papers_school_id_subject_id_wassce_subjects_school_id_id_fk": {
+          "name": "wassce_papers_school_id_subject_id_wassce_subjects_school_id_id_fk",
+          "tableFrom": "wassce_papers",
+          "tableTo": "wassce_subjects",
+          "columnsFrom": [
+            "school_id",
+            "subject_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_wassce_paper": {
+          "name": "uniq_wassce_paper",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "cohort_id",
+            "subject_id",
+            "name"
+          ]
+        },
+        "wassce_papers_tenant_uk": {
+          "name": "wassce_papers_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wassce_programmes": {
+      "name": "wassce_programmes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "programme": {
+          "name": "programme",
+          "type": "programme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_flag": {
+          "name": "active_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wassce_programmes_school_id_ref_school_id_fk": {
+          "name": "wassce_programmes_school_id_ref_school_id_fk",
+          "tableFrom": "wassce_programmes",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_wassce_programme_per_school": {
+          "name": "uniq_wassce_programme_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "programme"
+          ]
+        },
+        "wassce_programmes_tenant_uk": {
+          "name": "wassce_programmes_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wassce_subjects": {
+      "name": "wassce_subjects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "programme_id": {
+          "name": "programme_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "wassce_subject_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_flag": {
+          "name": "active_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wassce_subjects_programme_idx": {
+          "name": "wassce_subjects_programme_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "programme_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wassce_subjects_school_id_ref_school_id_fk": {
+          "name": "wassce_subjects_school_id_ref_school_id_fk",
+          "tableFrom": "wassce_subjects",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wassce_subjects_school_id_programme_id_wassce_programmes_school_id_id_fk": {
+          "name": "wassce_subjects_school_id_programme_id_wassce_programmes_school_id_id_fk",
+          "tableFrom": "wassce_subjects",
+          "tableTo": "wassce_programmes",
+          "columnsFrom": [
+            "school_id",
+            "programme_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_wassce_subject_per_programme": {
+          "name": "uniq_wassce_subject_per_programme",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "programme_id",
+            "name"
+          ]
+        },
+        "wassce_subjects_tenant_uk": {
+          "name": "wassce_subjects_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_admission": {
+      "name": "sickbay_admission",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visit_id": {
+          "name": "visit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bed_id": {
+          "name": "bed_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admitted_at": {
+          "name": "admitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admitted_by_user_id": {
+          "name": "admitted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_isolation": {
+          "name": "is_isolation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expected_discharge_at": {
+          "name": "expected_discharge_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discharge_criteria": {
+          "name": "discharge_criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overnight_plan": {
+          "name": "overnight_plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discharged_at": {
+          "name": "discharged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discharged_by_user_id": {
+          "name": "discharged_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discharge_note": {
+          "name": "discharge_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_sickbay_open_admission_bed": {
+          "name": "uniq_sickbay_open_admission_bed",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sickbay_admission\".\"discharged_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_sickbay_open_admission_student": {
+          "name": "uniq_sickbay_open_admission_student",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sickbay_admission\".\"discharged_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sickbay_admission_student_admitted_idx": {
+          "name": "sickbay_admission_student_admitted_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "admitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_admission_school_id_ref_school_id_fk": {
+          "name": "sickbay_admission_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_admission",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_admission_admitted_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_admission_admitted_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_admission",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "admitted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_admission_discharged_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_admission_discharged_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_admission",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "discharged_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_admission_school_id_visit_id_sickbay_visit_school_id_id_fk": {
+          "name": "sickbay_admission_school_id_visit_id_sickbay_visit_school_id_id_fk",
+          "tableFrom": "sickbay_admission",
+          "tableTo": "sickbay_visit",
+          "columnsFrom": [
+            "school_id",
+            "visit_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_admission_school_id_student_id_students_school_id_id_fk": {
+          "name": "sickbay_admission_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "sickbay_admission",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_admission_school_id_bed_id_sickbay_bed_school_id_id_fk": {
+          "name": "sickbay_admission_school_id_bed_id_sickbay_bed_school_id_id_fk",
+          "tableFrom": "sickbay_admission",
+          "tableTo": "sickbay_bed",
+          "columnsFrom": [
+            "school_id",
+            "bed_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_admission_tenant_uk": {
+          "name": "sickbay_admission_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        },
+        "uniq_sickbay_admission_visit": {
+          "name": "uniq_sickbay_admission_visit",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "visit_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_bed": {
+      "name": "sickbay_bed",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bed_number": {
+          "name": "bed_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_isolation": {
+          "name": "is_isolation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sickbay_bed_school_id_ref_school_id_fk": {
+          "name": "sickbay_bed_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_bed",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_sickbay_bed_number": {
+          "name": "uniq_sickbay_bed_number",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "bed_number"
+          ]
+        },
+        "sickbay_bed_tenant_uk": {
+          "name": "sickbay_bed_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_chronic_entry": {
+      "name": "sickbay_chronic_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition": {
+          "name": "condition",
+          "type": "chronic_condition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hm_restricted": {
+          "name": "hm_restricted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "\"condition\" = 'MENTAL_HEALTH'",
+            "type": "stored"
+          }
+        },
+        "condition_label": {
+          "name": "condition_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition_detail": {
+          "name": "condition_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "chronic_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'STABLE'"
+        },
+        "on_site_treatable": {
+          "name": "on_site_treatable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "referral_managed": {
+          "name": "referral_managed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "baseline_status": {
+          "name": "baseline_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "care_goals": {
+          "name": "care_goals",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_protocol": {
+          "name": "emergency_protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discharge_criteria": {
+          "name": "discharge_criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggers": {
+          "name": "triggers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "red_flags": {
+          "name": "red_flags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_action": {
+          "name": "first_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_clinical_home": {
+          "name": "external_clinical_home",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_pastoral_home": {
+          "name": "external_pastoral_home",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_care_cadence": {
+          "name": "external_care_cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_next_visit_at": {
+          "name": "external_next_visit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_user_id": {
+          "name": "reviewed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "co_reviewer_note": {
+          "name": "co_reviewer_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_sickbay_chronic_entry_condition": {
+          "name": "uniq_sickbay_chronic_entry_condition",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "condition",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sickbay_chronic_entry\".\"active\" AND \"sickbay_chronic_entry\".\"condition\" <> 'OTHER'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sickbay_chronic_entry_student_idx": {
+          "name": "sickbay_chronic_entry_student_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_chronic_entry_school_id_ref_school_id_fk": {
+          "name": "sickbay_chronic_entry_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_chronic_entry",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_chronic_entry_reviewed_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_chronic_entry_reviewed_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_chronic_entry",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "reviewed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_chronic_entry_school_id_student_id_students_school_id_id_fk": {
+          "name": "sickbay_chronic_entry_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "sickbay_chronic_entry",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_chronic_entry_tenant_uk": {
+          "name": "sickbay_chronic_entry_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        },
+        "sickbay_chronic_entry_hm_uk": {
+          "name": "sickbay_chronic_entry_hm_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id",
+            "hm_restricted"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "chronic_mental_health_referral_managed": {
+          "name": "chronic_mental_health_referral_managed",
+          "value": "\"sickbay_chronic_entry\".\"condition\" <> 'MENTAL_HEALTH' OR (\"sickbay_chronic_entry\".\"on_site_treatable\" = false AND \"sickbay_chronic_entry\".\"referral_managed\" = true)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sickbay_chronic_grant": {
+      "name": "sickbay_chronic_grant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hm_restricted": {
+          "name": "hm_restricted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_user_id": {
+          "name": "grantee_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "sickbay_grant_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_label": {
+          "name": "scope_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "directive_note": {
+          "name": "directive_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "house_id": {
+          "name": "house_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sickbay_chronic_grant_entry_idx": {
+          "name": "sickbay_chronic_grant_entry_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sickbay_chronic_grant_grantee_idx": {
+          "name": "sickbay_chronic_grant_grantee_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "grantee_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_chronic_grant_school_id_ref_school_id_fk": {
+          "name": "sickbay_chronic_grant_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_chronic_grant",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_chronic_grant_grantee_user_id_ref_user_id_fk": {
+          "name": "sickbay_chronic_grant_grantee_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_chronic_grant",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "grantee_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_chronic_grant_granted_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_chronic_grant_granted_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_chronic_grant",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "granted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_chronic_grant_revoked_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_chronic_grant_revoked_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_chronic_grant",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_chronic_grant_entry_hm_fk": {
+          "name": "sickbay_chronic_grant_entry_hm_fk",
+          "tableFrom": "sickbay_chronic_grant",
+          "tableTo": "sickbay_chronic_entry",
+          "columnsFrom": [
+            "school_id",
+            "entry_id",
+            "hm_restricted"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id",
+            "hm_restricted"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "sickbay_chronic_grant_school_id_house_id_house_school_id_id_fk": {
+          "name": "sickbay_chronic_grant_school_id_house_id_house_school_id_id_fk",
+          "tableFrom": "sickbay_chronic_grant",
+          "tableTo": "house",
+          "columnsFrom": [
+            "school_id",
+            "house_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chronic_grant_directive_needs_note": {
+          "name": "chronic_grant_directive_needs_note",
+          "value": "\"sickbay_chronic_grant\".\"scope\" <> 'DIRECTIVE' OR \"sickbay_chronic_grant\".\"directive_note\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sickbay_chronic_med": {
+      "name": "sickbay_chronic_med",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_name": {
+          "name": "drug_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dose_label": {
+          "name": "dose_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_prn": {
+          "name": "is_prn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "slot_id": {
+          "name": "slot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sickbay_chronic_med_slot_idx": {
+          "name": "sickbay_chronic_med_slot_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_chronic_med_school_id_ref_school_id_fk": {
+          "name": "sickbay_chronic_med_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_chronic_med",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_chronic_med_school_id_entry_id_sickbay_chronic_entry_school_id_id_fk": {
+          "name": "sickbay_chronic_med_school_id_entry_id_sickbay_chronic_entry_school_id_id_fk",
+          "tableFrom": "sickbay_chronic_med",
+          "tableTo": "sickbay_chronic_entry",
+          "columnsFrom": [
+            "school_id",
+            "entry_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_chronic_med_school_id_slot_id_sickbay_schedule_slot_school_id_id_fk": {
+          "name": "sickbay_chronic_med_school_id_slot_id_sickbay_schedule_slot_school_id_id_fk",
+          "tableFrom": "sickbay_chronic_med",
+          "tableTo": "sickbay_schedule_slot",
+          "columnsFrom": [
+            "school_id",
+            "slot_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_chronic_med_tenant_uk": {
+          "name": "sickbay_chronic_med_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        },
+        "uniq_sickbay_chronic_med_dose": {
+          "name": "uniq_sickbay_chronic_med_dose",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "entry_id",
+            "drug_name",
+            "slot_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "chronic_med_prn_xor_slot": {
+          "name": "chronic_med_prn_xor_slot",
+          "value": "\"sickbay_chronic_med\".\"is_prn\" = (\"sickbay_chronic_med\".\"slot_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sickbay_chronic_read": {
+      "name": "sickbay_chronic_read",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_on": {
+          "name": "read_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "sickbay_grant_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sickbay_chronic_read_school_id_ref_school_id_fk": {
+          "name": "sickbay_chronic_read_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_chronic_read",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_chronic_read_actor_user_id_ref_user_id_fk": {
+          "name": "sickbay_chronic_read_actor_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_chronic_read",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_chronic_read_school_id_entry_id_sickbay_chronic_entry_school_id_id_fk": {
+          "name": "sickbay_chronic_read_school_id_entry_id_sickbay_chronic_entry_school_id_id_fk",
+          "tableFrom": "sickbay_chronic_read",
+          "tableTo": "sickbay_chronic_entry",
+          "columnsFrom": [
+            "school_id",
+            "entry_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_sickbay_chronic_read_day": {
+          "name": "uniq_sickbay_chronic_read_day",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "entry_id",
+            "actor_user_id",
+            "read_on"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_controlled_movement": {
+      "name": "sickbay_controlled_movement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock_item_id": {
+          "name": "stock_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "movement_type": {
+          "name": "movement_type",
+          "type": "sickbay_stock_movement_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "witness_user_id": {
+          "name": "witness_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_ref": {
+          "name": "batch_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sickbay_controlled_movement_item_idx": {
+          "name": "sickbay_controlled_movement_item_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stock_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_controlled_movement_school_id_ref_school_id_fk": {
+          "name": "sickbay_controlled_movement_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_controlled_movement",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_controlled_movement_actor_user_id_ref_user_id_fk": {
+          "name": "sickbay_controlled_movement_actor_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_controlled_movement",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_controlled_movement_witness_user_id_ref_user_id_fk": {
+          "name": "sickbay_controlled_movement_witness_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_controlled_movement",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "witness_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_controlled_movement_school_id_stock_item_id_sickbay_stock_item_school_id_id_fk": {
+          "name": "sickbay_controlled_movement_school_id_stock_item_id_sickbay_stock_item_school_id_id_fk",
+          "tableFrom": "sickbay_controlled_movement",
+          "tableTo": "sickbay_stock_item",
+          "columnsFrom": [
+            "school_id",
+            "stock_item_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_doctor_consult": {
+      "name": "sickbay_doctor_consult",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visit_id": {
+          "name": "visit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "sickbay_consult_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clinician_name": {
+          "name": "clinician_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clinician_affiliation": {
+          "name": "clinician_affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sickbay_doctor_consult_visit_idx": {
+          "name": "sickbay_doctor_consult_visit_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_doctor_consult_school_id_ref_school_id_fk": {
+          "name": "sickbay_doctor_consult_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_doctor_consult",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_doctor_consult_recorded_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_doctor_consult_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_doctor_consult",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_doctor_consult_school_id_visit_id_sickbay_visit_school_id_id_fk": {
+          "name": "sickbay_doctor_consult_school_id_visit_id_sickbay_visit_school_id_id_fk",
+          "tableFrom": "sickbay_doctor_consult",
+          "tableTo": "sickbay_visit",
+          "columnsFrom": [
+            "school_id",
+            "visit_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_doctor_consult_tenant_uk": {
+          "name": "sickbay_doctor_consult_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_hospital": {
+      "name": "sickbay_hospital",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance_km": {
+          "name": "distance_km",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "services": {
+          "name": "services",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_nhis": {
+          "name": "accepts_nhis",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sickbay_hospital_school_id_ref_school_id_fk": {
+          "name": "sickbay_hospital_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_hospital",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_hospital_tenant_uk": {
+          "name": "sickbay_hospital_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_med_admin": {
+      "name": "sickbay_med_admin",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visit_id": {
+          "name": "visit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slot_id": {
+          "name": "slot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "sickbay_med_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chronic_med_id": {
+          "name": "chronic_med_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standing_order_id": {
+          "name": "standing_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consult_id": {
+          "name": "consult_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drug_name": {
+          "name": "drug_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dose_label": {
+          "name": "dose_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_controlled": {
+          "name": "is_controlled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dispensed_qty": {
+          "name": "dispensed_qty",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock_item_id": {
+          "name": "stock_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "sickbay_med_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "administered_at": {
+          "name": "administered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "administered_by_user_id": {
+          "name": "administered_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "witness_user_id": {
+          "name": "witness_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "witness_override_reason": {
+          "name": "witness_override_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corrects_admin_id": {
+          "name": "corrects_admin_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amendment_note": {
+          "name": "amendment_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sickbay_med_admin_student_idx": {
+          "name": "sickbay_med_admin_student_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "administered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sickbay_med_admin_slot_idx": {
+          "name": "sickbay_med_admin_slot_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "administered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sickbay_med_admin_visit_idx": {
+          "name": "sickbay_med_admin_visit_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_med_admin_school_id_ref_school_id_fk": {
+          "name": "sickbay_med_admin_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_med_admin",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_med_admin_administered_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_med_admin_administered_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_med_admin",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "administered_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_med_admin_witness_user_id_ref_user_id_fk": {
+          "name": "sickbay_med_admin_witness_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_med_admin",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "witness_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_med_admin_school_id_student_id_students_school_id_id_fk": {
+          "name": "sickbay_med_admin_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "sickbay_med_admin",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_med_admin_school_id_visit_id_sickbay_visit_school_id_id_fk": {
+          "name": "sickbay_med_admin_school_id_visit_id_sickbay_visit_school_id_id_fk",
+          "tableFrom": "sickbay_med_admin",
+          "tableTo": "sickbay_visit",
+          "columnsFrom": [
+            "school_id",
+            "visit_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_med_admin_school_id_slot_id_sickbay_schedule_slot_school_id_id_fk": {
+          "name": "sickbay_med_admin_school_id_slot_id_sickbay_schedule_slot_school_id_id_fk",
+          "tableFrom": "sickbay_med_admin",
+          "tableTo": "sickbay_schedule_slot",
+          "columnsFrom": [
+            "school_id",
+            "slot_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sickbay_med_admin_school_id_chronic_med_id_sickbay_chronic_med_school_id_id_fk": {
+          "name": "sickbay_med_admin_school_id_chronic_med_id_sickbay_chronic_med_school_id_id_fk",
+          "tableFrom": "sickbay_med_admin",
+          "tableTo": "sickbay_chronic_med",
+          "columnsFrom": [
+            "school_id",
+            "chronic_med_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sickbay_med_admin_school_id_standing_order_id_sickbay_standing_order_school_id_id_fk": {
+          "name": "sickbay_med_admin_school_id_standing_order_id_sickbay_standing_order_school_id_id_fk",
+          "tableFrom": "sickbay_med_admin",
+          "tableTo": "sickbay_standing_order",
+          "columnsFrom": [
+            "school_id",
+            "standing_order_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sickbay_med_admin_school_id_consult_id_sickbay_doctor_consult_school_id_id_fk": {
+          "name": "sickbay_med_admin_school_id_consult_id_sickbay_doctor_consult_school_id_id_fk",
+          "tableFrom": "sickbay_med_admin",
+          "tableTo": "sickbay_doctor_consult",
+          "columnsFrom": [
+            "school_id",
+            "consult_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sickbay_med_admin_school_id_stock_item_id_sickbay_stock_item_school_id_id_fk": {
+          "name": "sickbay_med_admin_school_id_stock_item_id_sickbay_stock_item_school_id_id_fk",
+          "tableFrom": "sickbay_med_admin",
+          "tableTo": "sickbay_stock_item",
+          "columnsFrom": [
+            "school_id",
+            "stock_item_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sickbay_med_admin_corrects_fk": {
+          "name": "sickbay_med_admin_corrects_fk",
+          "tableFrom": "sickbay_med_admin",
+          "tableTo": "sickbay_med_admin",
+          "columnsFrom": [
+            "school_id",
+            "corrects_admin_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_med_admin_tenant_uk": {
+          "name": "sickbay_med_admin_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "med_admin_controlled_needs_qty": {
+          "name": "med_admin_controlled_needs_qty",
+          "value": "\"sickbay_med_admin\".\"is_controlled\" = false OR \"sickbay_med_admin\".\"dispensed_qty\" IS NOT NULL"
+        },
+        "med_admin_controlled_needs_stock_item": {
+          "name": "med_admin_controlled_needs_stock_item",
+          "value": "NOT \"sickbay_med_admin\".\"is_controlled\" OR \"sickbay_med_admin\".\"stock_item_id\" IS NOT NULL"
+        },
+        "med_admin_controlled_given_witness": {
+          "name": "med_admin_controlled_given_witness",
+          "value": "NOT (\"sickbay_med_admin\".\"is_controlled\" AND \"sickbay_med_admin\".\"status\" = 'GIVEN') OR \"sickbay_med_admin\".\"witness_user_id\" IS NOT NULL OR \"sickbay_med_admin\".\"witness_override_reason\" IS NOT NULL"
+        },
+        "med_admin_witness_not_self": {
+          "name": "med_admin_witness_not_self",
+          "value": "\"sickbay_med_admin\".\"witness_user_id\" IS NULL OR \"sickbay_med_admin\".\"witness_user_id\" <> \"sickbay_med_admin\".\"administered_by_user_id\""
+        },
+        "med_admin_source_pointer_match": {
+          "name": "med_admin_source_pointer_match",
+          "value": "(\"sickbay_med_admin\".\"source\" = 'CHRONIC' AND \"sickbay_med_admin\".\"standing_order_id\" IS NULL AND \"sickbay_med_admin\".\"consult_id\" IS NULL)\n       OR (\"sickbay_med_admin\".\"source\" = 'STANDING_ORDER' AND \"sickbay_med_admin\".\"standing_order_id\" IS NOT NULL AND \"sickbay_med_admin\".\"chronic_med_id\" IS NULL AND \"sickbay_med_admin\".\"consult_id\" IS NULL)\n       OR (\"sickbay_med_admin\".\"source\" = 'DOCTOR_ORDERED' AND \"sickbay_med_admin\".\"consult_id\" IS NOT NULL AND \"sickbay_med_admin\".\"chronic_med_id\" IS NULL AND \"sickbay_med_admin\".\"standing_order_id\" IS NULL)\n       OR (\"sickbay_med_admin\".\"source\" = 'AD_HOC' AND \"sickbay_med_admin\".\"chronic_med_id\" IS NULL AND \"sickbay_med_admin\".\"standing_order_id\" IS NULL AND \"sickbay_med_admin\".\"consult_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sickbay_notification": {
+      "name": "sickbay_notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visit_id": {
+          "name": "visit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_id": {
+          "name": "referral_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_log_id": {
+          "name": "notification_log_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_of_id": {
+          "name": "retry_of_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "sickbay_notify_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "sickbay_notify_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "sickbay_notify_recipient",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_label": {
+          "name": "trigger_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "private_note": {
+          "name": "private_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "call_duration_seconds": {
+          "name": "call_duration_seconds",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered": {
+          "name": "answered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sickbay_notification_referral_idx": {
+          "name": "sickbay_notification_referral_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "referral_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sickbay_notification_student_idx": {
+          "name": "sickbay_notification_student_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_notification_school_id_ref_school_id_fk": {
+          "name": "sickbay_notification_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_notification",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_notification_notification_log_id_notification_log_id_fk": {
+          "name": "sickbay_notification_notification_log_id_notification_log_id_fk",
+          "tableFrom": "sickbay_notification",
+          "tableTo": "notification_log",
+          "columnsFrom": [
+            "notification_log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_notification_created_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_notification_created_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_notification",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_notification_school_id_student_id_students_school_id_id_fk": {
+          "name": "sickbay_notification_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "sickbay_notification",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_notification_school_id_visit_id_sickbay_visit_school_id_id_fk": {
+          "name": "sickbay_notification_school_id_visit_id_sickbay_visit_school_id_id_fk",
+          "tableFrom": "sickbay_notification",
+          "tableTo": "sickbay_visit",
+          "columnsFrom": [
+            "school_id",
+            "visit_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_notification_school_id_referral_id_sickbay_referral_school_id_id_fk": {
+          "name": "sickbay_notification_school_id_referral_id_sickbay_referral_school_id_id_fk",
+          "tableFrom": "sickbay_notification",
+          "tableTo": "sickbay_referral",
+          "columnsFrom": [
+            "school_id",
+            "referral_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_notification_retry_of_fk": {
+          "name": "sickbay_notification_retry_of_fk",
+          "tableFrom": "sickbay_notification",
+          "tableTo": "sickbay_notification",
+          "columnsFrom": [
+            "school_id",
+            "retry_of_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_notification_tenant_uk": {
+          "name": "sickbay_notification_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "sickbay_notification_tier_range": {
+          "name": "sickbay_notification_tier_range",
+          "value": "\"sickbay_notification\".\"tier\" BETWEEN 1 AND 3"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sickbay_referral": {
+      "name": "sickbay_referral",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visit_id": {
+          "name": "visit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hospital_id": {
+          "name": "hospital_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accompanied_by_user_id": {
+          "name": "accompanied_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hm_authorised_by_user_id": {
+          "name": "hm_authorised_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "sickbay_referral_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REFERRED'"
+        },
+        "transport_mode": {
+          "name": "transport_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hospital_ward": {
+          "name": "hospital_ward",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hospital_bed": {
+          "name": "hospital_bed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attending_clinician_name": {
+          "name": "attending_clinician_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hm_authorised_at": {
+          "name": "hm_authorised_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "departed_at": {
+          "name": "departed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_return_at": {
+          "name": "expected_return_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "returned_at": {
+          "name": "returned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "return_note": {
+          "name": "return_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_by_user_id": {
+          "name": "voided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nhis_card_number": {
+          "name": "nhis_card_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nhis_valid": {
+          "name": "nhis_valid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_referred_out": {
+          "name": "reason_referred_out",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pre_referral_care": {
+          "name": "pre_referral_care",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_labs": {
+          "name": "handoff_labs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_meal": {
+          "name": "last_meal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "menses_note": {
+          "name": "menses_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "travel_note": {
+          "name": "travel_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sickbay_referral_status_idx": {
+          "name": "sickbay_referral_status_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sickbay_referral_departed_idx": {
+          "name": "sickbay_referral_departed_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "departed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_referral_school_id_ref_school_id_fk": {
+          "name": "sickbay_referral_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_referral",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_referral_accompanied_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_referral_accompanied_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_referral",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "accompanied_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_referral_hm_authorised_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_referral_hm_authorised_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_referral",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "hm_authorised_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_referral_recorded_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_referral_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_referral",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_referral_voided_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_referral_voided_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_referral",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "voided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_referral_school_id_student_id_students_school_id_id_fk": {
+          "name": "sickbay_referral_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "sickbay_referral",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_referral_school_id_visit_id_sickbay_visit_school_id_id_fk": {
+          "name": "sickbay_referral_school_id_visit_id_sickbay_visit_school_id_id_fk",
+          "tableFrom": "sickbay_referral",
+          "tableTo": "sickbay_visit",
+          "columnsFrom": [
+            "school_id",
+            "visit_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_referral_school_id_hospital_id_sickbay_hospital_school_id_id_fk": {
+          "name": "sickbay_referral_school_id_hospital_id_sickbay_hospital_school_id_id_fk",
+          "tableFrom": "sickbay_referral",
+          "tableTo": "sickbay_hospital",
+          "columnsFrom": [
+            "school_id",
+            "hospital_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_referral_tenant_uk": {
+          "name": "sickbay_referral_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_referral_cost_line": {
+      "name": "sickbay_referral_cost_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referral_id": {
+          "name": "referral_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_label": {
+          "name": "item_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nhis_covered": {
+          "name": "nhis_covered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "out_of_pocket_amount": {
+          "name": "out_of_pocket_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_line_item_id": {
+          "name": "billing_line_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sickbay_referral_cost_line_referral_idx": {
+          "name": "sickbay_referral_cost_line_referral_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "referral_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_referral_cost_line_school_id_ref_school_id_fk": {
+          "name": "sickbay_referral_cost_line_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_referral_cost_line",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_referral_cost_line_billing_line_item_id_invoice_line_item_id_fk": {
+          "name": "sickbay_referral_cost_line_billing_line_item_id_invoice_line_item_id_fk",
+          "tableFrom": "sickbay_referral_cost_line",
+          "tableTo": "invoice_line_item",
+          "columnsFrom": [
+            "billing_line_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_referral_cost_line_school_id_referral_id_sickbay_referral_school_id_id_fk": {
+          "name": "sickbay_referral_cost_line_school_id_referral_id_sickbay_referral_school_id_id_fk",
+          "tableFrom": "sickbay_referral_cost_line",
+          "tableTo": "sickbay_referral",
+          "columnsFrom": [
+            "school_id",
+            "referral_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_referral_update": {
+      "name": "sickbay_referral_update",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referral_id": {
+          "name": "referral_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clinician_name": {
+          "name": "clinician_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinician_affiliation": {
+          "name": "clinician_affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sickbay_referral_update_referral_idx": {
+          "name": "sickbay_referral_update_referral_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "referral_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_referral_update_school_id_ref_school_id_fk": {
+          "name": "sickbay_referral_update_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_referral_update",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_referral_update_recorded_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_referral_update_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_referral_update",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_referral_update_school_id_referral_id_sickbay_referral_school_id_id_fk": {
+          "name": "sickbay_referral_update_school_id_referral_id_sickbay_referral_school_id_id_fk",
+          "tableFrom": "sickbay_referral_update",
+          "tableTo": "sickbay_referral",
+          "columnsFrom": [
+            "school_id",
+            "referral_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_schedule_slot": {
+      "name": "sickbay_schedule_slot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "sickbay_slot_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staffing": {
+          "name": "staffing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "days_of_week": {
+          "name": "days_of_week",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runs_on_holidays": {
+          "name": "runs_on_holidays",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_anchor": {
+          "name": "is_anchor",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_sickbay_anchor_slot": {
+          "name": "uniq_sickbay_anchor_slot",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sickbay_schedule_slot\".\"is_anchor\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_schedule_slot_school_id_ref_school_id_fk": {
+          "name": "sickbay_schedule_slot_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_schedule_slot",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_schedule_slot_tenant_uk": {
+          "name": "sickbay_schedule_slot_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_settings": {
+      "name": "sickbay_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "sickbay_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REFERRAL_ONLY'"
+        },
+        "matron_user_id": {
+          "name": "matron_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assistant_matron_user_id": {
+          "name": "assistant_matron_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visiting_doctor_name": {
+          "name": "visiting_doctor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visiting_doctor_affiliation": {
+          "name": "visiting_doctor_affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configured_at": {
+          "name": "configured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sickbay_settings_school_id_ref_school_id_fk": {
+          "name": "sickbay_settings_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_settings",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_settings_matron_user_id_ref_user_id_fk": {
+          "name": "sickbay_settings_matron_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_settings",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "matron_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_settings_assistant_matron_user_id_ref_user_id_fk": {
+          "name": "sickbay_settings_assistant_matron_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_settings",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "assistant_matron_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_settings_school_id_unique": {
+          "name": "sickbay_settings_school_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_standing_order": {
+      "name": "sickbay_standing_order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "complaint": {
+          "name": "complaint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "treatment": {
+          "name": "treatment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "escalation": {
+          "name": "escalation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ordered_by_doctor_name": {
+          "name": "ordered_by_doctor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sickbay_standing_order_school_id_ref_school_id_fk": {
+          "name": "sickbay_standing_order_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_standing_order",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_standing_order_created_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_standing_order_created_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_standing_order",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_standing_order_tenant_uk": {
+          "name": "sickbay_standing_order_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_stock_item": {
+      "name": "sickbay_stock_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_name": {
+          "name": "drug_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form_label": {
+          "name": "form_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qty_on_hand": {
+          "name": "qty_on_hand",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "reorder_point": {
+          "name": "reorder_point",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_restocked_at": {
+          "name": "last_restocked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_controlled": {
+          "name": "is_controlled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sickbay_stock_item_school_id_ref_school_id_fk": {
+          "name": "sickbay_stock_item_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_stock_item",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_stock_item_tenant_uk": {
+          "name": "sickbay_stock_item_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_visit": {
+      "name": "sickbay_visit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "presented_at": {
+          "name": "presented_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "presenting_complaint": {
+          "name": "presenting_complaint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intake_reported_by": {
+          "name": "intake_reported_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attending_user_id": {
+          "name": "attending_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "working_impression": {
+          "name": "working_impression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "red_flags_screened": {
+          "name": "red_flags_screened",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hydration_status": {
+          "name": "hydration_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "escalation_triggers": {
+          "name": "escalation_triggers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "surveillance_category": {
+          "name": "surveillance_category",
+          "type": "sickbay_surveillance_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessed_at": {
+          "name": "assessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "sickbay_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disposition_at": {
+          "name": "disposition_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_by_user_id": {
+          "name": "voided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_sickbay_open_visit_student": {
+          "name": "uniq_sickbay_open_visit_student",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sickbay_visit\".\"disposition\" IS NULL AND \"sickbay_visit\".\"voided_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sickbay_visit_presented_idx": {
+          "name": "sickbay_visit_presented_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "presented_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_visit_school_id_ref_school_id_fk": {
+          "name": "sickbay_visit_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_visit",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_visit_recorded_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_visit_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_visit",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_visit_attending_user_id_ref_user_id_fk": {
+          "name": "sickbay_visit_attending_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_visit",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "attending_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_visit_voided_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_visit_voided_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_visit",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "voided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_visit_school_id_student_id_students_school_id_id_fk": {
+          "name": "sickbay_visit_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "sickbay_visit",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sickbay_visit_tenant_uk": {
+          "name": "sickbay_visit_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sickbay_vital_reading": {
+      "name": "sickbay_vital_reading",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visit_id": {
+          "name": "visit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taken_at": {
+          "name": "taken_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taken_by_user_id": {
+          "name": "taken_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_c": {
+          "name": "temp_c",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "systolic": {
+          "name": "systolic",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diastolic": {
+          "name": "diastolic",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pulse_bpm": {
+          "name": "pulse_bpm",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spo2_pct": {
+          "name": "spo2_pct",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pain_score": {
+          "name": "pain_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sickbay_vital_reading_visit_idx": {
+          "name": "sickbay_vital_reading_visit_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "taken_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sickbay_vital_reading_school_id_ref_school_id_fk": {
+          "name": "sickbay_vital_reading_school_id_ref_school_id_fk",
+          "tableFrom": "sickbay_vital_reading",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sickbay_vital_reading_taken_by_user_id_ref_user_id_fk": {
+          "name": "sickbay_vital_reading_taken_by_user_id_ref_user_id_fk",
+          "tableFrom": "sickbay_vital_reading",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "taken_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sickbay_vital_reading_school_id_visit_id_sickbay_visit_school_id_id_fk": {
+          "name": "sickbay_vital_reading_school_id_visit_id_sickbay_visit_school_id_id_fk",
+          "tableFrom": "sickbay_vital_reading",
+          "tableTo": "sickbay_visit",
+          "columnsFrom": [
+            "school_id",
+            "visit_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_nhis_card": {
+      "name": "student_nhis_card",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_number": {
+          "name": "card_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "holder_name": {
+          "name": "holder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "holder_kind": {
+          "name": "holder_kind",
+          "type": "nhis_holder_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'STUDENT'"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_to": {
+          "name": "valid_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_guardian_id": {
+          "name": "student_guardian_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "student_nhis_card_school_id_ref_school_id_fk": {
+          "name": "student_nhis_card_school_id_ref_school_id_fk",
+          "tableFrom": "student_nhis_card",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_nhis_card_student_guardian_id_student_guardian_id_fk": {
+          "name": "student_nhis_card_student_guardian_id_student_guardian_id_fk",
+          "tableFrom": "student_nhis_card",
+          "tableTo": "student_guardian",
+          "columnsFrom": [
+            "student_guardian_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "student_nhis_card_school_id_student_id_students_school_id_id_fk": {
+          "name": "student_nhis_card_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "student_nhis_card",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_student_nhis_card": {
+          "name": "uniq_student_nhis_card",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vlc_pastoral_case": {
+      "name": "vlc_pastoral_case",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flag_id": {
+          "name": "flag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_revised_at": {
+          "name": "last_revised_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_revised_by_user_id": {
+          "name": "last_revised_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vlc_pastoral_case_school_id_ref_school_id_fk": {
+          "name": "vlc_pastoral_case_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_pastoral_case",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_case_last_revised_by_user_id_ref_user_id_fk": {
+          "name": "vlc_pastoral_case_last_revised_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_pastoral_case",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "last_revised_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_case_school_id_flag_id_vlc_pastoral_flag_school_id_id_fk": {
+          "name": "vlc_pastoral_case_school_id_flag_id_vlc_pastoral_flag_school_id_id_fk",
+          "tableFrom": "vlc_pastoral_case",
+          "tableTo": "vlc_pastoral_flag",
+          "columnsFrom": [
+            "school_id",
+            "flag_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_vlc_pastoral_case_flag": {
+          "name": "uniq_vlc_pastoral_case_flag",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "flag_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vlc_pastoral_case_summary_len": {
+          "name": "vlc_pastoral_case_summary_len",
+          "value": "char_length(\"vlc_pastoral_case\".\"summary\") <= 8000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vlc_pastoral_flag": {
+      "name": "vlc_pastoral_flag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_at": {
+          "name": "raised_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "raised_by_user_id": {
+          "name": "raised_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "surfaced_by": {
+          "name": "surfaced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vlc_pastoral_flag_active_idx": {
+          "name": "vlc_pastoral_flag_active_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"vlc_pastoral_flag\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vlc_pastoral_flag_school_id_ref_school_id_fk": {
+          "name": "vlc_pastoral_flag_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_pastoral_flag",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_flag_raised_by_user_id_ref_user_id_fk": {
+          "name": "vlc_pastoral_flag_raised_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_pastoral_flag",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "raised_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_flag_resolved_by_user_id_ref_user_id_fk": {
+          "name": "vlc_pastoral_flag_resolved_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_pastoral_flag",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_flag_school_id_student_id_students_school_id_id_fk": {
+          "name": "vlc_pastoral_flag_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "vlc_pastoral_flag",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_flag_school_id_session_id_vlc_session_school_id_id_fk": {
+          "name": "vlc_pastoral_flag_school_id_session_id_vlc_session_school_id_id_fk",
+          "tableFrom": "vlc_pastoral_flag",
+          "tableTo": "vlc_session",
+          "columnsFrom": [
+            "school_id",
+            "session_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vlc_pastoral_flag_tenant_uk": {
+          "name": "vlc_pastoral_flag_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vlc_pastoral_flag_surfaced_by_len": {
+          "name": "vlc_pastoral_flag_surfaced_by_len",
+          "value": "char_length(\"vlc_pastoral_flag\".\"surfaced_by\") <= 80"
+        },
+        "vlc_pastoral_flag_severity_valid": {
+          "name": "vlc_pastoral_flag_severity_valid",
+          "value": "\"vlc_pastoral_flag\".\"severity\" IN ('NOTE', 'CONCERN', 'CRISIS')"
+        },
+        "vlc_pastoral_flag_context_len": {
+          "name": "vlc_pastoral_flag_context_len",
+          "value": "char_length(\"vlc_pastoral_flag\".\"context\") <= 280"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vlc_pastoral_journal": {
+      "name": "vlc_pastoral_journal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vlc_pastoral_journal_student_idx": {
+          "name": "vlc_pastoral_journal_student_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vlc_pastoral_journal_school_id_ref_school_id_fk": {
+          "name": "vlc_pastoral_journal_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_pastoral_journal",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_journal_recorded_by_user_id_ref_user_id_fk": {
+          "name": "vlc_pastoral_journal_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_pastoral_journal",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_journal_school_id_student_id_students_school_id_id_fk": {
+          "name": "vlc_pastoral_journal_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "vlc_pastoral_journal",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_journal_school_id_session_id_vlc_session_school_id_id_fk": {
+          "name": "vlc_pastoral_journal_school_id_session_id_vlc_session_school_id_id_fk",
+          "tableFrom": "vlc_pastoral_journal",
+          "tableTo": "vlc_session",
+          "columnsFrom": [
+            "school_id",
+            "session_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vlc_pastoral_journal_body_len": {
+          "name": "vlc_pastoral_journal_body_len",
+          "value": "char_length(\"vlc_pastoral_journal\".\"body\") <= 4000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vlc_pastoral_note": {
+      "name": "vlc_pastoral_note",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vlc_pastoral_note_student_idx": {
+          "name": "vlc_pastoral_note_student_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vlc_pastoral_note_school_id_ref_school_id_fk": {
+          "name": "vlc_pastoral_note_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_pastoral_note",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_note_author_user_id_ref_user_id_fk": {
+          "name": "vlc_pastoral_note_author_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_pastoral_note",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_note_school_id_student_id_students_school_id_id_fk": {
+          "name": "vlc_pastoral_note_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "vlc_pastoral_note",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vlc_pastoral_note_body_len": {
+          "name": "vlc_pastoral_note_body_len",
+          "value": "char_length(\"vlc_pastoral_note\".\"body\") <= 4000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vlc_pastoral_observation": {
+      "name": "vlc_pastoral_observation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_by": {
+          "name": "observed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vlc_pastoral_observation_student_idx": {
+          "name": "vlc_pastoral_observation_student_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vlc_pastoral_observation_school_id_ref_school_id_fk": {
+          "name": "vlc_pastoral_observation_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_pastoral_observation",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_observation_recorded_by_user_id_ref_user_id_fk": {
+          "name": "vlc_pastoral_observation_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_pastoral_observation",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_observation_school_id_student_id_students_school_id_id_fk": {
+          "name": "vlc_pastoral_observation_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "vlc_pastoral_observation",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vlc_pastoral_observation_observed_by_len": {
+          "name": "vlc_pastoral_observation_observed_by_len",
+          "value": "char_length(\"vlc_pastoral_observation\".\"observed_by\") <= 80"
+        },
+        "vlc_pastoral_observation_body_len": {
+          "name": "vlc_pastoral_observation_body_len",
+          "value": "char_length(\"vlc_pastoral_observation\".\"body\") <= 4000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vlc_pastoral_paragraph": {
+      "name": "vlc_pastoral_paragraph",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_by_user_id": {
+          "name": "locked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vlc_pastoral_paragraph_school_id_ref_school_id_fk": {
+          "name": "vlc_pastoral_paragraph_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_pastoral_paragraph",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_paragraph_author_user_id_ref_user_id_fk": {
+          "name": "vlc_pastoral_paragraph_author_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_pastoral_paragraph",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_paragraph_updated_by_user_id_ref_user_id_fk": {
+          "name": "vlc_pastoral_paragraph_updated_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_pastoral_paragraph",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_paragraph_locked_by_user_id_ref_user_id_fk": {
+          "name": "vlc_pastoral_paragraph_locked_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_pastoral_paragraph",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "locked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_pastoral_paragraph_school_id_student_id_students_school_id_id_fk": {
+          "name": "vlc_pastoral_paragraph_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "vlc_pastoral_paragraph",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_vlc_pastoral_paragraph_student": {
+          "name": "uniq_vlc_pastoral_paragraph_student",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vlc_pastoral_paragraph_body_len": {
+          "name": "vlc_pastoral_paragraph_body_len",
+          "value": "char_length(\"vlc_pastoral_paragraph\".\"body\") <= 3000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vlc_peer_guide": {
+      "name": "vlc_peer_guide",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_period_id": {
+          "name": "academic_period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointed_at": {
+          "name": "appointed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "appointed_by_user_id": {
+          "name": "appointed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_vlc_peer_guide_active": {
+          "name": "uniq_vlc_peer_guide_active",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"vlc_peer_guide\".\"ended_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vlc_peer_guide_class_period_idx": {
+          "name": "vlc_peer_guide_class_period_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vlc_peer_guide_school_id_ref_school_id_fk": {
+          "name": "vlc_peer_guide_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_peer_guide",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_peer_guide_appointed_by_user_id_ref_user_id_fk": {
+          "name": "vlc_peer_guide_appointed_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_peer_guide",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "appointed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_peer_guide_school_id_student_id_students_school_id_id_fk": {
+          "name": "vlc_peer_guide_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "vlc_peer_guide",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_peer_guide_school_id_class_id_class_school_id_id_fk": {
+          "name": "vlc_peer_guide_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "vlc_peer_guide",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_peer_guide_school_id_academic_period_id_academic_period_school_id_period_id_fk": {
+          "name": "vlc_peer_guide_school_id_academic_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "vlc_peer_guide",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "academic_period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vlc_peer_guide_tenant_uk": {
+          "name": "vlc_peer_guide_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vlc_programme": {
+      "name": "vlc_programme",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_day": {
+          "name": "session_day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "session_start": {
+          "name": "session_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'14:30'"
+        },
+        "opener_min": {
+          "name": "opener_min",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "small_group_min": {
+          "name": "small_group_min",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 25
+        },
+        "plenary_min": {
+          "name": "plenary_min",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "reflection_min": {
+          "name": "reflection_min",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "close_min": {
+          "name": "close_min",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "configured_at": {
+          "name": "configured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vlc_programme_school_id_ref_school_id_fk": {
+          "name": "vlc_programme_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_programme",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vlc_programme_school_id_unique": {
+          "name": "vlc_programme_school_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vlc_programme_session_day_range": {
+          "name": "vlc_programme_session_day_range",
+          "value": "\"vlc_programme\".\"session_day\" BETWEEN 1 AND 7"
+        },
+        "vlc_programme_opener_min_positive": {
+          "name": "vlc_programme_opener_min_positive",
+          "value": "\"vlc_programme\".\"opener_min\" > 0"
+        },
+        "vlc_programme_small_group_min_positive": {
+          "name": "vlc_programme_small_group_min_positive",
+          "value": "\"vlc_programme\".\"small_group_min\" > 0"
+        },
+        "vlc_programme_plenary_min_positive": {
+          "name": "vlc_programme_plenary_min_positive",
+          "value": "\"vlc_programme\".\"plenary_min\" > 0"
+        },
+        "vlc_programme_reflection_min_positive": {
+          "name": "vlc_programme_reflection_min_positive",
+          "value": "\"vlc_programme\".\"reflection_min\" > 0"
+        },
+        "vlc_programme_close_min_positive": {
+          "name": "vlc_programme_close_min_positive",
+          "value": "\"vlc_programme\".\"close_min\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vlc_session": {
+      "name": "vlc_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_template_id": {
+          "name": "session_template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_date": {
+          "name": "session_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_by_user_id": {
+          "name": "held_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vlc_session_school_id_ref_school_id_fk": {
+          "name": "vlc_session_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_session",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_session_held_by_user_id_ref_user_id_fk": {
+          "name": "vlc_session_held_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_session",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "held_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_session_school_id_class_id_class_school_id_id_fk": {
+          "name": "vlc_session_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "vlc_session",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_session_school_id_session_template_id_vlc_session_template_school_id_id_fk": {
+          "name": "vlc_session_school_id_session_template_id_vlc_session_template_school_id_id_fk",
+          "tableFrom": "vlc_session",
+          "tableTo": "vlc_session_template",
+          "columnsFrom": [
+            "school_id",
+            "session_template_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vlc_session_tenant_uk": {
+          "name": "vlc_session_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        },
+        "uniq_vlc_session": {
+          "name": "uniq_vlc_session",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "class_id",
+            "session_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vlc_session_attendance": {
+      "name": "vlc_session_attendance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "attendance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minutes_late": {
+          "name": "minutes_late",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vlc_session_attendance_school_id_ref_school_id_fk": {
+          "name": "vlc_session_attendance_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_session_attendance",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_session_attendance_recorded_by_user_id_ref_user_id_fk": {
+          "name": "vlc_session_attendance_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_session_attendance",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_session_attendance_school_id_session_id_vlc_session_school_id_id_fk": {
+          "name": "vlc_session_attendance_school_id_session_id_vlc_session_school_id_id_fk",
+          "tableFrom": "vlc_session_attendance",
+          "tableTo": "vlc_session",
+          "columnsFrom": [
+            "school_id",
+            "session_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_session_attendance_school_id_student_id_students_school_id_id_fk": {
+          "name": "vlc_session_attendance_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "vlc_session_attendance",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_vlc_session_attendance": {
+          "name": "uniq_vlc_session_attendance",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "session_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vlc_session_attendance_minutes_late_nonneg": {
+          "name": "vlc_session_attendance_minutes_late_nonneg",
+          "value": "\"vlc_session_attendance\".\"minutes_late\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vlc_session_template": {
+      "name": "vlc_session_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_id": {
+          "name": "value_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot": {
+          "name": "slot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vlc_session_template_school_id_ref_school_id_fk": {
+          "name": "vlc_session_template_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_session_template",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_session_template_school_id_value_id_vlc_value_school_id_id_fk": {
+          "name": "vlc_session_template_school_id_value_id_vlc_value_school_id_id_fk",
+          "tableFrom": "vlc_session_template",
+          "tableTo": "vlc_value",
+          "columnsFrom": [
+            "school_id",
+            "value_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_vlc_session_template_value_slot": {
+          "name": "uniq_vlc_session_template_value_slot",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "value_id",
+            "slot"
+          ]
+        },
+        "vlc_session_template_tenant_uk": {
+          "name": "vlc_session_template_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vlc_session_template_slot_valid": {
+          "name": "vlc_session_template_slot_valid",
+          "value": "\"vlc_session_template\".\"slot\" IN ('A', 'B')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vlc_training": {
+      "name": "vlc_training",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_date": {
+          "name": "scheduled_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vlc_training_year_idx": {
+          "name": "vlc_training_year_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vlc_training_school_id_ref_school_id_fk": {
+          "name": "vlc_training_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_training",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vlc_training_tenant_uk": {
+          "name": "vlc_training_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vlc_training_duration_min_positive": {
+          "name": "vlc_training_duration_min_positive",
+          "value": "\"vlc_training\".\"duration_min\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vlc_training_absence": {
+      "name": "vlc_training_absence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "training_id": {
+          "name": "training_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peer_guide_id": {
+          "name": "peer_guide_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excused": {
+          "name": "excused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vlc_training_absence_peer_guide_idx": {
+          "name": "vlc_training_absence_peer_guide_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "peer_guide_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vlc_training_absence_school_id_ref_school_id_fk": {
+          "name": "vlc_training_absence_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_training_absence",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_training_absence_recorded_by_user_id_ref_user_id_fk": {
+          "name": "vlc_training_absence_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_training_absence",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_training_absence_school_id_training_id_vlc_training_school_id_id_fk": {
+          "name": "vlc_training_absence_school_id_training_id_vlc_training_school_id_id_fk",
+          "tableFrom": "vlc_training_absence",
+          "tableTo": "vlc_training",
+          "columnsFrom": [
+            "school_id",
+            "training_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_training_absence_school_id_peer_guide_id_vlc_peer_guide_school_id_id_fk": {
+          "name": "vlc_training_absence_school_id_peer_guide_id_vlc_peer_guide_school_id_id_fk",
+          "tableFrom": "vlc_training_absence",
+          "tableTo": "vlc_peer_guide",
+          "columnsFrom": [
+            "school_id",
+            "peer_guide_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_vlc_training_absence": {
+          "name": "uniq_vlc_training_absence",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "training_id",
+            "peer_guide_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vlc_value": {
+      "name": "vlc_value",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_twi": {
+          "name": "name_twi",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "term_group": {
+          "name": "term_group",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "descriptor": {
+          "name": "descriptor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_capstone": {
+          "name": "is_capstone",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vlc_value_school_id_ref_school_id_fk": {
+          "name": "vlc_value_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_value",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_vlc_value_ordinal": {
+          "name": "uniq_vlc_value_ordinal",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "ordinal"
+          ]
+        },
+        "vlc_value_tenant_uk": {
+          "name": "vlc_value_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vlc_value_term_group_range": {
+          "name": "vlc_value_term_group_range",
+          "value": "\"vlc_value\".\"term_group\" BETWEEN 1 AND 3"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vlc_value_change_request": {
+      "name": "vlc_value_change_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "op": {
+          "name": "op",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PROPOSED'"
+        },
+        "proposed_by_user_id": {
+          "name": "proposed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_at": {
+          "name": "proposed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_note": {
+          "name": "decision_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vlc_value_change_request_state_idx": {
+          "name": "vlc_value_change_request_state_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vlc_value_change_request_school_id_ref_school_id_fk": {
+          "name": "vlc_value_change_request_school_id_ref_school_id_fk",
+          "tableFrom": "vlc_value_change_request",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vlc_value_change_request_proposed_by_user_id_ref_user_id_fk": {
+          "name": "vlc_value_change_request_proposed_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_value_change_request",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "proposed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vlc_value_change_request_decided_by_user_id_ref_user_id_fk": {
+          "name": "vlc_value_change_request_decided_by_user_id_ref_user_id_fk",
+          "tableFrom": "vlc_value_change_request",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vlc_value_change_request_op_valid": {
+          "name": "vlc_value_change_request_op_valid",
+          "value": "\"vlc_value_change_request\".\"op\" IN ('ADD', 'REORDER', 'REMOVE')"
+        },
+        "vlc_value_change_request_state_valid": {
+          "name": "vlc_value_change_request_state_valid",
+          "value": "\"vlc_value_change_request\".\"state\" IN ('PROPOSED', 'APPROVED', 'REJECTED')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.plc": {
+      "name": "plc",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "facilitator_user_id": {
+          "name": "facilitator_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_frequency": {
+          "name": "override_frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_session_day": {
+          "name": "override_session_day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plc_school_id_ref_school_id_fk": {
+          "name": "plc_school_id_ref_school_id_fk",
+          "tableFrom": "plc",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plc_facilitator_user_id_ref_user_id_fk": {
+          "name": "plc_facilitator_user_id_ref_user_id_fk",
+          "tableFrom": "plc",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "facilitator_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plc_tenant_uk": {
+          "name": "plc_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "plc_type_valid": {
+          "name": "plc_type_valid",
+          "value": "\"plc\".\"type\" IN ('subject', 'cross-cutting', 'new-teacher')"
+        },
+        "plc_override_frequency_valid": {
+          "name": "plc_override_frequency_valid",
+          "value": "\"plc\".\"override_frequency\" IN ('WEEKLY', 'BIWEEKLY')"
+        },
+        "plc_override_session_day_range": {
+          "name": "plc_override_session_day_range",
+          "value": "\"plc\".\"override_session_day\" BETWEEN 1 AND 7"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.plc_cpd_ledger": {
+      "name": "plc_cpd_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attended_pts": {
+          "name": "attended_pts",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reflection_pts": {
+          "name": "reflection_pts",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plc_cpd_ledger_school_id_ref_school_id_fk": {
+          "name": "plc_cpd_ledger_school_id_ref_school_id_fk",
+          "tableFrom": "plc_cpd_ledger",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plc_cpd_ledger_user_id_ref_user_id_fk": {
+          "name": "plc_cpd_ledger_user_id_ref_user_id_fk",
+          "tableFrom": "plc_cpd_ledger",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "plc_cpd_ledger_school_id_session_id_plc_session_school_id_id_fk": {
+          "name": "plc_cpd_ledger_school_id_session_id_plc_session_school_id_id_fk",
+          "tableFrom": "plc_cpd_ledger",
+          "tableTo": "plc_session",
+          "columnsFrom": [
+            "school_id",
+            "session_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_plc_cpd_ledger": {
+          "name": "uniq_plc_cpd_ledger",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "session_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "plc_cpd_ledger_attended_pts_nonneg": {
+          "name": "plc_cpd_ledger_attended_pts_nonneg",
+          "value": "\"plc_cpd_ledger\".\"attended_pts\" >= 0"
+        },
+        "plc_cpd_ledger_reflection_pts_nonneg": {
+          "name": "plc_cpd_ledger_reflection_pts_nonneg",
+          "value": "\"plc_cpd_ledger\".\"reflection_pts\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.plc_membership": {
+      "name": "plc_membership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plc_id": {
+          "name": "plc_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plc_membership_user_idx": {
+          "name": "plc_membership_user_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plc_membership_school_id_ref_school_id_fk": {
+          "name": "plc_membership_school_id_ref_school_id_fk",
+          "tableFrom": "plc_membership",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plc_membership_user_id_ref_user_id_fk": {
+          "name": "plc_membership_user_id_ref_user_id_fk",
+          "tableFrom": "plc_membership",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "plc_membership_school_id_plc_id_plc_school_id_id_fk": {
+          "name": "plc_membership_school_id_plc_id_plc_school_id_id_fk",
+          "tableFrom": "plc_membership",
+          "tableTo": "plc",
+          "columnsFrom": [
+            "school_id",
+            "plc_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_plc_membership": {
+          "name": "uniq_plc_membership",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "plc_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plc_programme": {
+      "name": "plc_programme",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_day": {
+          "name": "session_day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "session_start": {
+          "name": "session_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'15:30'"
+        },
+        "session_length_min": {
+          "name": "session_length_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "weeks_per_semester": {
+          "name": "weeks_per_semester",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 12
+        },
+        "pts_per_attended_session": {
+          "name": "pts_per_attended_session",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.5'"
+        },
+        "pts_per_reflection": {
+          "name": "pts_per_reflection",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.5'"
+        },
+        "reflection_window_hours": {
+          "name": "reflection_window_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 48
+        },
+        "annual_plc_target": {
+          "name": "annual_plc_target",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'8'"
+        },
+        "configured_at": {
+          "name": "configured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plc_programme_school_id_ref_school_id_fk": {
+          "name": "plc_programme_school_id_ref_school_id_fk",
+          "tableFrom": "plc_programme",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plc_programme_school_id_unique": {
+          "name": "plc_programme_school_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "plc_programme_session_day_range": {
+          "name": "plc_programme_session_day_range",
+          "value": "\"plc_programme\".\"session_day\" BETWEEN 1 AND 7"
+        },
+        "plc_programme_session_length_min_positive": {
+          "name": "plc_programme_session_length_min_positive",
+          "value": "\"plc_programme\".\"session_length_min\" > 0"
+        },
+        "plc_programme_weeks_per_semester_positive": {
+          "name": "plc_programme_weeks_per_semester_positive",
+          "value": "\"plc_programme\".\"weeks_per_semester\" > 0"
+        },
+        "plc_programme_reflection_window_hours_positive": {
+          "name": "plc_programme_reflection_window_hours_positive",
+          "value": "\"plc_programme\".\"reflection_window_hours\" > 0"
+        },
+        "plc_programme_pts_per_attended_session_nonneg": {
+          "name": "plc_programme_pts_per_attended_session_nonneg",
+          "value": "\"plc_programme\".\"pts_per_attended_session\" >= 0"
+        },
+        "plc_programme_pts_per_reflection_nonneg": {
+          "name": "plc_programme_pts_per_reflection_nonneg",
+          "value": "\"plc_programme\".\"pts_per_reflection\" >= 0"
+        },
+        "plc_programme_annual_plc_target_nonneg": {
+          "name": "plc_programme_annual_plc_target_nonneg",
+          "value": "\"plc_programme\".\"annual_plc_target\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.plc_session": {
+      "name": "plc_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plc_id": {
+          "name": "plc_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_period_id": {
+          "name": "academic_period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_date": {
+          "name": "session_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agenda_json": {
+          "name": "agenda_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"items\": []}'::jsonb"
+        },
+        "opened_by_user_id": {
+          "name": "opened_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plc_session_school_id_ref_school_id_fk": {
+          "name": "plc_session_school_id_ref_school_id_fk",
+          "tableFrom": "plc_session",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plc_session_opened_by_user_id_ref_user_id_fk": {
+          "name": "plc_session_opened_by_user_id_ref_user_id_fk",
+          "tableFrom": "plc_session",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "opened_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "plc_session_school_id_plc_id_plc_school_id_id_fk": {
+          "name": "plc_session_school_id_plc_id_plc_school_id_id_fk",
+          "tableFrom": "plc_session",
+          "tableTo": "plc",
+          "columnsFrom": [
+            "school_id",
+            "plc_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plc_session_school_id_academic_period_id_academic_period_school_id_period_id_fk": {
+          "name": "plc_session_school_id_academic_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "plc_session",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "academic_period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plc_session_tenant_uk": {
+          "name": "plc_session_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        },
+        "uniq_plc_session": {
+          "name": "uniq_plc_session",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "plc_id",
+            "session_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plc_session_attendance": {
+      "name": "plc_session_attendance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "attendance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minutes_late": {
+          "name": "minutes_late",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plc_session_attendance_school_id_ref_school_id_fk": {
+          "name": "plc_session_attendance_school_id_ref_school_id_fk",
+          "tableFrom": "plc_session_attendance",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plc_session_attendance_user_id_ref_user_id_fk": {
+          "name": "plc_session_attendance_user_id_ref_user_id_fk",
+          "tableFrom": "plc_session_attendance",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "plc_session_attendance_recorded_by_user_id_ref_user_id_fk": {
+          "name": "plc_session_attendance_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "plc_session_attendance",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "plc_session_attendance_school_id_session_id_plc_session_school_id_id_fk": {
+          "name": "plc_session_attendance_school_id_session_id_plc_session_school_id_id_fk",
+          "tableFrom": "plc_session_attendance",
+          "tableTo": "plc_session",
+          "columnsFrom": [
+            "school_id",
+            "session_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_plc_session_attendance": {
+          "name": "uniq_plc_session_attendance",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "session_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "plc_session_attendance_minutes_late_nonneg": {
+          "name": "plc_session_attendance_minutes_late_nonneg",
+          "value": "\"plc_session_attendance\".\"minutes_late\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.plc_session_reflection": {
+      "name": "plc_session_reflection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "q1": {
+          "name": "q1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "q2": {
+          "name": "q2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "q3": {
+          "name": "q3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_by_user_id": {
+          "name": "confirmed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plc_session_reflection_school_id_ref_school_id_fk": {
+          "name": "plc_session_reflection_school_id_ref_school_id_fk",
+          "tableFrom": "plc_session_reflection",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plc_session_reflection_user_id_ref_user_id_fk": {
+          "name": "plc_session_reflection_user_id_ref_user_id_fk",
+          "tableFrom": "plc_session_reflection",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "plc_session_reflection_confirmed_by_user_id_ref_user_id_fk": {
+          "name": "plc_session_reflection_confirmed_by_user_id_ref_user_id_fk",
+          "tableFrom": "plc_session_reflection",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "confirmed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "plc_session_reflection_school_id_session_id_plc_session_school_id_id_fk": {
+          "name": "plc_session_reflection_school_id_session_id_plc_session_school_id_id_fk",
+          "tableFrom": "plc_session_reflection",
+          "tableTo": "plc_session",
+          "columnsFrom": [
+            "school_id",
+            "session_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_plc_session_reflection": {
+          "name": "uniq_plc_session_reflection",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "session_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plc_term_focus": {
+      "name": "plc_term_focus",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plc_id": {
+          "name": "plc_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_period_id": {
+          "name": "academic_period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "focus": {
+          "name": "focus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_by_user_id": {
+          "name": "set_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plc_term_focus_school_id_ref_school_id_fk": {
+          "name": "plc_term_focus_school_id_ref_school_id_fk",
+          "tableFrom": "plc_term_focus",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plc_term_focus_set_by_user_id_ref_user_id_fk": {
+          "name": "plc_term_focus_set_by_user_id_ref_user_id_fk",
+          "tableFrom": "plc_term_focus",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "set_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "plc_term_focus_school_id_plc_id_plc_school_id_id_fk": {
+          "name": "plc_term_focus_school_id_plc_id_plc_school_id_id_fk",
+          "tableFrom": "plc_term_focus",
+          "tableTo": "plc",
+          "columnsFrom": [
+            "school_id",
+            "plc_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plc_term_focus_school_id_academic_period_id_academic_period_school_id_period_id_fk": {
+          "name": "plc_term_focus_school_id_academic_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "plc_term_focus",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "academic_period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_plc_term_focus": {
+          "name": "uniq_plc_term_focus",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "plc_id",
+            "academic_period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "plc_term_focus_focus_len": {
+          "name": "plc_term_focus_focus_len",
+          "value": "char_length(\"plc_term_focus\".\"focus\") <= 500"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pta_action_item": {
+      "name": "pta_action_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agenda_item_id": {
+          "name": "agenda_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_user_id": {
+          "name": "person_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_name": {
+          "name": "external_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pta_action_item_agenda_item_idx": {
+          "name": "pta_action_item_agenda_item_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agenda_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pta_action_item_school_id_ref_school_id_fk": {
+          "name": "pta_action_item_school_id_ref_school_id_fk",
+          "tableFrom": "pta_action_item",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_action_item_person_user_id_ref_user_id_fk": {
+          "name": "pta_action_item_person_user_id_ref_user_id_fk",
+          "tableFrom": "pta_action_item",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "person_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pta_action_item_school_id_agenda_item_id_pta_agenda_item_school_id_id_fk": {
+          "name": "pta_action_item_school_id_agenda_item_id_pta_agenda_item_school_id_id_fk",
+          "tableFrom": "pta_action_item",
+          "tableTo": "pta_agenda_item",
+          "columnsFrom": [
+            "school_id",
+            "agenda_item_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pta_action_item_at_most_one_owner": {
+          "name": "pta_action_item_at_most_one_owner",
+          "value": "NOT (\"pta_action_item\".\"person_user_id\" IS NOT NULL AND \"pta_action_item\".\"external_name\" IS NOT NULL)"
+        },
+        "pta_action_item_status_valid": {
+          "name": "pta_action_item_status_valid",
+          "value": "\"pta_action_item\".\"status\" IN ('PENDING', 'DONE')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pta_agenda_item": {
+      "name": "pta_agenda_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minutes_id": {
+          "name": "minutes_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq_no": {
+          "name": "seq_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classification": {
+          "name": "classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "narrative": {
+          "name": "narrative",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pta_agenda_item_minutes_idx": {
+          "name": "pta_agenda_item_minutes_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "minutes_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq_no",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pta_agenda_item_school_id_ref_school_id_fk": {
+          "name": "pta_agenda_item_school_id_ref_school_id_fk",
+          "tableFrom": "pta_agenda_item",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_agenda_item_school_id_minutes_id_pta_minutes_school_id_id_fk": {
+          "name": "pta_agenda_item_school_id_minutes_id_pta_minutes_school_id_id_fk",
+          "tableFrom": "pta_agenda_item",
+          "tableTo": "pta_minutes",
+          "columnsFrom": [
+            "school_id",
+            "minutes_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pta_agenda_item_tenant_uk": {
+          "name": "pta_agenda_item_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pta_agenda_item_classification_valid": {
+          "name": "pta_agenda_item_classification_valid",
+          "value": "\"pta_agenda_item\".\"classification\" IS NULL OR \"pta_agenda_item\".\"classification\" IN ('DISCUSSION', 'ACTION', 'RESOLUTION')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pta_dues_charge": {
+      "name": "pta_dues_charge",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_item_id": {
+          "name": "line_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pta_id": {
+          "name": "pta_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_type": {
+          "name": "tier_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_period_id": {
+          "name": "academic_period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "basis": {
+          "name": "basis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cadence": {
+          "name": "cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_student_id": {
+          "name": "subject_student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_snapshot": {
+          "name": "rate_snapshot",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_pta_dues_per_student": {
+          "name": "uniq_pta_dues_per_student",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pta_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pta_dues_charge\".\"basis\" = 'PER_STUDENT'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_pta_dues_per_family": {
+          "name": "uniq_pta_dues_per_family",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pta_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "household_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pta_dues_charge\".\"basis\" = 'PER_FAMILY' AND \"pta_dues_charge\".\"household_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_pta_dues_per_family_of_one": {
+          "name": "uniq_pta_dues_per_family_of_one",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pta_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pta_dues_charge\".\"basis\" = 'PER_FAMILY' AND \"pta_dues_charge\".\"household_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pta_dues_charge_pta_idx": {
+          "name": "pta_dues_charge_pta_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pta_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pta_dues_charge_school_id_ref_school_id_fk": {
+          "name": "pta_dues_charge_school_id_ref_school_id_fk",
+          "tableFrom": "pta_dues_charge",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_dues_charge_school_id_line_item_id_invoice_line_item_school_id_id_fk": {
+          "name": "pta_dues_charge_school_id_line_item_id_invoice_line_item_school_id_id_fk",
+          "tableFrom": "pta_dues_charge",
+          "tableTo": "invoice_line_item",
+          "columnsFrom": [
+            "school_id",
+            "line_item_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_dues_charge_school_id_pta_id_ptas_school_id_id_fk": {
+          "name": "pta_dues_charge_school_id_pta_id_ptas_school_id_id_fk",
+          "tableFrom": "pta_dues_charge",
+          "tableTo": "ptas",
+          "columnsFrom": [
+            "school_id",
+            "pta_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_dues_charge_school_id_academic_period_id_academic_period_school_id_period_id_fk": {
+          "name": "pta_dues_charge_school_id_academic_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "pta_dues_charge",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "academic_period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_dues_charge_school_id_subject_student_id_students_school_id_id_fk": {
+          "name": "pta_dues_charge_school_id_subject_student_id_students_school_id_id_fk",
+          "tableFrom": "pta_dues_charge",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "subject_student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_dues_charge_school_id_household_id_household_school_id_id_fk": {
+          "name": "pta_dues_charge_school_id_household_id_household_school_id_id_fk",
+          "tableFrom": "pta_dues_charge",
+          "tableTo": "household",
+          "columnsFrom": [
+            "school_id",
+            "household_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_pta_dues_charge_line_item": {
+          "name": "uniq_pta_dues_charge_line_item",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "line_item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pta_dues_charge_tier_type_valid": {
+          "name": "pta_dues_charge_tier_type_valid",
+          "value": "\"pta_dues_charge\".\"tier_type\" IN ('FORM', 'HOUSE', 'GENERAL', 'EMERGENCY')"
+        },
+        "pta_dues_charge_basis_valid": {
+          "name": "pta_dues_charge_basis_valid",
+          "value": "\"pta_dues_charge\".\"basis\" IN ('PER_STUDENT', 'PER_FAMILY')"
+        },
+        "pta_dues_charge_cadence_valid": {
+          "name": "pta_dues_charge_cadence_valid",
+          "value": "\"pta_dues_charge\".\"cadence\" IN ('PER_TERM', 'PER_YEAR', 'ONE_OFF')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pta_dues_config_history": {
+      "name": "pta_dues_config_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_type": {
+          "name": "tier_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dues_enabled": {
+          "name": "dues_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dues_amount": {
+          "name": "dues_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dues_basis": {
+          "name": "dues_basis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dues_cadence": {
+          "name": "dues_cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pta_dues_config_history_tier_idx": {
+          "name": "pta_dues_config_history_tier_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tier_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pta_dues_config_history_school_id_ref_school_id_fk": {
+          "name": "pta_dues_config_history_school_id_ref_school_id_fk",
+          "tableFrom": "pta_dues_config_history",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_dues_config_history_changed_by_user_id_ref_user_id_fk": {
+          "name": "pta_dues_config_history_changed_by_user_id_ref_user_id_fk",
+          "tableFrom": "pta_dues_config_history",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pta_dues_config_history_school_id_tier_type_pta_tiers_config_school_id_tier_type_fk": {
+          "name": "pta_dues_config_history_school_id_tier_type_pta_tiers_config_school_id_tier_type_fk",
+          "tableFrom": "pta_dues_config_history",
+          "tableTo": "pta_tiers_config",
+          "columnsFrom": [
+            "school_id",
+            "tier_type"
+          ],
+          "columnsTo": [
+            "school_id",
+            "tier_type"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pta_meeting": {
+      "name": "pta_meeting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pta_id": {
+          "name": "pta_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_period_id": {
+          "name": "academic_period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_type": {
+          "name": "meeting_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_date": {
+          "name": "meeting_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agenda_json": {
+          "name": "agenda_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"items\": []}'::jsonb"
+        },
+        "invited_teacher_user_ids": {
+          "name": "invited_teacher_user_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "quorum_met": {
+          "name": "quorum_met",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "convened_by_user_id": {
+          "name": "convened_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parents_notified_at": {
+          "name": "parents_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pta_meeting_pta_idx": {
+          "name": "pta_meeting_pta_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pta_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "meeting_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pta_meeting_school_id_ref_school_id_fk": {
+          "name": "pta_meeting_school_id_ref_school_id_fk",
+          "tableFrom": "pta_meeting",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_meeting_convened_by_user_id_ref_user_id_fk": {
+          "name": "pta_meeting_convened_by_user_id_ref_user_id_fk",
+          "tableFrom": "pta_meeting",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "convened_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pta_meeting_school_id_pta_id_ptas_school_id_id_fk": {
+          "name": "pta_meeting_school_id_pta_id_ptas_school_id_id_fk",
+          "tableFrom": "pta_meeting",
+          "tableTo": "ptas",
+          "columnsFrom": [
+            "school_id",
+            "pta_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_meeting_school_id_academic_period_id_academic_period_school_id_period_id_fk": {
+          "name": "pta_meeting_school_id_academic_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "pta_meeting",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "academic_period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pta_meeting_tenant_uk": {
+          "name": "pta_meeting_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pta_meeting_attendance": {
+      "name": "pta_meeting_attendance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "register": {
+          "name": "register",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_guardian_id": {
+          "name": "student_guardian_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "attendance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minutes_late": {
+          "name": "minutes_late",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_pta_meeting_attendance_teacher": {
+          "name": "uniq_pta_meeting_attendance_teacher",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "meeting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pta_meeting_attendance\".\"register\" = 'TEACHER'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_pta_meeting_attendance_parent": {
+          "name": "uniq_pta_meeting_attendance_parent",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "meeting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_guardian_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pta_meeting_attendance\".\"register\" = 'PARENT'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pta_meeting_attendance_school_id_ref_school_id_fk": {
+          "name": "pta_meeting_attendance_school_id_ref_school_id_fk",
+          "tableFrom": "pta_meeting_attendance",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_meeting_attendance_user_id_ref_user_id_fk": {
+          "name": "pta_meeting_attendance_user_id_ref_user_id_fk",
+          "tableFrom": "pta_meeting_attendance",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pta_meeting_attendance_student_guardian_id_student_guardian_id_fk": {
+          "name": "pta_meeting_attendance_student_guardian_id_student_guardian_id_fk",
+          "tableFrom": "pta_meeting_attendance",
+          "tableTo": "student_guardian",
+          "columnsFrom": [
+            "student_guardian_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pta_meeting_attendance_recorded_by_user_id_ref_user_id_fk": {
+          "name": "pta_meeting_attendance_recorded_by_user_id_ref_user_id_fk",
+          "tableFrom": "pta_meeting_attendance",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pta_meeting_attendance_school_id_meeting_id_pta_meeting_school_id_id_fk": {
+          "name": "pta_meeting_attendance_school_id_meeting_id_pta_meeting_school_id_id_fk",
+          "tableFrom": "pta_meeting_attendance",
+          "tableTo": "pta_meeting",
+          "columnsFrom": [
+            "school_id",
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pta_meeting_attendance_register_valid": {
+          "name": "pta_meeting_attendance_register_valid",
+          "value": "\"pta_meeting_attendance\".\"register\" IN ('TEACHER', 'PARENT')"
+        },
+        "pta_meeting_attendance_register_identity": {
+          "name": "pta_meeting_attendance_register_identity",
+          "value": "(\"pta_meeting_attendance\".\"register\" = 'TEACHER' AND \"pta_meeting_attendance\".\"user_id\" IS NOT NULL AND \"pta_meeting_attendance\".\"student_guardian_id\" IS NULL)\n        OR (\"pta_meeting_attendance\".\"register\" = 'PARENT' AND \"pta_meeting_attendance\".\"student_guardian_id\" IS NOT NULL AND \"pta_meeting_attendance\".\"user_id\" IS NULL)"
+        },
+        "pta_meeting_attendance_minutes_late_nonneg": {
+          "name": "pta_meeting_attendance_minutes_late_nonneg",
+          "value": "\"pta_meeting_attendance\".\"minutes_late\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pta_minutes": {
+      "name": "pta_minutes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "secretary_id": {
+          "name": "secretary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adopted_by_user_id": {
+          "name": "adopted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adopted_at": {
+          "name": "adopted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distributed_at": {
+          "name": "distributed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pta_minutes_school_id_ref_school_id_fk": {
+          "name": "pta_minutes_school_id_ref_school_id_fk",
+          "tableFrom": "pta_minutes",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_minutes_secretary_id_ref_user_id_fk": {
+          "name": "pta_minutes_secretary_id_ref_user_id_fk",
+          "tableFrom": "pta_minutes",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "secretary_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pta_minutes_adopted_by_user_id_ref_user_id_fk": {
+          "name": "pta_minutes_adopted_by_user_id_ref_user_id_fk",
+          "tableFrom": "pta_minutes",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "adopted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pta_minutes_school_id_meeting_id_pta_meeting_school_id_id_fk": {
+          "name": "pta_minutes_school_id_meeting_id_pta_meeting_school_id_id_fk",
+          "tableFrom": "pta_minutes",
+          "tableTo": "pta_meeting",
+          "columnsFrom": [
+            "school_id",
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_pta_minutes_meeting": {
+          "name": "uniq_pta_minutes_meeting",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "meeting_id"
+          ]
+        },
+        "pta_minutes_tenant_uk": {
+          "name": "pta_minutes_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pta_minutes_status_valid": {
+          "name": "pta_minutes_status_valid",
+          "value": "\"pta_minutes\".\"status\" IN ('DRAFT', 'CHAIR_REVIEW', 'ADOPTED')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pta_officer": {
+      "name": "pta_officer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pta_id": {
+          "name": "pta_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_user_id": {
+          "name": "person_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_name": {
+          "name": "external_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "office": {
+          "name": "office",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_basis": {
+          "name": "assignment_basis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "election_ref": {
+          "name": "election_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "term_start": {
+          "name": "term_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "term_end": {
+          "name": "term_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_pta_officer_current": {
+          "name": "uniq_pta_officer_current",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pta_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "office",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pta_officer\".\"ended_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pta_officer_person_idx": {
+          "name": "pta_officer_person_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pta_officer_school_id_ref_school_id_fk": {
+          "name": "pta_officer_school_id_ref_school_id_fk",
+          "tableFrom": "pta_officer",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_officer_person_user_id_ref_user_id_fk": {
+          "name": "pta_officer_person_user_id_ref_user_id_fk",
+          "tableFrom": "pta_officer",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "person_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pta_officer_school_id_pta_id_ptas_school_id_id_fk": {
+          "name": "pta_officer_school_id_pta_id_ptas_school_id_id_fk",
+          "tableFrom": "pta_officer",
+          "tableTo": "ptas",
+          "columnsFrom": [
+            "school_id",
+            "pta_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pta_officer_at_most_one_holder": {
+          "name": "pta_officer_at_most_one_holder",
+          "value": "NOT (\"pta_officer\".\"person_user_id\" IS NOT NULL AND \"pta_officer\".\"external_name\" IS NOT NULL)"
+        },
+        "pta_officer_assignment_basis_valid": {
+          "name": "pta_officer_assignment_basis_valid",
+          "value": "\"pta_officer\".\"assignment_basis\" IN ('ELECTED', 'APPOINTED')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pta_resolution": {
+      "name": "pta_resolution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agenda_item_id": {
+          "name": "agenda_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution_no": {
+          "name": "resolution_no",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_text": {
+          "name": "resolution_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "votes_for": {
+          "name": "votes_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "votes_against": {
+          "name": "votes_against",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "votes_abstain": {
+          "name": "votes_abstain",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding": {
+          "name": "binding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pta_resolution_agenda_item_idx": {
+          "name": "pta_resolution_agenda_item_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agenda_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pta_resolution_school_id_ref_school_id_fk": {
+          "name": "pta_resolution_school_id_ref_school_id_fk",
+          "tableFrom": "pta_resolution",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pta_resolution_school_id_agenda_item_id_pta_agenda_item_school_id_id_fk": {
+          "name": "pta_resolution_school_id_agenda_item_id_pta_agenda_item_school_id_id_fk",
+          "tableFrom": "pta_resolution",
+          "tableTo": "pta_agenda_item",
+          "columnsFrom": [
+            "school_id",
+            "agenda_item_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_pta_resolution_no": {
+          "name": "uniq_pta_resolution_no",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "resolution_no"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pta_resolution_votes_for_nonneg": {
+          "name": "pta_resolution_votes_for_nonneg",
+          "value": "\"pta_resolution\".\"votes_for\" >= 0"
+        },
+        "pta_resolution_votes_against_nonneg": {
+          "name": "pta_resolution_votes_against_nonneg",
+          "value": "\"pta_resolution\".\"votes_against\" >= 0"
+        },
+        "pta_resolution_votes_abstain_nonneg": {
+          "name": "pta_resolution_votes_abstain_nonneg",
+          "value": "\"pta_resolution\".\"votes_abstain\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pta_tiers_config": {
+      "name": "pta_tiers_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_type": {
+          "name": "tier_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "frequency_norm": {
+          "name": "frequency_norm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "officer_roles": {
+          "name": "officer_roles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "quorum_rule": {
+          "name": "quorum_rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dues_enabled": {
+          "name": "dues_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dues_amount": {
+          "name": "dues_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dues_basis": {
+          "name": "dues_basis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dues_cadence": {
+          "name": "dues_cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier_settings": {
+          "name": "tier_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "configured_at": {
+          "name": "configured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pta_tiers_config_school_id_ref_school_id_fk": {
+          "name": "pta_tiers_config_school_id_ref_school_id_fk",
+          "tableFrom": "pta_tiers_config",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_pta_tiers_config": {
+          "name": "uniq_pta_tiers_config",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "tier_type"
+          ]
+        },
+        "pta_tiers_config_tenant_uk": {
+          "name": "pta_tiers_config_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pta_tiers_config_tier_type_valid": {
+          "name": "pta_tiers_config_tier_type_valid",
+          "value": "\"pta_tiers_config\".\"tier_type\" IN ('FORM', 'HOUSE', 'GENERAL', 'EMERGENCY')"
+        },
+        "pta_tiers_config_dues_basis_valid": {
+          "name": "pta_tiers_config_dues_basis_valid",
+          "value": "\"pta_tiers_config\".\"dues_basis\" IN ('PER_STUDENT', 'PER_FAMILY')"
+        },
+        "pta_tiers_config_dues_cadence_valid": {
+          "name": "pta_tiers_config_dues_cadence_valid",
+          "value": "\"pta_tiers_config\".\"dues_cadence\" IN ('PER_TERM', 'PER_YEAR', 'ONE_OFF')"
+        },
+        "pta_tiers_config_emergency_no_officers_no_dues": {
+          "name": "pta_tiers_config_emergency_no_officers_no_dues",
+          "value": "\"pta_tiers_config\".\"tier_type\" <> 'EMERGENCY' OR (\"pta_tiers_config\".\"officer_roles\" = '[]'::jsonb AND \"pta_tiers_config\".\"dues_enabled\" = false)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ptas": {
+      "name": "ptas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_type": {
+          "name": "tier_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "house_id": {
+          "name": "house_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_pta_form_scope": {
+          "name": "uniq_pta_form_scope",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"ptas\".\"tier_type\" = 'FORM'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_pta_house_scope": {
+          "name": "uniq_pta_house_scope",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "house_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"ptas\".\"tier_type\" = 'HOUSE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_pta_general_singleton": {
+          "name": "uniq_pta_general_singleton",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"ptas\".\"tier_type\" = 'GENERAL'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ptas_school_id_ref_school_id_fk": {
+          "name": "ptas_school_id_ref_school_id_fk",
+          "tableFrom": "ptas",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ptas_school_id_class_id_class_school_id_id_fk": {
+          "name": "ptas_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "ptas",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "ptas_school_id_house_id_house_school_id_id_fk": {
+          "name": "ptas_school_id_house_id_house_school_id_id_fk",
+          "tableFrom": "ptas",
+          "tableTo": "house",
+          "columnsFrom": [
+            "school_id",
+            "house_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ptas_tenant_uk": {
+          "name": "ptas_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ptas_tier_type_valid": {
+          "name": "ptas_tier_type_valid",
+          "value": "\"ptas\".\"tier_type\" IN ('FORM', 'HOUSE', 'GENERAL', 'EMERGENCY')"
+        },
+        "ptas_status_valid": {
+          "name": "ptas_status_valid",
+          "value": "\"ptas\".\"status\" IN ('ACTIVE', 'CLOSED')"
+        },
+        "ptas_tier_scope_binding": {
+          "name": "ptas_tier_scope_binding",
+          "value": "(\"ptas\".\"tier_type\" = 'FORM' AND \"ptas\".\"class_id\" IS NOT NULL AND \"ptas\".\"house_id\" IS NULL)\n        OR (\"ptas\".\"tier_type\" = 'HOUSE' AND \"ptas\".\"house_id\" IS NOT NULL AND \"ptas\".\"class_id\" IS NULL)\n        OR (\"ptas\".\"tier_type\" IN ('GENERAL', 'EMERGENCY') AND \"ptas\".\"class_id\" IS NULL AND \"ptas\".\"house_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.terminal_exam_result": {
+      "name": "terminal_exam_result",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exam_type": {
+          "name": "exam_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "female_candidates": {
+          "name": "female_candidates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "male_candidates": {
+          "name": "male_candidates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "female_passed": {
+          "name": "female_passed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "male_passed": {
+          "name": "male_passed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "captured_by": {
+          "name": "captured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "terminal_exam_result_school_id_ref_school_id_fk": {
+          "name": "terminal_exam_result_school_id_ref_school_id_fk",
+          "tableFrom": "terminal_exam_result",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_exam_result_captured_by_ref_user_id_fk": {
+          "name": "terminal_exam_result_captured_by_ref_user_id_fk",
+          "tableFrom": "terminal_exam_result",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "captured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_terminal_exam_result_sitting": {
+          "name": "uniq_terminal_exam_result_sitting",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "exam_type",
+            "year"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "terminal_exam_result_exam_type_valid": {
+          "name": "terminal_exam_result_exam_type_valid",
+          "value": "\"terminal_exam_result\".\"exam_type\" IN ('BECE', 'WASSCE')"
+        },
+        "terminal_exam_result_female_candidates_nonneg": {
+          "name": "terminal_exam_result_female_candidates_nonneg",
+          "value": "\"terminal_exam_result\".\"female_candidates\" >= 0"
+        },
+        "terminal_exam_result_male_candidates_nonneg": {
+          "name": "terminal_exam_result_male_candidates_nonneg",
+          "value": "\"terminal_exam_result\".\"male_candidates\" >= 0"
+        },
+        "terminal_exam_result_female_passed_bounds": {
+          "name": "terminal_exam_result_female_passed_bounds",
+          "value": "\"terminal_exam_result\".\"female_passed\" >= 0 AND \"terminal_exam_result\".\"female_passed\" <= \"terminal_exam_result\".\"female_candidates\""
+        },
+        "terminal_exam_result_male_passed_bounds": {
+          "name": "terminal_exam_result_male_passed_bounds",
+          "value": "\"terminal_exam_result\".\"male_passed\" >= 0 AND \"terminal_exam_result\".\"male_passed\" <= \"terminal_exam_result\".\"male_candidates\""
+        },
+        "terminal_exam_result_min_one_candidate": {
+          "name": "terminal_exam_result_min_one_candidate",
+          "value": "\"terminal_exam_result\".\"female_candidates\" + \"terminal_exam_result\".\"male_candidates\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.facilities_snapshot": {
+      "name": "facilities_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classrooms_total": {
+          "name": "classrooms_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classrooms_good": {
+          "name": "classrooms_good",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classrooms_repair": {
+          "name": "classrooms_repair",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "water_source": {
+          "name": "water_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "electricity_source": {
+          "name": "electricity_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latrines_boys": {
+          "name": "latrines_boys",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latrines_girls": {
+          "name": "latrines_girls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latrines_staff": {
+          "name": "latrines_staff",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latrine_type": {
+          "name": "latrine_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handwashing": {
+          "name": "handwashing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_library": {
+          "name": "has_library",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_ict_lab": {
+          "name": "has_ict_lab",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internet": {
+          "name": "internet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_kitchen": {
+          "name": "has_kitchen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gsfp_participating": {
+          "name": "gsfp_participating",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_book_count": {
+          "name": "library_book_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "library_staff_fte": {
+          "name": "library_staff_fte",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computers_total": {
+          "name": "computers_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computers_working": {
+          "name": "computers_working",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internet_type": {
+          "name": "internet_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meals_served_last_term": {
+          "name": "meals_served_last_term",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pupils_fed_daily_avg": {
+          "name": "pupils_fed_daily_avg",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caterer_name": {
+          "name": "caterer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "textbook_availability": {
+          "name": "textbook_availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_desks_usable": {
+          "name": "student_desks_usable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_desks_broken": {
+          "name": "student_desks_broken",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teacher_desks": {
+          "name": "teacher_desks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chalkboards": {
+          "name": "chalkboards",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "whiteboards": {
+          "name": "whiteboards",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projectors": {
+          "name": "projectors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "captured_by": {
+          "name": "captured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "facilities_snapshot_school_id_ref_school_id_fk": {
+          "name": "facilities_snapshot_school_id_ref_school_id_fk",
+          "tableFrom": "facilities_snapshot",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "facilities_snapshot_captured_by_ref_user_id_fk": {
+          "name": "facilities_snapshot_captured_by_ref_user_id_fk",
+          "tableFrom": "facilities_snapshot",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "captured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "facilities_snapshot_school_id_period_id_academic_period_school_id_period_id_fk": {
+          "name": "facilities_snapshot_school_id_period_id_academic_period_school_id_period_id_fk",
+          "tableFrom": "facilities_snapshot",
+          "tableTo": "academic_period",
+          "columnsFrom": [
+            "school_id",
+            "period_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "period_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_facilities_snapshot_term": {
+          "name": "uniq_facilities_snapshot_term",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "period_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "facilities_snapshot_classrooms_nonneg": {
+          "name": "facilities_snapshot_classrooms_nonneg",
+          "value": "\"facilities_snapshot\".\"classrooms_total\" >= 0 AND \"facilities_snapshot\".\"classrooms_good\" >= 0 AND \"facilities_snapshot\".\"classrooms_repair\" >= 0"
+        },
+        "facilities_snapshot_classrooms_sum": {
+          "name": "facilities_snapshot_classrooms_sum",
+          "value": "\"facilities_snapshot\".\"classrooms_good\" + \"facilities_snapshot\".\"classrooms_repair\" <= \"facilities_snapshot\".\"classrooms_total\""
+        },
+        "facilities_snapshot_water_source_valid": {
+          "name": "facilities_snapshot_water_source_valid",
+          "value": "\"facilities_snapshot\".\"water_source\" IN ('BOREHOLE', 'PIPE', 'WELL', 'NONE')"
+        },
+        "facilities_snapshot_electricity_source_valid": {
+          "name": "facilities_snapshot_electricity_source_valid",
+          "value": "\"facilities_snapshot\".\"electricity_source\" IN ('GRID', 'SOLAR', 'GENERATOR', 'NONE')"
+        },
+        "facilities_snapshot_latrines_nonneg": {
+          "name": "facilities_snapshot_latrines_nonneg",
+          "value": "\"facilities_snapshot\".\"latrines_boys\" >= 0 AND \"facilities_snapshot\".\"latrines_girls\" >= 0 AND \"facilities_snapshot\".\"latrines_staff\" >= 0"
+        },
+        "facilities_snapshot_latrine_type_valid": {
+          "name": "facilities_snapshot_latrine_type_valid",
+          "value": "\"facilities_snapshot\".\"latrine_type\" IN ('WC', 'KVIP', 'PIT', 'NONE')"
+        },
+        "facilities_snapshot_library_nonneg": {
+          "name": "facilities_snapshot_library_nonneg",
+          "value": "\"facilities_snapshot\".\"library_book_count\" >= 0 AND \"facilities_snapshot\".\"library_staff_fte\" >= 0"
+        },
+        "facilities_snapshot_computers_nonneg": {
+          "name": "facilities_snapshot_computers_nonneg",
+          "value": "\"facilities_snapshot\".\"computers_total\" >= 0 AND \"facilities_snapshot\".\"computers_working\" >= 0"
+        },
+        "facilities_snapshot_computers_bound": {
+          "name": "facilities_snapshot_computers_bound",
+          "value": "\"facilities_snapshot\".\"computers_working\" IS NULL OR \"facilities_snapshot\".\"computers_total\" IS NULL OR \"facilities_snapshot\".\"computers_working\" <= \"facilities_snapshot\".\"computers_total\""
+        },
+        "facilities_snapshot_gsfp_nonneg": {
+          "name": "facilities_snapshot_gsfp_nonneg",
+          "value": "\"facilities_snapshot\".\"meals_served_last_term\" >= 0 AND \"facilities_snapshot\".\"pupils_fed_daily_avg\" >= 0"
+        },
+        "facilities_snapshot_furniture_nonneg": {
+          "name": "facilities_snapshot_furniture_nonneg",
+          "value": "\"facilities_snapshot\".\"student_desks_usable\" >= 0 AND \"facilities_snapshot\".\"student_desks_broken\" >= 0 AND \"facilities_snapshot\".\"teacher_desks\" >= 0 AND \"facilities_snapshot\".\"chalkboards\" >= 0 AND \"facilities_snapshot\".\"whiteboards\" >= 0 AND \"facilities_snapshot\".\"projectors\" >= 0"
+        },
+        "facilities_snapshot_textbook_availability_valid": {
+          "name": "facilities_snapshot_textbook_availability_valid",
+          "value": "\"facilities_snapshot\".\"textbook_availability\" IN ('ADEQUATE', 'INADEQUATE')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.census_return": {
+      "name": "census_return",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cadence": {
+          "name": "cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "census_date": {
+          "name": "census_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_snapshot": {
+          "name": "auto_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hand_fill": {
+          "name": "hand_fill",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_by": {
+          "name": "generated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "census_return_school_id_ref_school_id_fk": {
+          "name": "census_return_school_id_ref_school_id_fk",
+          "tableFrom": "census_return",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "census_return_generated_by_ref_user_id_fk": {
+          "name": "census_return_generated_by_ref_user_id_fk",
+          "tableFrom": "census_return",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "generated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_census_return_filing": {
+          "name": "uniq_census_return_filing",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "cadence",
+            "academic_year"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "census_return_cadence_valid": {
+          "name": "census_return_cadence_valid",
+          "value": "\"census_return\".\"cadence\" IN ('MID_YEAR', 'ANNUAL')"
+        },
+        "census_return_status_valid": {
+          "name": "census_return_status_valid",
+          "value": "\"census_return\".\"status\" IN ('DRAFT', 'COMPLETED')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sen_module_adoption": {
+      "name": "sen_module_adoption",
+      "schema": "",
+      "columns": {
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled_at": {
+          "name": "enabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "enabled_by": {
+          "name": "enabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sen_module_adoption_school_id_ref_school_id_fk": {
+          "name": "sen_module_adoption_school_id_ref_school_id_fk",
+          "tableFrom": "sen_module_adoption",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sen_module_adoption_enabled_by_ref_user_id_fk": {
+          "name": "sen_module_adoption_enabled_by_ref_user_id_fk",
+          "tableFrom": "sen_module_adoption",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "enabled_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sen_register": {
+      "name": "sen_register",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "sen_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_categories": {
+          "name": "secondary_categories",
+          "type": "sen_category[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "sen_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "support_notes": {
+          "name": "support_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodations": {
+          "name": "accommodations",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnosis_source": {
+          "name": "diagnosis_source",
+          "type": "sen_diagnosis_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnosing_clinician": {
+          "name": "diagnosing_clinician",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnosing_institution": {
+          "name": "diagnosing_institution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnosis_year": {
+          "name": "diagnosis_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent_state": {
+          "name": "consent_state",
+          "type": "sen_consent_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_on_file_at": {
+          "name": "consent_on_file_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sen_register_school_id_ref_school_id_fk": {
+          "name": "sen_register_school_id_ref_school_id_fk",
+          "tableFrom": "sen_register",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sen_register_created_by_ref_user_id_fk": {
+          "name": "sen_register_created_by_ref_user_id_fk",
+          "tableFrom": "sen_register",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sen_register_school_id_student_id_students_school_id_id_fk": {
+          "name": "sen_register_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "sen_register",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_sen_register_student": {
+          "name": "uniq_sen_register_student",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "sen_register_secondary_not_primary": {
+          "name": "sen_register_secondary_not_primary",
+          "value": "\"sen_register\".\"secondary_categories\" IS NULL OR NOT (\"sen_register\".\"category\" = ANY(\"sen_register\".\"secondary_categories\"))"
+        },
+        "sen_register_pending_no_detail": {
+          "name": "sen_register_pending_no_detail",
+          "value": "\"sen_register\".\"consent_state\" = 'GRANTED' OR (\n        \"sen_register\".\"severity\" IS NULL\n        AND \"sen_register\".\"diagnosis_source\" IS NULL\n        AND \"sen_register\".\"diagnosing_clinician\" IS NULL\n        AND \"sen_register\".\"diagnosing_institution\" IS NULL\n        AND \"sen_register\".\"diagnosis_year\" IS NULL\n        AND \"sen_register\".\"support_notes\" IS NULL\n        AND \"sen_register\".\"accommodations\" IS NULL\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sen_support_grant": {
+      "name": "sen_support_grant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_user_id": {
+          "name": "grantee_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sen_support_grant_grantee_idx": {
+          "name": "sen_support_grant_grantee_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "grantee_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sen_support_grant_student_idx": {
+          "name": "sen_support_grant_student_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sen_support_grant_school_id_ref_school_id_fk": {
+          "name": "sen_support_grant_school_id_ref_school_id_fk",
+          "tableFrom": "sen_support_grant",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sen_support_grant_grantee_user_id_ref_user_id_fk": {
+          "name": "sen_support_grant_grantee_user_id_ref_user_id_fk",
+          "tableFrom": "sen_support_grant",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "grantee_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sen_support_grant_granted_by_user_id_ref_user_id_fk": {
+          "name": "sen_support_grant_granted_by_user_id_ref_user_id_fk",
+          "tableFrom": "sen_support_grant",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "granted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sen_support_grant_revoked_by_user_id_ref_user_id_fk": {
+          "name": "sen_support_grant_revoked_by_user_id_ref_user_id_fk",
+          "tableFrom": "sen_support_grant",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sen_support_grant_school_id_student_id_students_school_id_id_fk": {
+          "name": "sen_support_grant_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "sen_support_grant",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.timetable_slot": {
+      "name": "timetable_slot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_index": {
+          "name": "period_index",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teacher_user_id": {
+          "name": "teacher_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "timetable_teacher_slot_idx": {
+          "name": "timetable_teacher_slot_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "teacher_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "timetable_slot_school_id_ref_school_id_fk": {
+          "name": "timetable_slot_school_id_ref_school_id_fk",
+          "tableFrom": "timetable_slot",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "timetable_slot_subject_id_subject_id_fk": {
+          "name": "timetable_slot_subject_id_subject_id_fk",
+          "tableFrom": "timetable_slot",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "timetable_slot_teacher_user_id_ref_user_id_fk": {
+          "name": "timetable_slot_teacher_user_id_ref_user_id_fk",
+          "tableFrom": "timetable_slot",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "teacher_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "timetable_slot_school_id_class_id_class_school_id_id_fk": {
+          "name": "timetable_slot_school_id_class_id_class_school_id_id_fk",
+          "tableFrom": "timetable_slot",
+          "tableTo": "class",
+          "columnsFrom": [
+            "school_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_timetable_class_slot": {
+          "name": "uniq_timetable_class_slot",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "class_id",
+            "day_of_week",
+            "period_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.announcement": {
+      "name": "announcement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "audience",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'WHOLE_SCHOOL'"
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_by_user_id": {
+          "name": "posted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "announcement_school_id_ref_school_id_fk": {
+          "name": "announcement_school_id_ref_school_id_fk",
+          "tableFrom": "announcement",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "announcement_class_id_class_id_fk": {
+          "name": "announcement_class_id_class_id_fk",
+          "tableFrom": "announcement",
+          "tableTo": "class",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "announcement_posted_by_user_id_ref_user_id_fk": {
+          "name": "announcement_posted_by_user_id_ref_user_id_fk",
+          "tableFrom": "announcement",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "posted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "notif_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'QUEUED'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_ref": {
+          "name": "provider_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_by_user_id": {
+          "name": "sent_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notif_school_time_idx": {
+          "name": "notif_school_time_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_log_school_id_ref_school_id_fk": {
+          "name": "notification_log_school_id_ref_school_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_log_student_id_students_id_fk": {
+          "name": "notification_log_student_id_students_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_log_template_id_sms_template_id_fk": {
+          "name": "notification_log_template_id_sms_template_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "sms_template",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_log_sent_by_user_id_ref_user_id_fk": {
+          "name": "notification_log_sent_by_user_id_ref_user_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "sent_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_template": {
+      "name": "sms_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sms_template_school_id_ref_school_id_fk": {
+          "name": "sms_template_school_id_ref_school_id_fk",
+          "tableFrom": "sms_template",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_template_per_school": {
+          "name": "uniq_template_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "conversation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "assigned_to_user_id": {
+          "name": "assigned_to_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SMS'"
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "routed_by_rule_id": {
+          "name": "routed_by_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "routed_by_rule_name": {
+          "name": "routed_by_rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_school_activity_idx": {
+          "name": "conversation_school_activity_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_phone_idx": {
+          "name": "conversation_phone_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_school_id_ref_school_id_fk": {
+          "name": "conversation_school_id_ref_school_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_student_id_students_id_fk": {
+          "name": "conversation_student_id_students_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "conversation_assigned_to_user_id_ref_user_id_fk": {
+          "name": "conversation_assigned_to_user_id_ref_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "assigned_to_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_tenant_uk": {
+          "name": "conversation_tenant_uk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbox_message": {
+      "name": "inbox_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "message_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_by_user_id": {
+          "name": "sent_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inbox_message_conversation_idx": {
+          "name": "inbox_message_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbox_message_school_id_ref_school_id_fk": {
+          "name": "inbox_message_school_id_ref_school_id_fk",
+          "tableFrom": "inbox_message",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbox_message_sent_by_user_id_ref_user_id_fk": {
+          "name": "inbox_message_sent_by_user_id_ref_user_id_fk",
+          "tableFrom": "inbox_message",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "sent_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbox_message_school_id_conversation_id_conversation_school_id_id_fk": {
+          "name": "inbox_message_school_id_conversation_id_conversation_school_id_id_fk",
+          "tableFrom": "inbox_message",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "school_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbox_routing_rule": {
+      "name": "inbox_routing_rule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_fallback": {
+          "name": "is_fallback",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "match_topic": {
+          "name": "match_topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_class": {
+          "name": "match_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_keywords": {
+          "name": "match_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assign_to_user_id": {
+          "name": "assign_to_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_all_admins": {
+          "name": "notify_all_admins",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inbox_routing_rule_school_pos_idx": {
+          "name": "inbox_routing_rule_school_pos_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbox_routing_rule_school_id_ref_school_id_fk": {
+          "name": "inbox_routing_rule_school_id_ref_school_id_fk",
+          "tableFrom": "inbox_routing_rule",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbox_routing_rule_assign_to_user_id_ref_user_id_fk": {
+          "name": "inbox_routing_rule_assign_to_user_id_ref_user_id_fk",
+          "tableFrom": "inbox_routing_rule",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "assign_to_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite": {
+      "name": "invite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignments": {
+          "name": "assignments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_user_id": {
+          "name": "accepted_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invite_school_status_idx": {
+          "name": "invite_school_status_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_school_id_ref_school_id_fk": {
+          "name": "invite_school_id_ref_school_id_fk",
+          "tableFrom": "invite",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_invited_by_user_id_ref_user_id_fk": {
+          "name": "invite_invited_by_user_id_ref_user_id_fk",
+          "tableFrom": "invite",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invite_accepted_user_id_ref_user_id_fk": {
+          "name": "invite_accepted_user_id_ref_user_id_fk",
+          "tableFrom": "invite",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "accepted_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invite_school_id_student_id_students_school_id_id_fk": {
+          "name": "invite_school_id_student_id_students_school_id_id_fk",
+          "tableFrom": "invite",
+          "tableTo": "students",
+          "columnsFrom": [
+            "school_id",
+            "student_id"
+          ],
+          "columnsTo": [
+            "school_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_token_unique": {
+          "name": "invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_category": {
+      "name": "book_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "book_entry_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_category_school_idx": {
+          "name": "book_category_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_category_school_id_ref_school_id_fk": {
+          "name": "book_category_school_id_ref_school_id_fk",
+          "tableFrom": "book_category",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_book_category_per_school": {
+          "name": "uniq_book_category_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "kind",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_entry": {
+      "name": "book_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "book_entry_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_date": {
+          "name": "entry_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "party": {
+          "name": "party",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_entry_school_date_idx": {
+          "name": "book_entry_school_date_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entry_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_entry_school_id_ref_school_id_fk": {
+          "name": "book_entry_school_id_ref_school_id_fk",
+          "tableFrom": "book_entry",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_entry_category_id_book_category_id_fk": {
+          "name": "book_entry_category_id_book_category_id_fk",
+          "tableFrom": "book_entry",
+          "tableTo": "book_category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "book_entry_created_by_user_id_ref_user_id_fk": {
+          "name": "book_entry_created_by_user_id_ref_user_id_fk",
+          "tableFrom": "book_entry",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fixed_asset": {
+      "name": "fixed_asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acquired_on": {
+          "name": "acquired_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_cost": {
+          "name": "original_cost",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accumulated_depreciation": {
+          "name": "accumulated_depreciation",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "useful_life_years": {
+          "name": "useful_life_years",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fixed_asset_school_idx": {
+          "name": "fixed_asset_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fixed_asset_school_id_ref_school_id_fk": {
+          "name": "fixed_asset_school_id_ref_school_id_fk",
+          "tableFrom": "fixed_asset",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.whatsapp_template": {
+      "name": "whatsapp_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTILITY'"
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en_GH'"
+        },
+        "header_type": {
+          "name": "header_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NONE'"
+        },
+        "header_text": {
+          "name": "header_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_filename": {
+          "name": "header_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footer": {
+          "name": "footer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buttons": {
+          "name": "buttons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sample_values": {
+          "name": "sample_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "whatsapp_template_school_idx": {
+          "name": "whatsapp_template_school_idx",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "whatsapp_template_school_id_ref_school_id_fk": {
+          "name": "whatsapp_template_school_id_ref_school_id_fk",
+          "tableFrom": "whatsapp_template",
+          "tableTo": "ref_school",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "whatsapp_template_created_by_user_id_ref_user_id_fk": {
+          "name": "whatsapp_template_created_by_user_id_ref_user_id_fk",
+          "tableFrom": "whatsapp_template",
+          "tableTo": "ref_user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_whatsapp_template_name_per_school": {
+          "name": "uniq_whatsapp_template_name_per_school",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.admission_status": {
+      "name": "admission_status",
+      "schema": "public",
+      "values": [
+        "SUBMITTED",
+        "UNDER_REVIEW",
+        "ACCEPTED",
+        "REJECTED",
+        "WAITLISTED"
+      ]
+    },
+    "public.allocation_method": {
+      "name": "allocation_method",
+      "schema": "public",
+      "values": [
+        "MANUAL",
+        "AUTO_OLDEST_FIRST",
+        "AUTO_NEWEST_FIRST"
+      ]
+    },
+    "public.allocation_type": {
+      "name": "allocation_type",
+      "schema": "public",
+      "values": [
+        "INVOICE",
+        "CREDIT",
+        "REFUND"
+      ]
+    },
+    "public.anomaly_severity": {
+      "name": "anomaly_severity",
+      "schema": "public",
+      "values": [
+        "LOW",
+        "MEDIUM",
+        "HIGH"
+      ]
+    },
+    "public.app_role": {
+      "name": "app_role",
+      "schema": "public",
+      "values": [
+        "ADMIN",
+        "HEADMASTER",
+        "VICE_HEADMASTER_ACADEMIC",
+        "TEACHER",
+        "FORM_MASTER",
+        "HOUSEMASTER",
+        "STUDENT",
+        "PARENT",
+        "BURSAR",
+        "DEAN_OF_BOARDING",
+        "MATRON"
+      ]
+    },
+    "public.assessment_category": {
+      "name": "assessment_category",
+      "schema": "public",
+      "values": [
+        "ASSIGNMENT",
+        "MID_SEM_EXAM",
+        "END_SEM_EXAM",
+        "PROJECT"
+      ]
+    },
+    "public.attendance_status": {
+      "name": "attendance_status",
+      "schema": "public",
+      "values": [
+        "PRESENT",
+        "ABSENT",
+        "LATE",
+        "EXCUSED",
+        "MEDICAL"
+      ]
+    },
+    "public.audience": {
+      "name": "audience",
+      "schema": "public",
+      "values": [
+        "WHOLE_SCHOOL",
+        "CLASS"
+      ]
+    },
+    "public.benchmark_metric": {
+      "name": "benchmark_metric",
+      "schema": "public",
+      "values": [
+        "CREDIT_RATE",
+        "DISTINCTION_RATE"
+      ]
+    },
+    "public.benchmark_quality": {
+      "name": "benchmark_quality",
+      "schema": "public",
+      "values": [
+        "STRONG",
+        "MODERATE",
+        "DIRECTIONAL"
+      ]
+    },
+    "public.benchmark_scope": {
+      "name": "benchmark_scope",
+      "schema": "public",
+      "values": [
+        "SCHOOL",
+        "REGION",
+        "NATIONAL"
+      ]
+    },
+    "public.benchmark_source": {
+      "name": "benchmark_source",
+      "schema": "public",
+      "values": [
+        "SCHOOLUP_DIRECT",
+        "WAEC_NATIONAL",
+        "WAEC_REGIONAL_SUMMARY",
+        "INTERPOLATED",
+        "MULTI_SCHOOL_POOL"
+      ]
+    },
+    "public.boarding_day_type": {
+      "name": "boarding_day_type",
+      "schema": "public",
+      "values": [
+        "WEEKDAY",
+        "SATURDAY",
+        "SUNDAY",
+        "VISITING_SUNDAY"
+      ]
+    },
+    "public.boarding_event_type": {
+      "name": "boarding_event_type",
+      "schema": "public",
+      "values": [
+        "VISITING",
+        "EXEAT_WINDOW"
+      ]
+    },
+    "public.boarding_mode": {
+      "name": "boarding_mode",
+      "schema": "public",
+      "values": [
+        "RESUMPTION",
+        "VACATION"
+      ]
+    },
+    "public.book_entry_kind": {
+      "name": "book_entry_kind",
+      "schema": "public",
+      "values": [
+        "INCOME",
+        "EXPENSE"
+      ]
+    },
+    "public.capture_path": {
+      "name": "capture_path",
+      "schema": "public",
+      "values": [
+        "AUTO_COMPILE",
+        "SCAN_EXTRACT",
+        "DIRECT_ENTRY"
+      ]
+    },
+    "public.chronic_condition": {
+      "name": "chronic_condition",
+      "schema": "public",
+      "values": [
+        "SICKLE_CELL",
+        "ASTHMA",
+        "EPILEPSY",
+        "ALLERGY",
+        "MENTAL_HEALTH",
+        "DIABETES",
+        "OTHER"
+      ]
+    },
+    "public.chronic_status": {
+      "name": "chronic_status",
+      "schema": "public",
+      "values": [
+        "STABLE",
+        "MONITOR",
+        "ACTIVE_CRISIS"
+      ]
+    },
+    "public.conversation_status": {
+      "name": "conversation_status",
+      "schema": "public",
+      "values": [
+        "OPEN",
+        "CLOSED"
+      ]
+    },
+    "public.correction_status": {
+      "name": "correction_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPROVED",
+        "REJECTED"
+      ]
+    },
+    "public.discount_kind": {
+      "name": "discount_kind",
+      "schema": "public",
+      "values": [
+        "PERCENT",
+        "FIXED"
+      ]
+    },
+    "public.exeat_notification_kind": {
+      "name": "exeat_notification_kind",
+      "schema": "public",
+      "values": [
+        "DEPARTURE",
+        "REMINDER",
+        "OVERDUE_STAGE_1",
+        "OVERDUE_STAGE_2",
+        "OVERDUE_STAGE_3"
+      ]
+    },
+    "public.exeat_status": {
+      "name": "exeat_status",
+      "schema": "public",
+      "values": [
+        "REQUESTED",
+        "HM_APPROVED",
+        "SR_HM_SIGNED",
+        "DEPARTED",
+        "RETURNED",
+        "DECLINED"
+      ]
+    },
+    "public.exeat_type": {
+      "name": "exeat_type",
+      "schema": "public",
+      "values": [
+        "SCHEDULED",
+        "SPECIAL",
+        "FEE_COLLECTION"
+      ]
+    },
+    "public.guardian_relation": {
+      "name": "guardian_relation",
+      "schema": "public",
+      "values": [
+        "MOTHER",
+        "FATHER",
+        "GUARDIAN",
+        "OTHER"
+      ]
+    },
+    "public.house_gender": {
+      "name": "house_gender",
+      "schema": "public",
+      "values": [
+        "BOYS",
+        "GIRLS",
+        "COED"
+      ]
+    },
+    "public.house_kind": {
+      "name": "house_kind",
+      "schema": "public",
+      "values": [
+        "BOARDING",
+        "SPORTS"
+      ]
+    },
+    "public.infraction_severity": {
+      "name": "infraction_severity",
+      "schema": "public",
+      "values": [
+        "NOTE",
+        "WARNING",
+        "BOND",
+        "SUSPENSION",
+        "DEBOARDINIZATION"
+      ]
+    },
+    "public.infraction_source": {
+      "name": "infraction_source",
+      "schema": "public",
+      "values": [
+        "MANUAL",
+        "EXEAT_OVERDUE",
+        "INSPECTION_DAILY",
+        "INSPECTION_WEEKLY",
+        "VISIT_OVERSTAY",
+        "RESUMPTION_ABSENT"
+      ]
+    },
+    "public.infraction_status": {
+      "name": "infraction_status",
+      "schema": "public",
+      "values": [
+        "OPEN",
+        "RESOLVED",
+        "SUPERSEDED"
+      ]
+    },
+    "public.inspection_result": {
+      "name": "inspection_result",
+      "schema": "public",
+      "values": [
+        "PASS",
+        "PARTIAL",
+        "FAIL"
+      ]
+    },
+    "public.inspection_type": {
+      "name": "inspection_type",
+      "schema": "public",
+      "values": [
+        "DAILY",
+        "WEEKLY"
+      ]
+    },
+    "public.invite_status": {
+      "name": "invite_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "REVOKED",
+        "EXPIRED"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "ISSUED",
+        "PARTIAL",
+        "PAID",
+        "OVERDUE",
+        "EXEMPT",
+        "VOIDED"
+      ]
+    },
+    "public.ledger_correction_reason": {
+      "name": "ledger_correction_reason",
+      "schema": "public",
+      "values": [
+        "RE_GRADED",
+        "TRANSCRIPTION_ERROR",
+        "OTHER"
+      ]
+    },
+    "public.ledger_status": {
+      "name": "ledger_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "COMPLETE",
+        "STPSHS_READY"
+      ]
+    },
+    "public.message_direction": {
+      "name": "message_direction",
+      "schema": "public",
+      "values": [
+        "INBOUND",
+        "OUTBOUND"
+      ]
+    },
+    "public.nhis_holder_kind": {
+      "name": "nhis_holder_kind",
+      "schema": "public",
+      "values": [
+        "STUDENT",
+        "GUARDIAN"
+      ]
+    },
+    "public.notif_status": {
+      "name": "notif_status",
+      "schema": "public",
+      "values": [
+        "QUEUED",
+        "SENT",
+        "FAILED"
+      ]
+    },
+    "public.ownership_type": {
+      "name": "ownership_type",
+      "schema": "public",
+      "values": [
+        "PUBLIC",
+        "PRIVATE",
+        "MISSION",
+        "INTERNATIONAL"
+      ]
+    },
+    "public.parent_ack_method": {
+      "name": "parent_ack_method",
+      "schema": "public",
+      "values": [
+        "PHONE_OTP",
+        "IN_PERSON",
+        "PDF_UPLOAD"
+      ]
+    },
+    "public.payment_actor_type": {
+      "name": "payment_actor_type",
+      "schema": "public",
+      "values": [
+        "ADMIN",
+        "SYSTEM",
+        "WEBHOOK",
+        "RECONCILIATION_JOB"
+      ]
+    },
+    "public.payment_event_type": {
+      "name": "payment_event_type",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "ALLOCATION_ADDED",
+        "ALLOCATION_VOIDED",
+        "SETTLED",
+        "VOIDED",
+        "SMS_SENT",
+        "SMS_FAILED",
+        "REFUNDED",
+        "DISCOUNT_OVERRIDDEN"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "MTN_MOMO",
+        "TELECEL_CASH",
+        "AIRTELTIGO_MONEY",
+        "BANK_TRANSFER",
+        "CASH",
+        "CHEQUE",
+        "OTHER"
+      ]
+    },
+    "public.period_source": {
+      "name": "period_source",
+      "schema": "public",
+      "values": [
+        "GES_DEFAULT",
+        "SCHOOL_OVERRIDE"
+      ]
+    },
+    "public.period_type": {
+      "name": "period_type",
+      "schema": "public",
+      "values": [
+        "TERM",
+        "SEMESTER"
+      ]
+    },
+    "public.prefect_role": {
+      "name": "prefect_role",
+      "schema": "public",
+      "values": [
+        "HEAD",
+        "DINING",
+        "SANITATION",
+        "PREP",
+        "SICKBAY"
+      ]
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "public",
+      "values": [
+        "BASIC",
+        "SENIOR",
+        "OVERSIGHT"
+      ]
+    },
+    "public.programme": {
+      "name": "programme",
+      "schema": "public",
+      "values": [
+        "GENERAL_ARTS",
+        "GENERAL_SCIENCE",
+        "BUSINESS",
+        "AGRICULTURE",
+        "VISUAL_ARTS",
+        "HOME_ECONOMICS",
+        "TECHNICAL"
+      ]
+    },
+    "public.residency": {
+      "name": "residency",
+      "schema": "public",
+      "values": [
+        "BOARDER",
+        "DAY",
+        "DEBOARDINIZED"
+      ]
+    },
+    "public.sc_form": {
+      "name": "sc_form",
+      "schema": "public",
+      "values": [
+        "SC-3",
+        "SC-7",
+        "SC-12"
+      ]
+    },
+    "public.sc_status": {
+      "name": "sc_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "FILED",
+        "ACKNOWLEDGED",
+        "APPROVED",
+        "SCHEDULED",
+        "COMPLETED",
+        "REJECTED"
+      ]
+    },
+    "public.school_type": {
+      "name": "school_type",
+      "schema": "public",
+      "values": [
+        "BASIC",
+        "SENIOR",
+        "COMBINED"
+      ]
+    },
+    "public.sen_category": {
+      "name": "sen_category",
+      "schema": "public",
+      "values": [
+        "VISUAL",
+        "HEARING",
+        "PHYSICAL",
+        "INTELLECTUAL",
+        "SPEECH",
+        "OTHER"
+      ]
+    },
+    "public.sen_consent_state": {
+      "name": "sen_consent_state",
+      "schema": "public",
+      "values": [
+        "GRANTED",
+        "PENDING"
+      ]
+    },
+    "public.sen_diagnosis_source": {
+      "name": "sen_diagnosis_source",
+      "schema": "public",
+      "values": [
+        "CLINICAL_DIAGNOSIS",
+        "SCHOOL_OBSERVED"
+      ]
+    },
+    "public.sen_severity": {
+      "name": "sen_severity",
+      "schema": "public",
+      "values": [
+        "MILD",
+        "MODERATE",
+        "SEVERE"
+      ]
+    },
+    "public.settlement_status": {
+      "name": "settlement_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "CONFIRMED",
+        "SETTLED",
+        "RECONCILED",
+        "DISPUTED"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "MALE",
+        "FEMALE"
+      ]
+    },
+    "public.shs_category": {
+      "name": "shs_category",
+      "schema": "public",
+      "values": [
+        "A",
+        "B",
+        "C",
+        "D",
+        "E",
+        "F"
+      ]
+    },
+    "public.sickbay_consult_mode": {
+      "name": "sickbay_consult_mode",
+      "schema": "public",
+      "values": [
+        "PHONE",
+        "IN_PERSON"
+      ]
+    },
+    "public.sickbay_disposition": {
+      "name": "sickbay_disposition",
+      "schema": "public",
+      "values": [
+        "DISCHARGE",
+        "ADMIT",
+        "REFER"
+      ]
+    },
+    "public.sickbay_grant_scope": {
+      "name": "sickbay_grant_scope",
+      "schema": "public",
+      "values": [
+        "FULL_PLAN",
+        "PARTIAL",
+        "DIRECTIVE"
+      ]
+    },
+    "public.sickbay_med_source": {
+      "name": "sickbay_med_source",
+      "schema": "public",
+      "values": [
+        "CHRONIC",
+        "STANDING_ORDER",
+        "DOCTOR_ORDERED",
+        "AD_HOC"
+      ]
+    },
+    "public.sickbay_med_status": {
+      "name": "sickbay_med_status",
+      "schema": "public",
+      "values": [
+        "GIVEN",
+        "REFUSED",
+        "HELD",
+        "OMITTED"
+      ]
+    },
+    "public.sickbay_mode": {
+      "name": "sickbay_mode",
+      "schema": "public",
+      "values": [
+        "FULL",
+        "FIRST_AID",
+        "REFERRAL_ONLY"
+      ]
+    },
+    "public.sickbay_notify_channel": {
+      "name": "sickbay_notify_channel",
+      "schema": "public",
+      "values": [
+        "SMS",
+        "CALL",
+        "IN_APP",
+        "SYSTEM"
+      ]
+    },
+    "public.sickbay_notify_direction": {
+      "name": "sickbay_notify_direction",
+      "schema": "public",
+      "values": [
+        "OUTBOUND",
+        "INBOUND"
+      ]
+    },
+    "public.sickbay_notify_recipient": {
+      "name": "sickbay_notify_recipient",
+      "schema": "public",
+      "values": [
+        "PARENT",
+        "HOUSEMASTER",
+        "HEADMASTER",
+        "DISTRICT_HEALTH"
+      ]
+    },
+    "public.sickbay_referral_status": {
+      "name": "sickbay_referral_status",
+      "schema": "public",
+      "values": [
+        "REFERRED",
+        "INPATIENT",
+        "RETURNING",
+        "RETURNED"
+      ]
+    },
+    "public.sickbay_slot_kind": {
+      "name": "sickbay_slot_kind",
+      "schema": "public",
+      "values": [
+        "MEDICATION_ROUND",
+        "CLINIC",
+        "DOCTOR_VISIT",
+        "ON_CALL"
+      ]
+    },
+    "public.sickbay_stock_movement_type": {
+      "name": "sickbay_stock_movement_type",
+      "schema": "public",
+      "values": [
+        "RECEIPT",
+        "WASTAGE",
+        "ADJUSTMENT"
+      ]
+    },
+    "public.sickbay_surveillance_category": {
+      "name": "sickbay_surveillance_category",
+      "schema": "public",
+      "values": [
+        "MALARIA",
+        "RESPIRATORY",
+        "DIARRHOEA",
+        "SKIN",
+        "EYE",
+        "INJURY",
+        "OTHER"
+      ]
+    },
+    "public.student_status": {
+      "name": "student_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "INACTIVE",
+        "GRADUATED",
+        "WITHDRAWN",
+        "TRANSFERRED"
+      ]
+    },
+    "public.target_rank": {
+      "name": "target_rank",
+      "schema": "public",
+      "values": [
+        "FIRST_CHOICE",
+        "SECOND_CHOICE",
+        "THIRD_CHOICE"
+      ]
+    },
+    "public.university_type": {
+      "name": "university_type",
+      "schema": "public",
+      "values": [
+        "PUBLIC_UNIVERSITY",
+        "PRIVATE_UNIVERSITY",
+        "TECHNICAL_UNIVERSITY",
+        "POLYTECHNIC",
+        "NURSING_COLLEGE",
+        "EDUCATION_COLLEGE"
+      ]
+    },
+    "public.visit_notification_kind": {
+      "name": "visit_notification_kind",
+      "schema": "public",
+      "values": [
+        "INVITATION",
+        "REMINDER_T3",
+        "REMINDER_T1",
+        "ARRIVAL_CONFIRM",
+        "OVERSTAY"
+      ]
+    },
+    "public.visit_status": {
+      "name": "visit_status",
+      "schema": "public",
+      "values": [
+        "RSVP",
+        "ARRIVED",
+        "DEPARTED"
+      ]
+    },
+    "public.visit_verification": {
+      "name": "visit_verification",
+      "schema": "public",
+      "values": [
+        "VERIFIED",
+        "FLAGGED",
+        "HM_AUTHORISED"
+      ]
+    },
+    "public.visitor_approval_status": {
+      "name": "visitor_approval_status",
+      "schema": "public",
+      "values": [
+        "PENDING_REVIEW",
+        "APPROVED"
+      ]
+    },
+    "public.wassce_candidate_status": {
+      "name": "wassce_candidate_status",
+      "schema": "public",
+      "values": [
+        "REGISTERED",
+        "ACTIVE",
+        "WITHDRAWN",
+        "COMPLETED"
+      ]
+    },
+    "public.wassce_grade": {
+      "name": "wassce_grade",
+      "schema": "public",
+      "values": [
+        "A1",
+        "B2",
+        "B3",
+        "C4",
+        "C5",
+        "C6",
+        "D7",
+        "E8",
+        "F9"
+      ]
+    },
+    "public.wassce_paper_type": {
+      "name": "wassce_paper_type",
+      "schema": "public",
+      "values": [
+        "OBJECTIVE",
+        "ESSAY",
+        "PRACTICAL",
+        "ORAL",
+        "COMBINED"
+      ]
+    },
+    "public.wassce_reg_flag": {
+      "name": "wassce_reg_flag",
+      "schema": "public",
+      "values": [
+        "ON_MEDICAL",
+        "NHIS_ISSUE",
+        "FEE"
+      ]
+    },
+    "public.wassce_subject_type": {
+      "name": "wassce_subject_type",
+      "schema": "public",
+      "values": [
+        "CORE",
+        "ELECTIVE",
+        "OPTIONAL"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/omnischools/db/migrations/meta/_journal.json
+++ b/omnischools/db/migrations/meta/_journal.json
@@ -624,6 +624,13 @@
       "when": 1787819493414,
       "tag": "0088_fat_vengeance",
       "breakpoints": true
+    },
+    {
+      "idx": 89,
+      "version": "7",
+      "when": 1788163266036,
+      "tag": "0089_kind_blindfold",
+      "breakpoints": true
     }
   ]
 }

--- a/omnischools/db/schema/boarding.ts
+++ b/omnischools/db/schema/boarding.ts
@@ -344,6 +344,10 @@ export const boardingExeat = pgTable(
     refCode: text("ref_code").notNull(), // e.g. ASA-EX-2026-0341
     reason: text("reason"), // app-required for SPECIAL, auto-prefilled for FEE_COLLECTION
     parentInitiated: boolean("parent_initiated").notNull().default(true),
+    // TRUE only for a row created via parent_request_exeat (the parent portal). Powers the staff
+    // "From parent" chip accurately — parent_initiated is broadly true and NOT a provenance signal.
+    // Staff-created rows (lib/actions/boarding-exeat.ts requestExeat) keep the default false.
+    viaParentPortal: boolean("via_parent_portal").notNull().default(false),
     departAt: timestamp("depart_at", { withTimezone: true }), // planned out
     returnBy: timestamp("return_by", { withTimezone: true }), // planned in (return-by deadline)
     // --- 5 stage stamps, each + actor (global-table SET NULL → single-column FK) ---

--- a/omnischools/db/sql/policies.sql
+++ b/omnischools/db/sql/policies.sql
@@ -1605,11 +1605,11 @@ BEGIN
       BEGIN
         INSERT INTO boarding_exeat (
           school_id, student_id, house_id, academic_period_id,
-          exeat_type, status, ref_code, reason, parent_initiated,
+          exeat_type, status, ref_code, reason, parent_initiated, via_parent_portal,
           depart_at, return_by, requested_by_user_id, fee_owing_snapshot)
         VALUES (
           school, p_student, v_house, v_period,
-          'SPECIAL', 'REQUESTED', v_ref, NULLIF(btrim(p_reason), ''), true,
+          'SPECIAL', 'REQUESTED', v_ref, NULLIF(btrim(p_reason), ''), true, true,
           p_depart::timestamptz, v_return_by, v_requested_by, v_snapshot)
         RETURNING id INTO v_id;
         ok := true;

--- a/omnischools/db/sql/policies.sql
+++ b/omnischools/db/sql/policies.sql
@@ -1688,8 +1688,11 @@ BEGIN
   -- stays set so tenant_isolation still fences the school.
   PERFORM set_config('app.current_parent_user', '', true);
   RETURN QUERY
+    -- reason: echo ONLY for genuine portal-origin rows (via_parent_portal) — the parent's OWN words.
+    -- A staff-authored reason (welfare/discipline free text) is REDACTED to NULL here; parent_initiated
+    -- is broadly true and is NOT a provenance signal (Sarah leak-fix; the fn is the authority).
     SELECT be.id, be.ref_code, be.exeat_type::text, be.status::text, be.parent_initiated,
-           be.reason, be.depart_at, be.return_by, be.departed_at, be.returned_at,
+           CASE WHEN be.via_parent_portal THEN be.reason ELSE NULL END, be.depart_at, be.return_by, be.departed_at, be.returned_at,
            be.hm_approved_at, be.sr_hm_signed_at, h.name
     FROM boarding_exeat be
     JOIN house h ON h.school_id = be.school_id AND h.id = be.house_id

--- a/omnischools/db/sql/policies.sql
+++ b/omnischools/db/sql/policies.sql
@@ -1442,6 +1442,308 @@ BEGIN
 END
 $$;
 
+-- ---- INCR — PARENT EXEAT: Exeat Phase 2 (parent-initiated SPECIAL exeat request + own-child exeat
+-- status). Kept in sync with db/sql/prod-paste-0098-parent-exeat.sql — this block is DEV; that file is the
+-- hand-paste on PROD (⚠ RLS/functions are NOT auto-applied on prod; without the paste both fns are ABSENT
+-- and a boarder parent's Exeat surface 500s "function does not exist" — fail-closed, never a leak).
+--
+-- FUNCTION-ONLY: NO new parent_scope grant. boarding_exeat + exeat_notification STAY fully parent_deny (the
+-- catalog loop above already re-affirmed it — neither carries parent_scope). A parent touches boarding_exeat
+-- ONLY through the two SECURITY DEFINER fns below.
+--
+-- 🔴 Fn 1 parent_request_exeat — the guarded WRITE (the ONLY parent write into boarding_exeat). Server-forces
+-- exeat_type=SPECIAL / status=REQUESTED / parent_initiated=true; derives house_id + academic_period_id;
+-- return_by = p_return at getExeatPolicy.returnByTime (default 16:00); fee_owing_snapshot advisory-only
+-- (NEVER blocks); requested_by_user_id = pu only if a ref_user row exists (OC-3), else NULL. Own-child fence
+-- via the CAPTURED pu ARG (parent_student_ids), open-guard rejects a second live exeat (B9), ref_code
+-- retry-guarded against uniq_exeat_ref_code. GUC-clear device: clears app.current_parent_user for the
+-- parent_deny traverse (boarding_exeat/house/academic_period/audit_log) then restores VERBATIM;
+-- app.current_school stays set. Composite OUT {ok, ref_code, error}.
+-- 🔴 Fn 2 parent_exeat_list — the own-child READ projection (the ONLY parent read of boarding_exeat). Returns
+-- ONLY the C3-IN columns for ALL own-child exeats, newest first — NEVER fee_owing_snapshot / decline_reason /
+-- *_by_user_id / returned_late / house_id/dorm/bunk. Same GUC-clear/restore device; own-child fence via the
+-- CAPTURED pu ARG.
+-- pu IS NULL (staff/webhook/escalated) → both fns short-circuit to a no-op; the staff exeat console reads/
+-- writes boarding_exeat DIRECTLY via withSchool and is byte-unchanged.
+
+CREATE OR REPLACE FUNCTION parent_request_exeat(
+  school     uuid,
+  pu         uuid,
+  p_student  uuid,
+  p_reason   text,
+  p_depart   date,
+  p_return   date,
+  OUT ok        boolean,
+  OUT ref_code  text,
+  OUT error     text
+)
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public, pg_temp
+AS $$
+DECLARE
+  prev           text := current_setting('app.current_parent_user', true);  -- caller's GUC, captured VERBATIM
+  v_today        date := (now() AT TIME ZONE 'UTC')::date;
+  v_year         int  := EXTRACT(YEAR FROM now())::int;
+  v_res          text;
+  v_status       text;
+  v_house        uuid;
+  v_period       uuid;
+  v_owing        numeric;
+  v_snapshot     numeric;
+  v_return_time  text;
+  v_return_by    timestamptz;
+  v_requested_by uuid;
+  v_prefix       text;
+  v_base_seq     int;
+  v_attempt      int;
+  v_ref          text;
+  v_id           uuid;
+BEGIN
+  ok := false;
+  -- fail-CLOSED: no parent / no school → do nothing, GUC untouched. STAFF (pu IS NULL) short-circuit here.
+  IF pu IS NULL OR school IS NULL THEN
+    error := 'unauthorized';
+    RETURN;
+  END IF;
+
+  -- own-child fence (D1): the CAPTURED pu ARG, never the GUC. Checked BEFORE the clear → GUC untouched,
+  -- and the error is a NEUTRAL not-found (never reveals the child exists in another family/tenant).
+  IF NOT EXISTS (SELECT 1 FROM parent_student_ids(school, pu) sid WHERE sid = p_student) THEN
+    error := 'not_found';
+    RETURN;
+  END IF;
+
+  -- GUC-CLEAR DEVICE: boarding_exeat / house / academic_period / audit_log are parent_deny and
+  -- invoice / students / boarding_settings are parent_scope — with the parent GUC still set the definer
+  -- body reads 0 rows / a write denies under prod's non-superuser FORCE-RLS owner. Clear the parent GUC
+  -- for the traverse (parent_deny's `pu IS NULL` → TRUE); KEEP app.current_school so tenant_isolation
+  -- still fences the school. RESTORED verbatim at the single exit below.
+  PERFORM set_config('app.current_parent_user', '', true);
+
+  <<body>>
+  BEGIN
+    -- residency / house (E5 / A5). Read after the clear (own-child already proven above).
+    SELECT s.residency::text, s.status::text, s.house_id
+      INTO v_res, v_status, v_house
+      FROM students s
+      WHERE s.school_id = school AND s.id = p_student;
+    IF NOT FOUND OR v_house IS NULL THEN
+      error := 'That boarder is not assigned to a House.';        -- E5
+      EXIT body;
+    END IF;
+    IF v_status IS DISTINCT FROM 'ACTIVE' OR v_res IS DISTINCT FROM 'BOARDER' THEN
+      error := 'Only an active boarder can request an exeat.';    -- A5 belt
+      EXIT body;
+    END IF;
+
+    -- current SENIOR semester — mirrors lib/boarding/period.ts getCurrentPeriod (covering → latest
+    -- started → earliest). E2 when the school has no SENIOR period.
+    SELECT ap.period_id INTO v_period
+      FROM academic_period ap
+      WHERE ap.school_id = school AND ap.product_line = 'SENIOR'
+      ORDER BY
+        (ap.starts_on <= v_today AND ap.ends_on >= v_today) DESC,
+        (ap.starts_on <= v_today) DESC,
+        CASE WHEN ap.starts_on <= v_today THEN ap.starts_on END DESC,
+        ap.starts_on ASC
+      LIMIT 1;
+    IF v_period IS NULL THEN
+      error := 'No academic semester is configured.';            -- E2
+      EXIT body;
+    END IF;
+
+    -- OPEN-GUARD (B9, authoritative, in-tx): one live exeat at a time (any type).
+    IF EXISTS (
+      SELECT 1 FROM boarding_exeat be
+      WHERE be.school_id = school AND be.student_id = p_student
+        AND be.status::text IN ('REQUESTED','HM_APPROVED','SR_HM_SIGNED','DEPARTED')
+    ) THEN
+      error := 'This boarder already has an exeat in progress — please contact the House.';  -- B9
+      EXIT body;
+    END IF;
+
+    -- fee-owing snapshot (B8): SUM(invoice.balance_amount) over owing statuses; > 0 ? sum : NULL.
+    -- Advisory only — NEVER blocks (mirrors lib/boarding/exeat-data.ts feeOwingForStudent semantics).
+    SELECT COALESCE(SUM(i.balance_amount), 0) INTO v_owing
+      FROM invoice i
+      WHERE i.school_id = school AND i.student_id = p_student
+        AND i.status::text IN ('ISSUED','PARTIAL','OVERDUE');
+    v_snapshot := CASE WHEN v_owing > 0 THEN round(v_owing, 2) ELSE NULL END;
+
+    -- return_by = p_return at the policy return-by time (default 16:00 — getExeatPolicy.returnByTime).
+    SELECT bs.exeat_return_by INTO v_return_time
+      FROM boarding_settings bs WHERE bs.school_id = school;
+    v_return_time := COALESCE(NULLIF(v_return_time, ''), '16:00');
+    v_return_by := (p_return::text || ' ' || v_return_time)::timestamptz;
+
+    -- requested_by_user_id = pu ONLY if a ref_user row exists (OC-3), else NULL (the FK is SET NULL).
+    v_requested_by := CASE WHEN EXISTS (SELECT 1 FROM ref_user u WHERE u.id = pu) THEN pu ELSE NULL END;
+
+    -- ref-code prefix — mirrors refPrefix in lib/actions/boarding-exeat.ts: first 4 alnum of
+    -- short_name/name, upper-cased, else 'EXT'.
+    SELECT COALESCE(
+             NULLIF(left(upper(regexp_replace(COALESCE(rs.short_name, rs.name), '[^A-Za-z0-9]', '', 'g')), 4), ''),
+             'EXT')
+      INTO v_prefix
+      FROM ref_school rs WHERE rs.id = school;
+    v_prefix := COALESCE(v_prefix, 'EXT');
+
+    -- base sequence = max trailing number over the school's existing ref_codes + 1 (per-school).
+    SELECT COALESCE(MAX(substring(be.ref_code from '(\d+)\s*$')::int), 0) + 1
+      INTO v_base_seq
+      FROM boarding_exeat be WHERE be.school_id = school;
+
+    -- ponytail: the "PREFIX-EX-YYYY-NNNN" format is intentionally duplicated from formatRefCode/
+    -- nextExeatSequence in lib/boarding/exeat-decision.ts — it is a DISPLAY string, not lifecycle logic.
+    -- Computing it IN-fn (retry-on-collision, guarded by uniq_exeat_ref_code) keeps allocation atomic
+    -- with the unique constraint (no TOCTOU). Upgrade path: extract a shared codegen only if a third
+    -- caller appears.
+    <<alloc>>
+    FOR v_attempt IN 0..4 LOOP
+      v_ref := v_prefix || '-EX-' || v_year::text || '-' || lpad((v_base_seq + v_attempt)::text, 4, '0');
+      BEGIN
+        INSERT INTO boarding_exeat (
+          school_id, student_id, house_id, academic_period_id,
+          exeat_type, status, ref_code, reason, parent_initiated,
+          depart_at, return_by, requested_by_user_id, fee_owing_snapshot)
+        VALUES (
+          school, p_student, v_house, v_period,
+          'SPECIAL', 'REQUESTED', v_ref, NULLIF(btrim(p_reason), ''), true,
+          p_depart::timestamptz, v_return_by, v_requested_by, v_snapshot)
+        RETURNING id INTO v_id;
+        ok := true;
+        ref_code := v_ref;
+        EXIT alloc;
+      EXCEPTION WHEN unique_violation THEN
+        -- uniq_exeat_ref_code lost race — bump the sequence and retry.
+        CONTINUE alloc;
+      END;
+    END LOOP alloc;
+
+    IF NOT ok THEN
+      error := 'Could not allocate an exeat reference — please retry.';
+      EXIT body;
+    END IF;
+
+    -- D8 recursion note: this fn reads boarding_exeat (open-guard) AND inserts into it. With the parent
+    -- GUC cleared, boarding_exeat's parent_deny is a no-op and tenant_isolation is a plain predicate —
+    -- no policy or SECURITY DEFINER helper on boarding_exeat re-enters parent_request_exeat. No recursion.
+
+    -- AUDIT (parity with lib/actions/boarding-exeat.ts recordAudit / EXEAT_REQUESTED) — parent-sourced.
+    INSERT INTO audit_log (
+      school_id, actor_user_id, actor_role, action_type, entity_type, entity_id,
+      before_jsonb, after_jsonb, reason)
+    VALUES (
+      school, v_requested_by, 'PARENT', 'EXEAT_REQUESTED', 'boarding_exeat', v_id,
+      NULL,
+      jsonb_build_object(
+        'refCode', v_ref, 'type', 'SPECIAL', 'status', 'REQUESTED',
+        'parentInitiated', true, 'source', 'parent', 'feeSnapshot', v_snapshot),
+      NULLIF(btrim(p_reason), ''));
+  END body;
+
+  -- SINGLE restore point (every EXIT body + the success path land here). RESTORE VERBATIM:
+  -- COALESCE(prev,'') because current_setting(...,true) is NULL when unset. NEVER pu::text — pu is a fn
+  -- ARG that may differ from the caller's session GUC (see the parent_boarding_placement note).
+  PERFORM set_config('app.current_parent_user', COALESCE(prev, ''), true);
+  RETURN;
+END;
+$$;
+-- On Supabase every public function is a PostgREST RPC (EXECUTE defaults to PUBLIC); a privileged
+-- SECURITY DEFINER write must not be anon-callable. The owner keeps EXECUTE regardless of the REVOKE.
+REVOKE EXECUTE ON FUNCTION parent_request_exeat(uuid, uuid, uuid, text, date, date) FROM PUBLIC;
+DO $$ BEGIN
+  IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'omnischools_app') THEN
+    GRANT EXECUTE ON FUNCTION parent_request_exeat(uuid, uuid, uuid, text, date, date) TO omnischools_app;
+  END IF;
+END $$;
+
+CREATE OR REPLACE FUNCTION parent_exeat_list(school uuid, pu uuid)
+  RETURNS TABLE(
+    exeat_id        uuid,
+    ref_code        text,
+    exeat_type      text,
+    status          text,
+    parent_initiated boolean,
+    reason          text,
+    depart_at       timestamptz,
+    return_by       timestamptz,
+    departed_at     timestamptz,
+    returned_at     timestamptz,
+    hm_approved_at  timestamptz,
+    sr_hm_signed_at timestamptz,
+    house_name      text)
+  LANGUAGE plpgsql
+  STABLE
+  SECURITY DEFINER
+  SET search_path = public, pg_temp
+AS $$
+DECLARE
+  prev text := current_setting('app.current_parent_user', true);  -- caller's GUC, captured VERBATIM
+BEGIN
+  IF pu IS NULL OR school IS NULL THEN RETURN; END IF;  -- fail-closed; GUC untouched
+  -- Relax parent_deny on boarding_exeat + house for THIS read only (parent_deny's `pu IS NULL` → TRUE).
+  -- Own-child fencing uses the CAPTURED pu ARG (parent_student_ids), NOT the cleared GUC; app.current_school
+  -- stays set so tenant_isolation still fences the school.
+  PERFORM set_config('app.current_parent_user', '', true);
+  RETURN QUERY
+    SELECT be.id, be.ref_code, be.exeat_type::text, be.status::text, be.parent_initiated,
+           be.reason, be.depart_at, be.return_by, be.departed_at, be.returned_at,
+           be.hm_approved_at, be.sr_hm_signed_at, h.name
+    FROM boarding_exeat be
+    JOIN house h ON h.school_id = be.school_id AND h.id = be.house_id
+    WHERE be.school_id = school
+      AND be.student_id IN (SELECT parent_student_ids(school, pu))
+    ORDER BY be.created_at DESC;
+  -- RESTORE the caller's GUC VERBATIM. COALESCE(prev,'') because current_setting(...,true) yields NULL when
+  -- unset. NEVER pu::text: pu is a fn ARG that may differ from the caller's session GUC.
+  PERFORM set_config('app.current_parent_user', COALESCE(prev, ''), true);
+END;
+$$;
+-- On Supabase every public function is a PostgREST RPC and EXECUTE defaults to PUBLIC; a privileged
+-- SECURITY DEFINER read must not be anon-callable (no-op without the GUCs, but harden anyway).
+REVOKE EXECUTE ON FUNCTION parent_exeat_list(uuid, uuid) FROM PUBLIC;
+DO $$ BEGIN
+  IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'omnischools_app') THEN
+    GRANT EXECUTE ON FUNCTION parent_exeat_list(uuid, uuid) TO omnischools_app;
+  END IF;
+END $$;
+
+-- parent_deny catalog loop (re-affirm; this increment adds NO parent_scope, so boarding_exeat +
+-- exeat_notification and every other never-widen table stay auto-denied). Idempotent.
+DO $$
+DECLARE
+  tbl text;
+BEGIN
+  FOR tbl IN
+    SELECT c.relname
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = 'public'
+    WHERE c.relkind = 'r'
+      AND c.relforcerowsecurity
+      AND EXISTS (
+        SELECT 1 FROM information_schema.columns col
+        WHERE col.table_schema = 'public'
+          AND col.table_name = c.relname
+          AND col.column_name = 'school_id'
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_policy p
+        WHERE p.polrelid = c.oid AND p.polname = 'parent_scope'
+      )
+    ORDER BY c.relname
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS parent_deny ON %I;', tbl);
+    EXECUTE format(
+      'CREATE POLICY parent_deny ON %I AS RESTRICTIVE FOR ALL TO public '
+      'USING (NULLIF(current_setting(''app.current_parent_user'', true), '''') IS NULL);',
+      tbl
+    );
+  END LOOP;
+END
+$$;
+
 -- ============================================================================================
 -- CHRONIC-REGISTER per-staff read boundary (INCR-23a / Module 4.4) — THE THIRD RLS BOUNDARY.
 -- Kept in sync with db/sql/prod-paste-0058-sickbay-chronic.sql — this block is dev; that file is the

--- a/omnischools/db/sql/prod-paste-0098-parent-exeat.sql
+++ b/omnischools/db/sql/prod-paste-0098-parent-exeat.sql
@@ -306,8 +306,11 @@ BEGIN
   -- stays set so tenant_isolation still fences the school.
   PERFORM set_config('app.current_parent_user', '', true);
   RETURN QUERY
+    -- reason: echo ONLY for genuine portal-origin rows (via_parent_portal) — the parent's OWN words.
+    -- A staff-authored reason (welfare/discipline free text) is REDACTED to NULL here; parent_initiated
+    -- is broadly true and is NOT a provenance signal (Sarah leak-fix; the fn is the authority).
     SELECT be.id, be.ref_code, be.exeat_type::text, be.status::text, be.parent_initiated,
-           be.reason, be.depart_at, be.return_by, be.departed_at, be.returned_at,
+           CASE WHEN be.via_parent_portal THEN be.reason ELSE NULL END, be.depart_at, be.return_by, be.departed_at, be.returned_at,
            be.hm_approved_at, be.sr_hm_signed_at, h.name
     FROM boarding_exeat be
     JOIN house h ON h.school_id = be.school_id AND h.id = be.house_id

--- a/omnischools/db/sql/prod-paste-0098-parent-exeat.sql
+++ b/omnischools/db/sql/prod-paste-0098-parent-exeat.sql
@@ -1,7 +1,10 @@
 -- Omnischools — PROD paste 0098: PARENT EXEAT (INCR — Exeat Phase 2: parent-initiated SPECIAL exeat
--- request + own-child exeat status, parent-portal Boarding). FUNCTION-ONLY — ZERO new tables, ZERO enums,
--- ZERO altered columns, ZERO backfills, ZERO new parent_scope grants. It adds TWO SECURITY DEFINER
--- functions (parent_request_exeat = the ONLY parent write into boarding_exeat; parent_exeat_list = the
+-- request + own-child exeat status, parent-portal Boarding). ONE additive column + TWO fns — ZERO new
+-- tables, ZERO enums, ZERO backfills, ZERO new parent_scope grants. It adds ONE additive column
+-- (boarding_exeat.via_parent_portal boolean NOT NULL DEFAULT false — the accurate staff "From parent"
+-- provenance signal; Drizzle migration 0089 adds it on dev/source-of-truth, the idempotent ALTER below is
+-- belt-and-braces so this paste is self-contained) and TWO SECURITY DEFINER functions
+-- (parent_request_exeat = the ONLY parent write into boarding_exeat; parent_exeat_list = the
 -- ONLY parent read of boarding_exeat) and re-runs the catalog-driven parent_deny loop. Idempotent — safe
 -- to run more than once. Paste into the Supabase SQL editor on PROD after merging. Byte-identical in effect
 -- to the "INCR — PARENT EXEAT" block in db/sql/policies.sql (dev, db:policies).
@@ -43,7 +46,8 @@
 -- stays fully parent_deny), but a LOUD "the paste didn't run" signal, not a silent empty. Run this
 -- WITH/BEFORE the Exeat Phase 2 code release.
 --
--- SCOPE — NO TABLE CHANGES. Every policy on every table is untouched; boarding_exeat + exeat_notification
+-- SCOPE — ONE ADDITIVE COLUMN, NO POLICY CHANGES. boarding_exeat gains via_parent_portal (additive, NOT
+-- NULL DEFAULT false — no backfill, no RLS impact). Every policy on every table is untouched; boarding_exeat + exeat_notification
 -- keep tenant_isolation + parent_deny exactly as prod-paste-0046 / prod-paste-0097 left them. The catalog
 -- parent_deny loop at the tail re-affirms parent_deny on every FORCE-RLS + school_id table with NO
 -- parent_scope (both exeat tables included), so a future tenant table stays auto-denied with zero edits.
@@ -57,6 +61,14 @@
 --   where c.relname in ('boarding_exeat','exeat_notification') order by 1, 2;
 --   -- and db/sql/verify-prod-rls.sql: Query 1 must still return ZERO ROWS; parent_readable UNCHANGED (31 —
 --   -- no new parent_scope table is added by this increment).
+
+-- ---- ADDITIVE COLUMN (self-contained paste). The staff "From parent" chip must key on real portal
+-- provenance, not parent_initiated (which is broadly true). via_parent_portal is TRUE only for a row
+-- created by parent_request_exeat below; staff-created rows keep the default false. Additive, NOT NULL
+-- DEFAULT false → existing rows read false, no backfill. Drizzle migration 0089 adds it on dev/source-of-
+-- truth; this idempotent ALTER is belt-and-braces so the paste is self-contained (the updated fn below
+-- references the column). Idempotent.
+ALTER TABLE boarding_exeat ADD COLUMN IF NOT EXISTS via_parent_portal boolean NOT NULL DEFAULT false;
 
 -- ============================================================================================
 -- INCR — PARENT EXEAT (Exeat Phase 2). Two SECURITY DEFINER fns; byte-identical to the
@@ -205,11 +217,11 @@ BEGIN
       BEGIN
         INSERT INTO boarding_exeat (
           school_id, student_id, house_id, academic_period_id,
-          exeat_type, status, ref_code, reason, parent_initiated,
+          exeat_type, status, ref_code, reason, parent_initiated, via_parent_portal,
           depart_at, return_by, requested_by_user_id, fee_owing_snapshot)
         VALUES (
           school, p_student, v_house, v_period,
-          'SPECIAL', 'REQUESTED', v_ref, NULLIF(btrim(p_reason), ''), true,
+          'SPECIAL', 'REQUESTED', v_ref, NULLIF(btrim(p_reason), ''), true, true,
           p_depart::timestamptz, v_return_by, v_requested_by, v_snapshot)
         RETURNING id INTO v_id;
         ok := true;

--- a/omnischools/db/sql/prod-paste-0098-parent-exeat.sql
+++ b/omnischools/db/sql/prod-paste-0098-parent-exeat.sql
@@ -1,0 +1,354 @@
+-- Omnischools — PROD paste 0098: PARENT EXEAT (INCR — Exeat Phase 2: parent-initiated SPECIAL exeat
+-- request + own-child exeat status, parent-portal Boarding). FUNCTION-ONLY — ZERO new tables, ZERO enums,
+-- ZERO altered columns, ZERO backfills, ZERO new parent_scope grants. It adds TWO SECURITY DEFINER
+-- functions (parent_request_exeat = the ONLY parent write into boarding_exeat; parent_exeat_list = the
+-- ONLY parent read of boarding_exeat) and re-runs the catalog-driven parent_deny loop. Idempotent — safe
+-- to run more than once. Paste into the Supabase SQL editor on PROD after merging. Byte-identical in effect
+-- to the "INCR — PARENT EXEAT" block in db/sql/policies.sql (dev, db:policies).
+--
+-- WHAT IT SHIPS. Phase 1 (prod-paste-0097) left boarding_exeat + exeat_notification fully parent_deny and
+-- exeat/leave deferred. Phase 2 opens the two parent touchpoints as DEFINER FUNCTIONS, NOT parent_scope
+-- grants: (1) a parent of a BOARDER child files a SPECIAL exeat request (status REQUESTED, awaiting the
+-- staff HM→Sr-HM lane), and (2) reads the status/timeline of their OWN child's exeats. boarding_exeat and
+-- exeat_notification STAY fully parent_deny (they carry NO parent_scope, so the catalog loop below keeps
+-- them denied automatically) — a parent can touch boarding_exeat ONLY through these two fns.
+--
+-- 🔴 THE GUC-CLEAR DEVICE (the parent_bump_conversation / parent_boarding_placement / parent_house_names
+-- idiom). boarding_exeat, house, academic_period and audit_log are parent_deny; invoice, students and
+-- boarding_settings are parent_scope. Under PROD's non-superuser FORCE-RLS definer owner, a read/write of
+-- those tables with the parent GUC still set returns 0 rows / denies — so each fn CLEARS
+-- app.current_parent_user for its traverse (parent_deny's `pu IS NULL` → TRUE) then RESTORES it VERBATIM.
+-- app.current_school STAYS set → tenant_isolation still fences the school (defence in depth). Own-child
+-- fencing does NOT rely on the GUC — it uses the CAPTURED pu ARG via parent_student_ids(). RESTORE is
+-- COALESCE(prev,''), NEVER pu::text: pu is a fn ARG that may differ from the caller's session GUC (a
+-- pu::text restore would forge a scope that was never there — see the parent_boarding_placement note).
+--
+-- 🔴 STAFF UNAFFECTED — pu IS NULL → TOTAL NO-OP. Neither fn is on any staff path; the staff exeat console
+-- (lib/actions/boarding-exeat.ts) writes/reads boarding_exeat DIRECTLY via withSchool, which never sets
+-- app.current_parent_user. A staff/webhook/escalated caller that somehow invoked these fns with pu IS NULL
+-- returns immediately (no rows / unauthorized) and touches NOTHING — boarding_exeat behaviour is
+-- byte-unchanged for staff. Depends on parent_student_ids() (prod-paste-0055), already on prod.
+--
+-- 🔴 RLS IS ROW-LEVEL. parent_request_exeat SERVER-FORCES every security-critical field (exeat_type=SPECIAL,
+-- status=REQUESTED, parent_initiated=true, house_id/academic_period_id derived, all approval/departure/
+-- return stamps NULL) — the app cannot smuggle a pre-approved or mis-typed row. parent_exeat_list PROJECTS
+-- ONLY the C3-IN columns (never fee_owing_snapshot / decline_reason / any *_by_user_id / returned_late /
+-- house_id/dorm/bunk) — a parent can never reach the fee snapshot, the decline reason or staff PII even via
+-- a mutated reader. fee_owing_snapshot is captured advisory-only and NEVER blocks a request.
+--
+-- ⚠ WHAT HAPPENS IF THIS IS NOT RUN — FAIL-CLOSED, NEVER A LEAK (but paste it WITH the code, not after).
+-- db:policies configures LOCAL DEV ONLY. Without this paste both functions are ABSENT on prod: a parent of
+-- a BOARDER child who opens the Exeat surface hits `select … from parent_exeat_list(…)` (or submits a
+-- request), which 500s ("function does not exist") — fail-CLOSED (a 500 leaks NOTHING: boarding_exeat
+-- stays fully parent_deny), but a LOUD "the paste didn't run" signal, not a silent empty. Run this
+-- WITH/BEFORE the Exeat Phase 2 code release.
+--
+-- SCOPE — NO TABLE CHANGES. Every policy on every table is untouched; boarding_exeat + exeat_notification
+-- keep tenant_isolation + parent_deny exactly as prod-paste-0046 / prod-paste-0097 left them. The catalog
+-- parent_deny loop at the tail re-affirms parent_deny on every FORCE-RLS + school_id table with NO
+-- parent_scope (both exeat tables included), so a future tenant table stays auto-denied with zero edits.
+--
+-- Verify afterwards:
+--   -- both functions exist, owned by / executable to omnischools_app:
+--   select proname, pg_get_function_identity_arguments(oid) as args, proowner::regrole
+--   from pg_proc where proname in ('parent_request_exeat','parent_exeat_list') order by 1;
+--   -- boarding_exeat + exeat_notification carry NO parent_scope and DO carry parent_deny (never widened):
+--   select c.relname, p.polname, p.polcmd from pg_policy p join pg_class c on c.oid = p.polrelid
+--   where c.relname in ('boarding_exeat','exeat_notification') order by 1, 2;
+--   -- and db/sql/verify-prod-rls.sql: Query 1 must still return ZERO ROWS; parent_readable UNCHANGED (31 —
+--   -- no new parent_scope table is added by this increment).
+
+-- ============================================================================================
+-- INCR — PARENT EXEAT (Exeat Phase 2). Two SECURITY DEFINER fns; byte-identical to the
+-- "INCR — PARENT EXEAT" block in db/sql/policies.sql (dev). No parent_scope grant is added.
+-- ============================================================================================
+
+-- ---- Fn 1: parent_request_exeat — the guarded parent WRITE (the ONLY parent write into boarding_exeat).
+-- Server-forces a SPECIAL / REQUESTED / parent_initiated row for the parent's OWN active boarder child,
+-- one live exeat at a time, with a per-school retry-guarded ref_code. Composite OUT {ok, ref_code, error}.
+CREATE OR REPLACE FUNCTION parent_request_exeat(
+  school     uuid,
+  pu         uuid,
+  p_student  uuid,
+  p_reason   text,
+  p_depart   date,
+  p_return   date,
+  OUT ok        boolean,
+  OUT ref_code  text,
+  OUT error     text
+)
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public, pg_temp
+AS $$
+DECLARE
+  prev           text := current_setting('app.current_parent_user', true);  -- caller's GUC, captured VERBATIM
+  v_today        date := (now() AT TIME ZONE 'UTC')::date;
+  v_year         int  := EXTRACT(YEAR FROM now())::int;
+  v_res          text;
+  v_status       text;
+  v_house        uuid;
+  v_period       uuid;
+  v_owing        numeric;
+  v_snapshot     numeric;
+  v_return_time  text;
+  v_return_by    timestamptz;
+  v_requested_by uuid;
+  v_prefix       text;
+  v_base_seq     int;
+  v_attempt      int;
+  v_ref          text;
+  v_id           uuid;
+BEGIN
+  ok := false;
+  -- fail-CLOSED: no parent / no school → do nothing, GUC untouched. STAFF (pu IS NULL) short-circuit here.
+  IF pu IS NULL OR school IS NULL THEN
+    error := 'unauthorized';
+    RETURN;
+  END IF;
+
+  -- own-child fence (D1): the CAPTURED pu ARG, never the GUC. Checked BEFORE the clear → GUC untouched,
+  -- and the error is a NEUTRAL not-found (never reveals the child exists in another family/tenant).
+  IF NOT EXISTS (SELECT 1 FROM parent_student_ids(school, pu) sid WHERE sid = p_student) THEN
+    error := 'not_found';
+    RETURN;
+  END IF;
+
+  -- GUC-CLEAR DEVICE: boarding_exeat / house / academic_period / audit_log are parent_deny and
+  -- invoice / students / boarding_settings are parent_scope — with the parent GUC still set the definer
+  -- body reads 0 rows / a write denies under prod's non-superuser FORCE-RLS owner. Clear the parent GUC
+  -- for the traverse (parent_deny's `pu IS NULL` → TRUE); KEEP app.current_school so tenant_isolation
+  -- still fences the school. RESTORED verbatim at the single exit below.
+  PERFORM set_config('app.current_parent_user', '', true);
+
+  <<body>>
+  BEGIN
+    -- residency / house (E5 / A5). Read after the clear (own-child already proven above).
+    SELECT s.residency::text, s.status::text, s.house_id
+      INTO v_res, v_status, v_house
+      FROM students s
+      WHERE s.school_id = school AND s.id = p_student;
+    IF NOT FOUND OR v_house IS NULL THEN
+      error := 'That boarder is not assigned to a House.';        -- E5
+      EXIT body;
+    END IF;
+    IF v_status IS DISTINCT FROM 'ACTIVE' OR v_res IS DISTINCT FROM 'BOARDER' THEN
+      error := 'Only an active boarder can request an exeat.';    -- A5 belt
+      EXIT body;
+    END IF;
+
+    -- current SENIOR semester — mirrors lib/boarding/period.ts getCurrentPeriod (covering → latest
+    -- started → earliest). E2 when the school has no SENIOR period.
+    SELECT ap.period_id INTO v_period
+      FROM academic_period ap
+      WHERE ap.school_id = school AND ap.product_line = 'SENIOR'
+      ORDER BY
+        (ap.starts_on <= v_today AND ap.ends_on >= v_today) DESC,
+        (ap.starts_on <= v_today) DESC,
+        CASE WHEN ap.starts_on <= v_today THEN ap.starts_on END DESC,
+        ap.starts_on ASC
+      LIMIT 1;
+    IF v_period IS NULL THEN
+      error := 'No academic semester is configured.';            -- E2
+      EXIT body;
+    END IF;
+
+    -- OPEN-GUARD (B9, authoritative, in-tx): one live exeat at a time (any type).
+    IF EXISTS (
+      SELECT 1 FROM boarding_exeat be
+      WHERE be.school_id = school AND be.student_id = p_student
+        AND be.status::text IN ('REQUESTED','HM_APPROVED','SR_HM_SIGNED','DEPARTED')
+    ) THEN
+      error := 'This boarder already has an exeat in progress — please contact the House.';  -- B9
+      EXIT body;
+    END IF;
+
+    -- fee-owing snapshot (B8): SUM(invoice.balance_amount) over owing statuses; > 0 ? sum : NULL.
+    -- Advisory only — NEVER blocks (mirrors lib/boarding/exeat-data.ts feeOwingForStudent semantics).
+    SELECT COALESCE(SUM(i.balance_amount), 0) INTO v_owing
+      FROM invoice i
+      WHERE i.school_id = school AND i.student_id = p_student
+        AND i.status::text IN ('ISSUED','PARTIAL','OVERDUE');
+    v_snapshot := CASE WHEN v_owing > 0 THEN round(v_owing, 2) ELSE NULL END;
+
+    -- return_by = p_return at the policy return-by time (default 16:00 — getExeatPolicy.returnByTime).
+    SELECT bs.exeat_return_by INTO v_return_time
+      FROM boarding_settings bs WHERE bs.school_id = school;
+    v_return_time := COALESCE(NULLIF(v_return_time, ''), '16:00');
+    v_return_by := (p_return::text || ' ' || v_return_time)::timestamptz;
+
+    -- requested_by_user_id = pu ONLY if a ref_user row exists (OC-3), else NULL (the FK is SET NULL).
+    v_requested_by := CASE WHEN EXISTS (SELECT 1 FROM ref_user u WHERE u.id = pu) THEN pu ELSE NULL END;
+
+    -- ref-code prefix — mirrors refPrefix in lib/actions/boarding-exeat.ts: first 4 alnum of
+    -- short_name/name, upper-cased, else 'EXT'.
+    SELECT COALESCE(
+             NULLIF(left(upper(regexp_replace(COALESCE(rs.short_name, rs.name), '[^A-Za-z0-9]', '', 'g')), 4), ''),
+             'EXT')
+      INTO v_prefix
+      FROM ref_school rs WHERE rs.id = school;
+    v_prefix := COALESCE(v_prefix, 'EXT');
+
+    -- base sequence = max trailing number over the school's existing ref_codes + 1 (per-school).
+    SELECT COALESCE(MAX(substring(be.ref_code from '(\d+)\s*$')::int), 0) + 1
+      INTO v_base_seq
+      FROM boarding_exeat be WHERE be.school_id = school;
+
+    -- ponytail: the "PREFIX-EX-YYYY-NNNN" format is intentionally duplicated from formatRefCode/
+    -- nextExeatSequence in lib/boarding/exeat-decision.ts — it is a DISPLAY string, not lifecycle logic.
+    -- Computing it IN-fn (retry-on-collision, guarded by uniq_exeat_ref_code) keeps allocation atomic
+    -- with the unique constraint (no TOCTOU). Upgrade path: extract a shared codegen only if a third
+    -- caller appears.
+    <<alloc>>
+    FOR v_attempt IN 0..4 LOOP
+      v_ref := v_prefix || '-EX-' || v_year::text || '-' || lpad((v_base_seq + v_attempt)::text, 4, '0');
+      BEGIN
+        INSERT INTO boarding_exeat (
+          school_id, student_id, house_id, academic_period_id,
+          exeat_type, status, ref_code, reason, parent_initiated,
+          depart_at, return_by, requested_by_user_id, fee_owing_snapshot)
+        VALUES (
+          school, p_student, v_house, v_period,
+          'SPECIAL', 'REQUESTED', v_ref, NULLIF(btrim(p_reason), ''), true,
+          p_depart::timestamptz, v_return_by, v_requested_by, v_snapshot)
+        RETURNING id INTO v_id;
+        ok := true;
+        ref_code := v_ref;
+        EXIT alloc;
+      EXCEPTION WHEN unique_violation THEN
+        -- uniq_exeat_ref_code lost race — bump the sequence and retry.
+        CONTINUE alloc;
+      END;
+    END LOOP alloc;
+
+    IF NOT ok THEN
+      error := 'Could not allocate an exeat reference — please retry.';
+      EXIT body;
+    END IF;
+
+    -- D8 recursion note: this fn reads boarding_exeat (open-guard) AND inserts into it. With the parent
+    -- GUC cleared, boarding_exeat's parent_deny is a no-op and tenant_isolation is a plain predicate —
+    -- no policy or SECURITY DEFINER helper on boarding_exeat re-enters parent_request_exeat. No recursion.
+
+    -- AUDIT (parity with lib/actions/boarding-exeat.ts recordAudit / EXEAT_REQUESTED) — parent-sourced.
+    INSERT INTO audit_log (
+      school_id, actor_user_id, actor_role, action_type, entity_type, entity_id,
+      before_jsonb, after_jsonb, reason)
+    VALUES (
+      school, v_requested_by, 'PARENT', 'EXEAT_REQUESTED', 'boarding_exeat', v_id,
+      NULL,
+      jsonb_build_object(
+        'refCode', v_ref, 'type', 'SPECIAL', 'status', 'REQUESTED',
+        'parentInitiated', true, 'source', 'parent', 'feeSnapshot', v_snapshot),
+      NULLIF(btrim(p_reason), ''));
+  END body;
+
+  -- SINGLE restore point (every EXIT body + the success path land here). RESTORE VERBATIM:
+  -- COALESCE(prev,'') because current_setting(...,true) is NULL when unset. NEVER pu::text — pu is a fn
+  -- ARG that may differ from the caller's session GUC (see the parent_boarding_placement note).
+  PERFORM set_config('app.current_parent_user', COALESCE(prev, ''), true);
+  RETURN;
+END;
+$$;
+-- On Supabase every public function is a PostgREST RPC (EXECUTE defaults to PUBLIC); a privileged
+-- SECURITY DEFINER write must not be anon-callable. The owner keeps EXECUTE regardless of the REVOKE.
+REVOKE EXECUTE ON FUNCTION parent_request_exeat(uuid, uuid, uuid, text, date, date) FROM PUBLIC;
+DO $$ BEGIN
+  IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'omnischools_app') THEN
+    GRANT EXECUTE ON FUNCTION parent_request_exeat(uuid, uuid, uuid, text, date, date) TO omnischools_app;
+  END IF;
+END $$;
+
+-- ---- Fn 2: parent_exeat_list — the own-child exeat READ projection (the ONLY parent read of
+-- boarding_exeat). Returns ONLY the C3-IN columns for ALL of the parent's own child's exeats (any type),
+-- newest first. NEVER fee_owing_snapshot / decline_reason / *_by_user_id / returned_late / house_id/dorm/
+-- bunk — a parent can never reach the fee snapshot, the decline reason or staff PII even via a mutated
+-- reader. GUC-clear device: boarding_exeat + house are parent_deny, so clear the parent GUC for the read
+-- then restore it VERBATIM; own-child fencing uses the CAPTURED pu ARG (parent_student_ids).
+CREATE OR REPLACE FUNCTION parent_exeat_list(school uuid, pu uuid)
+  RETURNS TABLE(
+    exeat_id        uuid,
+    ref_code        text,
+    exeat_type      text,
+    status          text,
+    parent_initiated boolean,
+    reason          text,
+    depart_at       timestamptz,
+    return_by       timestamptz,
+    departed_at     timestamptz,
+    returned_at     timestamptz,
+    hm_approved_at  timestamptz,
+    sr_hm_signed_at timestamptz,
+    house_name      text)
+  LANGUAGE plpgsql
+  STABLE
+  SECURITY DEFINER
+  SET search_path = public, pg_temp
+AS $$
+DECLARE
+  prev text := current_setting('app.current_parent_user', true);  -- caller's GUC, captured VERBATIM
+BEGIN
+  IF pu IS NULL OR school IS NULL THEN RETURN; END IF;  -- fail-closed; GUC untouched
+  -- Relax parent_deny on boarding_exeat + house for THIS read only (parent_deny's `pu IS NULL` → TRUE).
+  -- Own-child fencing uses the CAPTURED pu ARG (parent_student_ids), NOT the cleared GUC; app.current_school
+  -- stays set so tenant_isolation still fences the school.
+  PERFORM set_config('app.current_parent_user', '', true);
+  RETURN QUERY
+    SELECT be.id, be.ref_code, be.exeat_type::text, be.status::text, be.parent_initiated,
+           be.reason, be.depart_at, be.return_by, be.departed_at, be.returned_at,
+           be.hm_approved_at, be.sr_hm_signed_at, h.name
+    FROM boarding_exeat be
+    JOIN house h ON h.school_id = be.school_id AND h.id = be.house_id
+    WHERE be.school_id = school
+      AND be.student_id IN (SELECT parent_student_ids(school, pu))
+    ORDER BY be.created_at DESC;
+  -- RESTORE the caller's GUC VERBATIM. COALESCE(prev,'') because current_setting(...,true) yields NULL when
+  -- unset. NEVER pu::text: pu is a fn ARG that may differ from the caller's session GUC.
+  PERFORM set_config('app.current_parent_user', COALESCE(prev, ''), true);
+END;
+$$;
+-- On Supabase every public function is a PostgREST RPC and EXECUTE defaults to PUBLIC; a privileged
+-- SECURITY DEFINER read must not be anon-callable (no-op without the GUCs, but harden anyway).
+REVOKE EXECUTE ON FUNCTION parent_exeat_list(uuid, uuid) FROM PUBLIC;
+DO $$ BEGIN
+  IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'omnischools_app') THEN
+    GRANT EXECUTE ON FUNCTION parent_exeat_list(uuid, uuid) TO omnischools_app;
+  END IF;
+END $$;
+
+-- ---- layer 1: parent_deny — the CATALOG-DRIVEN loop, verbatim from db/sql/policies.sql ----
+-- 🔴 RUN THIS. It re-affirms RESTRICTIVE parent_deny on every FORCE-RLS + school_id table that does NOT
+-- already carry a parent_scope policy. This increment adds NO parent_scope, so boarding_exeat +
+-- exeat_notification (and every other never-widen tenant table, and any future one) stay auto-denied.
+-- Idempotent.
+DO $$
+DECLARE
+  tbl text;
+BEGIN
+  FOR tbl IN
+    SELECT c.relname
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = 'public'
+    WHERE c.relkind = 'r'
+      AND c.relforcerowsecurity
+      AND EXISTS (
+        SELECT 1 FROM information_schema.columns col
+        WHERE col.table_schema = 'public'
+          AND col.table_name = c.relname
+          AND col.column_name = 'school_id'
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_policy p
+        WHERE p.polrelid = c.oid AND p.polname = 'parent_scope'
+      )
+    ORDER BY c.relname
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS parent_deny ON %I;', tbl);
+    EXECUTE format(
+      'CREATE POLICY parent_deny ON %I AS RESTRICTIVE FOR ALL TO public '
+      'USING (NULLIF(current_setting(''app.current_parent_user'', true), '''') IS NULL);',
+      tbl
+    );
+  END LOOP;
+END
+$$;

--- a/omnischools/lib/actions/parent-exeat.ts
+++ b/omnischools/lib/actions/parent-exeat.ts
@@ -1,0 +1,64 @@
+"use server";
+import { sql } from "drizzle-orm";
+import { z } from "zod";
+import { requireParent } from "@/lib/auth/server";
+import { withParentScope } from "@/lib/db/rls";
+import { safeRevalidate } from "@/lib/revalidate";
+
+/**
+ * 🔴 EXEAT PHASE 2 · the parent-initiated SPECIAL exeat request — the parent portal's second sanctioned
+ * WRITE (after Communications). Deliberately a THIN guarded caller (belt); the SECURITY DEFINER
+ * `parent_request_exeat` fn (Wells, prod-paste-0098) is the authority (braces): it server-forces
+ * exeat_type=SPECIAL / status=REQUESTED / parent_initiated=true, derives house/period/return-by/fee-snapshot,
+ * and enforces own-child + active-boarder + the one-live-exeat open-guard IN-transaction. We validate the
+ * inputs at the trust boundary and pass the fn's neutral errors straight through (never SMS, never a
+ * staff-field write). Mirrors the doctrine in lib/actions/parent-comms.ts.
+ */
+
+const DATE = /^\d{4}-\d{2}-\d{2}$/;
+const Schema = z.object({
+  studentId: z.string().uuid("Choose a boarder."),
+  reason: z.string().trim().min(4, "Tell the school why (a few words).").max(500, "That reason is too long."),
+  departDate: z.string().regex(DATE, "Choose a leave date."),
+  returnDate: z.string().regex(DATE, "Choose a return date."),
+});
+
+type Result = { ok: boolean; refCode?: string; error?: string };
+
+/** The two terse fn codes are not parent-facing copy; every other fn error IS a neutral sentence → pass it. */
+function mapExeatError(err: string | null | undefined): string {
+  if (!err) return "Couldn't submit your request. Please try again.";
+  if (err === "not_found" || err === "unauthorized") return "We couldn't find that child on your account.";
+  return err;
+}
+
+export async function requestParentExeat(input: unknown): Promise<Result> {
+  const { user, school } = await requireParent();
+  const parsed = Schema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: parsed.error.issues[0]?.message ?? "Please check the form." };
+  const { studentId, reason, departDate, returnDate } = parsed.data;
+
+  // Belt validation (the fn does not re-check calendar ordering): leave date not in the past, return ≥ depart.
+  const today = new Date().toISOString().slice(0, 10);
+  if (departDate < today) return { ok: false, error: "The leave date can't be in the past." };
+  if (returnDate < departDate) return { ok: false, error: "The return date must be on or after the leave date." };
+
+  let result: { ok: boolean; ref_code: string | null; error: string | null } | null;
+  try {
+    result = await withParentScope(school.id, user.id, async (tx) => {
+      const rows = (await tx.execute(sql`
+        select ok, ref_code, error
+        from parent_request_exeat(
+          ${school.id}::uuid, ${user.id}::uuid, ${studentId}::uuid,
+          ${reason}, ${departDate}::date, ${returnDate}::date)
+      `)) as unknown as { ok: boolean; ref_code: string | null; error: string | null }[];
+      return rows[0] ?? null;
+    });
+  } catch {
+    return { ok: false, error: "Couldn't submit your request. Please try again." };
+  }
+
+  if (!result?.ok) return { ok: false, error: mapExeatError(result?.error) };
+  safeRevalidate("/boarding");
+  return { ok: true, refCode: result.ref_code ?? undefined };
+}

--- a/omnischools/lib/boarding/exeat-data.ts
+++ b/omnischools/lib/boarding/exeat-data.ts
@@ -134,8 +134,8 @@ export interface ExeatRow {
   type: ExeatType;
   status: ExeatStatus;
   reason: string | null;
-  /** The parent asked for this exeat (portal request, or a special phoned in) — drives the "from parent" chip. */
-  parentInitiated: boolean;
+  /** Row was created via the parent portal (parent_request_exeat) — drives the accurate "from parent" chip. */
+  viaParentPortal: boolean;
   outLabel: string | null;
   inLabel: string | null;
   fee: FeeStatus;
@@ -215,7 +215,7 @@ interface RawExeat extends RawActorIds {
   type: ExeatType;
   status: ExeatStatus;
   reason: string | null;
-  parentInitiated: boolean;
+  viaParentPortal: boolean;
   departAt: Date | null;
   returnBy: Date | null;
   feeSnapshot: number;
@@ -281,7 +281,7 @@ function baseRow(r: RawExeat): ExeatRow {
     type: r.type,
     status: r.status,
     reason: r.reason,
-    parentInitiated: r.parentInitiated,
+    viaParentPortal: r.viaParentPortal,
     outLabel: fmtDateTime(r.departAt),
     inLabel: fmtDateTime(r.returnBy),
     fee: feeStatus(r.feeSnapshot),
@@ -405,7 +405,7 @@ export async function getExeatBoard(
         type: boardingExeat.exeatType,
         status: boardingExeat.status,
         reason: boardingExeat.reason,
-        parentInitiated: boardingExeat.parentInitiated,
+        viaParentPortal: boardingExeat.viaParentPortal,
         departAt: boardingExeat.departAt,
         returnBy: boardingExeat.returnBy,
         feeSnapshot: boardingExeat.feeOwingSnapshot,

--- a/omnischools/lib/boarding/exeat-data.ts
+++ b/omnischools/lib/boarding/exeat-data.ts
@@ -134,6 +134,8 @@ export interface ExeatRow {
   type: ExeatType;
   status: ExeatStatus;
   reason: string | null;
+  /** The parent asked for this exeat (portal request, or a special phoned in) — drives the "from parent" chip. */
+  parentInitiated: boolean;
   outLabel: string | null;
   inLabel: string | null;
   fee: FeeStatus;
@@ -213,6 +215,7 @@ interface RawExeat extends RawActorIds {
   type: ExeatType;
   status: ExeatStatus;
   reason: string | null;
+  parentInitiated: boolean;
   departAt: Date | null;
   returnBy: Date | null;
   feeSnapshot: number;
@@ -278,6 +281,7 @@ function baseRow(r: RawExeat): ExeatRow {
     type: r.type,
     status: r.status,
     reason: r.reason,
+    parentInitiated: r.parentInitiated,
     outLabel: fmtDateTime(r.departAt),
     inLabel: fmtDateTime(r.returnBy),
     fee: feeStatus(r.feeSnapshot),
@@ -401,6 +405,7 @@ export async function getExeatBoard(
         type: boardingExeat.exeatType,
         status: boardingExeat.status,
         reason: boardingExeat.reason,
+        parentInitiated: boardingExeat.parentInitiated,
         departAt: boardingExeat.departAt,
         returnBy: boardingExeat.returnBy,
         feeSnapshot: boardingExeat.feeOwingSnapshot,

--- a/omnischools/lib/parent/parent-boarding-data.ts
+++ b/omnischools/lib/parent/parent-boarding-data.ts
@@ -28,6 +28,7 @@ export type BoarderState = "PLACED" | "AWAITING";
 export type ParentBoarderChild = {
   studentId: string; // own child — the exeat-request form targets this (the fn re-fences own-child)
   firstName: string;
+  isActive: boolean; // status='ACTIVE' — gates the exeat-request form (a withdrawn boarder can't request; never says why)
   state: BoarderState;
   houseName: string | null;
   dormName: string | null;
@@ -68,7 +69,12 @@ export async function loadParentBoardingTx(
 ): Promise<ParentBoarding> {
   // Own children + residency (students is parent-readable). NO bunk id / house id read here.
   const kids = await tx
-    .select({ id: students.id, firstName: students.firstName, residency: students.residency })
+    .select({
+      id: students.id,
+      firstName: students.firstName,
+      residency: students.residency,
+      status: students.status,
+    })
     .from(students)
     .where(eq(students.schoolId, schoolId))
     .orderBy(asc(students.firstName));
@@ -91,6 +97,7 @@ export async function loadParentBoardingTx(
     return {
       studentId: k.id,
       firstName: k.firstName,
+      isActive: k.status === "ACTIVE",
       state: p ? "PLACED" : "AWAITING",
       houseName: p?.house_name ?? null,
       dormName: p?.dorm_name ?? null,

--- a/omnischools/lib/parent/parent-boarding-data.ts
+++ b/omnischools/lib/parent/parent-boarding-data.ts
@@ -26,6 +26,7 @@ import { students, boardingCalendarEvent, boardingSettings, academicPeriod } fro
 
 export type BoarderState = "PLACED" | "AWAITING";
 export type ParentBoarderChild = {
+  studentId: string; // own child — the exeat-request form targets this (the fn re-fences own-child)
   firstName: string;
   state: BoarderState;
   houseName: string | null;
@@ -88,6 +89,7 @@ export async function loadParentBoardingTx(
   const boarders: ParentBoarderChild[] = boarderKids.map((k) => {
     const p = placeById.get(k.id);
     return {
+      studentId: k.id,
       firstName: k.firstName,
       state: p ? "PLACED" : "AWAITING",
       houseName: p?.house_name ?? null,

--- a/omnischools/lib/parent/parent-boarding.test.ts
+++ b/omnischools/lib/parent/parent-boarding.test.ts
@@ -65,14 +65,14 @@ describe("parent-chrome · Boarding is a boarding-school-only 8th tab", () => {
     expect((s.match(/<span/g) ?? []).length).toBe(1);
   });
 
-  it("the boarding route is read-only, active-nav, and never reveals a removal or exeat", () => {
+  it("the boarding page stays a server component and never reveals a removal (exeat phase 2 now shipped)", () => {
     const s = page();
     expect(s).toMatch(/ParentNav active="Boarding"/);
     expect(s).toMatch(/NoChild/);
     expect(s).toMatch(/NotABoarder/); // day/deboardinized collapse
-    expect(s).not.toMatch(/^"use client"/m); // read-only server component
-    expect(s).not.toMatch(/Pay now|sendSms|gateway/i); // no write/gateway
+    expect(s).not.toMatch(/^"use client"/m); // the page is a server component (the exeat WRITE is a separate client form)
+    expect(s).not.toMatch(/Pay now|sendSms|gateway/i); // no gateway, no SMS from the page
     expect(s).not.toMatch(/deboardiniz|expelled|removed from board/i); // the removal is never shown
-    expect(s).not.toMatch(/\bexeat\b/i); // exeat is phase 2
+    expect(s).toMatch(/loadParentExeats/); // phase 2: own-child exeat status IS surfaced now
   });
 });

--- a/omnischools/lib/parent/parent-exeat-data.ts
+++ b/omnischools/lib/parent/parent-exeat-data.ts
@@ -12,10 +12,11 @@ import type { ExeatStatus, ExeatType } from "@/lib/boarding/exeat-decision";
  * projection are the authority. This module runs the fn inside `withParentScope` and pre-formats every
  * timestamp into a display string (the client takes strings, never Date — server-only leak rule).
  *
- * The fn ALREADY drops fee_owing_snapshot / decline_reason / *_by_user_id, so the only guard left to us is
- * the parent-facing copy: the friendly status label (Kofi C2) and the DETAIL rule — echo the parent's OWN
- * words only when THEY initiated the request, else a friendly TYPE label; a FEE_COLLECTION row is relabelled
- * to a bare "Fee collection" so its amount-bearing reason is never surfaced.
+ * The fn ALREADY drops fee_owing_snapshot / decline_reason / *_by_user_id AND redacts a non-portal
+ * (staff-authored) `reason` to NULL — via_parent_portal is the provenance authority, NOT the broadly-true
+ * parent_initiated flag (Sarah leak-fix). So a `reason` that reaches us is the parent's OWN words; our only
+ * copy guard is the friendly status label (Kofi C2) and the DETAIL rule — echo a present reason, else a
+ * friendly TYPE label; a FEE_COLLECTION row is relabelled to a bare "Fee collection".
  */
 
 /** Friendly status label — Kofi C2. Parent-facing; never the operational REQUESTED/HM_APPROVED vocabulary. */
@@ -46,17 +47,14 @@ export function exeatStatusLabel(status: string): string {
 /**
  * PURE — what to show as the row's "reason/detail" (Kofi C2 detail rule):
  *  • FEE_COLLECTION → a bare "Fee collection" — NEVER its amount-bearing reason.
- *  • parent-initiated → the parent's OWN words (what they typed on the request).
- *  • otherwise → a friendly TYPE label (a staff-recorded exeat's reason is not echoed to the parent).
+ *  • a present reason → the parent's OWN words. `parent_exeat_list` REDACTS a staff-authored reason to
+ *    NULL (via_parent_portal is the authority), so any reason that reaches here was parent-typed.
+ *  • no reason → a friendly TYPE label (a staff-recorded exeat's reason never reaches the parent).
  */
-export function exeatDetail(row: {
-  exeatType: string;
-  parentInitiated: boolean;
-  reason: string | null;
-}): string {
+export function exeatDetail(row: { exeatType: string; reason: string | null }): string {
   if (row.exeatType === "FEE_COLLECTION") return "Fee collection";
   const reason = row.reason?.trim();
-  if (row.parentInitiated && reason) return reason;
+  if (reason) return reason;
   return TYPE_LABEL[row.exeatType as ExeatType] ?? "Leave";
 }
 
@@ -117,7 +115,7 @@ export async function loadParentExeatsTx(
       id: r.exeat_id,
       refCode: r.ref_code,
       statusLabel: exeatStatusLabel(r.status),
-      detail: exeatDetail({ exeatType: r.exeat_type, parentInitiated: r.parent_initiated, reason: r.reason }),
+      detail: exeatDetail({ exeatType: r.exeat_type, reason: r.reason }),
       houseName: r.house_name,
       isOpen: OPEN_STATUSES.includes(r.status as ExeatStatus),
       milestones,

--- a/omnischools/lib/parent/parent-exeat-data.ts
+++ b/omnischools/lib/parent/parent-exeat-data.ts
@@ -1,0 +1,131 @@
+import "server-only";
+import { sql } from "drizzle-orm";
+import { withParentScope } from "@/lib/db/rls";
+import type { Tx } from "@/lib/db";
+import type { ExeatStatus, ExeatType } from "@/lib/boarding/exeat-decision";
+
+/**
+ * 🔴 EXEAT PHASE 2 · the PARENT-facing exeat READER (own-child status). SERVER-ONLY — imports the db
+ * driver, so a client component must never import it (only `pnpm build` catches the leak; the parent-*-data
+ * precedent). boarding_exeat + house STAY fully parent_deny — the parent reads them ONLY through the
+ * SECURITY DEFINER `parent_exeat_list` fn (Wells, prod-paste-0098), whose own-child fence + column
+ * projection are the authority. This module runs the fn inside `withParentScope` and pre-formats every
+ * timestamp into a display string (the client takes strings, never Date — server-only leak rule).
+ *
+ * The fn ALREADY drops fee_owing_snapshot / decline_reason / *_by_user_id, so the only guard left to us is
+ * the parent-facing copy: the friendly status label (Kofi C2) and the DETAIL rule — echo the parent's OWN
+ * words only when THEY initiated the request, else a friendly TYPE label; a FEE_COLLECTION row is relabelled
+ * to a bare "Fee collection" so its amount-bearing reason is never surfaced.
+ */
+
+/** Friendly status label — Kofi C2. Parent-facing; never the operational REQUESTED/HM_APPROVED vocabulary. */
+const STATUS_LABEL: Record<ExeatStatus, string> = {
+  REQUESTED: "Submitted — awaiting the school's approval",
+  HM_APPROVED: "Approved by the House — awaiting final sign-off",
+  SR_HM_SIGNED: "Approved and signed off",
+  DEPARTED: "Signed out — currently at home",
+  RETURNED: "Returned to school",
+  DECLINED: "Not approved — please contact the House",
+};
+
+/** Friendly TYPE label for a row the parent did NOT author (never echo staff-entered reason text). */
+const TYPE_LABEL: Record<ExeatType, string> = {
+  SCHEDULED: "Scheduled leave",
+  SPECIAL: "Special leave",
+  FEE_COLLECTION: "Fee collection",
+};
+
+/** Stages that count as an OPEN (live) exeat — mirrors the fn's B9 open-guard. Terminal = RETURNED/DECLINED. */
+const OPEN_STATUSES: readonly ExeatStatus[] = ["REQUESTED", "HM_APPROVED", "SR_HM_SIGNED", "DEPARTED"];
+
+/** PURE — the friendly status label (falls back to a neutral phrase for an unknown status). */
+export function exeatStatusLabel(status: string): string {
+  return STATUS_LABEL[status as ExeatStatus] ?? "In progress";
+}
+
+/**
+ * PURE — what to show as the row's "reason/detail" (Kofi C2 detail rule):
+ *  • FEE_COLLECTION → a bare "Fee collection" — NEVER its amount-bearing reason.
+ *  • parent-initiated → the parent's OWN words (what they typed on the request).
+ *  • otherwise → a friendly TYPE label (a staff-recorded exeat's reason is not echoed to the parent).
+ */
+export function exeatDetail(row: {
+  exeatType: string;
+  parentInitiated: boolean;
+  reason: string | null;
+}): string {
+  if (row.exeatType === "FEE_COLLECTION") return "Fee collection";
+  const reason = row.reason?.trim();
+  if (row.parentInitiated && reason) return reason;
+  return TYPE_LABEL[row.exeatType as ExeatType] ?? "Leave";
+}
+
+export type ParentExeatMilestone = { label: string; value: string };
+export type ParentExeatRow = {
+  id: string;
+  refCode: string;
+  statusLabel: string;
+  detail: string;
+  houseName: string | null;
+  isOpen: boolean; // any live stage → the request form disables submit (advisory; the fn is authoritative)
+  milestones: ParentExeatMilestone[]; // pre-formatted display strings, only the ones that exist
+};
+
+/** The raw fn row (timestamptz → Date via the pg driver). */
+type RawParentExeat = {
+  exeat_id: string;
+  ref_code: string;
+  exeat_type: string;
+  status: string;
+  parent_initiated: boolean;
+  reason: string | null;
+  depart_at: Date | null;
+  return_by: Date | null;
+  departed_at: Date | null;
+  returned_at: Date | null;
+  hm_approved_at: Date | null;
+  sr_hm_signed_at: Date | null;
+  house_name: string | null;
+};
+
+// UTC formatting (the DB session is UTC; a leave date must not drift with the server zone — the exam-time
+// precedent in lib/wassce/parent-copy.ts). Date-only for the planning dates; date+time for actual events.
+const D = new Intl.DateTimeFormat("en-GB", {
+  weekday: "short", day: "numeric", month: "short", timeZone: "UTC",
+});
+const DT = new Intl.DateTimeFormat("en-GB", {
+  weekday: "short", day: "numeric", month: "short", hour: "2-digit", minute: "2-digit", hour12: false, timeZone: "UTC",
+});
+
+/** MUST run on a `tx` already scoped by `withParentScope`. */
+export async function loadParentExeatsTx(
+  tx: Tx,
+  schoolId: string,
+  userId: string,
+): Promise<ParentExeatRow[]> {
+  const rows = (await tx.execute(
+    sql`select * from parent_exeat_list(${schoolId}::uuid, ${userId}::uuid)`,
+  )) as unknown as RawParentExeat[];
+
+  return rows.map((r) => {
+    const milestones: ParentExeatMilestone[] = [];
+    if (r.depart_at) milestones.push({ label: "Leaves", value: D.format(r.depart_at) });
+    if (r.return_by) milestones.push({ label: "Back by", value: DT.format(r.return_by) });
+    if (r.departed_at) milestones.push({ label: "Signed out", value: DT.format(r.departed_at) });
+    if (r.returned_at) milestones.push({ label: "Returned", value: DT.format(r.returned_at) });
+    return {
+      id: r.exeat_id,
+      refCode: r.ref_code,
+      statusLabel: exeatStatusLabel(r.status),
+      detail: exeatDetail({ exeatType: r.exeat_type, parentInitiated: r.parent_initiated, reason: r.reason }),
+      houseName: r.house_name,
+      isOpen: OPEN_STATUSES.includes(r.status as ExeatStatus),
+      milestones,
+    };
+  });
+}
+
+/** Entry point — the parent's own-child exeats under `withParentScope` (never `withSchool`). */
+export async function loadParentExeats(schoolId: string, userId: string): Promise<ParentExeatRow[]> {
+  return withParentScope(schoolId, userId, (tx) => loadParentExeatsTx(tx, schoolId, userId));
+}

--- a/omnischools/lib/parent/parent-exeat.test.ts
+++ b/omnischools/lib/parent/parent-exeat.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { readCode } from "@/lib/test-utils/source-shape";
+import { exeatStatusLabel, exeatDetail } from "./parent-exeat-data";
+
+/**
+ * EXEAT PHASE 2 · parent-initiated SPECIAL exeat + own-child status. The reader is mostly an IO projection
+ * over the SECURITY DEFINER fns, so the guards are (1) the PURE parent-facing copy — friendly status labels
+ * (Kofi C2) + the DETAIL rule (echo the parent's OWN words only, relabel FEE_COLLECTION so no amount leaks),
+ * and (2) source-shape: reader/action stay inside withParentScope, the write is a thin fn caller that
+ * server-forces nothing itself and sends no SMS. RLS/fn behaviour lives in db:rls-test.
+ */
+
+describe("exeatStatusLabel · friendly status copy (Kofi C2)", () => {
+  it("maps every lifecycle status to its parent-facing sentence", () => {
+    expect(exeatStatusLabel("REQUESTED")).toBe("Submitted — awaiting the school's approval");
+    expect(exeatStatusLabel("HM_APPROVED")).toBe("Approved by the House — awaiting final sign-off");
+    expect(exeatStatusLabel("SR_HM_SIGNED")).toBe("Approved and signed off");
+    expect(exeatStatusLabel("DEPARTED")).toBe("Signed out — currently at home");
+    expect(exeatStatusLabel("RETURNED")).toBe("Returned to school");
+    expect(exeatStatusLabel("DECLINED")).toBe("Not approved — please contact the House");
+  });
+
+  it("never leaks the raw operational vocabulary and falls back neutrally", () => {
+    for (const s of ["REQUESTED", "HM_APPROVED", "SR_HM_SIGNED", "DEPARTED", "RETURNED", "DECLINED"]) {
+      expect(exeatStatusLabel(s)).not.toBe(s);
+    }
+    expect(exeatStatusLabel("WEIRD_UNKNOWN")).toBe("In progress");
+  });
+});
+
+describe("exeatDetail · reason-echo gate + FEE_COLLECTION relabel", () => {
+  it("echoes the parent's OWN words only when THEY initiated the request", () => {
+    expect(
+      exeatDetail({ exeatType: "SPECIAL", parentInitiated: true, reason: "  Grandmother's funeral  " }),
+    ).toBe("Grandmother's funeral"); // trimmed, verbatim
+  });
+
+  it("shows a friendly TYPE label — never the staff reason — for a non-parent-initiated row", () => {
+    expect(exeatDetail({ exeatType: "SPECIAL", parentInitiated: false, reason: "internal note" })).toBe(
+      "Special leave",
+    );
+    expect(exeatDetail({ exeatType: "SCHEDULED", parentInitiated: false, reason: "routine" })).toBe(
+      "Scheduled leave",
+    );
+    // parent-initiated but empty reason → still the friendly type label (no blank detail)
+    expect(exeatDetail({ exeatType: "SPECIAL", parentInitiated: true, reason: "   " })).toBe("Special leave");
+  });
+
+  it("relabels FEE_COLLECTION to a bare 'Fee collection' — the amount-bearing reason is NEVER echoed", () => {
+    expect(
+      exeatDetail({ exeatType: "FEE_COLLECTION", parentInitiated: true, reason: "Collect GHS 340.00 outstanding" }),
+    ).toBe("Fee collection");
+    expect(
+      exeatDetail({ exeatType: "FEE_COLLECTION", parentInitiated: false, reason: "GHS 215.00 owed" }),
+    ).toBe("Fee collection");
+  });
+});
+
+describe("parent-exeat-data · reader stays inside the parent boundary (source-shape)", () => {
+  const reader = () => readCode("lib/parent/parent-exeat-data.ts");
+
+  it("runs under withParentScope only — never withSchool / withoutTenantScope", () => {
+    const s = reader();
+    expect(s).toMatch(/withParentScope/);
+    expect(s).not.toMatch(/withSchool|withoutTenantScope/);
+  });
+
+  it("reads boarding_exeat ONLY through the SECURITY DEFINER projection (the table stays parent_deny)", () => {
+    const s = reader();
+    expect(s).toMatch(/parent_exeat_list/);
+    expect(s).not.toMatch(/boardingExeat/); // never a direct Drizzle read of the denied table
+    expect(s).not.toMatch(/fee_owing_snapshot|feeOwingSnapshot/); // amount never reaches the parent wire
+  });
+});
+
+describe("parent-exeat action · the write trust boundary", () => {
+  const action = () => readCode("lib/actions/parent-exeat.ts");
+
+  it("is a parent-gated server action under withParentScope (not requireSchool)", () => {
+    const s = action();
+    expect(s).toMatch(/^"use server"/m);
+    expect(s).toMatch(/requireParent\(\)/);
+    expect(s).not.toMatch(/requireSchool/);
+    expect(s).toMatch(/withParentScope/);
+    expect(s).not.toMatch(/\bwithSchool\b/);
+  });
+
+  it("delegates to the SECURITY DEFINER write fn and never forges lifecycle fields itself", () => {
+    const s = action();
+    expect(s).toMatch(/parent_request_exeat/);
+    // the fn server-forces type/status/parent_initiated — the action must not set them (no direct insert).
+    expect(s).not.toMatch(/insert\(boardingExeat\)|\.values\(/);
+    expect(s).not.toMatch(/"SPECIAL"|"REQUESTED"/); // no type/status literal written from app code
+  });
+
+  it("validates the inputs and sends NO SMS", () => {
+    const s = action();
+    expect(s).toMatch(/z\.object\(/);
+    expect(s).toMatch(/\.min\(4/);
+    expect(s).toMatch(/\.max\(500/);
+    expect(s).toMatch(/departDate < today/); // not-in-the-past belt
+    expect(s).toMatch(/returnDate < departDate/); // ordering belt
+    expect(s).not.toMatch(/sendSms|sendSMS/);
+  });
+});
+
+describe("boarding page · the exeat form is a client component; no server-only leak", () => {
+  const form = () => readCode("app/(parent)/boarding/exeat-request.tsx");
+  const page = () => readCode("app/(parent)/boarding/page.tsx");
+
+  it("the request form is a client component calling the action only (never a server-only reader)", () => {
+    const s = form();
+    expect(s).toMatch(/^"use client"/m);
+    expect(s).toMatch(/requestParentExeat/);
+    expect(s).not.toMatch(/parent-exeat-data|loadParentExeats/); // the client never imports the db reader
+    expect(s).toMatch(/type="date"/); // native date input (no picker lib)
+  });
+
+  it("the page loads exeats server-side and passes pre-formatted rows to the client list", () => {
+    const s = page();
+    expect(s).toMatch(/loadParentExeats/);
+    expect(s).toMatch(/No leave requests yet\./); // empty state
+    expect(s).toMatch(/ParentNav active="Boarding"/); // still one tab, unchanged
+  });
+});

--- a/omnischools/lib/parent/parent-exeat.test.ts
+++ b/omnischools/lib/parent/parent-exeat.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { cwd } from "node:process";
 import { describe, it, expect } from "vitest";
 import { readCode } from "@/lib/test-utils/source-shape";
 import { exeatStatusLabel, exeatDetail } from "./parent-exeat-data";
@@ -121,5 +124,98 @@ describe("boarding page · the exeat form is a client component; no server-only 
     expect(s).toMatch(/loadParentExeats/);
     expect(s).toMatch(/No leave requests yet\./); // empty state
     expect(s).toMatch(/ParentNav active="Boarding"/); // still one tab, unchanged
+  });
+});
+
+/**
+ * The SECURITY DEFINER fns are the authority for the C non-leak projection and the B/A5/D write guards.
+ * db:rls-test (scripts/rls-test.ts) proves them BEHAVIOURALLY as the non-superuser owner — but that probe
+ * needs a live DB and is NOT in `pnpm test`. These source-shape guards run in CI: they bite the moment a
+ * future edit WIDENS the read projection (a fee/decline/actor-id leak) or DROPS a write guard in the SQL
+ * that db:policies applies. We test db/sql/policies.sql (the dev source of truth) and cross-check that the
+ * prod-paste projection has NOT drifted from it (a widened prod-paste is where a real prod leak would land).
+ */
+const POLICIES = readFileSync(resolve(cwd(), "db/sql/policies.sql"), "utf8");
+const PROD_PASTE = readFileSync(
+  resolve(cwd(), "db/sql/prod-paste-0098-parent-exeat.sql"),
+  "utf8",
+);
+/** Slice a `CREATE OR REPLACE FUNCTION <name>( ... $$;` block out of a SQL file. */
+function fnBlock(sqlText: string, name: string): string {
+  const start = sqlText.indexOf(`CREATE OR REPLACE FUNCTION ${name}(`);
+  expect(start, `fn ${name} present`).toBeGreaterThan(-1);
+  const end = sqlText.indexOf("$$;", start);
+  return sqlText.slice(start, end);
+}
+/** Drop `-- …` line comments so a token in prose can't create a false match (or a false clear). */
+const stripSql = (s: string): string => s.replace(/--.*$/gm, "");
+/** The declared column names of a fn's `RETURNS TABLE( … )` — the authoritative read projection. */
+function returnsTableCols(block: string): string[] {
+  const m = block.match(/RETURNS TABLE\(([\s\S]*?)\)\s*\n\s*LANGUAGE/);
+  expect(m, "RETURNS TABLE parsed").not.toBeNull();
+  // `name TYPE[,]` per line — match ANY type word (not a fixed allow-list) so a leaked column of an
+  // unexpected type (numeric, jsonb, …) still lands in the set and trips the exact-match assertion.
+  return [...m![1].matchAll(/^\s*(\w+)\s+\w/gm)].map((x) => x[1]);
+}
+
+// The C3-IN set — the ONLY columns a parent may ever read of an exeat (Kofi C3).
+const C3_IN = [
+  "exeat_id", "ref_code", "exeat_type", "status", "parent_initiated", "reason",
+  "depart_at", "return_by", "departed_at", "returned_at", "hm_approved_at", "sr_hm_signed_at",
+  "house_name",
+].sort();
+
+describe("C non-leak · parent_exeat_list projection is exactly the C3-IN set (SQL guard)", () => {
+  it("returns EXACTLY the C3-IN columns — no extras, none missing", () => {
+    const cols = returnsTableCols(fnBlock(POLICIES, "parent_exeat_list")).sort();
+    expect(cols).toEqual(C3_IN);
+  });
+
+  it("the read projection carries NONE of the OUT columns (fee/decline/actor-id/late/placement-ids)", () => {
+    // Scope the denylist to the RETURNS TABLE only — fee_owing_snapshot legitimately appears in the WRITE
+    // fn's INSERT (the snapshot is captured, just never READ back to the parent).
+    const rt = fnBlock(POLICIES, "parent_exeat_list").match(/RETURNS TABLE\(([\s\S]*?)\)\s*\n\s*LANGUAGE/)![1];
+    for (const banned of [
+      "fee_owing_snapshot", "decline_reason", "_by_user_id", "returned_late",
+      "house_id", "dorm", "bunk",
+    ]) {
+      expect(rt, `projection must not expose ${banned}`).not.toContain(banned);
+    }
+  });
+
+  it("the prod-paste read projection has NOT drifted from policies.sql (a prod-only leak surface)", () => {
+    const dev = returnsTableCols(fnBlock(POLICIES, "parent_exeat_list")).sort();
+    const prod = returnsTableCols(fnBlock(PROD_PASTE, "parent_exeat_list")).sort();
+    expect(prod).toEqual(dev);
+  });
+});
+
+describe("B/A5/D · parent_request_exeat server-forces the row and re-checks eligibility (SQL guard)", () => {
+  const write = () => stripSql(fnBlock(POLICIES, "parent_request_exeat"));
+
+  it("SERVER-FORCES exeat_type=SPECIAL / status=REQUESTED / parent_initiated=true on the INSERT (B/D)", () => {
+    const s = write();
+    // the security-critical fields are literals in the fn, never derived from parent input
+    expect(s).toMatch(/INSERT INTO boarding_exeat/);
+    expect(s).toMatch(/'SPECIAL',\s*'REQUESTED'/);
+    expect(s).toMatch(/parent_initiated/);
+    expect(s).toMatch(/NULLIF\(btrim\(p_reason\), ''\), true/); // parent_initiated forced true
+  });
+
+  it("re-checks OWN-CHILD via the captured pu ARG before any traverse (D)", () => {
+    expect(write()).toMatch(/parent_student_ids\(school, pu\)[\s\S]*?WHERE sid = p_student/);
+  });
+
+  it("re-checks ACTIVE BOARDER server-side (A5) and a House assignment (E5)", () => {
+    const s = write();
+    expect(s).toMatch(/v_house IS NULL/); // E5 no-House block
+    expect(s).toMatch(/v_status IS DISTINCT FROM 'ACTIVE'/); // A5 active
+    expect(s).toMatch(/v_res IS DISTINCT FROM 'BOARDER'/); // A5 boarder
+  });
+
+  it("carries the B9 open-guard over the four live statuses", () => {
+    expect(write()).toMatch(
+      /status::text IN \('REQUESTED','HM_APPROVED','SR_HM_SIGNED','DEPARTED'\)/,
+    );
   });
 });

--- a/omnischools/lib/parent/parent-exeat.test.ts
+++ b/omnischools/lib/parent/parent-exeat.test.ts
@@ -32,30 +32,29 @@ describe("exeatStatusLabel · friendly status copy (Kofi C2)", () => {
 });
 
 describe("exeatDetail · reason-echo gate + FEE_COLLECTION relabel", () => {
-  it("echoes the parent's OWN words only when THEY initiated the request", () => {
-    expect(
-      exeatDetail({ exeatType: "SPECIAL", parentInitiated: true, reason: "  Grandmother's funeral  " }),
-    ).toBe("Grandmother's funeral"); // trimmed, verbatim
+  // parent_exeat_list REDACTS a staff-authored reason to NULL (via_parent_portal is the provenance
+  // authority, NOT the broadly-true parent_initiated flag — Sarah leak-fix), so at THIS reader boundary a
+  // PRESENT reason is always the parent's own words. That fn-level redaction is proven BEHAVIOURALLY by
+  // db:rls-test (a staff SPECIAL's reason comes back NULL); it is not reachable from a pure unit test.
+  it("echoes a present reason (the parent's OWN words, trimmed) verbatim", () => {
+    expect(exeatDetail({ exeatType: "SPECIAL", reason: "  Grandmother's funeral  " })).toBe(
+      "Grandmother's funeral",
+    );
   });
 
-  it("shows a friendly TYPE label — never the staff reason — for a non-parent-initiated row", () => {
-    expect(exeatDetail({ exeatType: "SPECIAL", parentInitiated: false, reason: "internal note" })).toBe(
-      "Special leave",
-    );
-    expect(exeatDetail({ exeatType: "SCHEDULED", parentInitiated: false, reason: "routine" })).toBe(
-      "Scheduled leave",
-    );
-    // parent-initiated but empty reason → still the friendly type label (no blank detail)
-    expect(exeatDetail({ exeatType: "SPECIAL", parentInitiated: true, reason: "   " })).toBe("Special leave");
+  it("shows a friendly TYPE label when the reason is NULL — a staff reason is redacted upstream, never echoed", () => {
+    // A staff-authored exeat reaches the reader with reason=NULL (redacted by the fn) → type label only.
+    expect(exeatDetail({ exeatType: "SPECIAL", reason: null })).toBe("Special leave");
+    expect(exeatDetail({ exeatType: "SCHEDULED", reason: null })).toBe("Scheduled leave");
+    // empty/whitespace reason → still the friendly type label (no blank detail)
+    expect(exeatDetail({ exeatType: "SPECIAL", reason: "   " })).toBe("Special leave");
   });
 
   it("relabels FEE_COLLECTION to a bare 'Fee collection' — the amount-bearing reason is NEVER echoed", () => {
-    expect(
-      exeatDetail({ exeatType: "FEE_COLLECTION", parentInitiated: true, reason: "Collect GHS 340.00 outstanding" }),
-    ).toBe("Fee collection");
-    expect(
-      exeatDetail({ exeatType: "FEE_COLLECTION", parentInitiated: false, reason: "GHS 215.00 owed" }),
-    ).toBe("Fee collection");
+    expect(exeatDetail({ exeatType: "FEE_COLLECTION", reason: "Collect GHS 340.00 outstanding" })).toBe(
+      "Fee collection",
+    );
+    expect(exeatDetail({ exeatType: "FEE_COLLECTION", reason: "GHS 215.00 owed" })).toBe("Fee collection");
   });
 });
 

--- a/omnischools/scripts/rls-test.ts
+++ b/omnischools/scripts/rls-test.ts
@@ -712,6 +712,46 @@ async function main() {
           await tx`select set_config('app.current_parent_user', '', true)`;
           assertAtLeast("staff sees the created exeat (parent_deny is a no-op for pu IS NULL)", await c("boarding_exeat", `where student_id='${exOwn}'`), 1);
 
+          // (10) A5 / E5 server-side re-checks — a child the parent OWNS but who is NOT an eligible boarder
+          // is refused server-side (the write fn re-checks, not just the UI affordance). Link exOther to the
+          // parent so the own-child fence PASSES and only the boarder/House gate can reject.
+          await tx`reset role`;
+          await tx`insert into student_guardian
+                     (id, school_id, student_id, name, relationship, phone, is_primary, user_id)
+                   values (gen_random_uuid(), ${schoolId}, ${exOther}, 'RLSTEST', 'FATHER',
+                           '+233RLSTESTE2', false, ${exParent})`;
+          // E5: an active BOARDER with NO House → refused ("not assigned to a House").
+          await tx`update students set residency='BOARDER', status='ACTIVE', house_id=NULL where id=${exOther}`;
+          await tx`set local role omnischools_app`;
+          await tx`select set_config('app.current_school', ${schoolId}, true)`;
+          await tx`select set_config('app.current_parent_user', ${exParent}, true)`;
+          const [reqNoHouse] = await tx<{ ok: boolean; error: string | null }[]>`
+            select ok, error
+            from parent_request_exeat(${schoolId}::uuid, ${exParent}::uuid, ${exOther}::uuid,
+                                      'No house', '2026-09-05'::date, '2026-09-07'::date)`;
+          assertTrue("no-House boarder refused (E5, ok=false)", reqNoHouse?.ok === false);
+          assertTrue("no-House error mentions a House", (reqNoHouse?.error ?? "").includes("House"));
+          // A5: a DAY student (own child, has a House) → refused ("Only an active boarder…").
+          await tx`reset role`;
+          await tx`update students set residency='DAY', status='ACTIVE', house_id=${exHouse} where id=${exOther}`;
+          await tx`set local role omnischools_app`;
+          await tx`select set_config('app.current_school', ${schoolId}, true)`;
+          await tx`select set_config('app.current_parent_user', ${exParent}, true)`;
+          const [reqDay] = await tx<{ ok: boolean; error: string | null }[]>`
+            select ok, error
+            from parent_request_exeat(${schoolId}::uuid, ${exParent}::uuid, ${exOther}::uuid,
+                                      'Day student', '2026-09-05'::date, '2026-09-07'::date)`;
+          assertTrue("DAY student refused server-side (A5, ok=false)", reqDay?.ok === false);
+          assertTrue("A5 error mentions an active boarder", (reqDay?.error ?? "").toLowerCase().includes("active boarder"));
+          // and NEITHER refused request wrote a row (seed-immune: match on our own unique reasons, since
+          // the seeded DB may already carry an unrelated exeat for this student).
+          await tx`reset role`;
+          assert(
+            "neither A5/E5-refused request wrote a row",
+            await c("boarding_exeat", `where student_id='${exOther}' and reason in ('No house','Day student')`),
+            0,
+          );
+
           throw new Error(ROLLBACK_EX); // discard all probe rows + the fn owner switches
         });
       } catch (e) {

--- a/omnischools/scripts/rls-test.ts
+++ b/omnischools/scripts/rls-test.ts
@@ -762,6 +762,42 @@ async function main() {
             0,
           );
 
+          // (11) 🔴 SARAH LEAK-CLOSURE — the reason this probe exists. A STAFF-authored exeat carries
+          // parent_initiated=true (staff SPECIALs FORCE it — lib/actions/boarding-exeat.ts:199) but
+          // via_parent_portal=false (the parent fn is the ONLY writer that sets it true). Its free-text
+          // reason (welfare/discipline) must be REDACTED to NULL by parent_exeat_list — the CASE-on-
+          // via_parent_portal at the fn is the authority, NOT the broadly-true parent_initiated flag. The
+          // ORIGINAL bug projected bare be.reason, so this staff string leaked verbatim to the parent, and
+          // the unit fixture (parentInitiated:false — a shape a staff SPECIAL never has) hid it. Insert one
+          // for the OWN child as the superuser owner, read as the own-child parent: the distinctive string
+          // must NOT appear (staff row reason = NULL), while the genuine PORTAL row ('Funeral', from step 1)
+          // MUST still return its parent-typed reason. Reverting the fn to bare be.reason turns this red.
+          const STAFF_REASON = "SECRET-STAFF-DISCIPLINE-NOTE";
+          const staffRef = "STAFF-EX-2026-9001";
+          await tx`insert into boarding_exeat
+                     (school_id, student_id, house_id, academic_period_id, exeat_type, status, ref_code,
+                      reason, parent_initiated)
+                   values (${schoolId}, ${exOwn}, ${exHouse}, ${exPeriod[0].pid}, 'SPECIAL', 'RETURNED',
+                           ${staffRef}, ${STAFF_REASON}, true)`; // via_parent_portal DEFAULTs false = staff row
+          await tx`set local role omnischools_app`;
+          await tx`select set_config('app.current_school', ${schoolId}, true)`;
+          await tx`select set_config('app.current_parent_user', ${exParent}, true)`;
+          const leakRows = await tx<{ ref_code: string; reason: string | null }[]>`
+            select ref_code, reason from parent_exeat_list(${schoolId}::uuid, ${exParent}::uuid)`;
+          const staffRow = leakRows.find((r) => r.ref_code === staffRef);
+          const portalRow = leakRows.find((r) => r.ref_code === req.ref_code);
+          assertTrue("staff exeat IS visible to the own-child parent (row returned)", !!staffRow);
+          assertTrue("staff exeat reason REDACTED to NULL at the fn (leak CLOSED)", staffRow?.reason === null);
+          assertTrue(
+            "no returned reason leaks the distinctive staff string",
+            leakRows.every((r) => !(r.reason ?? "").includes(STAFF_REASON)),
+          );
+          assertTrue(
+            "genuine PORTAL row STILL returns its parent-typed reason (redaction is precise, not blanket)",
+            portalRow?.reason === "Funeral",
+          );
+          await tx`reset role`;
+
           throw new Error(ROLLBACK_EX); // discard all probe rows + the fn owner switches
         });
       } catch (e) {

--- a/omnischools/scripts/rls-test.ts
+++ b/omnischools/scripts/rls-test.ts
@@ -570,6 +570,154 @@ async function main() {
         if ((e as Error).message !== ROLLBACK_BR) throw e;
       }
     }
+
+    // ---------------------------------------------------------------------------------------------
+    // Parent EXEAT (write + read) — BEHAVIORAL RLS probe (INCR — Exeat Phase 2, prod-paste-0098).
+    // Proven as the NON-SUPERUSER omnischools_app; the dev superuser masks RLS.
+    //
+    // boarding_exeat stays fully parent_deny — the two parent touchpoints are SECURITY DEFINER fns:
+    //  • parent_request_exeat(...) — the ONLY parent write. Server-forces SPECIAL/REQUESTED/parent_initiated
+    //    for the parent's OWN active boarder; own-child fence via the pu ARG; open-guard rejects a 2nd live
+    //    exeat. The GUC-clear is LOAD-BEARING: under the prod-shaped owner (omnischools_app, FORCE RLS binds
+    //    the definer body) a no-clear version would hit boarding_exeat.parent_deny and create 0 rows.
+    //  • parent_exeat_list(...) — the ONLY parent read; returns exactly the C3-IN columns (no fee snapshot /
+    //    decline reason / *_by ids), newest first.
+    // Proves: a parent CREATES a SPECIAL for own child; CANNOT for another child (own-child fence) or a
+    // foreign tenant (tenant_isolation still fences the school arg); a DIRECT parent SELECT/INSERT/UPDATE/
+    // DELETE on boarding_exeat is denied; the open-guard blocks a 2nd request; staff (pu IS NULL) direct
+    // boarding_exeat access is byte-unchanged. All rows + the fn owner switches live in one rolled-back tx.
+    console.log("\nParent Exeat write+read path (behavioral):");
+    const exParentRows = await sql<{ id: string }[]>`select id from ref_user limit 1`;
+    const exKids = await sql<{ id: string }[]>`
+      select id from students where school_id = ${schoolId} order by id limit 2`;
+    const exPeriod = await sql<{ pid: string }[]>`
+      select period_id as pid from academic_period
+      where school_id = ${schoolId} and product_line = 'SENIOR' limit 1`;
+    if (exParentRows.length < 1 || exKids.length < 2 || exPeriod.length < 1) {
+      console.log("• skipped — needs ≥1 ref_user, ≥2 students, and a SENIOR academic period in the seed.");
+    } else {
+      const exParent = exParentRows[0].id;
+      const exOwn = exKids[0].id;
+      const exOther = exKids[1].id; // a real child in the SAME school, NOT linked to this parent
+      const exHouse = "77777777-0000-4000-8000-0000000e0001";
+      const ROLLBACK_EX = "__parent_exeat_probe_rollback__";
+      try {
+        await sql.begin(async (tx) => {
+          // ---- superuser setup (bypasses RLS) ----
+          await tx`insert into student_guardian
+                     (id, school_id, student_id, name, relationship, phone, is_primary, user_id)
+                   values (gen_random_uuid(), ${schoolId}, ${exOwn}, 'RLSTEST', 'MOTHER',
+                           '+233RLSTESTEX', true, ${exParent})`;
+          await tx`insert into house (id, school_id, name) values (${exHouse}, ${schoolId}, 'RLST Exeat House')`;
+          await tx`update students set residency='BOARDER', status='ACTIVE', house_id=${exHouse} where id=${exOwn}`;
+          await tx`update students set residency='BOARDER', status='ACTIVE', house_id=${exHouse} where id=${exOther}`;
+          // prod-shape: definer owner = the non-superuser role FORCE RLS actually binds
+          await tx`alter function parent_request_exeat(uuid, uuid, uuid, text, date, date) owner to omnischools_app`;
+          await tx`alter function parent_exeat_list(uuid, uuid) owner to omnischools_app`;
+
+          // ---- act as the parent (RLS enforced, non-superuser) ----
+          await tx`set local role omnischools_app`;
+          await tx`select set_config('app.current_school', ${schoolId}, true)`;
+          await tx`select set_config('app.current_parent_user', ${exParent}, true)`;
+          const c = async (t: string, w: string) =>
+            (await tx.unsafe(`select count(*)::int n from ${t} ${w}`))[0].n as number;
+
+          // (1) parent creates a SPECIAL for own child — the GUC-clear write LANDS under the prod-shaped owner.
+          const [req] = await tx<{ ok: boolean; ref_code: string; error: string | null }[]>`
+            select ok, ref_code, error
+            from parent_request_exeat(${schoolId}::uuid, ${exParent}::uuid, ${exOwn}::uuid,
+                                      'Funeral', '2026-09-05'::date, '2026-09-07'::date)`;
+          assertTrue("parent request for own child succeeds (ok)", req?.ok === true);
+          assertTrue("parent request returns a ref_code", !!req?.ref_code && req.ref_code.includes("-EX-"));
+
+          // (2) the created row is SPECIAL / REQUESTED / parent_initiated (read back as superuser via savepoint reset)
+          await tx`reset role`;
+          const [made] = await tx<
+            { exeat_type: string; status: string; parent_initiated: boolean; house_id: string }[]
+          >`select exeat_type, status, parent_initiated, house_id from boarding_exeat
+              where school_id=${schoolId} and student_id=${exOwn}`;
+          assertTrue("created exeat is SPECIAL", made?.exeat_type === "SPECIAL");
+          assertTrue("created exeat is REQUESTED", made?.status === "REQUESTED");
+          assertTrue("created exeat is parent_initiated", made?.parent_initiated === true);
+          assertTrue("created exeat carries the derived house_id", made?.house_id === exHouse);
+
+          // ---- back to the parent ----
+          await tx`set local role omnischools_app`;
+          await tx`select set_config('app.current_school', ${schoolId}, true)`;
+          await tx`select set_config('app.current_parent_user', ${exParent}, true)`;
+
+          // (3) parent_exeat_list returns own child's exeat with EXACTLY the C3-IN columns (no fee/decline/*_by)
+          const list = await tx<Record<string, unknown>[]>`
+            select * from parent_exeat_list(${schoolId}::uuid, ${exParent}::uuid)`;
+          assert("parent_exeat_list returns the own-child exeat", list.length, 1);
+          const lkeys = Object.keys(list[0] ?? {}).sort().join(",");
+          assertTrue(
+            "list columns are EXACTLY the C3-IN set (no fee_owing_snapshot/decline_reason/*_by ids)",
+            lkeys ===
+              [
+                "depart_at", "departed_at", "exeat_id", "exeat_type", "hm_approved_at", "house_name",
+                "parent_initiated", "reason", "ref_code", "return_by", "returned_at", "sr_hm_signed_at", "status",
+              ].join(","),
+          );
+
+          // (4) parent GUC restored VERBATIM after each fn call
+          const [{ cur }] = await tx<{ cur: string }[]>`
+            select current_setting('app.current_parent_user', true) as cur`;
+          assertTrue("parent GUC restored VERBATIM after the fn calls", cur === exParent);
+
+          // (5) own-child fence — a request for ANOTHER (unlinked) child is refused, no row created
+          const [reqOther] = await tx<{ ok: boolean; error: string | null }[]>`
+            select ok, error
+            from parent_request_exeat(${schoolId}::uuid, ${exParent}::uuid, ${exOther}::uuid,
+                                      'Forge', '2026-09-05'::date, '2026-09-07'::date)`;
+          assertTrue("parent request for ANOTHER child refused (ok=false)", reqOther?.ok === false);
+          assert("no exeat created for the unlinked child", await c("boarding_exeat", `where student_id='${exOther}'`), 0);
+
+          // (6) open-guard — a 2nd request while one is live is refused
+          const [reqAgain] = await tx<{ ok: boolean; error: string | null }[]>`
+            select ok, error
+            from parent_request_exeat(${schoolId}::uuid, ${exParent}::uuid, ${exOwn}::uuid,
+                                      'Second', '2026-09-10'::date, '2026-09-12'::date)`;
+          assertTrue("open-guard blocks a 2nd live request (ok=false)", reqAgain?.ok === false);
+          assertTrue("open-guard error mentions in-progress", (reqAgain?.error ?? "").includes("in progress"));
+
+          // (7) DIRECT parent access to boarding_exeat is denied every way (parent_deny)
+          assert("parent DIRECT read of boarding_exeat denied (0 rows)", await c("boarding_exeat", `where school_id='${schoolId}'`), 0);
+          let insDenied = false;
+          try {
+            await tx.savepoint(async (sp) => {
+              await sp.unsafe(
+                `insert into boarding_exeat (school_id, student_id, house_id, academic_period_id, exeat_type, status, ref_code)
+                 values ('${schoolId}', '${exOwn}', '${exHouse}', '${exPeriod[0].pid}', 'SPECIAL', 'HM_APPROVED', 'FORGE-EX-2026-9999')`,
+              );
+            });
+          } catch {
+            insDenied = true;
+          }
+          assertTrue("parent DIRECT INSERT into boarding_exeat denied", insDenied);
+          assert("parent DIRECT UPDATE boarding_exeat denied (rows)", (await tx`update boarding_exeat set status='HM_APPROVED' where student_id=${exOwn}`).count, 0);
+          assert("parent DIRECT DELETE boarding_exeat denied (rows)", (await tx`delete from boarding_exeat where student_id=${exOwn}`).count, 0);
+
+          // (8) cross-TENANT: scoped to a FOREIGN school, a request with the real school arg creates NOTHING
+          await tx`select set_config('app.current_school', ${FOREIGN_ID}, true)`;
+          const [reqForeign] = await tx<{ ok: boolean }[]>`
+            select ok from parent_request_exeat(${schoolId}::uuid, ${exParent}::uuid, ${exOther}::uuid,
+                                                'Cross', '2026-09-05'::date, '2026-09-07'::date)`;
+          assertTrue("cross-tenant request creates nothing (ok=false)", reqForeign?.ok === false);
+          await tx`select set_config('app.current_school', ${schoolId}, true)`;
+          const listAfter = await tx`select * from parent_exeat_list(${schoolId}::uuid, ${exParent}::uuid)`;
+          assert("still exactly one own-child exeat after every refused attempt", listAfter.length, 1);
+
+          // (9) staff (pu IS NULL) — direct boarding_exeat access is byte-unchanged (sees the created row)
+          await tx`select set_config('app.current_parent_user', '', true)`;
+          assertAtLeast("staff sees the created exeat (parent_deny is a no-op for pu IS NULL)", await c("boarding_exeat", `where student_id='${exOwn}'`), 1);
+
+          throw new Error(ROLLBACK_EX); // discard all probe rows + the fn owner switches
+        });
+      } catch (e) {
+        if ((e as Error).message !== ROLLBACK_EX) throw e;
+      }
+    }
   } finally {
     await sql.end();
   }

--- a/omnischools/scripts/rls-test.ts
+++ b/omnischools/scripts/rls-test.ts
@@ -633,12 +633,22 @@ async function main() {
           // (2) the created row is SPECIAL / REQUESTED / parent_initiated (read back as superuser via savepoint reset)
           await tx`reset role`;
           const [made] = await tx<
-            { exeat_type: string; status: string; parent_initiated: boolean; house_id: string }[]
-          >`select exeat_type, status, parent_initiated, house_id from boarding_exeat
+            {
+              exeat_type: string;
+              status: string;
+              parent_initiated: boolean;
+              via_parent_portal: boolean;
+              house_id: string;
+            }[]
+          >`select exeat_type, status, parent_initiated, via_parent_portal, house_id from boarding_exeat
               where school_id=${schoolId} and student_id=${exOwn}`;
           assertTrue("created exeat is SPECIAL", made?.exeat_type === "SPECIAL");
           assertTrue("created exeat is REQUESTED", made?.status === "REQUESTED");
           assertTrue("created exeat is parent_initiated", made?.parent_initiated === true);
+          // via_parent_portal is the accurate staff "From parent" provenance signal — TRUE only for a
+          // parent_request_exeat row (parent_initiated is broadly true and not a provenance signal). The
+          // select also proves the column exists on the dev DB.
+          assertTrue("created exeat is via_parent_portal (accurate From-parent chip)", made?.via_parent_portal === true);
           assertTrue("created exeat carries the derived house_id", made?.house_id === exHouse);
 
           // ---- back to the parent ----


### PR DESCRIPTION
## Exeat Phase 2 — parent-initiated SPECIAL request + own-child status

Two SECURITY DEFINER fns (`parent_request_exeat` write, `parent_exeat_list` read), parent TS/UI, additive column migration `0089` (`boarding_exeat.via_parent_portal`), and `prod-paste-0098`.

### Security leak-closure (Sarah BLOCK → CLEAN)
`parent_exeat_list` previously projected `be.reason` unconditionally and the reader echoed it on the broadly-true `parent_initiated` (staff SPECIALs set it too), leaking staff-authored welfare/discipline reasons to parents.

Fix (`e515e05`): redact at the fn — `CASE WHEN be.via_parent_portal THEN be.reason ELSE NULL END`. `via_parent_portal` is genuine provenance (set true ONLY by `parent_request_exeat`, defaults false, no UPDATE writer, staff path untouched). Reader dropped its `parent_initiated` gate. Applied byte-identically to `db/sql/policies.sql` and `db/sql/prod-paste-0098-parent-exeat.sql`. `RETURNS TABLE` column set unchanged (no new column on the parent wire).

Behavioral proof (`9d8979a`, `scripts/rls-test.ts`, non-superuser `omnischools_app`): a staff exeat's distinctive reason returns NULL to the own-child parent while a genuine portal row's reason still shows; mutation-checked to fail if the CASE is reverted.

### Gates
- Quinn GREEN — leak-closure proven behaviorally + mutation-checked; full suite + non-superuser probe green.
- Dex APPROVE — no seam/boundary/portability change in the redaction delta.
- Sarah APPROVE + MERGE — redaction at the DB authority, provenance airtight, GUC clear/restore intact, both SQL files byte-identical, no new PII projection/injection.

### Deploy note
`db/sql/prod-paste-0098-parent-exeat.sql` MUST be pasted on prod (adds `via_parent_portal` column + updated fns with the redaction). Owner runs prod SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)