### PR TITLE
feat(exeat): parent-downloadable exeat card PDF (Exeat Phase 3-A)

### DIFF
--- a/omnischools/app/(parent)/boarding/page.tsx
+++ b/omnischools/app/(parent)/boarding/page.tsx
@@ -177,6 +177,18 @@ function ExeatRow({ exeat }: { exeat: ParentExeatRow }) {
           </span>
         ))}
       </div>
+      {/* Phase 3-A: the card PDF is offered only for a download-eligible row (cardReady mirrors the fn's
+          eligibility gate — advisory; the /api route + parent_exeat_card fn are authoritative). */}
+      {exeat.cardReady && (
+        <a
+          href={`/api/parent/exeat-card/${exeat.id}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-2.5 inline-block text-xs font-bold text-gold"
+        >
+          Download exeat card →
+        </a>
+      )}
     </div>
   );
 }

--- a/omnischools/app/api/parent/exeat-card/[id]/route.ts
+++ b/omnischools/app/api/parent/exeat-card/[id]/route.ts
@@ -1,0 +1,100 @@
+import { z } from "zod";
+import { sql } from "drizzle-orm";
+import { requireParent } from "@/lib/auth/server";
+import { withParentScope } from "@/lib/db/rls";
+import { getExeatPolicy } from "@/lib/boarding/config";
+import { renderExeatCardPdf } from "@/lib/pdf/render-exeat-card";
+import type { ExeatCardPdfData } from "@/lib/pdf/exeat-card-document";
+
+// @react-pdf/renderer is Node-only (fontkit); never run this on the edge.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * 🔴 EXEAT PHASE 3-A · GET /api/parent/exeat-card/[id] — the parent-downloadable exeat CARD PDF for their
+ * OWN child. The ONLY parent card path. Keyed by the exeat id (a uuid from the PATH only — no student name
+ * or PII in the URL). Enforced SERVER-SIDE by the SECURITY DEFINER `parent_exeat_card` fn (Wells,
+ * prod-paste-0099), which is THE AUTHORITY: it returns a row ONLY for an own-child, download-eligible exeat
+ * (SPECIAL→SR_HM_SIGNED/DEPARTED; SCHEDULED/FEE_COLLECTION→HM_APPROVED/DEPARTED) and deliberately OMITS the
+ * fee snapshot / signer staff name / bunk. Any other id — ineligible, not-own-child, cross-tenant — returns
+ * 0 rows → a neutral 404 with NO bytes (never a leak). The card render is entirely server-side; the client
+ * holds only the <a href> link.
+ */
+
+const Id = z.string().uuid();
+
+const TYPE_LABEL: Record<string, string> = {
+  SCHEDULED: "Scheduled",
+  SPECIAL: "Special",
+  FEE_COLLECTION: "Fee collection",
+};
+
+// UTC — the DB session is UTC; a leave date must not drift with the server zone (the parent-portal
+// precedent in lib/parent/parent-exeat-data.ts). date-out (departed_at||depart_at) and date-in (return_by).
+const CARD_DT = new Intl.DateTimeFormat("en-GB", {
+  day: "numeric", month: "short", year: "numeric", hour: "2-digit", minute: "2-digit", hour12: false, timeZone: "UTC",
+});
+const fmt = (d: Date | null): string => (d ? CARD_DT.format(d) : "—");
+
+/** The fn's RETURNS TABLE row (timestamptz → Date via the pg driver). */
+type RawCard = {
+  school_name: string;
+  school_code: string;
+  ref_code: string;
+  student_name: string;
+  form_label: string | null;
+  house_name: string;
+  exeat_type: string;
+  date_out: Date | null;
+  date_in: Date | null;
+  academic_year: string;
+  status: string;
+};
+
+export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { user, school } = await requireParent();
+
+  // Next 15: route params are a Promise — await before use. A non-uuid id is a neutral 404 (no leak).
+  const parsed = Id.safeParse((await ctx.params).id);
+  if (!parsed.success) return new Response("Not found", { status: 404 });
+  const exeatId = parsed.data;
+
+  const row = await withParentScope(school.id, user.id, async (tx) => {
+    const rows = (await tx.execute(
+      sql`select * from parent_exeat_card(${school.id}::uuid, ${user.id}::uuid, ${exeatId}::uuid)`,
+    )) as unknown as RawCard[];
+    return rows[0] ?? null;
+  });
+
+  // The fn is the authority: 0 rows ⇒ not own-child / ineligible / cross-tenant ⇒ neutral 404, no bytes.
+  if (!row) return new Response("Not found", { status: 404 });
+
+  // Dress code + signer LABEL are school-config STRINGS (no staff PII) the app already holds; the fn
+  // deliberately omits the fee snapshot and the signer's name, so the parent card passes neither.
+  const policy = await getExeatPolicy(school.id);
+
+  const data: ExeatCardPdfData = {
+    school: { name: row.school_name, code: row.school_code },
+    refCode: row.ref_code,
+    studentName: row.student_name,
+    formHouseBunk: `${row.form_label ?? "—"} · ${row.house_name}`, // no bunk on the parent card (fn omits it)
+    typeLabel: TYPE_LABEL[row.exeat_type] ?? row.exeat_type,
+    dateOut: fmt(row.date_out),
+    dateIn: fmt(row.date_in),
+    dressCode: policy.dressCode,
+    signerLabel: policy.cardSigner, // policy label only — signerActor omitted ⇒ no staff name rendered
+    houseName: row.house_name,
+    academicYear: row.academic_year,
+    // feeLine + signerActor deliberately absent → no money, no staff PII on the parent card.
+  };
+
+  const pdf = await renderExeatCardPdf(data);
+  const filename = `Exeat-Card-${row.ref_code}.pdf`.replace(/[^A-Za-z0-9._-]+/g, "-");
+  return new Response(new Uint8Array(pdf), {
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": `inline; filename="${filename}"`,
+      "Cache-Control": "private, no-store",
+    },
+  });
+}

--- a/omnischools/db/sql/policies.sql
+++ b/omnischools/db/sql/policies.sql
@@ -1747,6 +1747,85 @@ BEGIN
 END
 $$;
 
+-- ---- INCR — PARENT EXEAT CARD: Exeat Phase 3-A (parent downloads the exeat CARD PDF for their OWN child).
+-- ONE additive SECURITY DEFINER read fn; byte-identical to db/sql/prod-paste-0099-parent-exeat-card.sql
+-- (the hand-paste on PROD). No parent_scope grant; boarding_exeat / house / academic_period / class stay
+-- fully parent_deny — the fn is the ONLY parent reach for the card fields.
+--
+-- 🔴 Fn parent_exeat_card — the own-child, download-eligible CARD projection. Returns ONLY the parent-safe
+-- A1 columns for ONE own-child exeat in a downloadable status: school name + GES/registration code,
+-- ref_code, student full name, class/form label, house NAME, exeat_type, date-out
+-- (COALESCE(departed_at, depart_at)), date-in (return_by), academic-year label and status. NEVER
+-- fee_owing_snapshot / any amount / signer staff name / bunk / dorm (the staff card source getExeatCardData
+-- reads those; this fn does not project them).
+-- 🔴 Eligibility gate embedded (Kofi A3 — the fn is the authority): SPECIAL → SR_HM_SIGNED/DEPARTED;
+-- SCHEDULED/FEE_COLLECTION → HM_APPROVED/DEPARTED; REQUESTED/DECLINED/(future)WITHDRAWN/RETURNED → 0 rows
+-- (RETURNED excluded per owner — live-window artefact). An ineligible / not-own-child / cross-tenant id → 0.
+-- 🔴 GUC-clear device (parent_exeat_list idiom): clear app.current_parent_user for the parent_deny reads
+-- (boarding_exeat/house/academic_period/class), keep app.current_school (tenant_isolation), restore VERBATIM
+-- (COALESCE(prev,''), never pu::text). Own-child fence via the CAPTURED pu ARG (parent_student_ids).
+CREATE OR REPLACE FUNCTION parent_exeat_card(school uuid, pu uuid, p_exeat_id uuid)
+  RETURNS TABLE(
+    school_name    text,
+    school_code    text,
+    ref_code       text,
+    student_name   text,
+    form_label     text,
+    house_name     text,
+    exeat_type     text,
+    date_out       timestamptz,
+    date_in        timestamptz,
+    academic_year  text,
+    status         text)
+  LANGUAGE plpgsql
+  STABLE
+  SECURITY DEFINER
+  SET search_path = public, pg_temp
+AS $$
+DECLARE
+  prev text := current_setting('app.current_parent_user', true);  -- caller's GUC, captured VERBATIM
+BEGIN
+  -- fail-closed; GUC untouched. STAFF (pu IS NULL) short-circuits here — total no-op.
+  IF pu IS NULL OR school IS NULL OR p_exeat_id IS NULL THEN RETURN; END IF;
+  -- Relax parent_deny on boarding_exeat + house + academic_period + class for THIS read only (parent_deny's
+  -- `pu IS NULL` → TRUE). Own-child fencing uses the CAPTURED pu ARG (parent_student_ids), NOT the cleared
+  -- GUC; app.current_school stays set so tenant_isolation still fences the school.
+  PERFORM set_config('app.current_parent_user', '', true);
+  RETURN QUERY
+    SELECT rs.name, rs.ges_code, be.ref_code,
+           s.first_name || ' ' || s.last_name,
+           c.name, h.name, be.exeat_type::text,
+           COALESCE(be.departed_at, be.depart_at), be.return_by,
+           ap.academic_year, be.status::text
+    FROM boarding_exeat be
+    JOIN students s        ON s.school_id = be.school_id AND s.id = be.student_id
+    JOIN house h           ON h.school_id = be.school_id AND h.id = be.house_id
+    JOIN academic_period ap ON ap.school_id = be.school_id AND ap.period_id = be.academic_period_id
+    JOIN ref_school rs     ON rs.id = be.school_id
+    LEFT JOIN class c      ON c.school_id = s.school_id AND c.id = s.class_id
+    WHERE be.school_id = school
+      AND be.id = p_exeat_id
+      AND be.student_id IN (SELECT parent_student_ids(school, pu))
+      -- eligibility gate — the fn is the authority (Kofi A3): only download-eligible statuses. RETURNED is
+      -- deliberately EXCLUDED (owner: the card is a live-window artefact, not a returned-trip receipt).
+      AND (
+        (be.exeat_type::text = 'SPECIAL' AND be.status::text IN ('SR_HM_SIGNED', 'DEPARTED'))
+        OR (be.exeat_type::text IN ('SCHEDULED', 'FEE_COLLECTION') AND be.status::text IN ('HM_APPROVED', 'DEPARTED'))
+      );
+  -- RESTORE the caller's GUC VERBATIM. COALESCE(prev,'') because current_setting(...,true) yields NULL when
+  -- unset. NEVER pu::text: pu is a fn ARG that may differ from the caller's session GUC.
+  PERFORM set_config('app.current_parent_user', COALESCE(prev, ''), true);
+END;
+$$;
+-- On Supabase every public function is a PostgREST RPC and EXECUTE defaults to PUBLIC; a privileged
+-- SECURITY DEFINER read must not be anon-callable (no-op without the GUCs, but harden anyway).
+REVOKE EXECUTE ON FUNCTION parent_exeat_card(uuid, uuid, uuid) FROM PUBLIC;
+DO $$ BEGIN
+  IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'omnischools_app') THEN
+    GRANT EXECUTE ON FUNCTION parent_exeat_card(uuid, uuid, uuid) TO omnischools_app;
+  END IF;
+END $$;
+
 -- ============================================================================================
 -- CHRONIC-REGISTER per-staff read boundary (INCR-23a / Module 4.4) — THE THIRD RLS BOUNDARY.
 -- Kept in sync with db/sql/prod-paste-0058-sickbay-chronic.sql — this block is dev; that file is the

--- a/omnischools/db/sql/prod-paste-0099-parent-exeat-card.sql
+++ b/omnischools/db/sql/prod-paste-0099-parent-exeat-card.sql
@@ -1,0 +1,175 @@
+-- Omnischools — PROD paste 0099: PARENT EXEAT CARD (INCR — Exeat Phase 3, Feature A: a parent downloads
+-- the exeat CARD PDF for their OWN child). ONE additive SECURITY DEFINER function — ZERO new tables, ZERO
+-- columns, ZERO enums, ZERO backfills, ZERO new parent_scope grants. It adds ONE read-only fn
+-- (parent_exeat_card = the ONLY parent reach for the card fields) and re-runs the catalog-driven
+-- parent_deny loop. Idempotent — safe to run more than once. Paste into the Supabase SQL editor on PROD
+-- after merging. Byte-identical in effect to the "INCR — PARENT EXEAT CARD" block in db/sql/policies.sql
+-- (dev, db:policies).
+--
+-- WHAT IT SHIPS. Phase 2 (prod-paste-0098) opened the parent's exeat WRITE (parent_request_exeat) and the
+-- own-child status LIST (parent_exeat_list). Phase 3-A adds the printable CARD: the same own-child exeat,
+-- projected to ONLY the parent-safe card fields (Kofi A1) — school name + GES/registration code, ref_code,
+-- student full name, class/form label, house NAME, exeat_type, date-out (COALESCE(departed_at, depart_at)),
+-- date-in (return_by), academic-year label and status. boarding_exeat / house / academic_period / class
+-- STAY fully parent_deny (they carry NO parent_scope, so the catalog loop below keeps them denied
+-- automatically) — a parent can touch the card fields ONLY through this fn.
+--
+-- 🔴 WHAT A PARENT NEVER GETS (the staff card source lib/boarding/exeat-data.ts getExeatCardData reads
+-- these; this fn does NOT project them): fee_owing_snapshot / any amount / the feeLine; the signer staff
+-- users.fullName (signerActor); the bunk / dormitory. The dress-code and signer LABEL are policy STRINGS
+-- the app already holds — this fn fetches NO staff PII for them. A mutated client can never widen the
+-- projection past the RETURNS TABLE contract.
+--
+-- 🔴 THE ELIGIBILITY GATE IS EMBEDDED IN THE FN (Kofi A3 — the fn is the authority, not the UI). The row
+-- is returned ONLY when the exeat is downloadable:
+--   SPECIAL                     → status ∈ (SR_HM_SIGNED, DEPARTED)
+--   SCHEDULED / FEE_COLLECTION  → status ∈ (HM_APPROVED,  DEPARTED)
+-- REQUESTED / DECLINED / (future) WITHDRAWN / RETURNED → 0 ROWS (RETURNED excluded per owner: the card is a
+-- live-window artefact, not a returned-trip receipt). A mutated client asking for an ineligible id — or a
+-- not-own-child / cross-tenant id — gets NOTHING (a route 404, no leak).
+--
+-- 🔴 THE GUC-CLEAR DEVICE (the parent_exeat_list / parent_boarding_placement / parent_house_names idiom).
+-- boarding_exeat, house, academic_period and class are parent_deny. Under PROD's non-superuser FORCE-RLS
+-- definer owner, a read of those tables with the parent GUC still set returns 0 rows — so the fn CLEARS
+-- app.current_parent_user for its traverse (parent_deny's `pu IS NULL` → TRUE) then RESTORES it VERBATIM.
+-- app.current_school STAYS set → tenant_isolation still fences the school (defence in depth). Own-child
+-- fencing does NOT rely on the GUC — it uses the CAPTURED pu ARG via parent_student_ids(). RESTORE is
+-- COALESCE(prev,''), NEVER pu::text: pu is a fn ARG that may differ from the caller's session GUC (a
+-- pu::text restore would forge a scope that was never there — see the parent_boarding_placement note).
+--
+-- 🔴 STAFF UNAFFECTED — pu IS NULL → TOTAL NO-OP. This fn is not on any staff path; the staff card console
+-- (lib/boarding/exeat-data.ts getExeatCardData) reads boarding_exeat DIRECTLY via withSchool, which never
+-- sets app.current_parent_user. A staff/webhook/escalated caller that somehow invoked this fn with
+-- pu IS NULL returns immediately (no rows) and touches NOTHING. Depends on parent_student_ids()
+-- (prod-paste-0055), already on prod.
+--
+-- ⚠ WHAT HAPPENS IF THIS IS NOT RUN — FAIL-CLOSED, NEVER A LEAK (but paste it WITH the code, not after).
+-- db:policies configures LOCAL DEV ONLY. Without this paste the function is ABSENT on prod: a parent who
+-- taps "Download card" hits `select … from parent_exeat_card(…)`, which 500s ("function does not exist") →
+-- the card route 404s / errors — fail-CLOSED (boarding_exeat stays fully parent_deny, nothing leaks), but a
+-- LOUD "the paste didn't run" signal, not a silent empty. Run this WITH/BEFORE the Exeat Phase 3-A release.
+--
+-- SCOPE — NO SCHEMA, NO POLICY CHANGES. Every policy on every table is untouched; boarding_exeat + house +
+-- academic_period + class keep tenant_isolation + parent_deny exactly as their creating pastes left them.
+-- The catalog parent_deny loop at the tail re-affirms parent_deny on every FORCE-RLS + school_id table with
+-- NO parent_scope, so a future tenant table stays auto-denied with zero edits.
+--
+-- Verify afterwards:
+--   -- the function exists, owned by / executable to omnischools_app:
+--   select proname, pg_get_function_identity_arguments(oid) as args, proowner::regrole
+--   from pg_proc where proname = 'parent_exeat_card';
+--   -- boarding_exeat carries NO parent_scope and DOES carry parent_deny (never widened):
+--   select c.relname, p.polname, p.polcmd from pg_policy p join pg_class c on c.oid = p.polrelid
+--   where c.relname = 'boarding_exeat' order by 2;
+--   -- and db/sql/verify-prod-rls.sql: Query 1 must still return ZERO ROWS; parent_readable UNCHANGED (31 —
+--   -- this increment adds NO parent_scope table).
+
+-- ============================================================================================
+-- INCR — PARENT EXEAT CARD (Exeat Phase 3-A). ONE SECURITY DEFINER read fn; byte-identical to the
+-- "INCR — PARENT EXEAT CARD" block in db/sql/policies.sql (dev). No parent_scope grant is added.
+-- ============================================================================================
+
+-- ---- Fn: parent_exeat_card — the own-child, download-eligible exeat CARD projection (the ONLY parent
+-- reach for the card fields). Returns ONLY the parent-safe A1 columns for ONE own-child exeat that is in a
+-- downloadable status. NEVER fee_owing_snapshot / any amount / signer staff name / bunk / dorm — a parent
+-- can never reach the fee snapshot or staff PII even via a mutated reader. GUC-clear device: boarding_exeat
+-- + house + academic_period + class are parent_deny, so clear the parent GUC for the read then restore it
+-- VERBATIM; own-child fencing uses the CAPTURED pu ARG (parent_student_ids).
+CREATE OR REPLACE FUNCTION parent_exeat_card(school uuid, pu uuid, p_exeat_id uuid)
+  RETURNS TABLE(
+    school_name    text,
+    school_code    text,
+    ref_code       text,
+    student_name   text,
+    form_label     text,
+    house_name     text,
+    exeat_type     text,
+    date_out       timestamptz,
+    date_in        timestamptz,
+    academic_year  text,
+    status         text)
+  LANGUAGE plpgsql
+  STABLE
+  SECURITY DEFINER
+  SET search_path = public, pg_temp
+AS $$
+DECLARE
+  prev text := current_setting('app.current_parent_user', true);  -- caller's GUC, captured VERBATIM
+BEGIN
+  -- fail-closed; GUC untouched. STAFF (pu IS NULL) short-circuits here — total no-op.
+  IF pu IS NULL OR school IS NULL OR p_exeat_id IS NULL THEN RETURN; END IF;
+  -- Relax parent_deny on boarding_exeat + house + academic_period + class for THIS read only (parent_deny's
+  -- `pu IS NULL` → TRUE). Own-child fencing uses the CAPTURED pu ARG (parent_student_ids), NOT the cleared
+  -- GUC; app.current_school stays set so tenant_isolation still fences the school.
+  PERFORM set_config('app.current_parent_user', '', true);
+  RETURN QUERY
+    SELECT rs.name, rs.ges_code, be.ref_code,
+           s.first_name || ' ' || s.last_name,
+           c.name, h.name, be.exeat_type::text,
+           COALESCE(be.departed_at, be.depart_at), be.return_by,
+           ap.academic_year, be.status::text
+    FROM boarding_exeat be
+    JOIN students s        ON s.school_id = be.school_id AND s.id = be.student_id
+    JOIN house h           ON h.school_id = be.school_id AND h.id = be.house_id
+    JOIN academic_period ap ON ap.school_id = be.school_id AND ap.period_id = be.academic_period_id
+    JOIN ref_school rs     ON rs.id = be.school_id
+    LEFT JOIN class c      ON c.school_id = s.school_id AND c.id = s.class_id
+    WHERE be.school_id = school
+      AND be.id = p_exeat_id
+      AND be.student_id IN (SELECT parent_student_ids(school, pu))
+      -- eligibility gate — the fn is the authority (Kofi A3): only download-eligible statuses. RETURNED is
+      -- deliberately EXCLUDED (owner: the card is a live-window artefact, not a returned-trip receipt).
+      AND (
+        (be.exeat_type::text = 'SPECIAL' AND be.status::text IN ('SR_HM_SIGNED', 'DEPARTED'))
+        OR (be.exeat_type::text IN ('SCHEDULED', 'FEE_COLLECTION') AND be.status::text IN ('HM_APPROVED', 'DEPARTED'))
+      );
+  -- RESTORE the caller's GUC VERBATIM. COALESCE(prev,'') because current_setting(...,true) yields NULL when
+  -- unset. NEVER pu::text: pu is a fn ARG that may differ from the caller's session GUC.
+  PERFORM set_config('app.current_parent_user', COALESCE(prev, ''), true);
+END;
+$$;
+-- On Supabase every public function is a PostgREST RPC and EXECUTE defaults to PUBLIC; a privileged
+-- SECURITY DEFINER read must not be anon-callable (no-op without the GUCs, but harden anyway).
+REVOKE EXECUTE ON FUNCTION parent_exeat_card(uuid, uuid, uuid) FROM PUBLIC;
+DO $$ BEGIN
+  IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'omnischools_app') THEN
+    GRANT EXECUTE ON FUNCTION parent_exeat_card(uuid, uuid, uuid) TO omnischools_app;
+  END IF;
+END $$;
+
+-- ---- layer 1: parent_deny — the CATALOG-DRIVEN loop, verbatim from db/sql/policies.sql ----
+-- 🔴 RUN THIS. It re-affirms RESTRICTIVE parent_deny on every FORCE-RLS + school_id table that does NOT
+-- already carry a parent_scope policy. This increment adds NO parent_scope, so boarding_exeat +
+-- exeat_notification (and every other never-widen tenant table, and any future one) stay auto-denied — the
+-- fn above is the ONLY parent reach. Idempotent.
+DO $$
+DECLARE
+  tbl text;
+BEGIN
+  FOR tbl IN
+    SELECT c.relname
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = 'public'
+    WHERE c.relkind = 'r'
+      AND c.relforcerowsecurity
+      AND EXISTS (
+        SELECT 1 FROM information_schema.columns col
+        WHERE col.table_schema = 'public'
+          AND col.table_name = c.relname
+          AND col.column_name = 'school_id'
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_policy p
+        WHERE p.polrelid = c.oid AND p.polname = 'parent_scope'
+      )
+    ORDER BY c.relname
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS parent_deny ON %I;', tbl);
+    EXECUTE format(
+      'CREATE POLICY parent_deny ON %I AS RESTRICTIVE FOR ALL TO public '
+      'USING (NULLIF(current_setting(''app.current_parent_user'', true), '''') IS NULL);',
+      tbl
+    );
+  END LOOP;
+END
+$$;

--- a/omnischools/lib/parent/parent-exeat-data.ts
+++ b/omnischools/lib/parent/parent-exeat-data.ts
@@ -45,6 +45,21 @@ export function exeatStatusLabel(status: string): string {
 }
 
 /**
+ * PURE (Exeat Phase 3-A) — is the exeat CARD PDF downloadable for this (status, type)? MIRRORS the
+ * eligibility gate embedded in `parent_exeat_card` (Wells, prod-paste-0099) so the UI only offers the link
+ * for a card-ready row. ADVISORY ONLY — the fn + the /api/parent/exeat-card route are the authority (an
+ * ineligible id gets 0 rows → a neutral 404). A SPECIAL needs the Senior-HM signature; a SCHEDULED/
+ * FEE_COLLECTION needs only the House approval. REQUESTED / DECLINED / RETURNED → false (RETURNED is
+ * excluded per owner — the card is a live-window artefact, not a returned-trip receipt).
+ */
+export function isCardReady(status: string, type: string): boolean {
+  if (type === "SPECIAL") return status === "SR_HM_SIGNED" || status === "DEPARTED";
+  if (type === "SCHEDULED" || type === "FEE_COLLECTION")
+    return status === "HM_APPROVED" || status === "DEPARTED";
+  return false;
+}
+
+/**
  * PURE — what to show as the row's "reason/detail" (Kofi C2 detail rule):
  *  • FEE_COLLECTION → a bare "Fee collection" — NEVER its amount-bearing reason.
  *  • a present reason → the parent's OWN words. `parent_exeat_list` REDACTS a staff-authored reason to
@@ -66,6 +81,7 @@ export type ParentExeatRow = {
   detail: string;
   houseName: string | null;
   isOpen: boolean; // any live stage → the request form disables submit (advisory; the fn is authoritative)
+  cardReady: boolean; // download-eligible → show the "Download exeat card" link (advisory; the route is authoritative)
   milestones: ParentExeatMilestone[]; // pre-formatted display strings, only the ones that exist
 };
 
@@ -118,6 +134,7 @@ export async function loadParentExeatsTx(
       detail: exeatDetail({ exeatType: r.exeat_type, reason: r.reason }),
       houseName: r.house_name,
       isOpen: OPEN_STATUSES.includes(r.status as ExeatStatus),
+      cardReady: isCardReady(r.status, r.exeat_type),
       milestones,
     };
   });

--- a/omnischools/lib/parent/parent-exeat.test.ts
+++ b/omnischools/lib/parent/parent-exeat.test.ts
@@ -170,6 +170,10 @@ const PROD_PASTE = readFileSync(
   resolve(cwd(), "db/sql/prod-paste-0098-parent-exeat.sql"),
   "utf8",
 );
+const PROD_PASTE_CARD = readFileSync(
+  resolve(cwd(), "db/sql/prod-paste-0099-parent-exeat-card.sql"),
+  "utf8",
+);
 /** Slice a `CREATE OR REPLACE FUNCTION <name>( ... $$;` block out of a SQL file. */
 function fnBlock(sqlText: string, name: string): string {
   const start = sqlText.indexOf(`CREATE OR REPLACE FUNCTION ${name}(`);
@@ -247,5 +251,70 @@ describe("B/A5/D · parent_request_exeat server-forces the row and re-checks eli
     expect(write()).toMatch(
       /status::text IN \('REQUESTED','HM_APPROVED','SR_HM_SIGNED','DEPARTED'\)/,
     );
+  });
+});
+
+/**
+ * A1 (non-leak) + A3 (eligibility) for the CARD fn — Exeat Phase 3-A (prod-paste-0099). The behavioural
+ * proof lives in db:rls-test (own-child card returns EXACTLY the A1 set; RETURNED → 0 rows; cross-tenant /
+ * another-family / staff-pu=NULL → 0), but that needs a live DB and is NOT in `pnpm test`. These SQL-shape
+ * guards run in CI and bite the moment a future edit WIDENS the card projection (a fee/signer/bunk leak),
+ * ADMITS an ineligible status into the gate (e.g. RETURNED, the owner's live-window exclusion), or DRIFTS
+ * the prod-paste away from policies.sql (where a prod-only leak would land — the fn is absent in CI).
+ */
+// The A1 set — the ONLY columns of an own-child card a parent may ever read (Kofi A1). NO fee/amount,
+// signer staff name, bunk or dorm.
+const A1_CARD = [
+  "school_name", "school_code", "ref_code", "student_name", "form_label", "house_name",
+  "exeat_type", "date_out", "date_in", "academic_year", "status",
+].sort();
+
+describe("A1/A3 · parent_exeat_card projection + eligibility gate (SQL guard)", () => {
+  const cardBlock = (sqlText: string) => fnBlock(sqlText, "parent_exeat_card");
+
+  it("A1 — the RETURNS TABLE is EXACTLY the A1 set (no extras, none missing)", () => {
+    expect(returnsTableCols(cardBlock(POLICIES)).sort()).toEqual(A1_CARD);
+  });
+
+  it("A1 — the projection carries NONE of the OUT fields (fee/amount/signer/bunk/dorm/*_by/decline)", () => {
+    const rt = cardBlock(POLICIES).match(/RETURNS TABLE\(([\s\S]*?)\)\s*\n\s*LANGUAGE/)![1];
+    for (const banned of [
+      "fee", "owing", "amount", "signer", "bunk", "dorm", "_by_user_id", "decline",
+    ]) {
+      expect(rt, `projection must not expose ${banned}`).not.toContain(banned);
+    }
+  });
+
+  it("A3 — the eligibility gate admits ONLY the two download-eligible (type × status) pairs", () => {
+    const s = stripSql(cardBlock(POLICIES));
+    expect(s).toMatch(/'SPECIAL'\s+AND\s+be\.status::text\s+IN\s*\('SR_HM_SIGNED',\s*'DEPARTED'\)/);
+    expect(s).toMatch(
+      /IN\s*\('SCHEDULED',\s*'FEE_COLLECTION'\)\s+AND\s+be\.status::text\s+IN\s*\('HM_APPROVED',\s*'DEPARTED'\)/,
+    );
+  });
+
+  it("A3 — REQUESTED / DECLINED / RETURNED are NOT admitted (RETURNED excluded per owner — live-window only)", () => {
+    // stripSql drops the `-- RETURNED is deliberately EXCLUDED …` prose so a comment can't false-match.
+    const s = stripSql(cardBlock(POLICIES));
+    expect(s).not.toMatch(/'RETURNED'/);
+    expect(s).not.toMatch(/'REQUESTED'/);
+    expect(s).not.toMatch(/'DECLINED'/);
+  });
+
+  it("A4/A5 — own-child fence via the captured pu ARG, staff (pu IS NULL) short-circuits, GUC clear+restore", () => {
+    const s = stripSql(cardBlock(POLICIES));
+    expect(s).toMatch(/be\.student_id IN \(SELECT parent_student_ids\(school, pu\)\)/); // own-child fence
+    expect(s).toMatch(/IF pu IS NULL[\s\S]*?THEN RETURN/); // staff no-op
+    expect(s).toMatch(/set_config\('app\.current_parent_user', ''/); // clear parent_deny for the read
+    expect(s).toMatch(/set_config\('app\.current_parent_user', COALESCE\(prev, ''\)/); // restore VERBATIM
+    expect(s).not.toMatch(/pu::text/); // never forge a scope from the arg
+  });
+
+  it("the prod-paste-0099 card fn has NOT drifted from policies.sql (cols + normalized body)", () => {
+    expect(returnsTableCols(cardBlock(PROD_PASTE_CARD)).sort()).toEqual(
+      returnsTableCols(cardBlock(POLICIES)).sort(),
+    );
+    const norm = (t: string) => stripSql(t).replace(/\s+/g, " ").trim();
+    expect(norm(cardBlock(PROD_PASTE_CARD))).toEqual(norm(cardBlock(POLICIES)));
   });
 });

--- a/omnischools/lib/parent/parent-exeat.test.ts
+++ b/omnischools/lib/parent/parent-exeat.test.ts
@@ -3,7 +3,7 @@ import { resolve } from "node:path";
 import { cwd } from "node:process";
 import { describe, it, expect } from "vitest";
 import { readCode } from "@/lib/test-utils/source-shape";
-import { exeatStatusLabel, exeatDetail } from "./parent-exeat-data";
+import { exeatStatusLabel, exeatDetail, isCardReady } from "./parent-exeat-data";
 
 /**
  * EXEAT PHASE 2 · parent-initiated SPECIAL exeat + own-child status. The reader is mostly an IO projection
@@ -55,6 +55,37 @@ describe("exeatDetail · reason-echo gate + FEE_COLLECTION relabel", () => {
       "Fee collection",
     );
     expect(exeatDetail({ exeatType: "FEE_COLLECTION", reason: "GHS 215.00 owed" })).toBe("Fee collection");
+  });
+});
+
+describe("isCardReady · card-download eligibility mirrors parent_exeat_card (Phase 3-A)", () => {
+  it("a SPECIAL is card-ready only once Senior-HM-signed or departed", () => {
+    expect(isCardReady("SR_HM_SIGNED", "SPECIAL")).toBe(true);
+    expect(isCardReady("DEPARTED", "SPECIAL")).toBe(true);
+    // a SPECIAL only HM-approved has NOT cleared the Senior-HM sign-off → not yet downloadable
+    expect(isCardReady("HM_APPROVED", "SPECIAL")).toBe(false);
+    expect(isCardReady("REQUESTED", "SPECIAL")).toBe(false);
+  });
+
+  it("a SCHEDULED / FEE_COLLECTION is card-ready once HM-approved or departed", () => {
+    for (const t of ["SCHEDULED", "FEE_COLLECTION"]) {
+      expect(isCardReady("HM_APPROVED", t)).toBe(true);
+      expect(isCardReady("DEPARTED", t)).toBe(true);
+      expect(isCardReady("REQUESTED", t)).toBe(false);
+    }
+  });
+
+  it("REQUESTED / DECLINED / RETURNED are never card-ready (RETURNED excluded per owner — live-window only)", () => {
+    for (const t of ["SCHEDULED", "SPECIAL", "FEE_COLLECTION"]) {
+      expect(isCardReady("REQUESTED", t)).toBe(false);
+      expect(isCardReady("DECLINED", t)).toBe(false);
+      expect(isCardReady("RETURNED", t)).toBe(false);
+    }
+  });
+
+  it("an unknown status or type is never card-ready (fail-closed)", () => {
+    expect(isCardReady("WEIRD", "SPECIAL")).toBe(false);
+    expect(isCardReady("DEPARTED", "WEIRD_TYPE")).toBe(false);
   });
 });
 

--- a/omnischools/lib/pdf/exeat-card-document.tsx
+++ b/omnischools/lib/pdf/exeat-card-document.tsx
@@ -31,9 +31,12 @@ export type ExeatCardPdfData = {
   dateOut: string;
   dateIn: string;
   dressCode: string;
-  feeLine: string;
+  /** STAFF card only — the parent card carries no money, so it omits this and the Fee row isn't rendered. */
+  feeLine?: string;
   signerLabel: string;
-  signerActor: string | null;
+  /** STAFF card: the signing staff member's name (or null = pending). ABSENT on the parent card (no staff
+   * PII) — the footer then shows the signer policy LABEL only, with no name line. */
+  signerActor?: string | null;
   houseName: string;
   academicYear: string;
 };
@@ -129,14 +132,17 @@ export function ExeatCardDocument({ data }: { data: ExeatCardPdfData }) {
             <CardLine label="Type" value={data.typeLabel} em />
             <CardLine label="Date out" value={data.dateOut} />
             <CardLine label="Date in" value={data.dateIn} em />
-            <CardLine label="Dress" value={data.dressCode} />
-            <CardLine label="Fees" value={data.feeLine} last />
+            <CardLine label="Dress" value={data.dressCode} last={!data.feeLine} />
+            {data.feeLine ? <CardLine label="Fees" value={data.feeLine} last /> : null}
           </View>
 
           <View style={s.foot}>
             <View>
               <Text style={s.footLabel}>{data.signerLabel}</Text>
-              <Text style={s.footSig}>signed · {data.signerActor ?? "pending"}</Text>
+              {/* Parent card omits signerActor entirely → policy label only, no staff name. */}
+              {data.signerActor !== undefined ? (
+                <Text style={s.footSig}>signed · {data.signerActor ?? "pending"}</Text>
+              ) : null}
             </View>
             <View style={s.stamp}>
               <Text style={s.stampText}>SCHOOL{"\n"}STAMP</Text>

--- a/omnischools/lib/pdf/exeat-card-parent.test.ts
+++ b/omnischools/lib/pdf/exeat-card-parent.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { renderExeatCardPdf } from "./render-exeat-card";
+import type { ExeatCardPdfData } from "./exeat-card-document";
+
+/**
+ * EXEAT PHASE 3-A · A1 non-leak at the RENDERED-card boundary. The parent route builds the card WITHOUT
+ * feeLine and WITHOUT signerActor (parent_exeat_card omits the fee snapshot + the signer staff name), so the
+ * document must render NEITHER the Fee row NOR a "signed · <name>" line — the staff card still passes both
+ * and renders them (A2). @react-pdf text is flate-compressed, so it isn't greppable; we prove omit-not-fake
+ * the board-pack-render.test.ts way — the parent PDF (rows DROPPED) is strictly SMALLER than a card that
+ * carries the same field. A future edit that renders Fees/signer unconditionally makes the parent card grow
+ * to match, and the `<` assertions bite. The null-vs-undefined split on signerActor is exercised explicitly:
+ * `null` (staff, pending) STILL renders "signed · pending"; absent (parent) renders no signer line at all.
+ */
+
+const base: Omit<ExeatCardPdfData, "feeLine" | "signerActor"> = {
+  school: { name: "Test Memorial SHS", code: "WR-WAW-014" },
+  refCode: "WAW-EX-2026-0001",
+  studentName: "Ama Mensah",
+  formHouseBunk: "SHS 2 Science · Unity", // no bunk on the parent card (fn omits it)
+  typeLabel: "Special",
+  dateOut: "05 Sep 2026 · 14:00",
+  dateIn: "07 Sep 2026 · 18:00",
+  dressCode: "Full school uniform",
+  signerLabel: "Senior Housemaster",
+  houseName: "Unity",
+  academicYear: "2025/26",
+};
+
+const parentCard: ExeatCardPdfData = { ...base }; // feeLine + signerActor deliberately ABSENT
+const feeOnly: ExeatCardPdfData = { ...base, feeLine: "GHS 340.00 outstanding — settle before return" };
+const signerNull: ExeatCardPdfData = { ...base, signerActor: null }; // staff pending → "signed · pending"
+
+describe("A1 · the parent card renders neither the Fee row nor the signer name", () => {
+  it("every variant renders to a valid %PDF buffer (a tsc-clean tree can still throw at render)", async () => {
+    for (const d of [parentCard, feeOnly, signerNull]) {
+      const pdf = await renderExeatCardPdf(d);
+      expect(pdf.subarray(0, 5).toString("latin1")).toBe("%PDF-");
+    }
+  });
+
+  it("A1 — the Fee row is DROPPED when feeLine is absent (parent card strictly smaller than a fee-bearing card)", async () => {
+    const [parent, withFee] = await Promise.all([
+      renderExeatCardPdf(parentCard),
+      renderExeatCardPdf(feeOnly),
+    ]);
+    expect(parent.length).toBeLessThan(withFee.length);
+  });
+
+  it("A1/A2 — the signer line is DROPPED when signerActor is absent, but RENDERED when null (staff pending)", async () => {
+    const [parent, pending] = await Promise.all([
+      renderExeatCardPdf(parentCard),
+      renderExeatCardPdf(signerNull),
+    ]);
+    // absent (undefined) ⇒ no signer line; null ⇒ "signed · pending" still renders ⇒ larger.
+    expect(parent.length).toBeLessThan(pending.length);
+  });
+});

--- a/omnischools/scripts/rls-test.ts
+++ b/omnischools/scripts/rls-test.ts
@@ -614,6 +614,7 @@ async function main() {
           // prod-shape: definer owner = the non-superuser role FORCE RLS actually binds
           await tx`alter function parent_request_exeat(uuid, uuid, uuid, text, date, date) owner to omnischools_app`;
           await tx`alter function parent_exeat_list(uuid, uuid) owner to omnischools_app`;
+          await tx`alter function parent_exeat_card(uuid, uuid, uuid) owner to omnischools_app`;
 
           // ---- act as the parent (RLS enforced, non-superuser) ----
           await tx`set local role omnischools_app`;
@@ -795,6 +796,80 @@ async function main() {
           assertTrue(
             "genuine PORTAL row STILL returns its parent-typed reason (redaction is precise, not blanket)",
             portalRow?.reason === "Funeral",
+          );
+          await tx`reset role`;
+
+          // (12) EXEAT CARD (Phase 3-A, prod-paste-0099) — parent_exeat_card own-child + eligibility + fence.
+          // Promote the step-1 PORTAL exeat (SPECIAL/REQUESTED) to a download-eligible status (SR_HM_SIGNED)
+          // as the superuser owner. The step-11 staff row (SPECIAL/RETURNED) is the INELIGIBLE fixture
+          // (RETURNED is deliberately excluded from the card — owner: live-window only).
+          await tx`update boarding_exeat set status='SR_HM_SIGNED' where school_id=${schoolId} and ref_code=${req.ref_code}`;
+          const [{ id: eligibleId }] = await tx<{ id: string }[]>`
+            select id from boarding_exeat where school_id=${schoolId} and ref_code=${req.ref_code}`;
+          const [{ id: ineligibleId }] = await tx<{ id: string }[]>`
+            select id from boarding_exeat where school_id=${schoolId} and ref_code=${staffRef}`;
+          await tx`set local role omnischools_app`;
+          await tx`select set_config('app.current_school', ${schoolId}, true)`;
+          await tx`select set_config('app.current_parent_user', ${exParent}, true)`;
+
+          // eligible own-child card → exactly the A1 columns, NO fee/signer/bunk/dorm/*_by
+          const card = await tx<Record<string, unknown>[]>`
+            select * from parent_exeat_card(${schoolId}::uuid, ${exParent}::uuid, ${eligibleId}::uuid)`;
+          assert("parent_exeat_card returns the eligible own-child card", card.length, 1);
+          const ckeys = Object.keys(card[0] ?? {}).sort();
+          assertTrue(
+            "card columns are EXACTLY the A1 set",
+            ckeys.join(",") ===
+              [
+                "academic_year", "date_in", "date_out", "exeat_type", "form_label", "house_name",
+                "ref_code", "school_code", "school_name", "status", "student_name",
+              ].join(","),
+          );
+          assertTrue(
+            "card projects NO fee/amount/signer/bunk/dorm/*_by column",
+            !ckeys.some((k) => /fee|owing|amount|signer|bunk|dorm|_by/.test(k)),
+          );
+          assertTrue("card status is the promoted eligible status", card[0]?.status === "SR_HM_SIGNED");
+
+          // INELIGIBLE own-child (RETURNED staff row) → 0 rows (the fn is the authority, not the UI)
+          assert(
+            "ineligible-status own-child card → 0 rows",
+            (await tx`select * from parent_exeat_card(${schoolId}::uuid, ${exParent}::uuid, ${ineligibleId}::uuid)`).length,
+            0,
+          );
+
+          // another family (a parent with no linked children) → 0 rows (own-child fence)
+          const strangerPu = "99999999-0000-4000-8000-0000000f0001";
+          assert(
+            "another family's parent → 0 rows (not own child)",
+            (await tx`select * from parent_exeat_card(${schoolId}::uuid, ${strangerPu}::uuid, ${eligibleId}::uuid)`).length,
+            0,
+          );
+
+          // cross-TENANT: real exeat id but a foreign school arg → 0 rows (tenant_isolation on the arg)
+          assert(
+            "cross-tenant school arg → 0 rows",
+            (await tx`select * from parent_exeat_card(${FOREIGN_ID}::uuid, ${exParent}::uuid, ${eligibleId}::uuid)`).length,
+            0,
+          );
+
+          // staff (pu IS NULL) → 0 rows (total no-op; the card fn is not on any staff path)
+          assert(
+            "staff pu=NULL card → 0 rows (no-op)",
+            (await tx`select * from parent_exeat_card(${schoolId}::uuid, ${null}::uuid, ${eligibleId}::uuid)`).length,
+            0,
+          );
+
+          // parent GUC restored VERBATIM after the card fn
+          const [{ cur: curCard }] = await tx<{ cur: string }[]>`
+            select current_setting('app.current_parent_user', true) as cur`;
+          assertTrue("parent GUC restored VERBATIM after parent_exeat_card", curCard === exParent);
+
+          // DIRECT parent read of boarding_exeat STILL denied — the card fn is the ONLY reach
+          assert(
+            "parent DIRECT read of boarding_exeat still denied (card fn is the only reach)",
+            await c("boarding_exeat", `where id='${eligibleId}'`),
+            0,
           );
           await tx`reset role`;
 


### PR DESCRIPTION
## Exeat Phase 3-A · Feature A — parent-downloadable exeat card PDF

Adds `GET /api/parent/exeat-card/[id]` — a parent downloads the printable exeat CARD PDF for their OWN child. The card is a strictly-smaller projection of the staff card: no fee amount, no signer staff name, no bunk.

### Sign-offs
- **Quinn GREEN** (`8183b49`): A1 non-leak proven at fn-projection AND rendered-PDF boundaries, A3 eligibility 404s, A4/A5 own-child + tenant isolation non-superuser, staff card backward-compatible, prod-paste ≡ policies locked by CI, mutation-proven.
- **Dex APPROVE** (`8183b49`): renderer backward-compat, route conventions, no fork, no new lock-in.
- **Sarah SECURITY APPROVE + MERGE** (`8183b49`):
  - Non-leak: `parent_exeat_card` RETURNS TABLE is the structural cap (11 A1 cols, no fee/signer/bunk/dorm/_by/decline); route omits `feeLine`/`signerActor`; renderer gates the Fee row + signer-name line on their absence. CI drift + banned-column guards + rls-test non-superuser matrix all lock it.
  - Own-child + tenant isolation: `requireParent`; school.id + user.id from session (never request input); uuid-only path (no PII in URL); own-child fence via captured `pu` arg; cross-tenant/another-family/ineligible/staff-null → 0 rows → neutral 404, no bytes. `boarding_exeat` + spine stay `parent_deny`. GUC clear→restore verbatim (`COALESCE(prev,'')`), `app.current_school` kept.
  - Hardening: zod uuid, parameterised SQL, `private, no-store`, bare 404 (no stack); fn `REVOKE ... FROM PUBLIC` + `GRANT ... TO omnischools_app`, `SET search_path`.
  - Prod parity: `prod-paste-0099` fn byte-identical to `policies.sql`; fail-closed if unrun.

### ⚠ DEPLOY NOTE
Run `db/sql/prod-paste-0099-parent-exeat-card.sql` on PROD at deploy (db:policies is dev-only). Fail-closed if skipped (route 404s; boarding_exeat stays parent_deny — no leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)