### PR TITLE
chore(exeat): address the two non-blocking Dex follow-ups

### DIFF
--- a/omnischools/lib/boarding/exeat-data.ts
+++ b/omnischools/lib/boarding/exeat-data.ts
@@ -90,8 +90,10 @@ export async function feeOwingForStudent(
 export { getCurrentPeriod };
 
 /**
- * Quota used = count(SCHEDULED+FEE_COLLECTION, status≠DECLINED) for this student × semester
- * (Kofi OQ3 / AC B). Derived by counting rows — there is deliberately no counter column.
+ * Quota used = count(SCHEDULED+FEE_COLLECTION, status ∉ {DECLINED, WITHDRAWN}) for this student × semester
+ * (Kofi OQ3 / AC B). Derived by counting rows — there is deliberately no counter column. WITHDRAWN is a
+ * no-op today (only SPECIAL is parent-withdrawable, and quota counts SCHEDULED/FEE) but keeps the filter
+ * correct if withdrawal ever widens (Dex).
  */
 export async function countQuotaUsed(
   tx: Tx,
@@ -109,6 +111,7 @@ export async function countQuotaUsed(
         eq(boardingExeat.academicPeriodId, periodId),
         inArray(boardingExeat.exeatType, ["SCHEDULED", "FEE_COLLECTION"]),
         ne(boardingExeat.status, "DECLINED"),
+        ne(boardingExeat.status, "WITHDRAWN"),
       ),
     );
   return row?.n ?? 0;

--- a/omnischools/lib/parent/parent-exeat-data.ts
+++ b/omnischools/lib/parent/parent-exeat-data.ts
@@ -67,6 +67,9 @@ export function isCardReady(status: string, type: string): boolean {
  * `exeatDetail` already trusts) — we never put via_parent_portal on the parent wire. ADVISORY ONLY: the
  * SECURITY DEFINER `parent_withdraw_exeat` fn is the authority (own-child + via_parent_portal + REQUESTED);
  * a mis-shown button just yields a neutral "contact the House". WITHDRAWN → false (no reason echoed; not REQUESTED).
+ * COUPLING (Dex): soundness also rests on the request path mandating a >=4-char reason
+ * (lib/actions/parent-exeat.ts) — if a parent reason ever becomes optional this silently false-negatives;
+ * upgrade to a server-computed `withdrawable` boolean in the parent_exeat_list projection then.
  */
 export function canWithdraw(row: { status: string; reason: string | null }): boolean {
   return row.status === "REQUESTED" && !!row.reason?.trim();


### PR DESCRIPTION
Two non-blocking follow-ups Dex flagged on the Exeat Phase 3-B (withdraw) review — landed together.

1. **`canWithdraw` proxy coupling (doc-only)** — the `reason-present ⟺ via_parent_portal` proxy also rests on the parent request path mandating a ≥4-char reason. Added a JSDoc COUPLING note + the upgrade path (a server-computed `withdrawable` boolean) if a parent reason ever becomes optional.
2. **`countQuotaUsed` — exclude `WITHDRAWN`** alongside `DECLINED`. No-op today (only SPECIAL is parent-withdrawable, quota counts only SCHEDULED/FEE_COLLECTION), but keeps the filter correct if withdrawal scope ever widens.

No RLS / route / schema change. `pnpm typecheck` clean; full suite **2398 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)